### PR TITLE
ghost-log: rate-limit per-cycle warp floods + complete the TS render-tracer coverage

### DIFF
--- a/Source/Parsek.Tests/GhostPlaybackLogHygieneTests.cs
+++ b/Source/Parsek.Tests/GhostPlaybackLogHygieneTests.cs
@@ -1,0 +1,241 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    /// <summary>
+    /// Log-hygiene regression tests for the ghost-playback per-cycle Verbose lines
+    /// that flooded KSP.log at high time warp. Each site was converted from a pure
+    /// <see cref="ParsekLog.Verbose"/> to <see cref="ParsekLog.VerboseRateLimited"/>
+    /// with a STABLE per-recording / per-ghost / per-index key.
+    /// <para>
+    /// The headline guard is the #1063 trap: a value that advances every frame at
+    /// warp (cycle index, UT, spawn-seed id, frame count) must NEVER be part of the
+    /// rate-limit KEY — only the message BODY. If a warp-advancing value leaks into
+    /// the key, the rate limiter creates a brand-new bucket every frame and emits on
+    /// every call, defeating the throttle. These tests hold the wall-clock fixed and
+    /// vary the UT inside the message: exactly one line must emit.
+    /// </para>
+    /// </summary>
+    [Collection("Sequential")]
+    public class GhostPlaybackLogHygieneTests : IDisposable
+    {
+        private readonly List<string> lines = new List<string>();
+        private double clock;
+
+        public GhostPlaybackLogHygieneTests()
+        {
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.ResetRateLimitsForTesting();
+            ParsekLog.SuppressLogging = false;
+            ParsekLog.VerboseOverrideForTesting = true;
+            ParsekLog.TestSinkForTesting = line => lines.Add(line);
+            clock = 1000.0;
+            ParsekLog.ClockOverrideForTesting = () => clock;
+        }
+
+        public void Dispose()
+        {
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.ResetRateLimitsForTesting();
+            ParsekLog.SuppressLogging = true;
+        }
+
+        // -------------------------------------------------------------------
+        // #1063 regression guard — driven through the real production helper
+        // LogPendingPlaybackInterpolationResolved (via the internal entry
+        // point TryResolvePendingPlaybackInterpolation). The key is built from
+        // (recId, source); the UT lives only in the message body. 50 calls with
+        // the SAME recording but a DIFFERENT playbackUT each call, clock held
+        // fixed, must emit exactly ONE line. Then advancing the clock past the
+        // 2 s interval must emit a second line carrying suppressed=.
+        // -------------------------------------------------------------------
+
+        [Fact]
+        public void PendingPlaybackInterpolation_SameKeyDifferentUT_EmitsOnceUntilIntervalElapses()
+        {
+            Recording rec = MakeTwoPointRecording("hygiene-1063");
+
+            // Fire the resolved-path helper 50 times: same recording (same recId +
+            // same "point interpolation" source = same key), DIFFERENT UT each call.
+            // Keep every UT strictly between the two points (100..300) so the resolver
+            // stays on the SAME "point interpolation" source branch — that isolates the
+            // test to the warp-advancing UT, the exact #1063 hazard.
+            for (int i = 0; i < 50; i++)
+            {
+                double playbackUT = 110.0 + i; // 110..159, advances every call, mimics warp
+                bool resolved = GhostPlaybackEngine.TryResolvePendingPlaybackInterpolation(
+                    rec, playbackUT, out _);
+                Assert.True(resolved);
+            }
+
+            var emitted = PendingPlaybackLines();
+
+            // Exactly one line proves the warp-advancing UT is in the BODY, not the KEY.
+            Assert.Single(emitted);
+            Assert.Contains("resolved from", emitted[0]);
+            Assert.DoesNotContain("suppressed=", emitted[0]);
+
+            // Advance the wall clock past the 2 s window: the next call re-opens the
+            // gate and surfaces the suppressed counter (the 49 throttled calls). Use a
+            // UT in-range so the source (and therefore the key) is unchanged.
+            clock += 2.5;
+            bool resolvedAgain = GhostPlaybackEngine.TryResolvePendingPlaybackInterpolation(
+                rec, 175.0, out _);
+            Assert.True(resolvedAgain);
+
+            emitted = PendingPlaybackLines();
+            Assert.Equal(2, emitted.Count);
+            Assert.Contains("suppressed=", emitted[1]);
+        }
+
+        [Fact]
+        public void PendingPlaybackInterpolation_DifferentRecordings_TrackedIndependently()
+        {
+            Recording recA = MakeTwoPointRecording("hygiene-recA");
+            Recording recB = MakeTwoPointRecording("hygiene-recB");
+
+            for (int i = 0; i < 10; i++)
+            {
+                GhostPlaybackEngine.TryResolvePendingPlaybackInterpolation(recA, 150.0 + i, out _);
+                GhostPlaybackEngine.TryResolvePendingPlaybackInterpolation(recB, 150.0 + i, out _);
+            }
+
+            // Two recordings = two distinct keys = one emit each (A does not suppress B).
+            Assert.Equal(2, PendingPlaybackLines().Count);
+        }
+
+        [Fact]
+        public void PendingPlaybackInterpolation_Unresolved_SeparateKeyFromResolved()
+        {
+            // Null trajectory drives the UNRESOLVED helper (separate key prefix
+            // "pending-playback-interp-unres-"). It must emit independently of any
+            // resolved-path traffic so a persistently-failing ghost stays visible.
+            for (int i = 0; i < 20; i++)
+            {
+                bool resolved = GhostPlaybackEngine.TryResolvePendingPlaybackInterpolation(
+                    null, 150.0 + i, out _);
+                Assert.False(resolved);
+            }
+
+            var unresolved = lines
+                .Where(l => l.Contains("[Engine]") && l.Contains("unresolved"))
+                .ToList();
+            Assert.Single(unresolved);
+        }
+
+        // -------------------------------------------------------------------
+        // Direct-call structural guards for the highest-volume rate-limited
+        // sites that are only reachable through Unity-heavy code (debris-skip,
+        // overlap lifecycle / remove, defer-overlap-sweep). We exercise
+        // VerboseRateLimited exactly the way each site does — stable key,
+        // warp-advancing value only in the body — and assert the collapse.
+        // -------------------------------------------------------------------
+
+        [Fact]
+        public void DebrisSkip_StableIndexKey_CollapsesToOneEmitPerWindow()
+        {
+            // Mirrors GhostMapPresence.cs HandleFlightGhostCreatedMapPresence debris
+            // skip: key "skip-map-debris-{index}", 3 s window, cycle/UT in the body.
+            int index = 7;
+            for (int cycle = 0; cycle < 60; cycle++)
+            {
+                ParsekLog.VerboseRateLimited("Policy", $"skip-map-debris-{index}",
+                    $"Skipped ghost map for #{index} \"Debris\" - debris (cycle={cycle})",
+                    3.0);
+                clock += 1.0 / 60.0; // ~1 s of wall clock total
+            }
+
+            int emitted = lines.Count(l =>
+                l.Contains("[Policy]") && l.Contains("- debris"));
+            Assert.Equal(1, emitted);
+        }
+
+        [Fact]
+        public void OverlapLifecycle_StableRecIdxKey_CollapsesAndSurfacesSuppressed()
+        {
+            // Mirrors GhostMapPresence.cs EnsureOverlapInstances lifecycle line:
+            // key "overlap-lifecycle-{recIdx}", 2 s window. currentUT advances per
+            // frame and lives ONLY in the body. ~5 s of wall clock at 2 s window.
+            int recIdx = 3;
+            for (int frame = 0; frame < 300; frame++)
+            {
+                double currentUT = 5000.0 + frame; // warp-advancing body value
+                ParsekLog.VerboseRateLimited("GhostMap", "overlap-lifecycle-" + recIdx,
+                    $"Overlap per-instance lifecycle rec=#{recIdx} \"Loop\" created=1 currentUT={currentUT:F1}",
+                    2.0);
+                clock += 1.0 / 60.0;
+            }
+
+            var emitted = lines
+                .Where(l => l.Contains("[GhostMap]") && l.Contains("Overlap per-instance lifecycle"))
+                .ToList();
+
+            // Small constant, not 300. And the suppressed counter is surfaced.
+            Assert.InRange(emitted.Count, 1, 4);
+            Assert.Contains(emitted, l => l.Contains("suppressed="));
+        }
+
+        [Fact]
+        public void OverlapRemove_StableRecIdxKey_CycleInBodyNotKey()
+        {
+            // Mirrors GhostMapPresence.cs RemoveOverlapInstance: key
+            // "overlap-remove-{recIdx}", 2 s window. The cycle id (warp-advancing)
+            // must be in the body, NOT the key — so distinct cycles collapse.
+            int recIdx = 2;
+            for (long cycle = 0; cycle < 50; cycle++)
+            {
+                ParsekLog.VerboseRateLimited("GhostMap", "overlap-remove-" + recIdx,
+                    $"Removed overlap per-instance map vessel rec=#{recIdx} cycle={cycle} reason=expired",
+                    2.0);
+                // clock held fixed: a single window
+            }
+
+            int emitted = lines.Count(l =>
+                l.Contains("[GhostMap]") && l.Contains("Removed overlap per-instance map vessel"));
+            Assert.Equal(1, emitted);
+        }
+
+        // -------------------------------------------------------------------
+        // Helpers
+        // -------------------------------------------------------------------
+
+        private List<string> PendingPlaybackLines()
+        {
+            return lines
+                .Where(l => l.Contains("[Engine]") && l.Contains("Pending playback interpolation"))
+                .ToList();
+        }
+
+        private static Recording MakeTwoPointRecording(string recordingId)
+        {
+            // Two points, no track sections, no orbit segments: the resolver lands on
+            // the flat-point interpolation branch and reports source "point interpolation".
+            return new Recording
+            {
+                RecordingId = recordingId,
+                VesselName = recordingId,
+                Points = new List<TrajectoryPoint>
+                {
+                    new TrajectoryPoint
+                    {
+                        ut = 100,
+                        bodyName = "Mun",
+                        altitude = 200,
+                        velocity = new Vector3(0, 10, 0)
+                    },
+                    new TrajectoryPoint
+                    {
+                        ut = 300,
+                        bodyName = "Mun",
+                        altitude = 250,
+                        velocity = new Vector3(0, 15, 0)
+                    }
+                }
+            };
+        }
+    }
+}

--- a/Source/Parsek.Tests/MapRenderTraceTests.cs
+++ b/Source/Parsek.Tests/MapRenderTraceTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
 using Xunit;
 
@@ -18,6 +19,8 @@ namespace Parsek.Tests
     {
         private readonly List<string> logLines = new List<string>();
 
+        private double clock = 1000.0;
+
         public MapRenderTraceTests()
         {
             MapRenderTrace.Reset();
@@ -25,9 +28,11 @@ namespace Parsek.Tests
             MapRenderTrace.FrameCounterOverrideForTesting = () => 42;
             ParsekSettings.CurrentOverrideForTesting = null;
             ParsekLog.ResetTestOverrides();
+            ParsekLog.ResetRateLimitsForTesting();
             ParsekLog.SuppressLogging = false;
             ParsekLog.VerboseOverrideForTesting = true;
             ParsekLog.TestSinkForTesting = line => logLines.Add(line);
+            ParsekLog.ClockOverrideForTesting = () => clock;
             ParsekSettingsPersistence.ResetForTesting();
         }
 
@@ -39,6 +44,7 @@ namespace Parsek.Tests
             ParsekSettings.CurrentOverrideForTesting = null;
             ParsekSettingsPersistence.ResetForTesting();
             ParsekLog.ResetTestOverrides();
+            ParsekLog.ResetRateLimitsForTesting();
             ParsekLog.SuppressLogging = true;
         }
 
@@ -656,6 +662,30 @@ namespace Parsek.Tests
             Assert.False(MapRenderTrace.TryGetFreshLineIntent("7", 101, out _));
         }
 
+        // ---- warp safeguard: per-cycle marker-decision keys do not grow the dict unbounded ----
+
+        [Fact]
+        public void EmitMarkerDecisionOnChange_PerCycleKeysAtWarp_DictStaysBounded()
+        {
+            // GAP-1's per-instance overlap decision key is recordingId#cycle; at high warp the cycle
+            // index advances without bound WITHIN a scene (Reset only fires on scene switch), minting a
+            // fresh key every cycle. The MaxTrackedMarkerDecisionKeys cap must keep the change-detection
+            // dict bounded so a long tracing session at warp does not leak. Push far past the cap.
+            MapRenderTrace.ForceEnabledForTesting = true;
+
+            for (int i = 0; i < 12000; i++)
+                MapRenderTrace.EmitMarkerDecisionOnChange(
+                    MapRenderTrace.RenderSurface.AtmosphericMarker,
+                    "recA#" + i.ToString(System.Globalization.CultureInfo.InvariantCulture),
+                    1000.0 + i,
+                    "outcome=DrawnNonProto ride=rode-leg0 posSource=polyline");
+
+            // Bounded by the cap (<= 4096), never approaching the unbounded 12000.
+            Assert.True(MapRenderTrace.MarkerDecisionSignatureCountForTesting <= 4096,
+                "marker-decision dict grew to "
+                    + MapRenderTrace.MarkerDecisionSignatureCountForTesting + " (cap 4096)");
+        }
+
         // ---- polyline-orbit-overlap anomaly ----
 
         [Fact]
@@ -721,6 +751,86 @@ namespace Parsek.Tests
             MapRenderTrace.EmitMarker(
                 MapRenderTrace.RenderSurface.AtmosphericMarker, "rec-marker-disabled", 100.0, "vessel=X");
             Assert.Empty(logLines);
+        }
+
+        // ---- GAP-2: first-class Polyline-surface trace at the shared Driver's per-leg draw site ----
+
+        [Fact]
+        public void EmitMarker_Polyline_EmitsMarkerDrawWithPolylineSurface()
+        {
+            // GAP-2: the polyline leg draw now emits a first-class MapRenderTrace line so the
+            // surface=Polyline slot is greppable in BOTH scenes (the insertion lives in the shared
+            // Driver). Phase is MarkerDraw (EmitMarker's phase).
+            MapRenderTrace.ForceEnabledForTesting = true;
+
+            MapRenderTrace.EmitMarker(
+                MapRenderTrace.RenderSurface.Polyline, "rec-polyline", 500.0,
+                "scene=TRACKSTATION leg=2 body=Kerbin pts=40 owned=False");
+
+            Assert.Contains(logLines, l =>
+                l.Contains("[VERBOSE]")
+                && l.Contains("[MapRenderTrace]")
+                && l.Contains("phase=MarkerDraw")
+                && l.Contains("surface=Polyline")
+                && l.Contains("pid=rec-polyline")
+                && l.Contains("body=Kerbin"));
+        }
+
+        [Fact]
+        public void EmitMarker_Polyline_SameKeyWithinInterval_CollapsesToOneLine()
+        {
+            // GAP-2 warp-stability: the rate-limit KEY is (Polyline, recId) only - warp-stable per the
+            // #1063 rule. Two draws of the SAME recording inside the interval (the per-leg index / UT
+            // advance every frame and live in the BODY, never the key) collapse to a single emitted
+            // line. Clock held fixed via ClockOverrideForTesting so both calls fall in one window.
+            MapRenderTrace.ForceEnabledForTesting = true;
+
+            MapRenderTrace.EmitMarker(
+                MapRenderTrace.RenderSurface.Polyline, "rec-warp", 1000.0,
+                "scene=FLIGHT leg=0 body=Kerbin pts=12 owned=True");
+            // Same (Polyline, recId) key, DIFFERENT leg + UT in the body, clock unchanged.
+            MapRenderTrace.EmitMarker(
+                MapRenderTrace.RenderSurface.Polyline, "rec-warp", 1001.0,
+                "scene=FLIGHT leg=5 body=Kerbin pts=18 owned=True");
+
+            int polylineLines = logLines.Count(l =>
+                l.Contains("[MapRenderTrace]")
+                && l.Contains("surface=Polyline")
+                && l.Contains("pid=rec-warp"));
+            Assert.Equal(1, polylineLines);
+        }
+
+        [Fact]
+        public void EmitMarker_Polyline_DifferentRecordings_TrackedIndependently()
+        {
+            // Two distinct recordingIds => two distinct (Polyline, recId) keys => one emit each
+            // (recording A does not throttle recording B inside the same window).
+            MapRenderTrace.ForceEnabledForTesting = true;
+
+            MapRenderTrace.EmitMarker(
+                MapRenderTrace.RenderSurface.Polyline, "rec-A", 1000.0, "scene=FLIGHT leg=0");
+            MapRenderTrace.EmitMarker(
+                MapRenderTrace.RenderSurface.Polyline, "rec-B", 1000.0, "scene=FLIGHT leg=0");
+
+            Assert.Contains(logLines, l => l.Contains("surface=Polyline") && l.Contains("pid=rec-A"));
+            Assert.Contains(logLines, l => l.Contains("surface=Polyline") && l.Contains("pid=rec-B"));
+        }
+
+        [Fact]
+        public void EmitMarker_Polyline_AfterIntervalElapses_EmitsAgain()
+        {
+            // Advancing the wall clock past the 2 s interval re-opens the gate for the same key.
+            MapRenderTrace.ForceEnabledForTesting = true;
+
+            MapRenderTrace.EmitMarker(
+                MapRenderTrace.RenderSurface.Polyline, "rec-interval", 1000.0, "scene=FLIGHT leg=0");
+            clock += 2.5; // past the default 2 s interval
+            MapRenderTrace.EmitMarker(
+                MapRenderTrace.RenderSurface.Polyline, "rec-interval", 1001.0, "scene=FLIGHT leg=3");
+
+            int polylineLines = logLines.Count(l =>
+                l.Contains("surface=Polyline") && l.Contains("pid=rec-interval"));
+            Assert.Equal(2, polylineLines);
         }
 
         // ---- Marker-decision observability (per-pid WHY a marker drew / was skipped) ----

--- a/Source/Parsek.Tests/MarkerDrawDecisionTests.cs
+++ b/Source/Parsek.Tests/MarkerDrawDecisionTests.cs
@@ -162,5 +162,119 @@ namespace Parsek.Tests
                 Assert.Equal(MapRenderTrace.MarkerOutcome.SkippedDecisionFalse,
                     ParsekTrackingStation.MapSkipReasonToMarkerOutcome(reason));
         }
+
+        // --- GAP-1: TS overlap instance can now carry a REAL ride field on its decision line ---
+
+        [Fact]
+        public void BuildMarkerDecisionSignature_TsOverlapInstance_CarriesRealRideAndPolylineSource()
+        {
+            // GAP-1 proof: the TS overlap path (DrawOneTsOverlapInstanceMarker) rode a leg and threads
+            // the real rideReason/legIndex from the diagnostic TryAnchorMarkerToPolyline overload into
+            // its per-instance decision line. Before the fix the TS path hardcoded ride=not-attempted
+            // posSource=traj, which LIED for an instance that actually rode the shared polyline.
+            string sig = MapRenderTrace.BuildMarkerDecisionSignature(
+                recordingIndex: 5,
+                vesselName: "Hopper",
+                gateOn: true,
+                directorTracedPathActive: false,
+                polylineOwning: true,
+                iconSuppressed: false,
+                shouldDrawNonProto: true,
+                outcome: MapRenderTrace.MarkerOutcome.DrawnNonProto,
+                rideReason: MapRenderTrace.MarkerRideReason.RodeLeg,
+                legIndex: 3,
+                posSource: "polyline");
+
+            Assert.Contains("ride=rode-leg3", sig);
+            Assert.Contains("posSource=polyline", sig);
+            // No tsSkip on a drawn marker (the param defaulted to null).
+            Assert.DoesNotContain("tsSkip=", sig);
+        }
+
+        // --- C-1: optional tsSkip= field appends only when set; flight stays byte-identical ---
+
+        [Fact]
+        public void BuildMarkerDecisionSignature_TsSkipParam_AppendsTokenWhenSet()
+        {
+            // A skipped TS marker carries the raw finer reason as a trailing tsSkip= field so the
+            // taxonomy the shared MarkerOutcome folds away survives on the per-ghost line.
+            string sig = MapRenderTrace.BuildMarkerDecisionSignature(
+                recordingIndex: 1,
+                vesselName: "Probe",
+                gateOn: false,
+                directorTracedPathActive: false,
+                polylineOwning: false,
+                iconSuppressed: false,
+                shouldDrawNonProto: false,
+                outcome: MapRenderTrace.MarkerOutcome.SkippedDecisionFalse,
+                rideReason: MapRenderTrace.MarkerRideReason.NotAttempted,
+                legIndex: -1,
+                posSource: "traj",
+                tsSkipReason: "outside-time-range");
+
+            Assert.Contains("outcome=skipped-decision-false", sig);
+            Assert.Contains("tsSkip=outside-time-range", sig);
+            // The new field is appended LAST so it never shifts the existing field order.
+            Assert.EndsWith("tsSkip=outside-time-range", sig);
+        }
+
+        [Fact]
+        public void BuildMarkerDecisionSignature_TsSkipParam_OmittedWhenNullOrEmpty_FlightByteIdentical()
+        {
+            // FLIGHT passes nothing for tsSkipReason (the default). The produced signature must be
+            // BYTE-IDENTICAL to the same call without the new param - so flight signatures (and the
+            // existing flight tests) are unchanged. Both null and empty omit the field.
+            string baseline = MapRenderTrace.BuildMarkerDecisionSignature(
+                4, "Munar Probe", true, true, false, false, true,
+                MapRenderTrace.MarkerOutcome.DrawnNonProto,
+                MapRenderTrace.MarkerRideReason.RodeLeg, 2, "polyline");
+
+            string withNull = MapRenderTrace.BuildMarkerDecisionSignature(
+                4, "Munar Probe", true, true, false, false, true,
+                MapRenderTrace.MarkerOutcome.DrawnNonProto,
+                MapRenderTrace.MarkerRideReason.RodeLeg, 2, "polyline",
+                tsSkipReason: null);
+
+            string withEmpty = MapRenderTrace.BuildMarkerDecisionSignature(
+                4, "Munar Probe", true, true, false, false, true,
+                MapRenderTrace.MarkerOutcome.DrawnNonProto,
+                MapRenderTrace.MarkerRideReason.RodeLeg, 2, "polyline",
+                tsSkipReason: "");
+
+            Assert.Equal(baseline, withNull);
+            Assert.Equal(baseline, withEmpty);
+            Assert.DoesNotContain("tsSkip=", baseline);
+        }
+
+        // --- C-1: AtmosphericMarkerSkipReasonToken maps each finer reason to a stable token ---
+
+        [Fact]
+        public void AtmosphericMarkerSkipReasonToken_MapsEveryReason()
+        {
+            Assert.Equal("none",
+                ParsekTrackingStation.AtmosphericMarkerSkipReasonToken(
+                    ParsekTrackingStation.AtmosphericMarkerSkipReason.None));
+            Assert.Equal("native-icon-active",
+                ParsekTrackingStation.AtmosphericMarkerSkipReasonToken(
+                    ParsekTrackingStation.AtmosphericMarkerSkipReason.NativeIconActive));
+            Assert.Equal("null-recording",
+                ParsekTrackingStation.AtmosphericMarkerSkipReasonToken(
+                    ParsekTrackingStation.AtmosphericMarkerSkipReason.NullRecording));
+            Assert.Equal("debris",
+                ParsekTrackingStation.AtmosphericMarkerSkipReasonToken(
+                    ParsekTrackingStation.AtmosphericMarkerSkipReason.Debris));
+            Assert.Equal("no-trajectory-points",
+                ParsekTrackingStation.AtmosphericMarkerSkipReasonToken(
+                    ParsekTrackingStation.AtmosphericMarkerSkipReason.NoTrajectoryPoints));
+            Assert.Equal("outside-time-range",
+                ParsekTrackingStation.AtmosphericMarkerSkipReasonToken(
+                    ParsekTrackingStation.AtmosphericMarkerSkipReason.OutsideTimeRange));
+            Assert.Equal("suppressed-by-chain-filter",
+                ParsekTrackingStation.AtmosphericMarkerSkipReasonToken(
+                    ParsekTrackingStation.AtmosphericMarkerSkipReason.SuppressedByChainFilter));
+            Assert.Equal("orbit-segment-active",
+                ParsekTrackingStation.AtmosphericMarkerSkipReasonToken(
+                    ParsekTrackingStation.AtmosphericMarkerSkipReason.OrbitSegmentActive));
+        }
     }
 }

--- a/Source/Parsek/Display/GhostTrajectoryPolylineRenderer.cs
+++ b/Source/Parsek/Display/GhostTrajectoryPolylineRenderer.cs
@@ -2266,6 +2266,27 @@ namespace Parsek.Display
                     // array (set.legs is the same array reference the dict holds).
                     set.legs[p.legIndex] = leg;
                     if (legDrawn) drawn++;
+
+                    // GAP-2: first-class Polyline-surface trace at the ACTUAL draw site. The
+                    // surface=Polyline slot was previously blind under MapRenderTrace (the Driver only
+                    // emitted Verbose lines on its own tag), so a reader could not grep the polyline
+                    // draw under the tracer - exactly the TS-invisible-polyline bug class (the layer-31
+                    // fix above is "decided to draw but didn't paint where expected"). This lives in the
+                    // SHARED Driver, so the one insertion covers FLIGHT and TRACKSTATION. Rate-limit /
+                    // change KEY is (Polyline, p.recordingId) only - warp-stable per the #1063 rule;
+                    // the per-leg index / UT / draw count / frame are warp-advancing and live in the
+                    // message BODY, never the key (EmitMarker rate-limits per (surface, key) on
+                    // wall-clock). Emitted only on an ACTUAL leg draw so a skipped leg is not traced.
+                    if (legDrawn && MapRenderTrace.IsEnabled)
+                        MapRenderTrace.EmitMarker(
+                            MapRenderTrace.RenderSurface.Polyline, p.recordingId,
+                            Planetarium.GetUniversalTime(),
+                            string.Format(System.Globalization.CultureInfo.InvariantCulture,
+                                "scene={0} leg={1} body={2} pts={3} owned={4} layer={5} startUT={6:F1} endUT={7:F1}",
+                                HighLogic.LoadedScene, p.legIndex,
+                                string.IsNullOrEmpty(leg.bodyName) ? "<none>" : leg.bodyName,
+                                leg.PointCount, p.ownedByTreatment, pendingTargetLayer,
+                                leg.startUT, leg.endUT));
                 }
                 pendingDraws.Clear();
 

--- a/Source/Parsek/GhostMapPresence.cs
+++ b/Source/Parsek/GhostMapPresence.cs
@@ -10672,12 +10672,13 @@ namespace Parsek
 
             if (created > 0 || destroyed > 0)
             {
-                ParsekLog.Verbose(Tag,
+                ParsekLog.VerboseRateLimited(Tag, "overlap-lifecycle-" + recIdx,
                     string.Format(ic,
                         "Overlap per-instance lifecycle rec=#{0} \"{1}\" cycles=[{2}..{3}] " +
                         "created={4} destroyed={5} liveNow={6} currentUT={7:F1}",
                         recIdx, rec.VesselName ?? "(null)", firstCycle, lastCycle,
-                        created, destroyed, GetOverlapInstanceCount(recIdx), currentUT));
+                        created, destroyed, GetOverlapInstanceCount(recIdx), currentUT),
+                    2.0);
             }
 
             return created;
@@ -11006,10 +11007,11 @@ namespace Parsek
             overlapInstanceVessels.Remove((recIdx, cycle));
             lifecycleDestroyedThisTick++;
 
-            ParsekLog.Verbose(Tag,
+            ParsekLog.VerboseRateLimited(Tag, "overlap-remove-" + recIdx,
                 string.Format(ic,
                     "Removed overlap per-instance map vessel rec=#{0} cycle={1} pid={2} reason={3}",
-                    recIdx, cycle, ghostPid, reason ?? "(none)"));
+                    recIdx, cycle, ghostPid, reason ?? "(none)"),
+                2.0);
         }
 
         /// <summary>
@@ -12084,8 +12086,9 @@ namespace Parsek
             if (evt.Trajectory == null || evt.Trajectory.IsDebris)
             {
                 if (evt.Trajectory?.IsDebris == true)
-                    ParsekLog.Verbose("Policy",
-                        $"Skipped ghost map for #{evt.Index} \"{evt.Trajectory?.VesselName}\" - debris");
+                    ParsekLog.VerboseRateLimited("Policy", $"skip-map-debris-{evt.Index}",
+                        $"Skipped ghost map for #{evt.Index} \"{evt.Trajectory?.VesselName}\" - debris",
+                        3.0);
                 return;
             }
 
@@ -12115,11 +12118,12 @@ namespace Parsek
                 if (committedForOverlap != null && evt.Index >= 0 && evt.Index < committedForOverlap.Count
                     && ShouldDriveOverlapPerInstance(committedForOverlap[evt.Index], evt.Index, committedForOverlap, loopUnits))
                 {
-                    ParsekLog.Verbose("Policy",
+                    ParsekLog.VerboseRateLimited("Policy", $"defer-overlap-sweep-{evt.Index}",
                         string.Format(CultureInfo.InvariantCulture,
                             "Ghost map for #{0} \"{1}\" deferred to per-instance overlap sweep " +
                             "(looped overlap recording / Mission-unit overlap member, director-drive on)",
-                            evt.Index, evt.Trajectory.VesselName ?? "(null)"));
+                            evt.Index, evt.Trajectory.VesselName ?? "(null)"),
+                        3.0);
                     return;
                 }
             }
@@ -12209,7 +12213,7 @@ namespace Parsek
                     evt.Trajectory,
                     allowSoiGapStateVectorFallback: false,
                     expectedSoiGapBody: null);
-                ParsekLog.Verbose("Policy",
+                ParsekLog.VerboseRateLimited("Policy", $"defer-map-{evt.Index}",
                     string.Format(CultureInfo.InvariantCulture,
                         "Deferred ghost map vessel for #{0} \"{1}\": {2} (source={3} loopShift={4:F2} renderHidden={5})",
                         evt.Index,
@@ -12219,7 +12223,8 @@ namespace Parsek
                             : "recording starts pre-orbital",
                         source,
                         initialLoopShift,
-                        initialRenderHidden));
+                        initialRenderHidden),
+                    3.0);
             }
         }
 

--- a/Source/Parsek/GhostPlaybackEngine.cs
+++ b/Source/Parsek/GhostPlaybackEngine.cs
@@ -6247,17 +6247,22 @@ namespace Parsek
                     $"Chain-seam spawn: vessel='{state.vesselName}' rec={shortRecId} UT={playbackUT:F2}: force-immediate-build + skip activation-settle (predecessor pose is continuous)"));
             }
 
+            string pendingSpawnRecId = state.recordingId ?? string.Empty;
             if (TryResolvePendingPlaybackInterpolation(traj, playbackUT, out InterpolationResult initialPlayback))
             {
                 state.SetInterpolated(initialPlayback);
                 string seededBodyName = initialPlayback.bodyName ?? "(null)";
-                ParsekLog.Verbose("Engine", FormattableString.Invariant(
-                    $"Pending spawn interpolation seed: vessel='{state.vesselName}' lifecycle={lifecycle} UT={playbackUT:F1} body='{seededBodyName}' altitude={initialPlayback.altitude:F1}"));
+                ParsekLog.VerboseRateLimited("Engine", "pending-spawn-seed-" + pendingSpawnRecId,
+                    FormattableString.Invariant(
+                        $"Pending spawn interpolation seed: vessel='{state.vesselName}' lifecycle={lifecycle} UT={playbackUT:F1} body='{seededBodyName}' altitude={initialPlayback.altitude:F1}"),
+                    2.0);
             }
             else
             {
-                ParsekLog.Verbose("Engine", FormattableString.Invariant(
-                    $"Pending spawn interpolation seed unavailable: vessel='{state.vesselName}' lifecycle={lifecycle} UT={playbackUT:F1}"));
+                ParsekLog.VerboseRateLimited("Engine", "pending-spawn-seed-unavail-" + pendingSpawnRecId,
+                    FormattableString.Invariant(
+                        $"Pending spawn interpolation seed unavailable: vessel='{state.vesselName}' lifecycle={lifecycle} UT={playbackUT:F1}"),
+                    2.0);
             }
 
             return state;
@@ -6320,8 +6325,9 @@ namespace Parsek
                         $"(loop cycle={state.loopCycleIndex})");
                     if (retired)
                     {
-                        ParsekLog.Verbose("Engine",
-                            $"finalize-spawn retire: suppressing RetargetToNewGhost (anchor retired on first spawn) ghost #{index} \"{vesselName}\" lifecycle=LoopEnter cycle={state.loopCycleIndex}");
+                        ParsekLog.VerboseRateLimited("Engine", $"finalize-retire-loop-{index}",
+                            $"finalize-spawn retire: suppressing RetargetToNewGhost (anchor retired on first spawn) ghost #{index} \"{vesselName}\" lifecycle=LoopEnter cycle={state.loopCycleIndex}",
+                            3.0);
                         break;
                     }
                     OnLoopCameraAction?.Invoke(new CameraActionEvent
@@ -6341,8 +6347,9 @@ namespace Parsek
                         $"at UT {playbackUT:F1} (overlap)");
                     if (retired)
                     {
-                        ParsekLog.Verbose("Engine",
-                            $"finalize-spawn retire: suppressing RetargetToNewGhost (anchor retired on first spawn) ghost #{index} \"{vesselName}\" lifecycle=OverlapPrimaryEnter cycle={state.loopCycleIndex}");
+                        ParsekLog.VerboseRateLimited("Engine", $"finalize-retire-overlap-{index}",
+                            $"finalize-spawn retire: suppressing RetargetToNewGhost (anchor retired on first spawn) ghost #{index} \"{vesselName}\" lifecycle=OverlapPrimaryEnter cycle={state.loopCycleIndex}",
+                            3.0);
                         break;
                     }
                     OnOverlapCameraAction?.Invoke(new CameraActionEvent
@@ -7709,15 +7716,21 @@ namespace Parsek
                 if (surfaceSkip && canUseOrbitPrecedence)
                 {
                     string vesselName = traj.VesselName ?? "Unknown";
-                    ParsekLog.Verbose("Engine", FormattableString.Invariant(
-                        $"Pending playback interpolation: vessel='{vesselName}' UT={playbackUT:F1} surface track section active, skipping orbit precedence"));
+                    string branchRecId = traj.RecordingId ?? string.Empty;
+                    ParsekLog.VerboseRateLimited("Engine", "pending-playback-branch-1-" + branchRecId,
+                        FormattableString.Invariant(
+                            $"Pending playback interpolation: vessel='{vesselName}' UT={playbackUT:F1} surface track section active, skipping orbit precedence"),
+                        2.0);
                 }
 
                 if (!surfaceSkip && authoredGapHasShadow && canUseOrbitPrecedence)
                 {
                     string vesselName = traj.VesselName ?? "Unknown";
-                    ParsekLog.Verbose("Engine", FormattableString.Invariant(
-                        $"Pending playback interpolation: vessel='{vesselName}' UT={playbackUT:F1} skipping orbit precedence: authored-frame gap body-fixed primary available"));
+                    string branchRecId = traj.RecordingId ?? string.Empty;
+                    ParsekLog.VerboseRateLimited("Engine", "pending-playback-branch-2-" + branchRecId,
+                        FormattableString.Invariant(
+                            $"Pending playback interpolation: vessel='{vesselName}' UT={playbackUT:F1} skipping orbit precedence: authored-frame gap body-fixed primary available"),
+                        2.0);
                 }
 
                 if (!surfaceSkip && !authoredGapHasShadow && canUseOrbitPrecedence)
@@ -7746,8 +7759,11 @@ namespace Parsek
                 else
                 {
                     string vesselName = traj.VesselName ?? "Unknown";
-                    ParsekLog.Verbose("Engine", FormattableString.Invariant(
-                        $"Pending playback interpolation: vessel='{vesselName}' UT={playbackUT:F1} relative section active with no body-fixed primary, skipping flat relative point metadata"));
+                    string branchRecId = traj.RecordingId ?? string.Empty;
+                    ParsekLog.VerboseRateLimited("Engine", "pending-playback-branch-3-" + branchRecId,
+                        FormattableString.Invariant(
+                            $"Pending playback interpolation: vessel='{vesselName}' UT={playbackUT:F1} relative section active with no body-fixed primary, skipping flat relative point metadata"),
+                        2.0);
                 }
             }
 
@@ -7909,8 +7925,11 @@ namespace Parsek
         {
             string vesselName = traj?.VesselName ?? "Unknown";
             string bodyName = result.bodyName ?? "(null)";
-            ParsekLog.Verbose("Engine", FormattableString.Invariant(
-                $"Pending playback interpolation: vessel='{vesselName}' UT={playbackUT:F1} resolved from {source} body='{bodyName}' altitude={result.altitude:F1}"));
+            string recId = traj?.RecordingId ?? string.Empty;
+            ParsekLog.VerboseRateLimited("Engine", "pending-playback-interp-" + recId + "-" + source,
+                FormattableString.Invariant(
+                    $"Pending playback interpolation: vessel='{vesselName}' UT={playbackUT:F1} resolved from {source} body='{bodyName}' altitude={result.altitude:F1}"),
+                2.0);
             return true;
         }
 
@@ -7918,8 +7937,11 @@ namespace Parsek
             IPlaybackTrajectory traj, double playbackUT, string reason)
         {
             string vesselName = traj?.VesselName ?? "Unknown";
-            ParsekLog.Verbose("Engine", FormattableString.Invariant(
-                $"Pending playback interpolation: vessel='{vesselName}' UT={playbackUT:F1} unresolved ({reason})"));
+            string recId = traj?.RecordingId ?? string.Empty;
+            ParsekLog.VerboseRateLimited("Engine", "pending-playback-interp-unres-" + recId + "-" + reason,
+                FormattableString.Invariant(
+                    $"Pending playback interpolation: vessel='{vesselName}' UT={playbackUT:F1} unresolved ({reason})"),
+                2.0);
             return false;
         }
 
@@ -8026,23 +8048,29 @@ namespace Parsek
 
             // #375: was Info, demoted to Verbose after the #258 fix (first-visible-frame
             // activation) was field-validated. High-volume with many debris ghosts.
-            ParsekLog.Verbose("GhostAppearance",
-                $"Ghost #{index} \"{traj?.VesselName ?? state.vesselName ?? "unknown"}\" " +
-                $"appearance#{state.appearanceCount} reason={reason} " +
-                $"ut={playbackUT.ToString("F2", CultureInfo.InvariantCulture)} " +
-                $"requestedUT={requestedUT.ToString("F2", CultureInfo.InvariantCulture)} " +
-                $"firstFrameClamped={(firstFrameClamped ? "T" : "F")} " +
-                $"activationStart={activationStartUT.ToString("F2", CultureInfo.InvariantCulture)} " +
-                $"activationLead={(playbackUT - activationStartUT).ToString("F2", CultureInfo.InvariantCulture)} " +
-                $"zone={state.currentZone} dist={FormatPlaybackDistanceForLog(state.lastDistance)} " +
-                $"{activeSectionSummary} " +
-                $"root={FormatVector3d(rootPos)} rootRot={FormatQuaternion(rootRot)} " +
-                $"boundsCenter={FormatVector3d(boundsCenter)} bounds-root={FormatVector3d(boundsRootDelta)} " +
-                $"firstVisiblePart={firstVisiblePartLabel}:{FormatVector3d(firstVisiblePartPos)} " +
-                $"part-root={FormatVector3d(firstVisiblePartRootDelta)} " +
-                $"{recordingStartSummary} " +
-                $"snapshotCoM={(hasSnapshotCoM ? FormatVector3(snapshotCoM) : "none")} " +
-                $"{rootPartSummary}{rootPartWorldSummary} visibleRenderers={rendererCount}");
+            // The on-change gate above (state.hadVisibleRenderersLastFrame) is the inner
+            // throttle; this outer wall-clock rate limit additionally collapses the
+            // overlap-cycle-rebuild case where ResetGhostAppearanceTracking flips the
+            // flag every loop/overlap cycle (many times/sec at warp).
+            ParsekLog.VerboseRateLimited("GhostAppearance", $"ghost-appearance-{index}",
+                () =>
+                    $"Ghost #{index} \"{traj?.VesselName ?? state.vesselName ?? "unknown"}\" " +
+                    $"appearance#{state.appearanceCount} reason={reason} " +
+                    $"ut={playbackUT.ToString("F2", CultureInfo.InvariantCulture)} " +
+                    $"requestedUT={requestedUT.ToString("F2", CultureInfo.InvariantCulture)} " +
+                    $"firstFrameClamped={(firstFrameClamped ? "T" : "F")} " +
+                    $"activationStart={activationStartUT.ToString("F2", CultureInfo.InvariantCulture)} " +
+                    $"activationLead={(playbackUT - activationStartUT).ToString("F2", CultureInfo.InvariantCulture)} " +
+                    $"zone={state.currentZone} dist={FormatPlaybackDistanceForLog(state.lastDistance)} " +
+                    $"{activeSectionSummary} " +
+                    $"root={FormatVector3d(rootPos)} rootRot={FormatQuaternion(rootRot)} " +
+                    $"boundsCenter={FormatVector3d(boundsCenter)} bounds-root={FormatVector3d(boundsRootDelta)} " +
+                    $"firstVisiblePart={firstVisiblePartLabel}:{FormatVector3d(firstVisiblePartPos)} " +
+                    $"part-root={FormatVector3d(firstVisiblePartRootDelta)} " +
+                    $"{recordingStartSummary} " +
+                    $"snapshotCoM={(hasSnapshotCoM ? FormatVector3(snapshotCoM) : "none")} " +
+                    $"{rootPartSummary}{rootPartWorldSummary} visibleRenderers={rendererCount}",
+                2.0);
         }
 
         internal static string DescribeAppearanceActiveSection(IPlaybackTrajectory traj, double playbackUT)

--- a/Source/Parsek/GhostVisualBuilder.cs
+++ b/Source/Parsek/GhostVisualBuilder.cs
@@ -2474,10 +2474,12 @@ namespace Parsek
             if (loopSourceCount > 0)
             {
                 string ghostName = result.root != null ? result.root.name : "<null-root>";
-                ParsekLog.Verbose("GhostAudio",
+                ParsekLog.VerboseRateLimited("GhostAudio",
+                    "watch-pivot-audio-" + ghostName,
                     $"Attached watch-pivot ghost audio on '{ghostName}' to '{cameraPivot.name}' " +
                     $"(loop={loopSourceCount}, " +
-                    $"spatialBlend={GhostAudioSpatialBlend:0.##}, panStereo=0)");
+                    $"spatialBlend={GhostAudioSpatialBlend:0.##}, panStereo=0)",
+                    2.0);
             }
         }
 

--- a/Source/Parsek/MapRenderTrace.cs
+++ b/Source/Parsek/MapRenderTrace.cs
@@ -270,6 +270,14 @@ namespace Parsek
         /// the polyline ride reason + the fallback position source actually used. Kept pure (no Unity
         /// reads) so the schema is unit-testable. <paramref name="legIndex"/> is only meaningful when
         /// <paramref name="rideReason"/> is <see cref="MarkerRideReason.RodeLeg"/>.
+        ///
+        /// <para>C-1: the optional <paramref name="tsSkipReason"/> carries the finer
+        /// tracking-station <c>AtmosphericMarkerSkipReason</c> token that the shared
+        /// <see cref="MarkerOutcome"/> folds away (several distinct TS reasons collapse to
+        /// <see cref="MarkerOutcome.SkippedDecisionFalse"/> / <see cref="MarkerOutcome.SkippedPositionFail"/>).
+        /// When non-null/non-empty it appends a trailing <c> tsSkip={token}</c> field; when
+        /// null/empty the field is omitted entirely, so FLIGHT signatures (which pass nothing) stay
+        /// byte-identical. The token is appended LAST so it never shifts the existing field order.</para>
         /// </summary>
         internal static string BuildMarkerDecisionSignature(
             int recordingIndex,
@@ -282,7 +290,8 @@ namespace Parsek
             MarkerOutcome outcome,
             MarkerRideReason rideReason,
             int legIndex,
-            string posSource)
+            string posSource,
+            string tsSkipReason = null)
         {
             string s = "rec=" + recordingIndex.ToString(CultureInfo.InvariantCulture)
                 + " vessel=" + Token(vesselName)
@@ -295,6 +304,8 @@ namespace Parsek
             if (outcome == MarkerOutcome.DrawnNonProto)
                 s += " ride=" + MarkerRideReasonToken(rideReason, legIndex)
                     + " posSource=" + Token(posSource);
+            if (!string.IsNullOrEmpty(tsSkipReason))
+                s += " tsSkip=" + tsSkipReason;
             return s;
         }
 
@@ -306,6 +317,17 @@ namespace Parsek
         // post-re-entry transition.
         private static readonly Dictionary<string, string> lastMarkerDecisionSignatureByPid =
             new Dictionary<string, string>(StringComparer.Ordinal);
+
+        // Warp safeguard: the per-instance overlap decision key (recordingId#cycle) mints a FRESH key
+        // every loop/overlap cycle, and at high time warp cycles advance without bound WITHIN a scene
+        // (Reset() only fires on scene switch), so this dict would grow unbounded in tracing mode. Cap
+        // it - clearing is correctness-neutral (each active ghost simply re-emits its current signature
+        // on its next change). 4096 covers any realistic live-ghost/instance count many times over.
+        private const int MaxTrackedMarkerDecisionKeys = 4096;
+
+        /// <summary>Test-only: current size of the marker-decision change-detection dict (to assert the
+        /// warp cap bounds it).</summary>
+        internal static int MarkerDecisionSignatureCountForTesting => lastMarkerDecisionSignatureByPid.Count;
 
         /// <summary>
         /// Change-based per-pid marker-decision emit (Tier-B, routed to Verbose via
@@ -328,6 +350,13 @@ namespace Parsek
             if (lastMarkerDecisionSignatureByPid.TryGetValue(pidKey, out last)
                 && string.Equals(last, signature, StringComparison.Ordinal))
                 return; // unchanged outcome for this ghost -> suppress
+
+            // Warp safeguard (see MaxTrackedMarkerDecisionKeys): bound the dict before inserting a NEW
+            // per-cycle key. This key's change was already decided above, so clearing here only drops
+            // OTHER ghosts' cached signatures (harmless - they re-emit on their next change).
+            if (!lastMarkerDecisionSignatureByPid.ContainsKey(pidKey)
+                && lastMarkerDecisionSignatureByPid.Count >= MaxTrackedMarkerDecisionKeys)
+                lastMarkerDecisionSignatureByPid.Clear();
 
             lastMarkerDecisionSignatureByPid[pidKey] = signature;
             EmitOnChange("MarkerDecision", surface, pidKey, currentUT, currentUT, signature);

--- a/Source/Parsek/ParsekTrackingStation.cs
+++ b/Source/Parsek/ParsekTrackingStation.cs
@@ -397,11 +397,21 @@ namespace Parsek
                 // Mirrors the flight-map DrawMapMarkers tracer: one change-based line per ghost saying
                 // WHY its atmospheric marker drew or was skipped, carrying the four
                 // ResolveMarkerDrawDecision disjuncts (resolved only when a proto ghost vessel exists,
-                // false otherwise). The TS path never rides the polyline, so the ride reason stays
-                // NotAttempted and the position source is always "traj".
+                // false otherwise). This NON-OVERLAP single-marker path does NOT ride the polyline today
+                // (it draws at the body-fixed head), so the ride reason stays NotAttempted and the
+                // position source is "traj" - honest. The OVERLAP instance path
+                // (DrawOneTsOverlapInstanceMarker) DOES ride the shared polyline and emits its OWN
+                // per-instance decision line carrying the real ride reason + posSource=polyline (GAP-1),
+                // so this closure is correct ONLY for the single-marker tail below.
+                //
+                // C-1: this path also threads the raw AtmosphericMarkerSkipReason token as a tsSkip=
+                // field so the finer TS taxonomy (which MapSkipReasonToMarkerOutcome folds into the
+                // shared MarkerOutcome) survives on the per-ghost decision line, not just the aggregate
+                // summary. Pass tsSkipReason=None on the draw path -> the optional field is omitted.
                 bool decGateOn = false, decDirectorTraced = false, decPolylineOwning = false,
                     decIconSuppressed = false, decShouldDraw = false;
-                void EmitMarkerDecision(MapRenderTrace.MarkerOutcome outcome)
+                void EmitMarkerDecision(MapRenderTrace.MarkerOutcome outcome,
+                    AtmosphericMarkerSkipReason tsSkipReason = AtmosphericMarkerSkipReason.None)
                 {
                     if (!traceOn || rec == null || string.IsNullOrEmpty(rec.RecordingId))
                         return;
@@ -410,7 +420,10 @@ namespace Parsek
                         MapRenderTrace.BuildMarkerDecisionSignature(
                             i, rec.VesselName, decGateOn, decDirectorTraced, decPolylineOwning,
                             decIconSuppressed, decShouldDraw, outcome,
-                            MapRenderTrace.MarkerRideReason.NotAttempted, -1, "traj"));
+                            MapRenderTrace.MarkerRideReason.NotAttempted, -1, "traj",
+                            tsSkipReason: tsSkipReason == AtmosphericMarkerSkipReason.None
+                                ? null
+                                : AtmosphericMarkerSkipReasonToken(tsSkipReason)));
                 }
 
                 // ---- Slice (iii) TS port: per-instance overlap markers riding the ONE shared polyline ----
@@ -499,7 +512,9 @@ namespace Parsek
                 if (skipReason != AtmosphericMarkerSkipReason.None)
                 {
                     CountAtmosphericMarkerSkip(ref summary, skipReason);
-                    EmitMarkerDecision(MapSkipReasonToMarkerOutcome(skipReason));
+                    // C-1: pass the RAW skip reason so the finer TS taxonomy (folded away by
+                    // MapSkipReasonToMarkerOutcome) survives as the tsSkip= field on this ghost's line.
+                    EmitMarkerDecision(MapSkipReasonToMarkerOutcome(skipReason), skipReason);
                     continue;
                 }
 
@@ -659,6 +674,30 @@ namespace Parsek
             }
         }
 
+        /// <summary>
+        /// C-1: stable lowercase-token name for the FINER <see cref="AtmosphericMarkerSkipReason"/>,
+        /// appended verbatim as the optional <c>tsSkip=</c> field on the TS marker-decision line so the
+        /// distinct reasons that <see cref="MapSkipReasonToMarkerOutcome"/> folds into a single shared
+        /// <see cref="MapRenderTrace.MarkerOutcome"/> survive per-ghost (not just in the aggregate
+        /// summary). Pure; unit-testable. <c>None</c> maps to <c>none</c> but the call site omits the
+        /// field entirely for <c>None</c>, so this token is only emitted for an actual skip reason.
+        /// </summary>
+        internal static string AtmosphericMarkerSkipReasonToken(AtmosphericMarkerSkipReason reason)
+        {
+            switch (reason)
+            {
+                case AtmosphericMarkerSkipReason.None: return "none";
+                case AtmosphericMarkerSkipReason.NativeIconActive: return "native-icon-active";
+                case AtmosphericMarkerSkipReason.NullRecording: return "null-recording";
+                case AtmosphericMarkerSkipReason.Debris: return "debris";
+                case AtmosphericMarkerSkipReason.NoTrajectoryPoints: return "no-trajectory-points";
+                case AtmosphericMarkerSkipReason.OutsideTimeRange: return "outside-time-range";
+                case AtmosphericMarkerSkipReason.SuppressedByChainFilter: return "suppressed-by-chain-filter";
+                case AtmosphericMarkerSkipReason.OrbitSegmentActive: return "orbit-segment-active";
+                default: return "unknown";
+            }
+        }
+
         internal static AtmosphericMarkerSkipReason ClassifyAtmosphericMarkerSkip(
             Recording rec, int recordingIndex, double currentUT,
             HashSet<string> suppressedIds)
@@ -786,9 +825,15 @@ namespace Parsek
                     rec, headUT, ref cached, out Vector3d worldPos, out _, out _, out _))
                 return false;
 
-            // Ride the SINGLE shared polyline at this instance's head; never draw off-line.
+            // Ride the SINGLE shared polyline at this instance's head; never draw off-line. GAP-1: use
+            // the DIAGNOSTIC overload so we capture the REAL ride reason + leg index for THIS instance,
+            // then thread them into this instance's marker-decision line below. The ride LOGIC is
+            // byte-identical to the 3-arg wrapper (the wrapper just discards the out-params), so this is
+            // pure instrumentation - no second anchor call, no control-flow change beyond capturing the
+            // out-params the diagnostic overload already computes.
             if (!Parsek.Display.GhostTrajectoryPolylineRenderer.TryAnchorMarkerToPolyline(
-                    rec.RecordingId, headUT, out Vector3 onLinePos))
+                    rec.RecordingId, headUT, out Vector3 onLinePos,
+                    out MapRenderTrace.MarkerRideReason rideReason, out int rideLegIndex))
                 return false;
 
             // Per-instance key (hover-collision fix): distinct keys, identical labels are fine
@@ -808,6 +853,33 @@ namespace Parsek
                 markerColor,
                 vtype,
                 context => OnAtmosphericMarkerClicked(recordingIndexForClick, markerRecording, context));
+
+            // GAP-1: per-INSTANCE marker-decision line, keyed by the SAME per-instance markerKey
+            // (recId#cycle) the EmitMarker call below uses - NOT the bare recordingId. The overlap path
+            // runs N instances under ONE recordingId; keying the change-detection signature on the bare
+            // recordingId would let the N instances thrash a single signature (false "changed" churn /
+            // masking). This is the TS analogue the flight overlap path lacks: the flight branch emits
+            // one per-RECORDING decision line with ride=not-attempted, so its ride field cannot
+            // represent a specific instance. Here each instance's line carries ITS OWN real ride reason
+            // + posSource=polyline (it just rode a leg above), finally answering the canonical TS debug
+            // question "did this icon ride its line or fall off?" per instance.
+            if (MapRenderTrace.IsEnabled && !string.IsNullOrEmpty(markerKey))
+                MapRenderTrace.EmitMarkerDecisionOnChange(
+                    MapRenderTrace.RenderSurface.AtmosphericMarker, markerKey, headUT,
+                    MapRenderTrace.BuildMarkerDecisionSignature(
+                        recordingIndex, label,
+                        // gateOn = the mapRenderDirectorDrive gate that makes this per-instance overlap
+                        // path reachable at all (IsOverlapPerInstanceGateOn); polylineOwning + shouldDraw
+                        // are true because this instance just rode the shared polyline above.
+                        gateOn: GhostMapPresence.IsOverlapPerInstanceGateOn(),
+                        directorTracedPathActive: false,
+                        polylineOwning: true,
+                        iconSuppressed: false,
+                        shouldDrawNonProto: true,
+                        outcome: MapRenderTrace.MarkerOutcome.DrawnNonProto,
+                        rideReason: rideReason,
+                        legIndex: rideLegIndex,
+                        posSource: "polyline"));
 
             // Throttle key is per-RECORDING (rec.RecordingId), NOT the per-cycle markerKey: at high
             // time warp the overlap cycle index advances every frame, so a per-cycle key yields a fresh


### PR DESCRIPTION
## Close the logging gaps surfaced by the per-instance overlap warp validation

Two parts, both about making the ghost map/TS logging useful and warp-robust.

### Part A - stop the per-cycle VERBOSE floods at high time warp (commit 1)
The 57x-warp validation produced ~2,500 Parsek lines/s. Root cause: a fresh loop/overlap **cycle** completes many times/sec at warp and re-enters the spawn/build funnels; the per-frame `MaxSpawnsPerFrame` cap bounds spawns per *frame* but not per *second*, so the per-cycle VERBOSE traces slip through. Converted ~16 sites to `VerboseRateLimited` (wall-clock throttle, warp-safe, appends `suppressed=N`).

**Critically, no rate-limit key contains a warp-advancing value** (cycle / UT / spawn-seed / frameCount) - that is the #1063 trap (a warp-advancing key mints a fresh key each frame and defeats the throttle). Keys use recordingId / recIdx / evt.Index / pid-baked ghost name / finite phase strings only; the warp-advancing values stay in the message body. Resolved vs unavailable/unresolved branches stay on separate keys so a persistently-failing ghost still surfaces ~1/interval. Includes two audit-miss per-cycle `defer` sites and the (untested) orbital create/destroy churn sites, proactively. Left the one-shot "Created overlap per-instance map vessel" as `Info`.

### Part B - complete the rendering tracer's Tracking Station coverage (commit 2)
The maintainer asked that `MapRenderTrace` log everything useful in the **Tracking Station**, not just flight map. An audit found TS is mostly scene-complete already (probe, orbit-line patch, lifecycle, director reconcile, marker decision/draw/summary are scene-agnostic), with real gaps:
- **GAP-1:** the TS marker-decision line hardcoded `ride=not-attempted posSource=traj` even though TS **overlap** markers genuinely ride the shared polyline - so the single most useful TS debug field ("did the icon ride its line?") was a constant lie. Now uses the diagnostic `TryAnchorMarkerToPolyline` overload (no second anchor call) and emits a **per-instance** decision line with the real `ride=rode-legN posSource=polyline`, keyed `recId#cycle` so the N instances don't thrash one change-detection signature. Stale "TS never rides the polyline" comment fixed.
- **GAP-2:** a first-class `surface=Polyline` leg-draw trace at the shared `Draw3D` site (covers both scenes from one insertion), keyed `(Polyline, recordingId)`.
- **C-1:** the finer TS `AtmosphericMarkerSkipReason` now survives on the per-ghost decision line via an optional `tsSkip=` field (defaulted -> flight signatures byte-identical).
- **Warp safeguard (last-review fix):** GAP-1's `recId#cycle` key mints a fresh change-detection entry every cycle; at warp cycles advance without bound within a scene, so the signature dict would grow unbounded in tracing mode (cleared only on scene switch). Capped at 4096 (clearing is correctness-neutral).

### Safety / scope
Pure logging changes: no render or control-flow behavior change; flight signatures byte-identical (C-1 defaulted). All new tracer lines gated behind `mapRenderTracing` and warp-stable. Out of scope (flagged, not changed): conditional FX/animation build-path Verbose lines, the narrow Re-Fly/gap per-tick lines, field-parity nits.

### Process
Plan -> review (SOUND WITH CHANGES, folded in: 2 audit-miss sites + site-5 promotion) -> implement -> combined review (SHIP) -> last review (supervisor, found + fixed the GAP-1 dict-growth cap).

### Tests + build
Build clean (0/0). Full suite **13534 passed**. New `GhostPlaybackLogHygieneTests` (incl. the #1063 regression guard: same key, advancing UT, fixed clock -> 1 emit, then `suppressed=`) + extended `MarkerDrawDecisionTests` / `MapRenderTraceTests` (GAP-1 ride, C-1 byte-identity, GAP-2 surface + key collapse, the warp-cap bound).