### PR TITLE
maprender(8e-S0): coverage-closure instruments for the legacy-deletion gate

### DIFF
--- a/Source/Parsek.Tests/MapRenderS0CoverageTests.cs
+++ b/Source/Parsek.Tests/MapRenderS0CoverageTests.cs
@@ -1,0 +1,364 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Parsek.MapRender;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    /// <summary>
+    /// Phase 8e S0 coverage-closure instrument unit tests. PURELY ADDITIVE diagnostics that prove, before
+    /// any legacy deletion, that the Director's accounted set is a superset of what the autonomous render
+    /// path draws.
+    /// <list type="bullet">
+    /// <item><b>Instrument 1</b> - the polyline accounted-vs-drawn assertion (RecordingId domain): the pure
+    /// <see cref="GhostMapPresence.IsDrawnRecordingAccounted"/> predicate + the end-to-end
+    /// <see cref="GhostMapPresence.AssertDrawnRecordingsAccounted"/> seam. The assertion must FIRE for a
+    /// proto-less drawn recording NOT in the coverage set, and PASS for one that is + for a proto-bearing
+    /// one (non-vacuity).</item>
+    /// <item><b>Instrument 2</b> - the icon-floor gap counter: the pure
+    /// <see cref="IconFloorGapCounter.Classify"/> reason mapping + the per-frame accumulator + a
+    /// warp-stable-key guard on the rate-limited summary (vary UT, hold the clock fixed -&gt; one emit;
+    /// mirrors <see cref="GhostPlaybackLogHygieneTests"/> / <see cref="MapRenderTraceTests"/>).</item>
+    /// </list>
+    /// Touches shared static state (GhostMapPresence coverage sets + pid bridge, IconFloorGapCounter
+    /// accumulator, ParsekLog sink), so it runs in the Sequential collection.
+    /// </summary>
+    [Collection("Sequential")]
+    public class MapRenderS0CoverageTests : IDisposable
+    {
+        private readonly List<string> logLines = new List<string>();
+        private double clock = 1000.0;
+
+        public MapRenderS0CoverageTests()
+        {
+            GhostMapPresence.ResetCoverageSetsForTesting();
+            GhostMapPresence.ResetForTesting();
+            IconFloorGapCounter.ResetForTesting();
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.ResetRateLimitsForTesting();
+            ParsekLog.SuppressLogging = false;
+            ParsekLog.VerboseOverrideForTesting = true;
+            ParsekLog.TestSinkForTesting = line => logLines.Add(line);
+            ParsekLog.ClockOverrideForTesting = () => clock;
+        }
+
+        public void Dispose()
+        {
+            GhostMapPresence.ResetCoverageSetsForTesting();
+            GhostMapPresence.ResetForTesting();
+            IconFloorGapCounter.ResetForTesting();
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.ResetRateLimitsForTesting();
+            ParsekLog.SuppressLogging = true;
+        }
+
+        // =====================================================================
+        // Instrument 1 - pure accounted predicate (RecordingId domain)
+        // =====================================================================
+
+        [Fact]
+        public void IsDrawnRecordingAccounted_ProtoBearing_Accounted()
+        {
+            // A drawn recording whose RecordingId is in the proto-bearing set (the Director's enumerated
+            // pid set bridged to RecordingIds) is accounted via the pid path, NOT via the coverage set.
+            var protoBearing = new HashSet<string>(StringComparer.Ordinal) { "rec-proto" };
+            var coverage = new HashSet<string>(StringComparer.Ordinal);
+
+            Assert.True(GhostMapPresence.IsDrawnRecordingAccounted("rec-proto", protoBearing, coverage));
+        }
+
+        [Fact]
+        public void IsDrawnRecordingAccounted_InProtoLessCoverage_Accounted()
+        {
+            // A proto-less (pid-0) drawn recording in the coverage set is accounted via the non-proto path.
+            var protoBearing = new HashSet<string>(StringComparer.Ordinal);
+            var coverage = new HashSet<string>(StringComparer.Ordinal) { "rec-atmo" };
+
+            Assert.True(GhostMapPresence.IsDrawnRecordingAccounted("rec-atmo", protoBearing, coverage));
+        }
+
+        [Fact]
+        public void IsDrawnRecordingAccounted_DrawnButInNeither_FIRES()
+        {
+            // NON-VACUITY: a recording drawn by the autonomous walk but NEITHER proto-bearing NOR in the
+            // proto-less coverage set is UNACCOUNTED - the deletion-blocker the assertion exists to surface.
+            var protoBearing = new HashSet<string>(StringComparer.Ordinal) { "rec-other-proto" };
+            var coverage = new HashSet<string>(StringComparer.Ordinal) { "rec-other-atmo" };
+
+            Assert.False(GhostMapPresence.IsDrawnRecordingAccounted("rec-orphan", protoBearing, coverage));
+        }
+
+        [Fact]
+        public void IsDrawnRecordingAccounted_NullOrEmpty_NeverFlagged()
+        {
+            // A null/empty id is not a real drawn recording; never flag it (would be a false anomaly).
+            Assert.True(GhostMapPresence.IsDrawnRecordingAccounted(null, null, null));
+            Assert.True(GhostMapPresence.IsDrawnRecordingAccounted("", null, null));
+        }
+
+        // =====================================================================
+        // Instrument 1 - end-to-end assertion seam (the pid-bridge into the RecordingId domain)
+        // =====================================================================
+
+        [Fact]
+        public void AssertDrawnRecordingsAccounted_ProtoLessDrawnNotInCoverage_FIRES()
+        {
+            // A proto-LESS recording (pid 0) is drawn but NOT folded into the coverage set: the assertion
+            // must fire. This models the deletion-blocker case where the non-proto walk drew something the
+            // Director never accounted for. (We stamp drawn=true, protoLess=false so it goes only into the
+            // drawn set, simulating a draw path that bypassed NoteDrawnRecordingCoverage's pid-0 fold.)
+            GhostMapPresence.SetFrameCoverageForTesting("rec-orphan", drawn: true, protoLess: false);
+            // No proto-bearing pid maps to rec-orphan, so the pid bridge cannot account for it either.
+
+            var unaccounted = new List<string>();
+            GhostMapPresence.AssertDrawnRecordingsAccounted(
+                (recId, pb, plc, drawn) => unaccounted.Add(recId));
+
+            Assert.Contains("rec-orphan", unaccounted);
+        }
+
+        [Fact]
+        public void AssertDrawnRecordingsAccounted_ProtoLessInCoverage_DoesNotFire()
+        {
+            // A proto-less recording drawn AND folded into the coverage set is accounted - no fire.
+            GhostMapPresence.SetFrameCoverageForTesting("rec-atmo", drawn: true, protoLess: true);
+
+            var unaccounted = new List<string>();
+            GhostMapPresence.AssertDrawnRecordingsAccounted(
+                (recId, pb, plc, drawn) => unaccounted.Add(recId));
+
+            Assert.Empty(unaccounted);
+        }
+
+        [Fact]
+        public void AssertDrawnRecordingsAccounted_ProtoBearingDrawn_AccountedViaPidBridge()
+        {
+            // A proto-BEARING recording drawn via the polyline (pid != 0, so deliberately NOT in the
+            // coverage set) is accounted by the RecordingId-DOMAIN bridge from the live pid map. This is
+            // the critical non-vacuity guard: the bridge must translate the proto-bearing pid back into
+            // the RecordingId domain (the draw domain) so the pid-0-vs-pid-set false "absent" trap is
+            // avoided. Drawn but NOT in coverage; only the pid bridge can account for it.
+            GhostMapPresence.SetProtoBearingPidForTesting(pid: 12345, recordingId: "rec-proto");
+            GhostMapPresence.SetFrameCoverageForTesting("rec-proto", drawn: true, protoLess: false);
+
+            var unaccounted = new List<string>();
+            GhostMapPresence.AssertDrawnRecordingsAccounted(
+                (recId, pb, plc, drawn) => unaccounted.Add(recId));
+
+            Assert.Empty(unaccounted); // accounted via the pid bridge, not the coverage set
+        }
+
+        [Fact]
+        public void AssertDrawnRecordingsAccounted_MixedFrame_FiresOnlyForTheOrphan()
+        {
+            // A realistic frame: a proto-bearing recording, a proto-less covered recording, and one orphan.
+            // Only the orphan fires.
+            GhostMapPresence.SetProtoBearingPidForTesting(pid: 1, recordingId: "rec-proto");
+            GhostMapPresence.SetFrameCoverageForTesting("rec-proto", drawn: true, protoLess: false);
+            GhostMapPresence.SetFrameCoverageForTesting("rec-atmo", drawn: true, protoLess: true);
+            GhostMapPresence.SetFrameCoverageForTesting("rec-orphan", drawn: true, protoLess: false);
+
+            var unaccounted = new List<string>();
+            GhostMapPresence.AssertDrawnRecordingsAccounted(
+                (recId, pb, plc, drawn) => unaccounted.Add(recId));
+
+            Assert.Single(unaccounted);
+            Assert.Equal("rec-orphan", unaccounted[0]);
+        }
+
+        [Fact]
+        public void AssertDrawnRecordingsAccounted_NothingDrawn_NoOp()
+        {
+            int fires = 0;
+            GhostMapPresence.AssertDrawnRecordingsAccounted((recId, pb, plc, drawn) => fires++);
+            Assert.Equal(0, fires);
+        }
+
+        [Fact]
+        public void NoteDrawnRecordingCoverage_PidZero_AddsToBothSets()
+        {
+            // The live producer semantics: a pid-0 draw goes into BOTH the drawn set and the proto-less
+            // coverage set (so the assertion accounts for it). End-to-end: nothing fires.
+            GhostMapPresence.NoteDrawnRecordingCoverage("rec-atmo", ghostPid: 0);
+
+            var unaccounted = new List<string>();
+            GhostMapPresence.AssertDrawnRecordingsAccounted(
+                (recId, pb, plc, drawn) => unaccounted.Add(recId));
+            Assert.Empty(unaccounted);
+        }
+
+        [Fact]
+        public void NoteDrawnRecordingCoverage_NonZeroPid_DrawnButNotCoverage_NeedsPidBridge()
+        {
+            // The live producer semantics: a proto-bearing (pid != 0) draw goes into the drawn set ONLY,
+            // NOT the coverage set. Without a matching pid bridge it would be UNACCOUNTED - proving the
+            // proto-less fold is genuinely gated on pid 0 (not "echo every draw").
+            GhostMapPresence.NoteDrawnRecordingCoverage("rec-proto", ghostPid: 999);
+            // No SetProtoBearingPidForTesting => the pid bridge is empty => unaccounted.
+
+            var unaccounted = new List<string>();
+            GhostMapPresence.AssertDrawnRecordingsAccounted(
+                (recId, pb, plc, drawn) => unaccounted.Add(recId));
+            Assert.Contains("rec-proto", unaccounted);
+        }
+
+        [Fact]
+        public void ClearFrameCoverageSets_EmptiesTheDrawnSet()
+        {
+            GhostMapPresence.NoteDrawnRecordingCoverage("rec-atmo", ghostPid: 0);
+            GhostMapPresence.ClearFrameCoverageSets();
+
+            int fires = 0;
+            GhostMapPresence.AssertDrawnRecordingsAccounted((recId, pb, plc, drawn) => fires++);
+            Assert.Equal(0, fires); // drawn set empty after the per-frame clear
+        }
+
+        // =====================================================================
+        // Instrument 2 - pure icon-floor reason classifier
+        // =====================================================================
+
+        [Fact]
+        public void Classify_GateOff_ReturnsGateOff_NotCountable()
+        {
+            var r = IconFloorGapCounter.Classify(
+                gateOn: false, hasBounds: true, freshSeed: true, seedBodyResolved: true);
+            Assert.Equal(IconFloorGapCounter.FloorReason.GateOff, r);
+            Assert.False(IconFloorGapCounter.IsCountableFloor(r));
+        }
+
+        [Fact]
+        public void Classify_NoBounds_ReturnsNoBounds_Countable()
+        {
+            var r = IconFloorGapCounter.Classify(
+                gateOn: true, hasBounds: false, freshSeed: false, seedBodyResolved: false);
+            Assert.Equal(IconFloorGapCounter.FloorReason.NoBounds, r);
+            Assert.True(IconFloorGapCounter.IsCountableFloor(r));
+        }
+
+        [Fact]
+        public void Classify_FreshSeedBodyUnresolved_ReturnsUnresolvableSeedBody_Countable()
+        {
+            var r = IconFloorGapCounter.Classify(
+                gateOn: true, hasBounds: true, freshSeed: true, seedBodyResolved: false);
+            Assert.Equal(IconFloorGapCounter.FloorReason.UnresolvableSeedBody, r);
+            Assert.True(IconFloorGapCounter.IsCountableFloor(r));
+        }
+
+        [Fact]
+        public void Classify_NoFreshSeed_ReturnsNoFreshSeed_Countable()
+        {
+            var r = IconFloorGapCounter.Classify(
+                gateOn: true, hasBounds: true, freshSeed: false, seedBodyResolved: false);
+            Assert.Equal(IconFloorGapCounter.FloorReason.NoFreshSeed, r);
+            Assert.True(IconFloorGapCounter.IsCountableFloor(r));
+        }
+
+        [Fact]
+        public void Classify_DirectorDrove_ReturnsNone_NotCountable()
+        {
+            // Gate on, bounds present, fresh seed, body resolves => the Director DROVE the icon. Not a
+            // legacy-floor frame. Mirrors ShadowRenderDriver.IsDirectorDriveActive exactly.
+            var r = IconFloorGapCounter.Classify(
+                gateOn: true, hasBounds: true, freshSeed: true, seedBodyResolved: true);
+            Assert.Equal(IconFloorGapCounter.FloorReason.None, r);
+            Assert.False(IconFloorGapCounter.IsCountableFloor(r));
+        }
+
+        // =====================================================================
+        // Instrument 2 - accumulator + flush (no-op for non-countable reasons)
+        // =====================================================================
+
+        [Fact]
+        public void NoteLegacyFloor_CountableReason_Accumulates()
+        {
+            IconFloorGapCounter.NoteLegacyFloor(7, IconFloorGapCounter.FloorReason.NoFreshSeed);
+            IconFloorGapCounter.NoteLegacyFloor(7, IconFloorGapCounter.FloorReason.NoFreshSeed);
+            Assert.Equal(2, IconFloorGapCounter.CountForTesting(7, IconFloorGapCounter.FloorReason.NoFreshSeed));
+        }
+
+        [Fact]
+        public void NoteLegacyFloor_NonCountableReason_NoOp()
+        {
+            IconFloorGapCounter.NoteLegacyFloor(7, IconFloorGapCounter.FloorReason.None);
+            IconFloorGapCounter.NoteLegacyFloor(7, IconFloorGapCounter.FloorReason.GateOff);
+            Assert.Equal(0, IconFloorGapCounter.BucketCountForTesting);
+        }
+
+        [Fact]
+        public void FlushFrameSummary_EmitsAggregate_ThenResets()
+        {
+            MapRenderTrace.ForceEnabledForTesting = true;
+
+            IconFloorGapCounter.NoteLegacyFloor(11, IconFloorGapCounter.FloorReason.NoFreshSeed);
+            IconFloorGapCounter.NoteLegacyFloor(22, IconFloorGapCounter.FloorReason.NoBounds);
+            IconFloorGapCounter.FlushFrameSummary();
+
+            Assert.Contains(logLines, l =>
+                l.Contains("[MapRender]") && l.Contains("icon-floor:")
+                && l.Contains("pids=[11,22]") && l.Contains("no-bounds") && l.Contains("no-fresh-seed"));
+            // Accumulator reset after the flush.
+            Assert.Equal(0, IconFloorGapCounter.BucketCountForTesting);
+
+            MapRenderTrace.ForceEnabledForTesting = false;
+        }
+
+        [Fact]
+        public void FlushFrameSummary_NothingAccumulated_NoOp()
+        {
+            MapRenderTrace.ForceEnabledForTesting = true;
+            IconFloorGapCounter.FlushFrameSummary();
+            Assert.DoesNotContain(logLines, l => l.Contains("icon-floor:"));
+            MapRenderTrace.ForceEnabledForTesting = false;
+        }
+
+        // =====================================================================
+        // Instrument 2 - WARP-STABLE rate-limit key guard (the #1063 / #1064 lesson)
+        // =====================================================================
+
+        [Fact]
+        public void FlushFrameSummary_WarpAdvancingPidsAndCounts_SameKeyCollapsesToOneLine()
+        {
+            // The summary's rate-limit KEY is the constant "icon-floor-fallback" - WARP-STABLE. Across N
+            // frames the per-frame pids / reasons / counts ADVANCE (they live in the BODY), but the key
+            // does not, so within one wall-clock window exactly ONE line emits. Clock held fixed; vary the
+            // accumulated content every "frame" to mimic warp churn.
+            MapRenderTrace.ForceEnabledForTesting = true;
+
+            for (int frame = 0; frame < 50; frame++)
+            {
+                // A different pid + reason mix each frame (warp-advancing content), clock unchanged.
+                IconFloorGapCounter.NoteLegacyFloor(
+                    (uint)(100 + frame),
+                    (frame % 2 == 0)
+                        ? IconFloorGapCounter.FloorReason.NoFreshSeed
+                        : IconFloorGapCounter.FloorReason.NoBounds);
+                IconFloorGapCounter.FlushFrameSummary();
+            }
+
+            int emitted = logLines.Count(l => l.Contains("[MapRender]") && l.Contains("icon-floor:"));
+            // Exactly one line proves the warp-advancing pids/counts are in the BODY, not the KEY.
+            Assert.Equal(1, emitted);
+
+            MapRenderTrace.ForceEnabledForTesting = false;
+        }
+
+        [Fact]
+        public void FlushFrameSummary_AfterIntervalElapses_EmitsAgain()
+        {
+            // Advancing the wall clock past the 5 s rate-limit window re-opens the gate for the same key.
+            MapRenderTrace.ForceEnabledForTesting = true;
+
+            IconFloorGapCounter.NoteLegacyFloor(1, IconFloorGapCounter.FloorReason.NoFreshSeed);
+            IconFloorGapCounter.FlushFrameSummary();
+            clock += 6.0; // past the 5 s interval
+            IconFloorGapCounter.NoteLegacyFloor(2, IconFloorGapCounter.FloorReason.NoBounds);
+            IconFloorGapCounter.FlushFrameSummary();
+
+            int emitted = logLines.Count(l => l.Contains("[MapRender]") && l.Contains("icon-floor:"));
+            Assert.Equal(2, emitted);
+
+            MapRenderTrace.ForceEnabledForTesting = false;
+        }
+    }
+}

--- a/Source/Parsek/Display/GhostTrajectoryPolylineRenderer.cs
+++ b/Source/Parsek/Display/GhostTrajectoryPolylineRenderer.cs
@@ -1863,6 +1863,14 @@ namespace Parsek.Display
                 activeLegRecordings.Clear();
                 directorOwnedLegRecordings.Clear();
 
+                // Phase 8e S0 (PURELY ADDITIVE diagnostics): clear this frame's coverage-closure sets on
+                // the SAME pre-early-return lifecycle as the ownership sets, so they reflect only the
+                // recordings this frame's walk draws (empty when the polyline is off / not in map view /
+                // wrong scene). Only touched in tracing mode (the populate site below is IsEnabled-gated),
+                // but the clear is unconditional + cheap so a tracing toggle mid-session never leaves a
+                // stale drawn/coverage entry behind for the probe to misread.
+                GhostMapPresence.ClearFrameCoverageSets();
+
                 // Pan-stability (FIX 1): drop last frame's pending-draw handoff before any early return,
                 // so a frame that bails (wrong scene / not in map view / no controller) leaves nothing for
                 // the onPreCull pass to draw. The pending list is repopulated below only for legs that
@@ -2179,6 +2187,15 @@ namespace Parsek.Display
                         // Tell GhostMapPresence the polyline owns this recording's
                         // current phase so it hides the overlapping orbit line.
                         activeLegRecordings.Add(rec.RecordingId);
+
+                        // Phase 8e S0 Instrument 1 (PURELY ADDITIVE): record this recording into the
+                        // coverage-closure DRAWN set (will-draw == actual-draw here), and - when it has
+                        // NO ProtoVessel ghost (ghostPid == 0, a pid-0 atmospheric/ascent recording the
+                        // Director's ghostMapVesselPids enumeration cannot see) - into the proto-less
+                        // COVERAGE set, the Director's genuine accounting of it via this non-proto walk.
+                        // Gated on tracing so default play pays nothing; no render/draw effect.
+                        if (MapRenderTrace.IsEnabled)
+                            GhostMapPresence.NoteDrawnRecordingCoverage(rec.RecordingId, ghostPid);
                     }
                 }
 

--- a/Source/Parsek/GhostMapPresence.cs
+++ b/Source/Parsek/GhostMapPresence.cs
@@ -920,6 +920,46 @@ namespace Parsek
         /// </summary>
         private static readonly Dictionary<uint, string> vesselPidToRecordingId = new Dictionary<uint, string>();
 
+        // ---- Phase 8e S0: coverage-closure accounting (PURELY ADDITIVE diagnostics) ----
+        // These two per-frame RecordingId-keyed sets let the MapRenderProbe prove, before any
+        // legacy deletion, that the Director's accounted set is a SUPERSET of what the autonomous
+        // polyline walk actually draws. Both are populated by the polyline Driver's per-frame decide
+        // walk (the ONLY producer) and cleared each frame at the top of that walk; the probe reads
+        // them at end-of-frame (exec-order 10000, same frame, after the -50 decide pass). They are
+        // purely instrumentation: nothing in the live render/draw path reads them. Gated by the
+        // Driver on MapRenderTrace.IsEnabled so default play never populates them.
+
+        /// <summary>
+        /// S0 Instrument 1 (DRAWN set, RecordingId domain): every committed recording the autonomous
+        /// polyline walk decided to draw a non-orbital leg for THIS frame (the will-draw == actual-draw
+        /// set the <c>PendingLegDraw</c> queue is built from). Populated by
+        /// <see cref="NoteDrawnRecordingCoverage"/> from the Driver's decide walk; cleared by
+        /// <see cref="ClearFrameCoverageSets"/> at the top of every Driver LateUpdate. The probe iterates
+        /// this set to assert each drawn recording is ACCOUNTED. Diagnostic-only.
+        /// </summary>
+        private static readonly HashSet<string> drawnRecordingIdsThisFrame =
+            new HashSet<string>(StringComparer.Ordinal);
+
+        /// <summary>
+        /// S0 Instrument 1 (proto-less COVERAGE set, RecordingId domain): the subset of
+        /// <see cref="drawnRecordingIdsThisFrame"/> whose committed recording has NO ProtoVessel ghost
+        /// (<see cref="GetGhostVesselPidForRecording"/> == 0) - i.e. the pid-0 atmospheric/ascent
+        /// recordings the Director's enumerated <see cref="ghostMapVesselPids"/> set cannot see, drawn
+        /// ONLY by the autonomous <c>CommittedRecordings</c> walk. This is the Director's GENUINE
+        /// accounting of those recordings via the non-proto path (it acknowledges "this proto-less
+        /// recording is being rendered"). NOT "all committed recordings": a proto-BEARING drawn recording
+        /// is deliberately excluded here (it is accounted via the pid bridge instead), so the assertion
+        /// stays non-vacuous. Populated + cleared on the same lifecycle as the drawn set. Diagnostic-only.
+        /// </summary>
+        private static readonly HashSet<string> protoLessCoverageRecordingIdsThisFrame =
+            new HashSet<string>(StringComparer.Ordinal);
+
+        // Scratch holding the proto-bearing RecordingId set built once per assertion pass from the live
+        // vesselPidToRecordingId values, so the per-drawn-recording check is O(1). Reused (cleared, not
+        // re-allocated) to keep the gated path allocation-light.
+        private static readonly HashSet<string> protoBearingRecordingIdScratch =
+            new HashSet<string>(StringComparer.Ordinal);
+
         /// <summary>
         /// Orbit segment time bounds per ghost vessel PID. Used by GhostOrbitArcPatch
         /// to clip the orbit line to only the visible arc (between segment startUT and endUT).
@@ -9089,6 +9129,136 @@ namespace Parsek
             return GetNewestOverlapInstancePidForRecording(recordingIndex);
         }
 
+        // ---- Phase 8e S0 Instrument 1: coverage-closure accounting (PURELY ADDITIVE) ----
+
+        /// <summary>
+        /// Clears this frame's coverage-closure sets. Called by the polyline Driver at the TOP of every
+        /// LateUpdate decide walk (the same lifecycle the ownership-publish sets clear on) so the sets
+        /// reflect ONLY the recordings the walk drew this frame. Diagnostic-only; nothing in the live
+        /// render path reads these.
+        /// </summary>
+        internal static void ClearFrameCoverageSets()
+        {
+            drawnRecordingIdsThisFrame.Clear();
+            protoLessCoverageRecordingIdsThisFrame.Clear();
+        }
+
+        /// <summary>
+        /// Records that the autonomous polyline walk decided to DRAW a non-orbital leg for
+        /// <paramref name="recordingId"/> this frame (the will-draw == actual-draw signal). When
+        /// <paramref name="ghostPid"/> is 0 the recording has NO ProtoVessel ghost (pid-0
+        /// atmospheric/ascent), so it is ALSO added to the proto-less coverage set - the Director's
+        /// genuine accounting of a recording its enumerated <see cref="ghostMapVesselPids"/> set cannot
+        /// see. Called from the Driver's decide walk, already gated by the Driver on
+        /// <see cref="MapRenderTrace.IsEnabled"/>. Diagnostic-only; no render/draw effect.
+        /// </summary>
+        internal static void NoteDrawnRecordingCoverage(string recordingId, uint ghostPid)
+        {
+            if (string.IsNullOrEmpty(recordingId))
+                return;
+            drawnRecordingIdsThisFrame.Add(recordingId);
+            // pid 0 => no proto vessel => the Director's enumerated set (ghostMapVesselPids) misses it;
+            // the non-proto polyline path is the ONLY thing rendering it, so account for it here. A
+            // proto-BEARING recording is intentionally NOT added (it is accounted via the pid bridge),
+            // which keeps the assertion non-vacuous.
+            if (ghostPid == 0)
+                protoLessCoverageRecordingIdsThisFrame.Add(recordingId);
+        }
+
+        /// <summary>
+        /// PURE accounting predicate (S0 Instrument 1): is a DRAWN recording ACCOUNTED FOR by the
+        /// Director's coverage? Expressed entirely in the RecordingId domain (the draw domain). A drawn
+        /// recording is accounted when EITHER it maps to a proto-bearing ghost pid (the Director's
+        /// enumerated <see cref="ghostMapVesselPids"/> set, bridged back to RecordingIds via
+        /// <see cref="vesselPidToRecordingId"/>) OR it is in the proto-less coverage set (the non-proto
+        /// path's accounting). A drawn recording in NEITHER is the deletion-blocker: the autonomous walk
+        /// drew it but the Director's accounted set does not cover it, so deleting the legacy ownership
+        /// would silently drop it. Unit-testable (no Unity / no live state - all three inputs are
+        /// passed in), so it can FIRE for a genuinely-unaccounted recording and PASS for an accounted one.
+        /// </summary>
+        internal static bool IsDrawnRecordingAccounted(
+            string drawnRecordingId,
+            ICollection<string> protoBearingRecordingIds,
+            ICollection<string> protoLessCoverageRecordingIds)
+        {
+            if (string.IsNullOrEmpty(drawnRecordingId))
+                return true; // a null/empty id is not a real drawn recording; never flag it
+            if (protoBearingRecordingIds != null && protoBearingRecordingIds.Contains(drawnRecordingId))
+                return true;
+            if (protoLessCoverageRecordingIds != null
+                && protoLessCoverageRecordingIds.Contains(drawnRecordingId))
+                return true;
+            return false;
+        }
+
+        /// <summary>
+        /// Runs the S0 coverage-closure assertion over this frame's drawn-recording set, invoking
+        /// <paramref name="onUnaccounted"/> once per drawn recording that is NEITHER proto-bearing NOR in
+        /// the proto-less coverage set. Builds the proto-bearing RecordingId set ONCE (from the live
+        /// <see cref="vesselPidToRecordingId"/> values - the Director's enumerated pid set bridged to the
+        /// RecordingId domain) so the per-recording check is O(1). The callback receives
+        /// <c>(recordingId, protoBearingCount, protoLessCoverageCount, drawnCount)</c> for the anomaly
+        /// line. Diagnostic-only; the caller gates on <see cref="MapRenderTrace.IsEnabled"/>. No-ops when
+        /// nothing drew this frame.
+        /// </summary>
+        internal static void AssertDrawnRecordingsAccounted(
+            System.Action<string, int, int, int> onUnaccounted)
+        {
+            if (drawnRecordingIdsThisFrame.Count == 0)
+                return;
+
+            // Bridge the proto-bearing pids back into the RecordingId DOMAIN (the draw domain). Comparing
+            // a pid-0 recording against a pid SET would always report "absent" - the task's explicit
+            // false-positive trap. The values of vesselPidToRecordingId ARE the proto-bearing RecordingIds.
+            protoBearingRecordingIdScratch.Clear();
+            foreach (var kv in vesselPidToRecordingId)
+                if (!string.IsNullOrEmpty(kv.Value))
+                    protoBearingRecordingIdScratch.Add(kv.Value);
+
+            foreach (string recId in drawnRecordingIdsThisFrame)
+            {
+                if (IsDrawnRecordingAccounted(
+                        recId, protoBearingRecordingIdScratch, protoLessCoverageRecordingIdsThisFrame))
+                    continue;
+                onUnaccounted?.Invoke(
+                    recId,
+                    protoBearingRecordingIdScratch.Count,
+                    protoLessCoverageRecordingIdsThisFrame.Count,
+                    drawnRecordingIdsThisFrame.Count);
+            }
+        }
+
+        /// <summary>Test-only seam: stamp this frame's drawn / proto-less coverage sets so
+        /// <see cref="AssertDrawnRecordingsAccounted"/> and the pid-bridge can be exercised end-to-end
+        /// from xUnit (the real producer is the Unity-coupled Driver walk). Mirrors the live
+        /// <see cref="NoteDrawnRecordingCoverage"/> semantics.</summary>
+        internal static void SetFrameCoverageForTesting(string recordingId, bool drawn, bool protoLess)
+        {
+            if (string.IsNullOrEmpty(recordingId))
+                return;
+            if (drawn) drawnRecordingIdsThisFrame.Add(recordingId);
+            else drawnRecordingIdsThisFrame.Remove(recordingId);
+            if (protoLess) protoLessCoverageRecordingIdsThisFrame.Add(recordingId);
+            else protoLessCoverageRecordingIdsThisFrame.Remove(recordingId);
+        }
+
+        /// <summary>Test-only seam: stamp the proto-bearing pid bridge (pid -> recordingId) so the
+        /// assertion's RecordingId-domain bridge can be exercised from xUnit.</summary>
+        internal static void SetProtoBearingPidForTesting(uint pid, string recordingId)
+        {
+            if (string.IsNullOrEmpty(recordingId)) vesselPidToRecordingId.Remove(pid);
+            else vesselPidToRecordingId[pid] = recordingId;
+        }
+
+        /// <summary>Test-only: clear all S0 coverage-closure state (the two frame sets + the scratch),
+        /// so a test starts from a known-empty accounting.</summary>
+        internal static void ResetCoverageSetsForTesting()
+        {
+            drawnRecordingIdsThisFrame.Clear();
+            protoLessCoverageRecordingIdsThisFrame.Clear();
+            protoBearingRecordingIdScratch.Clear();
+        }
+
         internal static bool TryGetCommittedRecordingById(
             string recordingId,
             out int recordingIndex,
@@ -9363,6 +9533,7 @@ namespace Parsek
             overlapInstanceVessels.Clear();
             vesselPidToRecordingIndex.Clear();
             vesselPidToRecordingId.Clear();
+            ResetCoverageSetsForTesting();
             trackingStationStateVectorOrbitTrajectories.Clear();
             trackingStationStateVectorCachedIndices.Clear();
             activeReFlyDeferredStateVectorGhostSessions.Clear();

--- a/Source/Parsek/InGameTests/ExtendedRuntimeTests.cs
+++ b/Source/Parsek/InGameTests/ExtendedRuntimeTests.cs
@@ -2024,4 +2024,91 @@ namespace Parsek.InGameTests
                 $"{conflicts} spawned vessel PID(s) conflict with ghost map vessels");
         }
     }
+
+    // ════════════════════════════════════════════════════════════════
+    //  Phase 8e S0 coverage-closure instruments (PURELY ADDITIVE)
+    // ════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// Exercises the S0 Instrument 1 accounted-vs-drawn seam under the LIVE KSP runtime/JIT (the pure
+    /// helper logic is covered by xUnit; this proves the static accounting + the RecordingId-domain pid
+    /// bridge run end-to-end in-game). Drives the seam DETERMINISTICALLY via the test stamps - no live
+    /// ghost / no full Driver frame needed - so it is robust regardless of what is on the map. Restores
+    /// the coverage state on exit. A full scene-driven assertion (live ghosts through the polyline walk)
+    /// is left as a manual tracing-on playtest, noted in the S0 report.
+    /// </summary>
+    public class MapRenderS0CoverageInGameTests
+    {
+        [InGameTest(Category = "GhostMapOrbits", Scene = GameScenes.FLIGHT,
+            Description = "S0 Instrument 1: the accounted set covers proto-bearing + proto-less drawn recordings; fires for an orphan")]
+        public void AccountedSetCoversDrawnSet()
+        {
+            // Snapshot live coverage state so the synthetic stamps below do not perturb a real frame's
+            // accounting. ResetCoverageSetsForTesting clears the two frame sets + the scratch; we only add
+            // synthetic ids and clear them again, leaving the live pid bridge untouched except for the one
+            // synthetic pid we add and remove.
+            GhostMapPresence.ResetCoverageSetsForTesting();
+            const uint syntheticPid = 999001u;
+            try
+            {
+                // A proto-bearing draw (pid != 0, NOT in the coverage set) - accounted via the pid bridge.
+                GhostMapPresence.SetProtoBearingPidForTesting(syntheticPid, "s0-ingame-proto");
+                GhostMapPresence.NoteDrawnRecordingCoverage("s0-ingame-proto", syntheticPid);
+                // A proto-less draw (pid 0) - folded into the coverage set, accounted via the non-proto path.
+                GhostMapPresence.NoteDrawnRecordingCoverage("s0-ingame-atmo", 0u);
+                // An orphan: drawn, proto-less-looking, but withheld from the coverage set (simulating a
+                // draw path that bypassed the fold) and with no pid bridge - must be flagged.
+                GhostMapPresence.SetFrameCoverageForTesting("s0-ingame-orphan", drawn: true, protoLess: false);
+
+                var unaccounted = new List<string>();
+                GhostMapPresence.AssertDrawnRecordingsAccounted(
+                    (recId, pb, plc, drawn) => unaccounted.Add(recId));
+
+                ParsekLog.Info("TestRunner",
+                    $"S0 accounting in-game: unaccounted=[{string.Join(",", unaccounted)}]");
+
+                InGameAssert.IsFalse(unaccounted.Contains("s0-ingame-proto"),
+                    "proto-bearing drawn recording must be accounted via the RecordingId-domain pid bridge");
+                InGameAssert.IsFalse(unaccounted.Contains("s0-ingame-atmo"),
+                    "proto-less drawn recording must be accounted via the coverage set");
+                InGameAssert.IsTrue(unaccounted.Contains("s0-ingame-orphan"),
+                    "an unaccounted drawn recording must fire (non-vacuity)");
+                InGameAssert.AreEqual(1, unaccounted.Count,
+                    "exactly the orphan is unaccounted");
+            }
+            finally
+            {
+                GhostMapPresence.SetProtoBearingPidForTesting(syntheticPid, null);
+                GhostMapPresence.ResetCoverageSetsForTesting();
+            }
+        }
+
+        [InGameTest(Category = "GhostMapOrbits", Scene = GameScenes.FLIGHT,
+            Description = "S0 Instrument 2: the icon-floor classifier maps the live branch inputs to the right reason in-game")]
+        public void IconFloorClassifierMapsLiveBranches()
+        {
+            // The classifier is Unity-free, but running it in-game proves the JIT path the icon-drive
+            // Prefix actually hits. Mirror the four live branch shapes.
+            InGameAssert.AreEqual(
+                Parsek.MapRender.IconFloorGapCounter.FloorReason.NoBounds,
+                Parsek.MapRender.IconFloorGapCounter.Classify(
+                    gateOn: true, hasBounds: false, freshSeed: false, seedBodyResolved: false),
+                "no recorded bounds => NoBounds");
+            InGameAssert.AreEqual(
+                Parsek.MapRender.IconFloorGapCounter.FloorReason.NoFreshSeed,
+                Parsek.MapRender.IconFloorGapCounter.Classify(
+                    gateOn: true, hasBounds: true, freshSeed: false, seedBodyResolved: false),
+                "bounds but no fresh seed => NoFreshSeed");
+            InGameAssert.AreEqual(
+                Parsek.MapRender.IconFloorGapCounter.FloorReason.UnresolvableSeedBody,
+                Parsek.MapRender.IconFloorGapCounter.Classify(
+                    gateOn: true, hasBounds: true, freshSeed: true, seedBodyResolved: false),
+                "fresh seed but body unresolved => UnresolvableSeedBody");
+            InGameAssert.AreEqual(
+                Parsek.MapRender.IconFloorGapCounter.FloorReason.None,
+                Parsek.MapRender.IconFloorGapCounter.Classify(
+                    gateOn: true, hasBounds: true, freshSeed: true, seedBodyResolved: true),
+                "director drove the icon => None (not a floor frame)");
+        }
+    }
 }

--- a/Source/Parsek/MapRender/IconFloorGapCounter.cs
+++ b/Source/Parsek/MapRender/IconFloorGapCounter.cs
@@ -1,0 +1,185 @@
+using System.Collections.Generic;
+using System.Globalization;
+
+namespace Parsek.MapRender
+{
+    /// <summary>
+    /// Phase 8e S0 Instrument 2 (PURELY ADDITIVE): per-frame gap-counter proving the SEPARATE deletion
+    /// invariant the polyline coverage assertion does NOT cover - that the legacy effUT ICON floor is
+    /// dead for in-scope ghosts. A proto-BEARING StockConic ghost still falls to the legacy effUT icon
+    /// drive on any frame with no fresh Director seed: the <c>!fresh || !directorDriveActive</c> branch
+    /// in <c>GhostOrbitIconDrivePatch.Prefix</c> (the <c>propagateUT = driveUT</c> legacy path) and the
+    /// no-bounds loiter-&gt;burn early return. This counter MEASURES those legacy-floor frames, tagged by
+    /// pid + reason; the count must reach 0 for in-scope ghosts before a later slice (S2) deletes the
+    /// icon floor. S0 only counts - it does NOT change the fallback behavior.
+    ///
+    /// <para>The classifier is pure (Unity-free, unit-tested). The accumulator + the rate-limited summary
+    /// are gated by the call sites on <see cref="MapRenderTrace.IsEnabled"/> so default play pays nothing.
+    /// The accumulator is per (pid, reason); the summary is emitted once per frame with a WARP-STABLE
+    /// rate-limit key (the stable tag <c>"icon-floor-fallback"</c>, never a cycle/UT/frame value - the
+    /// #1063 / #1064 lesson), carrying the aggregate count + the distinct pids + reasons in the BODY.</para>
+    /// </summary>
+    internal static class IconFloorGapCounter
+    {
+        /// <summary>Why a proto-bearing StockConic ghost took the legacy icon floor this frame.</summary>
+        internal enum FloorReason : byte
+        {
+            /// <summary>Not a legacy-floor frame (the Director drove the icon, or the gate was off). The
+            /// classifier returns this when nothing should be counted.</summary>
+            None = 0,
+
+            /// <summary>The director-drive gate is OFF, so the legacy floor is the ONLY path. Counting it
+            /// is meaningless ("under gate-ON" is the in-scope condition), so this is NOT counted - the
+            /// classifier returns it only so the gate-off case is explicit, not folded into a real reason.</summary>
+            GateOff = 1,
+
+            /// <summary>No recorded arc bounds (the no-bounds loiter-&gt;burn early return): stock
+            /// propagates at the live clock with no Director ownership of the icon. Also covers the benign
+            /// terminal-orbit shift-0 case, which the reader separates by pid.</summary>
+            NoBounds = 2,
+
+            /// <summary>Gate ON, recorded bounds present, but the Director recorded NO fresh StockConic
+            /// seed for this pid this frame, so the icon-drive ran the legacy effUT path. (A re-aim TRIM
+            /// GAP, where the seed expires for a frame, manifests as this same observable - the icon-drive
+            /// site has no cheap re-aim context to distinguish it, so it folds into no-fresh-seed.)</summary>
+            NoFreshSeed = 3,
+
+            /// <summary>Gate ON, a FRESH StockConic seed existed, but its body name did not resolve
+            /// (degenerate / unknown body, never for a real recording), so the icon-drive fell back to the
+            /// legacy effUT path rather than baking the epoch.</summary>
+            UnresolvableSeedBody = 4,
+        }
+
+        internal static string FloorReasonToken(FloorReason reason)
+        {
+            switch (reason)
+            {
+                case FloorReason.GateOff: return "gate-off";
+                case FloorReason.NoBounds: return "no-bounds";
+                case FloorReason.NoFreshSeed: return "no-fresh-seed";
+                case FloorReason.UnresolvableSeedBody: return "unresolvable-seed-body";
+                default: return "none";
+            }
+        }
+
+        /// <summary>
+        /// PURE classifier (Unity-free): given the icon-drive Prefix's observable branch inputs, which
+        /// legacy-floor reason (if any) applies for a proto-bearing StockConic ghost this frame?
+        /// <list type="bullet">
+        /// <item><paramref name="gateOn"/> false -&gt; <see cref="FloorReason.GateOff"/> (NOT counted -
+        /// the legacy path is the only path with the gate off).</item>
+        /// <item><paramref name="hasBounds"/> false -&gt; <see cref="FloorReason.NoBounds"/> (the
+        /// loiter-&gt;burn / terminal-orbit no-bounds early return).</item>
+        /// <item>bounds present, <paramref name="freshSeed"/> true, <paramref name="seedBodyResolved"/>
+        /// false -&gt; <see cref="FloorReason.UnresolvableSeedBody"/>.</item>
+        /// <item>bounds present, <paramref name="freshSeed"/> false -&gt;
+        /// <see cref="FloorReason.NoFreshSeed"/>.</item>
+        /// <item>bounds present, fresh seed, body resolves -&gt; <see cref="FloorReason.None"/> (the
+        /// Director DROVE the icon; NOT a legacy-floor frame).</item>
+        /// </list>
+        /// Mirrors EXACTLY the live branch order in <c>GhostOrbitIconDrivePatch.Prefix</c> /
+        /// <c>ShadowRenderDriver.IsDirectorDriveActive</c> (gate AND fresh seed AND body resolves), so a
+        /// "None" result == a director-driven frame and any non-None/non-GateOff result == a real legacy
+        /// floor under the gate.
+        /// </summary>
+        internal static FloorReason Classify(
+            bool gateOn, bool hasBounds, bool freshSeed, bool seedBodyResolved)
+        {
+            if (!gateOn)
+                return FloorReason.GateOff;
+            if (!hasBounds)
+                return FloorReason.NoBounds;
+            if (freshSeed && !seedBodyResolved)
+                return FloorReason.UnresolvableSeedBody;
+            if (!freshSeed)
+                return FloorReason.NoFreshSeed;
+            return FloorReason.None; // director drove the icon - not a floor frame
+        }
+
+        /// <summary>True when <paramref name="reason"/> is a real legacy-floor-under-gate-ON reason worth
+        /// counting (everything except <see cref="FloorReason.None"/> and <see cref="FloorReason.GateOff"/>).
+        /// Pure.</summary>
+        internal static bool IsCountableFloor(FloorReason reason)
+            => reason != FloorReason.None && reason != FloorReason.GateOff;
+
+        // Per-frame accumulator: (pid, reason) -> count. Reset every frame by FlushFrameSummary. Tracked
+        // distinct pids + reasons feed the summary body. Bounded by the live-ghost count (a handful) +
+        // the small reason enum, so no warp-unbounded growth.
+        private static readonly Dictionary<(uint pid, FloorReason reason), int> floorCountsThisFrame =
+            new Dictionary<(uint, FloorReason), int>();
+
+        /// <summary>
+        /// Record one legacy-floor frame for <paramref name="pid"/> with <paramref name="reason"/>. No-op
+        /// for a non-countable reason (None / GateOff) so the call site can pass the raw classifier result.
+        /// Caller gates on <see cref="MapRenderTrace.IsEnabled"/> so default play never accumulates. NOT a
+        /// behavior change - pure measurement.
+        /// </summary>
+        internal static void NoteLegacyFloor(uint pid, FloorReason reason)
+        {
+            if (!IsCountableFloor(reason))
+                return;
+            var key = (pid, reason);
+            floorCountsThisFrame.TryGetValue(key, out int n);
+            floorCountsThisFrame[key] = n + 1;
+        }
+
+        /// <summary>
+        /// Emit the once-per-frame rate-limited summary of the accumulated legacy-floor frames, then reset
+        /// the accumulator. Called once per frame from <c>ShadowRenderDriver.RunFrame</c> (the single
+        /// once-per-frame Director entry), gated by the caller on <see cref="MapRenderTrace.IsEnabled"/>.
+        /// The rate-limit KEY is the WARP-STABLE constant <c>"icon-floor-fallback"</c> (never a cycle / UT
+        /// / frame, per the #1063 / #1064 lesson); the aggregate count + the distinct pids + reasons live
+        /// in the message BODY. No-op when nothing hit the floor this frame.
+        /// </summary>
+        internal static void FlushFrameSummary()
+        {
+            if (floorCountsThisFrame.Count == 0)
+                return;
+
+            int total = 0;
+            var pids = new HashSet<uint>();
+            var reasons = new HashSet<FloorReason>();
+            foreach (var kv in floorCountsThisFrame)
+            {
+                total += kv.Value;
+                pids.Add(kv.Key.pid);
+                reasons.Add(kv.Key.reason);
+            }
+
+            var pidList = new List<string>(pids.Count);
+            foreach (uint p in pids)
+                pidList.Add(p.ToString(CultureInfo.InvariantCulture));
+            pidList.Sort(System.StringComparer.Ordinal);
+
+            var reasonList = new List<string>(reasons.Count);
+            foreach (FloorReason r in reasons)
+                reasonList.Add(FloorReasonToken(r));
+            reasonList.Sort(System.StringComparer.Ordinal);
+
+            ParsekLog.VerboseRateLimited("MapRender", "icon-floor-fallback",
+                string.Format(CultureInfo.InvariantCulture,
+                    "icon-floor: {0} proto-bearing StockConic frame(s) hit the legacy icon floor this window "
+                    + "(distinctPids={1} pids=[{2}] reasons=[{3}]) - must reach 0 before S2 deletes the floor",
+                    total, pids.Count, string.Join(",", pidList.ToArray()),
+                    string.Join(",", reasonList.ToArray())),
+                5.0);
+
+            floorCountsThisFrame.Clear();
+        }
+
+        /// <summary>Test-only: current accumulated count for a (pid, reason) so the accumulator can be
+        /// asserted before a flush.</summary>
+        internal static int CountForTesting(uint pid, FloorReason reason)
+            => floorCountsThisFrame.TryGetValue((pid, reason), out int n) ? n : 0;
+
+        /// <summary>Test-only: number of distinct (pid, reason) buckets accumulated this frame.</summary>
+        internal static int BucketCountForTesting => floorCountsThisFrame.Count;
+
+        /// <summary>Drop the accumulator (defensive scene-switch reset; the per-frame flush also clears
+        /// it). Diagnostic-only.</summary>
+        internal static void Reset() => floorCountsThisFrame.Clear();
+
+        /// <summary>Test-only alias of <see cref="Reset"/> so a test starts from empty.</summary>
+        internal static void ResetForTesting() => Reset();
+    }
+}

--- a/Source/Parsek/MapRender/ShadowRenderDriver.cs
+++ b/Source/Parsek/MapRender/ShadowRenderDriver.cs
@@ -342,6 +342,17 @@ namespace Parsek.MapRender
                     "shadow frame ghosts={0} shadowed={1} skipReaim={2} overlapShadowed={3} unresolved={4}",
                     pids?.Count ?? 0, shadowed, skipReaim, overlapShadowed, unresolved),
                 5.0);
+
+            // Phase 8e S0 Instrument 2 (PURELY ADDITIVE): flush the per-frame icon-floor gap counter
+            // ONCE here (RunFrame is the single once-per-frame Director entry, called from both
+            // ParsekFlight + ParsekTrackingStation). The increments happen per-FixedUpdate in
+            // GhostOrbitIconDrivePatch; this emits the rate-limited aggregate summary (warp-stable key)
+            // and resets the accumulator. Only when render tracing is on - RunFrame can also be entered
+            // with tracing OFF but the director-drive gate ON (ShadowRenderDriver.Enabled), and the
+            // increments are themselves IsEnabled-gated, so without this guard the flush would still be a
+            // no-op, but guarding it keeps the contract explicit + free.
+            if (MapRenderTrace.IsEnabled)
+                IconFloorGapCounter.FlushFrameSummary();
         }
 
         // PURE, COVERAGE-AWARE: decide whether to skip the ACTIVE heliocentric (star-relative) segment of a

--- a/Source/Parsek/MapRenderProbe.cs
+++ b/Source/Parsek/MapRenderProbe.cs
@@ -90,6 +90,13 @@ namespace Parsek
         // Soft rate-limit timestamps for the per-pid polyline-orbit-overlap anomaly (a PERSISTENT
         // condition through a whole burn, so it must not fire every frame).
         private readonly Dictionary<uint, double> lastPolylineOverlapEmitRealtime = new Dictionary<uint, double>();
+        // Phase 8e S0: soft rate-limit timestamps for the per-RECORDING unaccounted-drawn-recording
+        // anomaly (Instrument 1). Keyed by RecordingId, not pid, because the drawn set is RecordingId-
+        // keyed and a drawn recording may be proto-LESS (pid 0). A PERSISTENT condition (would fire every
+        // frame), so throttled to one line per recording per second; cleared on scene change.
+        private const double UnaccountedAnomalyMinIntervalSeconds = 1.0;
+        private readonly Dictionary<string, double> lastUnaccountedEmitRealtime =
+            new Dictionary<string, double>(System.StringComparer.Ordinal);
         // Pids that have already had their Tier-A FirstPosition event emitted on
         // the first end-of-frame truth read for that pid. Cleared on scene change
         // alongside the other per-pid state, so re-entering a scene re-emits a
@@ -125,6 +132,11 @@ namespace Parsek
             // Also flush MapRenderTrace's pid-keyed stores (detailed windows + line/render intents) so they
             // do not grow unbounded across the AppDomain lifetime; mirrors this probe's own per-pid reset.
             MapRenderTrace.Reset();
+            // Phase 8e S0: drop any S0 coverage / icon-floor state straddling the scene switch (both are
+            // per-frame-cleared by their producers, so this is belt-and-suspenders against a switch landing
+            // between accumulate and flush). Diagnostic-only.
+            GhostMapPresence.ClearFrameCoverageSets();
+            Parsek.MapRender.IconFloorGapCounter.Reset();
             ParsekLog.Verbose(MapRenderTrace.Tag,
                 string.Format(ic,
                     "probe per-pid state cleared on scene switch from={0} to={1}",
@@ -145,6 +157,7 @@ namespace Parsek
             lastOffOrbitEmitRealtime.Clear();
             lastPolylineOverlapEmitRealtime.Clear();
             firstPositionEmittedPids.Clear();
+            lastUnaccountedEmitRealtime.Clear();
         }
 
         void LateUpdate()
@@ -191,6 +204,50 @@ namespace Parsek
                     "probe frame summary frame={0} ghosts={1} sampled={2} resolveMisses={3}",
                     frame, pids.Count, sampled, resolveMisses),
                 5.0);
+
+            // --- Phase 8e S0 Instrument 1: accounted-vs-drawn coverage assertion ---
+            // Once per frame (NOT inside the per-pid loop above - a drawn recording may be PROTO-LESS,
+            // i.e. pid-0, and therefore absent from ghostMapVesselPids). For EVERY recording the
+            // autonomous polyline walk drew this frame, confirm it is ACCOUNTED: its RecordingId maps to
+            // a proto-bearing pid (the Director's enumerated set, bridged into the RecordingId domain) OR
+            // it is in the proto-less coverage set the walk populated. A drawn recording in NEITHER is a
+            // deletion-blocker - the legacy ownership cannot be deleted until this is silent. The whole
+            // LateUpdate is already IsEnabled-gated; the per-recId soft rate-limit below keeps a
+            // persistent unaccounted recording from flooding the log (the condition holds every frame).
+            AssertDrawnRecordingsAccounted(currentUT, realtime);
+        }
+
+        private void AssertDrawnRecordingsAccounted(double currentUT, double realtime)
+        {
+            GhostMapPresence.AssertDrawnRecordingsAccounted(
+                (recId, protoBearingCount, protoLessCoverageCount, drawnCount) =>
+                {
+                    if (!PassesUnaccountedRateLimit(recId, realtime))
+                        return;
+                    // Tier-C anomaly. Keyed (surface=Polyline) by the unaccounted RecordingId (carried in
+                    // the prefix pid= slot, the marker-surface convention). A CLEAN run (zero of these) is
+                    // the deletion-readiness signal: the Director's accounted set is a superset of the
+                    // autonomous walk's drawn set.
+                    MapRenderTrace.EmitAnomaly(
+                        MapRenderTrace.RenderSurface.Polyline, recId, currentUT, currentUT,
+                        "unaccounted-drawn-recording",
+                        string.Format(ic,
+                            "recId={0} drawnByAutonomousWalk=true protoBearing=false inProtoLessCoverage=false "
+                            + "| protoBearingRecs={1} protoLessCoverageRecs={2} drawnRecs={3}",
+                            recId, protoBearingCount, protoLessCoverageCount, drawnCount));
+                });
+        }
+
+        private bool PassesUnaccountedRateLimit(string recId, double realtime)
+        {
+            if (string.IsNullOrEmpty(recId))
+                return false;
+            double last;
+            if (lastUnaccountedEmitRealtime.TryGetValue(recId, out last)
+                && realtime - last < UnaccountedAnomalyMinIntervalSeconds)
+                return false;
+            lastUnaccountedEmitRealtime[recId] = realtime;
+            return true;
         }
 
         private void Sample(

--- a/Source/Parsek/Patches/GhostOrbitLinePatch.cs
+++ b/Source/Parsek/Patches/GhostOrbitLinePatch.cs
@@ -170,6 +170,17 @@ namespace Parsek.Patches
                 // once the Director re-establishes a StockConic drive (the hyperbolic).
                 if (Parsek.MapRender.ShadowRenderDriver.IsDirectorTracking(pid, Time.frameCount))
                     GhostMapPresence.ghostsWithSuppressedIcon.Add(pid);
+
+                // Phase 8e S0 Instrument 2 (PURELY ADDITIVE): this proto-bearing StockConic ghost took
+                // the no-bounds legacy icon floor (stock propagates at the live clock; the Director did
+                // not own the icon). Count it so S2 can prove the floor is dead before deleting it. Only
+                // under the gate (gate-off is the only-path case) + only in tracing mode. NO behavior
+                // change - the return true above stands.
+                if (MapRenderTrace.IsEnabled
+                    && ParsekSettings.Current != null && ParsekSettings.Current.mapRenderDirectorDrive)
+                    Parsek.MapRender.IconFloorGapCounter.NoteLegacyFloor(
+                        pid, Parsek.MapRender.IconFloorGapCounter.FloorReason.NoBounds);
+
                 return true;
             }
 
@@ -275,6 +286,20 @@ namespace Parsek.Patches
                         pid, fresh, directorDriveActive, Time.frameCount, liveDriveUT, driveUT, shift,
                         directorDriveActive ? dirSeg.epoch + shift : double.NaN, dirBody ?? "-"),
                     1.0);
+
+                // Phase 8e S0 Instrument 2 (PURELY ADDITIVE): gate is ON and recorded bounds exist, but
+                // the Director did NOT drive this icon (directorDriveActive == false) - so the legacy
+                // effUT floor (propagateUT = driveUT) runs below. Count it, tagged by the observable
+                // reason: a fresh seed whose body didn't resolve (UnresolvableSeedBody) vs no fresh seed
+                // at all (NoFreshSeed - a re-aim trim gap folds in here). seedBodyResolved == the
+                // directorDriveActive flag (it is the only thing that flips it true). Tracing-gated;
+                // measurement only - the legacy propagation below is unchanged.
+                if (MapRenderTrace.IsEnabled && !directorDriveActive)
+                    Parsek.MapRender.IconFloorGapCounter.NoteLegacyFloor(
+                        pid,
+                        Parsek.MapRender.IconFloorGapCounter.Classify(
+                            gateOn: true, hasBounds: true, freshSeed: fresh,
+                            seedBodyResolved: directorDriveActive));
             }
 
             // Replicate stock OrbitDriver.updateFromParameters(bool) verbatim, but propagate at the


### PR DESCRIPTION
## Phase 8e, slice S0 - the deletion-readiness prerequisite (additive, no deletion)

Phase 8e deletes the legacy map/TS render fallbacks + drops the \`mapRenderDirectorDrive\` gate to reach the design end state (a single modular system). **S0 lands the instruments that PROVE deletion is safe, before anything is removed.** Purely additive: **917 insertions, 0 deletions** (zero deleted lines in the render files); no render/draw behavior change. Both instruments gated behind \`mapRenderTracing\`; warp-stable rate-limit keys. Scoping + status: \`docs/dev/plans/map-ts-render-rewrite-phases.md\`, \`maprender-rewrite-status.md\`.

### Context: the coverage gap re-assessed
Integrations 1-2 (re-aim, overlap) closed most of the old fallback gap. The Director now owns re-aim, overlap, and hyperbolic-escape. The remaining gap is **pid-0 proto-less atmospheric/ascent recordings**: the Director only enumerates proto-bearing pids, so a no-ProtoVessel recording is drawn only by the legacy autonomous polyline walk. Deleting the legacy fallback without proving coverage would silently drop those.

### Instrument 1 - polyline accounted-vs-drawn assertion
A per-frame proto-less coverage set + an end-of-frame assertion (\`MapRenderProbe\`) that every recording the walk DREW is accounted: proto-bearing (bridged from \`ghostMapVesselPids\` into the RecordingId domain) OR in the proto-less coverage set, else a Tier-C \`unaccounted-drawn-recording\` anomaly.

### Instrument 2 - icon-floor gap-counter
\`MapRender/IconFloorGapCounter.cs\`: counts proto-bearing StockConic frames that still hit the legacy effUT icon drive under gate-ON (reasons NoBounds / UnresolvableSeedBody / NoFreshSeed; \`Classify\` mirrors \`IsDirectorDriveActive\`). Flushed once per frame as a warp-stable \`icon-floor-fallback\` summary. **This count must reach 0 for in-scope ghosts before S2 deletes the icon floor** - S0 only measures.

### Last-review nuance (for S2/S3 design)
Instrument 1 populates the coverage set FROM the walk's own pid-0 draws, so it auto-accounts every pid-0 draw and cannot fire for the pid-0 case. That is correct IF S3 keeps the walk drawing pid-0 independent of \`activeLegRecordings\` (then pid-0 is not at deletion risk), but it means Instrument 1 currently confirms a draw *categorization*, not yet a sharp gate against the specific \`activeLegRecordings\` removal. **When S3 deletes \`activeLegRecordings\`, the gate must prove \`activeLegRecordings\` is a subset of \`directorOwnedLegRecordings\` union the kept walk's pid-0 draws - sharpen the assertion there.** Instrument 2 is a direct gate for the S2 icon deletion.

### Process + tests
Scoping plan-review (SOUND with changes, folded in: the second icon-floor instrument + the RecordingId-domain bridge) -> implement -> code review (SHIP) -> last review (found the pid-0 auto-accounting nuance above). Build clean; full suite **13557 passed** (+23 S0 xUnit: assertion fires for an orphan / passes for proto-bearing-via-bridge + proto-less-in-coverage, the pid bridge, the classifier reasons, a warp-stable-key guard; + 2 in-game seam tests). ERS/ELS GrepAudit clean.

### Validation ask (S1, before any deletion)
With \`mapRenderDirectorDrive\` + \`mapRenderTracing\` ON, fly s15 "Duna One" (looped re-aim) + a non-looped atmospheric mission in map view, then check the log: zero \`unaccounted-drawn-recording\` anomalies, and read the \`icon-floor-fallback\` count (it must be driven to 0 for in-scope ghosts before the icon deletion).