### PR TITLE
maprender(overlap 2b-iii TS): per-instance overlap markers in the Tracking Station

### DIFF
--- a/Source/Parsek.Tests/OverlapPerInstanceTests.cs
+++ b/Source/Parsek.Tests/OverlapPerInstanceTests.cs
@@ -576,5 +576,170 @@ namespace Parsek.Tests
                 && l.Contains("autoIsOverlapLoop=True")
                 && l.Contains("isMember=False"));
         }
+
+        // =================================================================
+        //  Slice (iii): per-instance head-UT resolution (the marker ride set)
+        // =================================================================
+
+        [Fact]
+        public void TryGetLiveOverlapHeadUTs_SameCycleSetAsOverlapCyclesForTesting()
+        {
+            // The N markers that ride the shared polyline must be the SAME live cycle set slice (i)
+            // materializes (and the flight engine drives): TryGetLiveOverlapHeadUTs's cycle set ==
+            // OverlapCyclesForTesting's [firstCycle, lastCycle].
+            var committed = new List<Recording> { MakeLoopRec(100, 300, 30) };
+            double currentUT = 250.0;
+
+            GhostMapPresence.OverlapCyclesForTesting(
+                committed[0], 0, committed, NoUnits, currentUT,
+                out long expectedFirst, out long expectedLast);
+
+            var buffer = new List<(long cycle, double headUT)>();
+            bool ok = GhostMapPresence.TryGetLiveOverlapHeadUTs(
+                committed[0], 0, committed, NoUnits, currentUT, buffer);
+
+            Assert.True(ok);
+            var cycles = buffer.Select(e => e.cycle).ToList();
+            // Contiguous [first, last] set, byte-identical to OverlapCyclesForTesting.
+            var expected = new List<long>();
+            for (long c = expectedFirst; c <= expectedLast; c++) expected.Add(c);
+            Assert.Equal(expected, cycles);
+        }
+
+        [Theory]
+        [InlineData(130.0)]
+        [InlineData(250.0)]
+        [InlineData(400.0)]
+        public void TryGetLiveOverlapHeadUTs_CycleSetMatchesGetActiveCycles(double currentUT)
+        {
+            // 5s period over a 200s duration -> up to 40 cycles, capped at 20: exercises the cap clamp,
+            // mirroring OverlapCyclesForTesting_MatchesGetActiveCycles but on the slice-(iii) head path.
+            var committed = new List<Recording> { MakeLoopRec(100, 300, 5) };
+            GhostMapPresence.ResolveOverlapSchedule(
+                committed[0], 0, committed, NoUnits,
+                out _, out double scheduleStartUT,
+                out double duration, out double effectiveCadence, out _);
+
+            GhostPlaybackLogic.GetActiveCycles(
+                currentUT, scheduleStartUT, scheduleStartUT + duration,
+                effectiveCadence, GhostPlayback.MaxOverlapGhostsPerRecording,
+                out long engineFirst, out long engineLast);
+
+            var buffer = new List<(long cycle, double headUT)>();
+            bool ok = GhostMapPresence.TryGetLiveOverlapHeadUTs(
+                committed[0], 0, committed, NoUnits, currentUT, buffer);
+
+            Assert.True(ok);
+            Assert.Equal(engineLast - engineFirst + 1, buffer.Count);
+            Assert.Equal(engineFirst, buffer[0].cycle);
+            Assert.Equal(engineLast, buffer[buffer.Count - 1].cycle);
+            Assert.True(buffer.Count <= GhostPlayback.MaxOverlapGhostsPerRecording);
+        }
+
+        [Fact]
+        public void TryGetLiveOverlapHeadUTs_PerCycleHeadEqualsComputeOverlapCyclePlaybackUT()
+        {
+            // Each instance's head UT must be ComputeOverlapCyclePlaybackUT(cycle) DIRECTLY (NOT routed
+            // through the span-clock collapse), and the heads must be DISTINCT across cycles.
+            var committed = new List<Recording> { MakeLoopRec(100, 300, 30) };
+            double currentUT = 250.0;
+
+            GhostMapPresence.ResolveOverlapSchedule(
+                committed[0], 0, committed, NoUnits,
+                out double playbackStartUT, out double scheduleStartUT,
+                out double duration, out _, out double cycleDuration);
+
+            var buffer = new List<(long cycle, double headUT)>();
+            bool ok = GhostMapPresence.TryGetLiveOverlapHeadUTs(
+                committed[0], 0, committed, NoUnits, currentUT, buffer);
+            Assert.True(ok);
+            Assert.True(buffer.Count >= 2, "expected several overlapping cycles for distinctness check");
+
+            var seen = new HashSet<double>();
+            foreach (var (cycle, headUT) in buffer)
+            {
+                double expected = GhostPlaybackLogic.ComputeOverlapCyclePlaybackUT(
+                    currentUT, scheduleStartUT, playbackStartUT, duration, cycleDuration, cycle);
+                Assert.Equal(expected, headUT, 6);
+                // Distinct heads across cycles (staggered launches sit at different playback phases).
+                Assert.True(seen.Add(headUT), $"duplicate head UT {headUT} for cycle {cycle}");
+            }
+        }
+
+        [Fact]
+        public void TryGetLiveOverlapHeadUTs_MissionUnit_PerCycleHeadEqualsComputeUT()
+        {
+            // Source (b): a self-overlapping Mission member (rec.LoopPlayback=false). The head set must
+            // still be ComputeOverlapCyclePlaybackUT per cycle off the unit tuple.
+            var committed = new List<Recording> { MakeMemberRec(1000, 1200) };
+            var units = MakeOverlapUnitSet(
+                0, spanStartUT: 1000, spanEndUT: 1200, overlapCadenceSeconds: 20, phaseAnchorUT: 5000);
+            double currentUT = 5130.0;
+
+            GhostMapPresence.ResolveOverlapSchedule(
+                committed[0], 0, committed, units,
+                out double playbackStartUT, out double scheduleStartUT,
+                out double duration, out _, out double cycleDuration);
+
+            var buffer = new List<(long cycle, double headUT)>();
+            bool ok = GhostMapPresence.TryGetLiveOverlapHeadUTs(
+                committed[0], 0, committed, units, currentUT, buffer);
+            Assert.True(ok);
+            Assert.NotEmpty(buffer);
+
+            foreach (var (cycle, headUT) in buffer)
+            {
+                double expected = GhostPlaybackLogic.ComputeOverlapCyclePlaybackUT(
+                    currentUT, scheduleStartUT, playbackStartUT, duration, cycleDuration, cycle);
+                Assert.Equal(expected, headUT, 6);
+            }
+        }
+
+        [Fact]
+        public void TryGetLiveOverlapHeadUTs_GateOff_FalseAndClears()
+        {
+            // Gate off -> false -> the caller's legacy single-marker tail runs byte-identically.
+            ParsekSettings.CurrentOverrideForTesting.mapRenderDirectorDrive = false;
+            var committed = new List<Recording> { MakeLoopRec(100, 300, 30) };
+            var buffer = new List<(long cycle, double headUT)> { (99L, 1.0) }; // pre-populated
+            bool ok = GhostMapPresence.TryGetLiveOverlapHeadUTs(
+                committed[0], 0, committed, NoUnits, 250.0, buffer);
+            Assert.False(ok);
+            Assert.Empty(buffer); // cleared even on the false return
+        }
+
+        [Fact]
+        public void TryGetLiveOverlapHeadUTs_NonOverlap_False()
+        {
+            // A looping-but-NON-overlapping recording (period > duration) is single-instance: false.
+            var committed = new List<Recording> { MakeLoopRec(100, 300, 500) };
+            var buffer = new List<(long cycle, double headUT)>();
+            bool ok = GhostMapPresence.TryGetLiveOverlapHeadUTs(
+                committed[0], 0, committed, NoUnits, 250.0, buffer);
+            Assert.False(ok);
+            Assert.Empty(buffer);
+        }
+
+        [Fact]
+        public void TryGetLiveOverlapHeadUTs_BeforeScheduleStart_False()
+        {
+            // currentUT before the first launch: no live instances yet -> false (legacy tail).
+            var committed = new List<Recording> { MakeLoopRec(100, 300, 30) };
+            var buffer = new List<(long cycle, double headUT)>();
+            bool ok = GhostMapPresence.TryGetLiveOverlapHeadUTs(
+                committed[0], 0, committed, NoUnits, 50.0, buffer);
+            Assert.False(ok);
+            Assert.Empty(buffer);
+        }
+
+        [Fact]
+        public void TryGetOverlapInstancePidForCycle_EmptyStore_ReturnsZero()
+        {
+            // Pure-suborbital case: overlapInstanceVessels is empty for the recording, so every cycle's
+            // proto lookup is 0 -> the marker path draws every polyline marker (the maintainer's mission).
+            Assert.Equal(0u, GhostMapPresence.TryGetOverlapInstancePidForCycle(0, 0));
+            Assert.Equal(0u, GhostMapPresence.TryGetOverlapInstancePidForCycle(0, 5));
+            Assert.Equal(0u, GhostMapPresence.TryGetOverlapInstancePidForCycle(3, 2));
+        }
     }
 }

--- a/Source/Parsek/GhostMapPresence.cs
+++ b/Source/Parsek/GhostMapPresence.cs
@@ -11112,6 +11112,73 @@ namespace Parsek
         }
 
         /// <summary>
+        /// Slice (iii): resolve the per-instance playback head UTs that the flight-map marker path
+        /// should ride for an OVERLAP recording this frame - one entry per live overlap cycle, each
+        /// at its own <see cref="GhostPlaybackLogic.ComputeOverlapCyclePlaybackUT"/> head (NOT the
+        /// span-clock collapse of <see cref="GhostPlaybackLogic.ResolveTrackingStationSampleUT"/>).
+        /// The cycle SET is byte-identical to the slice-(i) <see cref="OverlapCyclesForTesting"/> /
+        /// <see cref="EnsureOverlapInstances"/> set (same gate + same schedule + same GetActiveCycles
+        /// call), so the N markers on the shared polyline match the N flight meshes.
+        ///
+        /// Returns false (so the caller's legacy single-marker tail runs byte-identically) when the
+        /// recording is not driven by the per-instance path (gate off / non-overlap), the schedule is
+        /// unresolvable, or <paramref name="currentUT"/> precedes the first launch. On true,
+        /// <paramref name="outBuffer"/> holds (cycle, headUT) for each live cycle in
+        /// [firstCycle, lastCycle].
+        /// </summary>
+        internal static bool TryGetLiveOverlapHeadUTs(
+            Recording rec, int recIdx, IReadOnlyList<Recording> committed,
+            GhostPlaybackLogic.LoopUnitSet loopUnits, double currentUT,
+            List<(long cycle, double headUT)> outBuffer)
+        {
+            if (outBuffer == null)
+                return false;
+            outBuffer.Clear();
+
+            if (!ShouldDriveOverlapPerInstance(rec, recIdx, committed, loopUnits))
+                return false;
+
+            if (!ResolveOverlapSchedule(
+                    rec, recIdx, committed, loopUnits,
+                    out double playbackStartUT, out double scheduleStartUT,
+                    out double duration, out double effectiveCadence, out double cycleDuration))
+                return false;
+
+            if (currentUT < scheduleStartUT)
+                return false;
+
+            GhostPlaybackLogic.GetActiveCycles(
+                currentUT, scheduleStartUT, scheduleStartUT + duration,
+                effectiveCadence, GhostPlayback.MaxOverlapGhostsPerRecording,
+                out long firstCycle, out long lastCycle);
+
+            for (long cycle = firstCycle; cycle <= lastCycle; cycle++)
+            {
+                double headUT = GhostPlaybackLogic.ComputeOverlapCyclePlaybackUT(
+                    currentUT, scheduleStartUT, playbackStartUT,
+                    duration, cycleDuration, cycle);
+                outBuffer.Add((cycle, headUT));
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Slice (iii) orbital-interaction join: resolve the live per-instance ProtoVessel pid for a
+        /// specific overlap (recIdx, cycle), or 0 when no instance exists for that cycle (the
+        /// pure-suborbital case - <see cref="overlapInstanceVessels"/> never holds a state-vector cycle
+        /// - or a cycle not yet materialized this frame). Lets the marker path decide per-cycle whether
+        /// the polyline marker is redundant with a live proto icon (skip) or is the sole indicator
+        /// (draw).
+        /// </summary>
+        internal static uint TryGetOverlapInstancePidForCycle(int recIdx, long cycle)
+        {
+            if (overlapInstanceVessels.TryGetValue((recIdx, cycle), out Vessel inst) && inst != null)
+                return inst.persistentId;
+            return 0u;
+        }
+
+        /// <summary>
         /// Build a per-instance overlap map ProtoVessel from a recorded state-vector point (physics-only
         /// suborbital ascent cycle), without the per-index <see cref="TrackRecordingGhostVessel"/> write
         /// or the Re-Fly suppression machinery in <see cref="CreateGhostVesselFromStateVectors"/> (which

--- a/Source/Parsek/InGameTests/ExtendedRuntimeTests.cs
+++ b/Source/Parsek/InGameTests/ExtendedRuntimeTests.cs
@@ -273,6 +273,109 @@ namespace Parsek.InGameTests
                 $"{mismatches} overlap recording(s) have TS map instance count mismatched vs GetActiveCycles");
         }
 
+        [InGameTest(Category = "GhostLifecycle", Scene = GameScenes.TRACKSTATION,
+            Description = "Slice (iii) TS port: per-instance overlap marker head count matches the pure GetActiveCycles size; no-double disjunction coherent")]
+        public void OverlapMarkerHeadCountMatchesScheduleTS()
+        {
+            // TS analogue of OverlapMarkerHeadCountMatchesFlight: the flight engine does not exist in the
+            // Tracking Station, so the per-instance marker HEAD set (what DrawAtmosphericMarkers'
+            // per-instance branch rides via DrawOneTsOverlapInstanceMarker) must equal the PURE recomputed
+            // active-cycle set for each overlap recording. Slice (iii) requires the director drive ON; off
+            // the gate TryGetLiveOverlapHeadUTs returns false (-> legacy single marker), so there is no
+            // per-instance head set to assert on.
+            if (ParsekSettings.Current == null || !ParsekSettings.Current.mapRenderDirectorDrive)
+                InGameAssert.Skip("mapRenderDirectorDrive off — per-instance marker path inactive");
+
+            var committed = RecordingStore.CommittedRecordings;
+            if (committed == null || committed.Count == 0)
+                InGameAssert.Skip("No committed recordings");
+
+            // Rebuild the TS span-clock loop-unit set exactly as ParsekTrackingStation.DriveMissionLoopUnits
+            // does (the SAME set DrawAtmosphericMarkers' per-instance branch passes as cachedLoopUnits), so a
+            // Mission-tab loop (source b) is recognized identically to the live scene.
+            double autoLoopIntervalSeconds = ParsekSettings.Current?.autoLoopIntervalSeconds
+                                             ?? LoopTiming.DefaultLoopIntervalSeconds;
+            var loopUnits = MissionLoopUnitBuilder.Build(
+                MissionStore.Missions, RecordingStore.CommittedTrees, committed,
+                autoLoopIntervalSeconds, FlightGlobalsBodyInfo.Instance,
+                ParsekSettings.Current?.TransitedBodyRotationMode ?? TransitedBodyRotationMode.Loose);
+
+            int cap = GhostPlayback.MaxOverlapGhostsPerRecording;
+            double currentUT = Planetarium.GetUniversalTime();
+            var headBuffer = new List<(long cycle, double headUT)>();
+            int checkedRecordings = 0;
+            int mismatches = 0;
+            int doubleViolations = 0;
+
+            for (int i = 0; i < committed.Count; i++)
+            {
+                var rec = committed[i];
+                // The head set is what the TS per-instance branch rides; it is produced by the SAME
+                // TryGetLiveOverlapHeadUTs the branch calls, gated identically (ShouldDriveOverlapPerInstance).
+                if (!GhostMapPresence.TryGetLiveOverlapHeadUTs(
+                        rec, i, committed, loopUnits, currentUT, headBuffer))
+                    continue;
+
+                // Independent pure recompute of the expected cycle count via GetActiveCycles (the schedule),
+                // matching OverlapMapInstanceCountMatchesScheduleTS.
+                if (!GhostMapPresence.ResolveOverlapSchedule(
+                        rec, i, committed, loopUnits,
+                        out _, out double scheduleStartUT,
+                        out double duration, out double effectiveCadence, out _))
+                    continue;
+                if (currentUT < scheduleStartUT)
+                    continue;
+
+                GhostPlaybackLogic.GetActiveCycles(
+                    currentUT, scheduleStartUT, scheduleStartUT + duration,
+                    effectiveCadence, cap, out long firstCycle, out long lastCycle);
+                int expected = (int)System.Math.Min(cap, lastCycle - firstCycle + 1);
+                int headCount = headBuffer.Count;
+
+                checkedRecordings++;
+                // The head count is the SAME GetActiveCycles span, so it must equal expected exactly
+                // (never above the cap).
+                if (headCount > cap || headCount != expected)
+                {
+                    mismatches++;
+                    ParsekLog.Warn("TestRunner",
+                        $"TS overlap marker head count mismatch rec=#{i}: heads={headCount} " +
+                        $"expectedCycles={expected} cap={cap}");
+                }
+
+                // No-double-marker disjunction coherence: for every live cycle, the per-cycle decision is
+                // exactly one of {proto icon owns it} XOR {polyline marker is the sole indicator}. pid 0
+                // (no proto for the cycle) MUST take the draw branch; pid != 0 routes through
+                // ShouldDrawNonProtoMarkerForGhost (true -> polyline marker draws, false -> proto owns).
+                // Either way the disjunction is total and unambiguous, so this never throws — it asserts the
+                // pid lookup + decision predicate stay callable/coherent for each head the branch will draw.
+                for (int hi = 0; hi < headBuffer.Count; hi++)
+                {
+                    long cycle = headBuffer[hi].cycle;
+                    uint pid = GhostMapPresence.TryGetOverlapInstancePidForCycle(i, cycle);
+                    bool protoOwns = pid != 0
+                        && !GhostMapPresence.ShouldDrawNonProtoMarkerForGhost(pid);
+                    bool polylineDraws = !protoOwns;
+                    if (protoOwns == polylineDraws) // impossible by construction; guards a future regression
+                    {
+                        doubleViolations++;
+                        ParsekLog.Warn("TestRunner",
+                            $"TS overlap no-double disjunction incoherent rec=#{i} cycle={cycle} pid={pid}");
+                    }
+                }
+            }
+
+            if (checkedRecordings == 0)
+                InGameAssert.Skip("No overlap recordings active");
+
+            ParsekLog.Info("TestRunner",
+                $"TS overlap marker head count: {checkedRecordings - mismatches}/{checkedRecordings} recordings match GetActiveCycles (cap={cap}); doubleViolations={doubleViolations}");
+            InGameAssert.AreEqual(0, mismatches,
+                $"{mismatches} overlap recording(s) have TS marker head count mismatched vs GetActiveCycles");
+            InGameAssert.AreEqual(0, doubleViolations,
+                $"{doubleViolations} TS overlap cycle(s) have an incoherent no-double disjunction");
+        }
+
         [InGameTest(Category = "GhostLifecycle", Scene = GameScenes.FLIGHT,
             Description = "Slice (iii): flight-map per-instance overlap marker head count matches flight overlap ghost count + 1 (capped)")]
         public void OverlapMarkerHeadCountMatchesFlight()

--- a/Source/Parsek/InGameTests/ExtendedRuntimeTests.cs
+++ b/Source/Parsek/InGameTests/ExtendedRuntimeTests.cs
@@ -274,6 +274,64 @@ namespace Parsek.InGameTests
         }
 
         [InGameTest(Category = "GhostLifecycle", Scene = GameScenes.FLIGHT,
+            Description = "Slice (iii): flight-map per-instance overlap marker head count matches flight overlap ghost count + 1 (capped)")]
+        public void OverlapMarkerHeadCountMatchesFlight()
+        {
+            var flight = ParsekFlight.Instance;
+            if (flight == null) InGameAssert.Skip("No ParsekFlight instance");
+
+            // Slice (iii) requires the director drive ON; off the gate TryGetLiveOverlapHeadUTs returns
+            // false (-> legacy single marker) and there is no per-instance marker set to assert on.
+            if (ParsekSettings.Current == null || !ParsekSettings.Current.mapRenderDirectorDrive)
+                InGameAssert.Skip("mapRenderDirectorDrive off — per-instance marker path inactive");
+
+            var committed = RecordingStore.CommittedRecordings;
+            if (committed == null || committed.Count == 0)
+                InGameAssert.Skip("No committed recordings");
+
+            int cap = GhostPlayback.MaxOverlapGhostsPerRecording;
+            double currentUT = Planetarium.GetUniversalTime();
+            var loopUnits = flight.Engine.CurrentLoopUnits;
+            var headBuffer = new List<(long cycle, double headUT)>();
+            int checkedRecordings = 0;
+            int mismatches = 0;
+
+            for (int i = 0; i < committed.Count; i++)
+            {
+                if (!flight.Engine.TryGetOverlapGhosts(i, out var overlaps) || overlaps == null)
+                    continue;
+                // The marker head set is what the flight-map per-instance branch rides; it must equal
+                // the engine's live overlap mesh count (overlapGhosts[i] + the primary ghost), capped.
+                if (!GhostMapPresence.TryGetLiveOverlapHeadUTs(
+                        committed[i], i, committed, loopUnits, currentUT, headBuffer))
+                    continue;
+
+                int flightInstances = overlaps.Count + 1; // primary (newest) + staggered list
+                int expected = System.Math.Min(flightInstances, cap);
+                int headCount = headBuffer.Count;
+
+                checkedRecordings++;
+                // Allow a +/-1 transient (the flight spawn throttle can be one frame ahead/behind the
+                // pure head recompute); never above the cap.
+                if (headCount > cap || System.Math.Abs(headCount - expected) > 1)
+                {
+                    mismatches++;
+                    ParsekLog.Warn("TestRunner",
+                        $"Overlap marker head count mismatch rec=#{i}: heads={headCount} " +
+                        $"flightMeshes={flightInstances} expected~={expected} cap={cap}");
+                }
+            }
+
+            if (checkedRecordings == 0)
+                InGameAssert.Skip("No overlap recordings active");
+
+            ParsekLog.Info("TestRunner",
+                $"Overlap marker head count: {checkedRecordings - mismatches}/{checkedRecordings} recordings match flight (cap={cap})");
+            InGameAssert.AreEqual(0, mismatches,
+                $"{mismatches} overlap recording(s) have marker head count mismatched vs flight meshes");
+        }
+
+        [InGameTest(Category = "GhostLifecycle", Scene = GameScenes.FLIGHT,
             Description = "Loop phase offsets are all finite (no NaN/Infinity)")]
         public void LoopPhaseOffsetsFinite()
         {

--- a/Source/Parsek/ParsekTrackingStation.cs
+++ b/Source/Parsek/ParsekTrackingStation.cs
@@ -65,6 +65,13 @@ namespace Parsek
         /// <summary>Cached interpolation indices for atmospheric ghost icon rendering (per recording index).</summary>
         private readonly Dictionary<int, int> atmosCachedIndices = new Dictionary<int, int>();
 
+        // Slice (iii) TS port: reusable per-recording head-UT buffer for the per-instance overlap marker
+        // branch (mirror of ParsekUI.cs:67). Cleared (not reallocated) per overlap recording inside
+        // GhostMapPresence.TryGetLiveOverlapHeadUTs, so drawing N markers on the one shared polyline in the
+        // tracking station allocates nothing per frame.
+        private static readonly List<(long cycle, double headUT)> tsOverlapHeadUtBuffer =
+            new List<(long, double)>();
+
         /// <summary>Tracks the last known committed recording count for live-update detection.</summary>
         private int lastKnownCommittedCount;
 
@@ -406,6 +413,61 @@ namespace Parsek
                             MapRenderTrace.MarkerRideReason.NotAttempted, -1, "traj"));
                 }
 
+                // ---- Slice (iii) TS port: per-instance overlap markers riding the ONE shared polyline ----
+                // Port of the flight-map DrawMapMarkers per-instance branch (ParsekUI.cs:1191-1252) to the
+                // tracking-station marker path. For an OVERLAPPING looped mission rendered via the trajectory
+                // polyline, draw N markers - one per live overlap instance - each at its own
+                // ComputeOverlapCyclePlaybackUT head along the SINGLE shared polyline (the polyline Driver
+                // draws once keyed by RecordingId in TS too), so the tracking station shows the SAME N
+                // markers the flight scene does. Gated behind ShouldDriveOverlapPerInstance (inside
+                // TryGetLiveOverlapHeadUTs = mapRenderDirectorDrive AND overlap): non-overlap / gate-off
+                // returns false and falls straight through to the UNCHANGED span-clock effUT block + 8c proto
+                // gate (ClassifyAtmosphericMarkerSkip) + single-marker tail below, byte-identically.
+                //
+                // HOISTED above the span-clock effUT/renderHidden block AND the
+                // ClassifyAtmosphericMarkerSkip 8c proto gate (which consults ONLY the newest instance's
+                // pid). This matches the flight slice (iii) hoist: a MIXED overlap recording - newest cycle
+                // mid-orbit (visible proto icon) while OLDER cycles are simultaneously in a non-orbital
+                // reentry/descent phase - must not get pre-empted by the newest-only skip and silently drop
+                // the older instances' polyline markers. Safe to hoist because the PER-CYCLE no-double rule
+                // inside DrawOneTsOverlapInstanceMarker (TryGetOverlapInstancePidForCycle +
+                // ShouldDrawNonProtoMarkerForGhost) makes the correct per-cycle orbital-vs-polyline decision.
+                // Uses cachedLoopUnits (the SAME TS span-clock set the lifecycle + legacy marker path read)
+                // and the TS-valid currentUT = Planetarium.GetUniversalTime(). Debris is guarded here to
+                // preserve the IsDebris filter the 8c block below applies.
+                if (i < committed.Count && rec != null && !rec.IsDebris
+                    && GhostMapPresence.TryGetLiveOverlapHeadUTs(
+                        rec, i, committed, cachedLoopUnits, currentUT, tsOverlapHeadUtBuffer))
+                {
+                    int instancesDrawn = 0;
+                    int liveCycles = tsOverlapHeadUtBuffer.Count;
+                    for (int hi = 0; hi < tsOverlapHeadUtBuffer.Count; hi++)
+                    {
+                        var (cycle, headUT) = tsOverlapHeadUtBuffer[hi];
+                        if (DrawOneTsOverlapInstanceMarker(i, committed, rec, headUT, cycle))
+                            instancesDrawn++;
+                    }
+                    summary.Candidates += instancesDrawn > 1 ? instancesDrawn - 1 : 0;
+                    summary.Drawn += instancesDrawn;
+
+                    EmitMarkerDecision(MapRenderTrace.MarkerOutcome.DrawnNonProto);
+
+                    // One rate-limited per-recording summary (batch-counting convention): how many of the N
+                    // live cycles actually drew a polyline marker this frame (an instance skips when its head
+                    // is out-of-window / between legs / off-line, or its cycle is drawn by a live
+                    // non-suppressed proto icon). Mirrors the flight branch's liveCycles/drawn summary.
+                    int recIdxForLog = i;
+                    string overlapNameForLog = rec.VesselName;
+                    ParsekLog.VerboseRateLimited(Tag,
+                        "ts-overlap-instance-markers-"
+                            + recIdxForLog.ToString(CultureInfo.InvariantCulture),
+                        () => string.Format(CultureInfo.InvariantCulture,
+                            "TS overlap per-instance markers: rec={0} vessel={1} liveCycles={2} drawn={3}",
+                            recIdxForLog, overlapNameForLog ?? "Ghost", liveCycles, instancesDrawn),
+                        2.0);
+                    continue; // per-instance markers drew (or all skipped) — bypass effUT + 8c gate + tail
+                }
+
                 // Phase F: substitute the shared Mission span-clock loopUT for the live UT when this
                 // committed index is a loop-unit member. A member outside its loop window this cycle
                 // is skipped (no marker). Inert (effUT == currentUT, renderHidden false) for
@@ -670,6 +732,90 @@ namespace Parsek
                     context.Button,
                     context.ScreenPosition.x,
                     context.ScreenPosition.y));
+            return true;
+        }
+
+        /// <summary>
+        /// Slice (iii) TS port: draw ONE per-instance overlap marker for a single live overlap cycle at its
+        /// own playback head UT (<paramref name="headUT"/> = <c>ComputeOverlapCyclePlaybackUT(cycle)</c>),
+        /// riding the SINGLE shared polyline keyed by RecordingId in the tracking station. Returns true when
+        /// a marker drew, false when the instance was skipped (head out-of-window / between legs / off-line,
+        /// or the cycle is currently represented by a live non-suppressed proto icon). TS-local analogue of
+        /// the flight <c>ParsekUI.DrawOneOverlapInstanceMarker</c> using TS primitives (the TS resolver +
+        /// the world-pos <see cref="MapMarkerRenderer.DrawMarker"/> overload + the TS click handler).
+        ///
+        /// Orbital no-double-marker rule: for an ORBITAL overlap recording slice (i) creates N ProtoVessels
+        /// with orbit icons. If this cycle has a live instance proto AND its icon is NOT suppressed, the
+        /// proto icon already draws the cycle - skip the polyline marker. Otherwise (pid 0: pure-suborbital
+        /// or pre-materialize, OR the icon is suppressed for a non-orbital phase) the polyline marker is the
+        /// sole indicator - draw it.
+        ///
+        /// Position contract mirrors the TS single-marker tail: resolve the body-fixed head via
+        /// <see cref="TryResolveRecordingWorldPosition"/> at the per-cycle headUT (NOT the span-clock
+        /// effUT), skip on failure, then RIDE the shared polyline via
+        /// <see cref="Parsek.Display.GhostTrajectoryPolylineRenderer.TryAnchorMarkerToPolyline(string,double,out Vector3)"/>
+        /// - use the on-line position when it rides, else skip this instance (never draw off-line). The
+        /// per-instance marker key is <c>recId + "#" + cycle</c> so hover/sticky state is independent across
+        /// instances; the visible label is the shared mission name for all N (they ARE the same mission).
+        /// The click handler is the SAME <see cref="OnAtmosphericMarkerClicked"/> the single TS marker wires,
+        /// so per-instance markers stay clickable (a TS nuance: flight markers are not clickable).
+        /// </summary>
+        private bool DrawOneTsOverlapInstanceMarker(
+            int recordingIndex, IReadOnlyList<Recording> committed, Recording rec,
+            double headUT, long cycle)
+        {
+            if (rec == null || committed == null
+                || recordingIndex < 0 || recordingIndex >= committed.Count)
+                return false;
+
+            // Orbital no-double-marker join: if a live, non-suppressed proto icon already draws this cycle,
+            // skip the polyline marker. pid 0 means no proto for the cycle (pure-suborbital or not yet
+            // materialized) -> draw the polyline marker.
+            uint instancePid = GhostMapPresence.TryGetOverlapInstancePidForCycle(recordingIndex, cycle);
+            if (instancePid != 0
+                && !GhostMapPresence.ShouldDrawNonProtoMarkerForGhost(instancePid))
+            {
+                // The proto icon owns this cycle this frame — no polyline marker (no double).
+                return false;
+            }
+
+            // Body-fixed head for the instance at the PER-CYCLE headUT; skip on failure (out-of-window /
+            // between legs). A fresh local cache index per call is fine (N <= 20 cycles).
+            int cached = -1;
+            if (!TryResolveRecordingWorldPosition(
+                    rec, headUT, ref cached, out Vector3d worldPos, out _, out _, out _))
+                return false;
+
+            // Ride the SINGLE shared polyline at this instance's head; never draw off-line.
+            if (!Parsek.Display.GhostTrajectoryPolylineRenderer.TryAnchorMarkerToPolyline(
+                    rec.RecordingId, headUT, out Vector3 onLinePos))
+                return false;
+
+            // Per-instance key (hover-collision fix): distinct keys, identical labels are fine
+            // (MapMarkerRenderer keys hover/sticky on markerKey, not the label).
+            string markerKey = string.IsNullOrEmpty(rec.RecordingId)
+                ? null
+                : rec.RecordingId + "#" + cycle.ToString(CultureInfo.InvariantCulture);
+            string label = rec.VesselName ?? "(unknown)";
+            VesselType vtype = ResolveVesselTypeWithFallback(committed, rec);
+            Color markerColor = MapMarkerRenderer.GetColorForType(vtype);
+            int recordingIndexForClick = recordingIndex;
+            Recording markerRecording = rec;
+            MapMarkerRenderer.DrawMarker(
+                onLinePos,
+                markerKey,
+                label,
+                markerColor,
+                vtype,
+                context => OnAtmosphericMarkerClicked(recordingIndexForClick, markerRecording, context));
+
+            if (MapRenderTrace.IsEnabled)
+                MapRenderTrace.EmitMarker(
+                    MapRenderTrace.RenderSurface.AtmosphericMarker, markerKey, headUT,
+                    string.Format(CultureInfo.InvariantCulture,
+                        "vessel={0} cycle={1} markerPos={2} overlapInstance=True",
+                        label, cycle, MapRenderTrace.FormatVector3(onLinePos)));
+
             return true;
         }
 

--- a/Source/Parsek/ParsekUI.cs
+++ b/Source/Parsek/ParsekUI.cs
@@ -61,6 +61,12 @@ namespace Parsek
         // Reusable per-frame buffers (used by DrawMapMarkers for chain dedup)
         private static readonly Dictionary<string, int> chainTipIndexBuffer = new Dictionary<string, int>();
 
+        // Slice (iii): reusable per-recording head-UT buffer for the per-instance overlap marker
+        // branch. Cleared (not reallocated) per overlap recording inside TryGetLiveOverlapHeadUTs so
+        // drawing N markers on the one shared polyline allocates nothing per frame.
+        private static readonly List<(long cycle, double headUT)> overlapHeadUtBuffer =
+            new List<(long, double)>();
+
         // The labeled marker uses GhostMapPresence.IsPolylineRecentlyOwningGhostPhase to decide
         // when to prefer trajPos over the stale OrbitDriver mesh transform during the brief
         // post-polyline-release window (the seg-drive dispatcher runs on a ~0.5s cadence so the
@@ -1182,6 +1188,69 @@ namespace Parsek
                     continue;
                 }
 
+                // ---- Slice (iii): per-instance overlap markers riding the ONE shared polyline ----
+                // For an OVERLAPPING looped mission rendered via the trajectory polyline (the
+                // maintainer's sub-2km hop with ZERO orbit), draw N markers - one per live overlap
+                // instance - each at its own ComputeOverlapCyclePlaybackUT head along the single shared
+                // polyline, so the map matches the N flight ghosts. The polyline GEOMETRY is untouched
+                // (it draws ONCE keyed by RecordingId); this only adds N markers riding it. Gated behind
+                // ShouldDriveOverlapPerInstance (inside TryGetLiveOverlapHeadUTs): non-overlap / gate-off
+                // returns false and falls through to the UNCHANGED 8c proto gate + single-marker tail
+                // below, byte-identically.
+                //
+                // HOISTED above the 8c proto gate (which consults ONLY the newest instance's pid) and
+                // the chain-non-tip gate so a MIXED overlap recording - newest cycle mid-orbit (visible
+                // proto icon) while OLDER cycles are simultaneously in a non-orbital reentry/descent
+                // phase - does NOT get pre-empted by the newest-only `continue` and silently drop the
+                // older instances' polyline markers. Safe to hoist because the PER-CYCLE no-double rule
+                // inside DrawOneOverlapInstanceMarker (TryGetOverlapInstancePidForCycle +
+                // ShouldDrawNonProtoMarkerForGhost(instancePid)) makes the correct per-cycle
+                // orbital-vs-polyline decision: a cycle whose proto icon is visible is skipped (the proto
+                // draws it), a cycle that is suborbital/suppressed draws its polyline marker. So moving
+                // the whole branch up cannot double-draw and closes the dropped-marker gap. Debris is
+                // still skipped here (overlap recordings are top-level mission members, but guard anyway
+                // to preserve the IsDebris filter the 8c block below applied).
+                //
+                // Map-view only: the per-instance heads ride the polyline scratchScaledSpace (filled at
+                // onPreCull) and resolve world positions via the map's scaled-space anchoring; in flight
+                // view currentUT is 0 and there is no shared map polyline to ride, so overlap markers
+                // stay on the single-instance (newest) path below.
+                if (isMapView && kvp.Key < committed.Count
+                    && !committed[kvp.Key].IsDebris
+                    && GhostMapPresence.TryGetLiveOverlapHeadUTs(
+                        committed[kvp.Key], kvp.Key, committed,
+                        flight.Engine.CurrentLoopUnits, currentUT, overlapHeadUtBuffer))
+                {
+                    int instancesDrawn = 0;
+                    for (int hi = 0; hi < overlapHeadUtBuffer.Count; hi++)
+                    {
+                        var (cycle, headUT) = overlapHeadUtBuffer[hi];
+                        if (DrawOneOverlapInstanceMarker(kvp.Key, committed, headUT, cycle))
+                            instancesDrawn++;
+                    }
+                    summary.Drawn += instancesDrawn;
+
+                    decOutcome = MapRenderTrace.MarkerOutcome.DrawnNonProto;
+                    EmitMarkerDecision();
+
+                    // A single rate-limited summary per overlap recording (per the batch-counting
+                    // convention): how many of the N live cycles actually drew a polyline marker this
+                    // frame (an instance skips when its head is out-of-window / between legs / off-line,
+                    // or when its cycle is currently drawn by a live non-suppressed proto icon).
+                    int recIdxForOverlapLog = kvp.Key;
+                    int liveCyclesForLog = overlapHeadUtBuffer.Count;
+                    int drawnForLog = instancesDrawn;
+                    string overlapNameForLog = committed[kvp.Key].VesselName;
+                    ParsekLog.VerboseRateLimited("GhostMap",
+                        "overlap-instance-markers-"
+                            + recIdxForOverlapLog.ToString(System.Globalization.CultureInfo.InvariantCulture),
+                        () => string.Format(System.Globalization.CultureInfo.InvariantCulture,
+                            "Overlap per-instance markers: rec={0} vessel={1} liveCycles={2} drawn={3}",
+                            recIdxForOverlapLog, overlapNameForLog ?? "Ghost", liveCyclesForLog, drawnForLog),
+                        2.0);
+                    continue; // per-instance markers drew (or all skipped) — skip the 8c gate + tail
+                }
+
                 // Skip if native KSP icon is active (ProtoVessel exists and icon not suppressed).
                 // When the Harmony patch suppresses the icon (below atmosphere), we draw
                 // our custom marker at the ghost mesh position instead.
@@ -1467,6 +1536,79 @@ namespace Parsek
             }
 
             LogMapMarkerSummary(summary);
+        }
+
+        /// <summary>
+        /// Slice (iii): draw ONE per-instance overlap marker for a single live overlap cycle at its
+        /// own playback head UT (<paramref name="headUT"/> = <c>ComputeOverlapCyclePlaybackUT(cycle)</c>),
+        /// riding the SINGLE shared polyline keyed by RecordingId. Returns true when a marker drew, false
+        /// when the instance was skipped (head out-of-window / between legs / off-line, or the cycle is
+        /// currently represented by a live non-suppressed proto icon). Map-view only (the caller gates
+        /// on isMapView).
+        ///
+        /// Orbital no-double-marker rule: for an ORBITAL overlap recording slice (i) creates N
+        /// ProtoVessels with orbit icons. If this cycle has a live instance proto AND its icon is NOT
+        /// suppressed, the proto icon already draws the cycle - skip the polyline marker. Otherwise (no
+        /// proto for the cycle: pure-suborbital or pre-materialize, OR the icon is suppressed for a
+        /// non-orbital phase) the polyline marker is the sole indicator - draw it. For the maintainer's
+        /// pure-suborbital case overlapInstanceVessels is empty so every cycle takes the draw branch.
+        ///
+        /// Position contract mirrors the single-instance polyline tail in DrawMapMarkers verbatim:
+        /// resolve the body-fixed head via TryComputeGhostWorldPosition (skip on failure), then RIDE the
+        /// shared polyline via TryAnchorMarkerToPolyline - use the on-line position when it rides, else
+        /// skip this instance's marker (never draw off-line). The per-instance marker key is
+        /// <c>recId + "#" + cycle</c> so hover/sticky state is independent across instances; the visible
+        /// label is the shared mission name for all N (they ARE the same mission).
+        /// </summary>
+        private bool DrawOneOverlapInstanceMarker(
+            int recordingIndex, IReadOnlyList<Recording> committed, double headUT, long cycle)
+        {
+            if (committed == null || recordingIndex < 0 || recordingIndex >= committed.Count)
+                return false;
+            Recording rec = committed[recordingIndex];
+            if (rec == null)
+                return false;
+
+            // Orbital no-double-marker join: if a live, non-suppressed proto icon already draws this
+            // cycle, skip the polyline marker. A pid of 0 means no proto for the cycle (pure-suborbital
+            // or not yet materialized) -> draw the polyline marker.
+            uint instancePid = GhostMapPresence.TryGetOverlapInstancePidForCycle(recordingIndex, cycle);
+            if (instancePid != 0
+                && !GhostMapPresence.ShouldDrawNonProtoMarkerForGhost(instancePid))
+            {
+                // The proto icon owns this cycle this frame — no polyline marker (no double).
+                return false;
+            }
+
+            // Body-fixed head for the instance; skip on failure (out-of-window / between legs).
+            if (!TryComputeGhostWorldPosition(
+                    recordingIndex, committed, headUT, out Vector3 markerPos, out _))
+                return false;
+
+            // Ride the SINGLE shared polyline at this instance's head; never draw off-line.
+            if (!Parsek.Display.GhostTrajectoryPolylineRenderer.TryAnchorMarkerToPolyline(
+                    rec.RecordingId, headUT, out Vector3 onLinePos))
+                return false;
+            markerPos = onLinePos;
+
+            // Per-instance key (hover-collision fix): distinct keys, identical labels are fine
+            // (MapMarkerRenderer keys hover/sticky on markerKey, not the label).
+            string markerKey = string.IsNullOrEmpty(rec.RecordingId)
+                ? null
+                : rec.RecordingId + "#" + cycle.ToString(System.Globalization.CultureInfo.InvariantCulture);
+            string label = rec.VesselName ?? "Ghost";
+            VesselType vtype = GhostMapPresence.ResolveVesselType(rec.VesselSnapshot);
+            Color markerColor = GetGhostMarkerColorForType(vtype);
+            DrawMapMarkerAt(markerPos, markerKey, label, markerColor, vtype);
+
+            if (MapRenderTrace.IsEnabled)
+                MapRenderTrace.EmitMarker(
+                    MapRenderTrace.RenderSurface.ImguiLabeledMarker, markerKey, headUT,
+                    string.Format(System.Globalization.CultureInfo.InvariantCulture,
+                        "vessel={0} cycle={1} markerPos={2} overlapInstance=True",
+                        label, cycle, MapRenderTrace.FormatVector3(markerPos)));
+
+            return true;
         }
 
         /// <summary>

--- a/docs/dev/plans/maprender-rewrite-status.md
+++ b/docs/dev/plans/maprender-rewrite-status.md
@@ -401,11 +401,26 @@ reconciler for decision-vs-old-truth parity, and resolve the in-game probes befo
       `ShouldDrawNonProtoMarkerForGhost`: a cycle with a visible proto icon skips its polyline marker;
       pid-0/suppressed draws it) + per-instance marker key `recId#cycle`. The polyline GEOMETRY is
       untouched (one draw, keyed by RecordingId - the maintainer's "ride a single polyline" steer).
-      Flight-map only (TS per-instance markers deferred). Needs slice (ii)? NO. Gate-off + non-overlap
-      byte-identical (pure short-circuit, additive diff). Two clean reviews (plan + code SHIP-with-the-
-      hoist-fix-applied). Build clean; suite green (13519). **In-game gate:** "Kerbal X #2" (suborbital,
-      Missions-tab loop period<length, director-drive ON), map view past a relaunch: N markers on the ONE
-      shared ascent line matching the N flight ghosts; gate-off / non-overlap = one marker. Efficiency:
+      Needs slice (ii)? NO. Gate-off + non-overlap byte-identical (pure short-circuit, additive diff).
+      Two clean reviews (plan + code SHIP-with-the-hoist-fix-applied). Build clean; suite green (13519).
+      **In-game gate:** "Kerbal X #2" (suborbital, Missions-tab loop period<length, director-drive ON),
+      map view past a relaunch: N markers on the ONE shared ascent line matching the N flight ghosts;
+      gate-off / non-overlap = one marker.
+    - **TS per-instance markers - DONE (this branch, awaiting in-game gate):** ported the slice-(iii)
+      flight-map branch to the Tracking Station marker path (`ParsekTrackingStation.DrawAtmosphericMarkers`)
+      so the TS renders the SAME as map view: N markers on the one shared polyline for an overlapping
+      mission (maintainer request). Reuses the scene-agnostic `TryGetLiveOverlapHeadUTs` (fed the TS
+      `cachedLoopUnits`) + `TryGetOverlapInstancePidForCycle` no-double rule + `TryAnchorMarkerToPolyline`
+      ride (the polyline Driver draws in TS too); new TS-LOCAL `DrawOneTsOverlapInstanceMarker` (TS
+      `TryResolveRecordingWorldPosition` head + `MapMarkerRenderer.DrawMarker` world-pos + the
+      `OnAtmosphericMarkerClicked` click handler so the per-instance markers stay clickable - a TS nuance).
+      Hoisted ABOVE the newest-only 8c gate (same mixed-case fix). Per-instance key `recId#cycle`. Flight
+      path + shared helpers UNTOUCHED (TS-local; no over-refactor). Gate-off + non-overlap byte-identical.
+      Clean review SHIP (no fixes). Build clean; suite green (13519). **In-game gate:** the overlap mission
+      in the TRACKING STATION view (director-drive ON) -> N markers matching flight map view; gate-off /
+      non-overlap = one marker. (Watch-item: the recording-level `lastGoodOnLine` hold is shared across the
+      N cycles - assessed cosmetic-only under warp transients, not changed; if it strobes, the fix is a
+      per-(recId,cycle) hold in the shared renderer.) Efficiency:
       overlap-ONLY gate so non-overlap recordings stay EXACTLY
       one-per-recording (zero new cost); reuse the engine's cycles; throttle per-instance ProtoVessel
       create/destroy (the biggest risk = warp-time cycle churn); cap at 20. Gate-OFF stays legacy

--- a/docs/dev/plans/maprender-rewrite-status.md
+++ b/docs/dev/plans/maprender-rewrite-status.md
@@ -387,9 +387,26 @@ reconciler for decision-vs-old-truth parity, and resolve the in-game probes befo
       `MaxOverlapGhostsPerRecording=20`) - reuse it, do not reinvent. FULL per-instance (not icon-only:
       N icons on one shared line is visibly wrong for non-orbital ascent/descent instances). Stacks on 2a
       (instance 0 = newest cycle = today's single ghost). Slices: **(i) map presence N-per-overlapping-
-      recording lifecycle [the bulk] - DONE (awaiting in-game gate)**, (ii) Director per-instance
-      enumeration + the existing `instanceKey` wiring (caches are already pid-keyed), (iii) polyline +
-      marker per-instance. Efficiency: overlap-ONLY gate so non-overlap recordings stay EXACTLY
+      recording lifecycle [the bulk] - DONE+MERGED (PR #1053, gate fix incl.)**, **(ii) Director
+      per-instance enumeration + instanceKey - NOT NEEDED (slice (i) review proved instanceKey is a no-op
+      for the per-pid icon path; slice (iii) confirmed it needs nothing from (ii)) - SKIPPED**, **(iii) N
+      markers on the ONE shared polyline - DONE (awaiting in-game gate)**: for an overlapping recording
+      rendered via the POLYLINE (suborbital/ascent, e.g. "Kerbal X #2", a sub-2km hop with zero orbit -
+      slice (i) creates NO ProtoVessels for it), `ParsekUI.DrawMapMarkers` draws N markers (one per live
+      overlap cycle) riding the SINGLE shared polyline at each cycle's head UT. New
+      `GhostMapPresence.TryGetLiveOverlapHeadUTs` (reuses `ResolveOverlapSchedule` + `GetActiveCycles` +
+      `ComputeOverlapCyclePlaybackUT`; head UT direct, not span-clock-collapsed) + the per-instance branch
+      (hoisted ABOVE the newest-only 8c proto gate so a MIXED orbital/non-orbital overlap doesn't drop the
+      non-newest markers - review-caught) + per-cycle no-double rule (`TryGetOverlapInstancePidForCycle` +
+      `ShouldDrawNonProtoMarkerForGhost`: a cycle with a visible proto icon skips its polyline marker;
+      pid-0/suppressed draws it) + per-instance marker key `recId#cycle`. The polyline GEOMETRY is
+      untouched (one draw, keyed by RecordingId - the maintainer's "ride a single polyline" steer).
+      Flight-map only (TS per-instance markers deferred). Needs slice (ii)? NO. Gate-off + non-overlap
+      byte-identical (pure short-circuit, additive diff). Two clean reviews (plan + code SHIP-with-the-
+      hoist-fix-applied). Build clean; suite green (13519). **In-game gate:** "Kerbal X #2" (suborbital,
+      Missions-tab loop period<length, director-drive ON), map view past a relaunch: N markers on the ONE
+      shared ascent line matching the N flight ghosts; gate-off / non-overlap = one marker. Efficiency:
+      overlap-ONLY gate so non-overlap recordings stay EXACTLY
       one-per-recording (zero new cost); reuse the engine's cycles; throttle per-instance ProtoVessel
       create/destroy (the biggest risk = warp-time cycle churn); cap at 20. Gate-OFF stays legacy
       one-per-recording.


### PR DESCRIPTION
## TS per-instance overlap markers (mirror map view)

Ports the flight-map slice-(iii) per-instance overlap markers to the **Tracking Station** marker path, so TS renders the same as map view: N markers - one per live overlap instance - riding the single shared polyline for an overlapping looped mission. Maintainer request ("I want the TS to render the same as map view"). TS-LOCAL addition - the flight path (`ParsekUI.cs`) and the shared helpers are untouched (no over-refactor). Stacks on #1058 (slice iii). Full plan: `docs/dev/plans/maprender-overlap-per-instance.md`.

### Change (all in `ParsekTrackingStation.cs`)
- A per-instance branch in `DrawAtmosphericMarkers`, **hoisted above** the span-clock `effUT`/`renderHidden` block and the newest-only 8c `ClassifyAtmosphericMarkerSkip` gate (after the not-on-map + `IsDebris` checks) - the same mixed orbital/non-orbital fix slice (iii) needed, so non-newest markers aren't dropped. It loops the live `(cycle, headUT)` set from the scene-agnostic `GhostMapPresence.TryGetLiveOverlapHeadUTs` (fed the TS `cachedLoopUnits` + `Planetarium.GetUniversalTime()`) and `continue`s past the unchanged single-marker tail.
- `DrawOneTsOverlapInstanceMarker` (TS-local analogue of the flight helper): the per-cycle no-double rule (`TryGetOverlapInstancePidForCycle` + `ShouldDrawNonProtoMarkerForGhost`); the TS head via `TryResolveRecordingWorldPosition(rec, headUT)`; the polyline ride `TryAnchorMarkerToPolyline(recId, headUT)` (skip off-line); draw via `MapMarkerRenderer.DrawMarker(onLinePos, recId#cycle, VesselName, ...)` with the `OnAtmosphericMarkerClicked` click handler so per-instance markers stay clickable (a TS nuance).

### Safety
- **Gate-off + non-overlap byte-identical**: the branch fires only when `TryGetLiveOverlapHeadUTs` is true (gated on `mapRenderDirectorDrive` AND overlap); otherwise the unchanged span-clock + 8c + single-marker tail runs. Additive diff (numstat 146/0 + 103/0 - pure insertions).
- Flight path + shared helpers (`ParsekUI`, `GhostMapPresence`, the polyline renderer, `MapMarkerRenderer`) untouched - TS only calls them.
- Suborbital overlap -> all N markers; orbital -> per-cycle proto-or-polyline (no double, no gap). No slice (ii) needed.
- The recording-level `lastGoodOnLine` hold is shared across the N cycles - assessed cosmetic-only under warp transients, not changed (per-(recId,cycle) hold deferred to the shared renderer if it ever strobes).

### Review
Clean-context code review: SHIP, all 9 items pass (the hoist/mixed case, gate-off identity, the draw helper + per-instance click handler, no-double totality, flight-path-untouched, efficiency, summary coherence). No fixes required.

### Tests + build
- Build clean (0 warnings / 0 errors). Full suite green: 13519 passed.
- New TS in-game test `OverlapMarkerHeadCountMatchesScheduleTS` (asserts the TS head count == the schedule `GetActiveCycles` count, cap 20, + the no-double disjunction). The pure head-UT contract is already covered scene-agnostically by `OverlapPerInstanceTests`.

### In-game gate (please)
The overlapping mission ("Kerbal X #2") in the **Tracking Station** view with director-render ON -> N markers on the one shared polyline, matching the flight map view; toggle the gate off / a non-overlap mission -> one marker.

This completes the per-instance overlap feature across both flight map and the Tracking Station.