### PR TITLE
maprender(8e-S3a): sharpened deletion gate for the legacy polyline ownership publish

### DIFF
--- a/Source/Parsek.Tests/MapRenderS3CoverageTests.cs
+++ b/Source/Parsek.Tests/MapRenderS3CoverageTests.cs
@@ -1,0 +1,317 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Parsek.Display;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    /// <summary>
+    /// Phase 8e S3a deletion-safety gate unit tests. PURELY ADDITIVE diagnostics that PROVE, before S3b
+    /// deletes the legacy polyline ownership publish (<c>activeLegRecordings</c>), that the deletion drops
+    /// nothing: every recording the autonomous walk publishes into the LEGACY ownership set this frame is
+    /// EITHER director-owned (so it keeps its proto-line/icon SUPPRESSION) OR pid-0 / proto-less (nothing to
+    /// suppress; the kept walk draws it regardless of ownership). A legacy-owned leg in NEITHER set is
+    /// proto-BEARING and not director-owned: deleting the legacy ownership would lose its suppression and
+    /// produce a double-draw artifact - the deletion BLOCKER the gate surfaces.
+    /// <list type="bullet">
+    /// <item>the pure <see cref="GhostMapPresence.IsLegacyOwnedLegCoveredByDeletion"/> predicate: FIRES for
+    /// a proto-bearing legacy-owned recId in NEITHER set (the blocker), PASSES for a director-owned one,
+    /// PASSES for a pid-0 one in the proto-less set, never flags null/empty.</item>
+    /// <item>the end-to-end <see cref="GhostMapPresence.AssertLegacyOwnedLegsCovered"/> seam, driving the
+    /// legacy-owned set (GhostMapPresence) + the director-owned view
+    /// (<see cref="GhostTrajectoryPolylineRenderer.DirectorOwnedLegRecordingsThisFrame"/> via
+    /// <c>SetOwnershipPublishForTesting</c>).</item>
+    /// <item>a WARP-STABLE-key guard on the new anomaly's per-recId rate-limit
+    /// (<see cref="MapRenderProbe.PassesPerRecIdRateLimit"/>): vary the UT/leg content every frame, hold the
+    /// wall clock -&gt; ONE pass per recId per window (the recId is the KEY; UT lives in the body). Mirrors
+    /// the S0 instrument warp-stable test (<see cref="MapRenderS0CoverageTests"/>).</item>
+    /// </list>
+    /// Touches shared static state (GhostMapPresence coverage sets + the polyline renderer ownership sets),
+    /// so it runs in the Sequential collection.
+    /// </summary>
+    [Collection("Sequential")]
+    public class MapRenderS3CoverageTests : IDisposable
+    {
+        private readonly List<string> logLines = new List<string>();
+        private double clock = 2000.0;
+
+        public MapRenderS3CoverageTests()
+        {
+            GhostMapPresence.ResetCoverageSetsForTesting();
+            GhostMapPresence.ResetForTesting();
+            GhostTrajectoryPolylineRenderer.Clear();
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.ResetRateLimitsForTesting();
+            ParsekLog.SuppressLogging = false;
+            ParsekLog.VerboseOverrideForTesting = true;
+            ParsekLog.TestSinkForTesting = line => logLines.Add(line);
+            ParsekLog.ClockOverrideForTesting = () => clock;
+        }
+
+        public void Dispose()
+        {
+            GhostMapPresence.ResetCoverageSetsForTesting();
+            GhostMapPresence.ResetForTesting();
+            GhostTrajectoryPolylineRenderer.Clear();
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.ResetRateLimitsForTesting();
+            ParsekLog.SuppressLogging = true;
+        }
+
+        // =====================================================================
+        // Pure deletion-safety predicate (RecordingId domain)
+        // =====================================================================
+
+        [Fact]
+        public void IsLegacyOwnedLegCoveredByDeletion_DirectorOwned_Covered()
+        {
+            // A legacy-owned recording also in the director-owned set keeps its proto-line/icon suppression
+            // after the legacy publish is deleted (the director-owned set still grants it). Covered.
+            var directorOwned = new HashSet<string>(StringComparer.Ordinal) { "rec-director" };
+            var protoLess = new HashSet<string>(StringComparer.Ordinal);
+
+            Assert.True(GhostMapPresence.IsLegacyOwnedLegCoveredByDeletion(
+                "rec-director", directorOwned, protoLess));
+        }
+
+        [Fact]
+        public void IsLegacyOwnedLegCoveredByDeletion_ProtoLess_Covered()
+        {
+            // A pid-0 / proto-less legacy-owned recording has NO proto to suppress, and the kept walk draws
+            // it independent of ownership, so dropping the legacy ownership is invisible. Covered.
+            var directorOwned = new HashSet<string>(StringComparer.Ordinal);
+            var protoLess = new HashSet<string>(StringComparer.Ordinal) { "rec-atmo" };
+
+            Assert.True(GhostMapPresence.IsLegacyOwnedLegCoveredByDeletion(
+                "rec-atmo", directorOwned, protoLess));
+        }
+
+        [Fact]
+        public void IsLegacyOwnedLegCoveredByDeletion_ProtoBearingNotDirectorOwned_FIRES()
+        {
+            // NON-VACUITY: a legacy-owned recording in NEITHER set is proto-BEARING (not pid-0) AND not
+            // director-owned -> deleting the legacy ownership loses its suppression (double-draw). The
+            // deletion BLOCKER the gate exists to surface.
+            var directorOwned = new HashSet<string>(StringComparer.Ordinal) { "rec-other-director" };
+            var protoLess = new HashSet<string>(StringComparer.Ordinal) { "rec-other-atmo" };
+
+            Assert.False(GhostMapPresence.IsLegacyOwnedLegCoveredByDeletion(
+                "rec-blocker", directorOwned, protoLess));
+        }
+
+        [Fact]
+        public void IsLegacyOwnedLegCoveredByDeletion_NullOrEmpty_NeverFlagged()
+        {
+            // A null/empty id is not a real legacy-owned leg; never flag it (would be a false anomaly).
+            Assert.True(GhostMapPresence.IsLegacyOwnedLegCoveredByDeletion(null, null, null));
+            Assert.True(GhostMapPresence.IsLegacyOwnedLegCoveredByDeletion("", null, null));
+        }
+
+        // =====================================================================
+        // End-to-end assertion seam (legacy-owned set + director-owned view)
+        // =====================================================================
+
+        [Fact]
+        public void AssertLegacyOwnedLegsCovered_ProtoBearingNotDirectorOwned_FIRES()
+        {
+            // A legacy-owned recording that is NOT director-owned and NOT proto-less must fire: the
+            // deletion-blocker case where the legacy publish granted suppression nothing else covers.
+            GhostMapPresence.SetLegacyOwnedForTesting("rec-blocker", legacyOwned: true);
+            // No director-owned publish, no proto-less coverage for rec-blocker.
+
+            var uncovered = new List<string>();
+            GhostMapPresence.AssertLegacyOwnedLegsCovered(
+                (recId, doCount, plCount, loCount) => uncovered.Add(recId));
+
+            Assert.Contains("rec-blocker", uncovered);
+        }
+
+        [Fact]
+        public void AssertLegacyOwnedLegsCovered_DirectorOwned_DoesNotFire()
+        {
+            // A legacy-owned recording ALSO published into the director-owned set (the same-frame view from
+            // GhostTrajectoryPolylineRenderer) is covered - no fire.
+            GhostMapPresence.SetLegacyOwnedForTesting("rec-director", legacyOwned: true);
+            GhostTrajectoryPolylineRenderer.SetOwnershipPublishForTesting(
+                "rec-director", inDirectorOwnedSet: true, inLegacySet: true);
+
+            var uncovered = new List<string>();
+            GhostMapPresence.AssertLegacyOwnedLegsCovered(
+                (recId, doCount, plCount, loCount) => uncovered.Add(recId));
+
+            Assert.Empty(uncovered);
+        }
+
+        [Fact]
+        public void AssertLegacyOwnedLegsCovered_ProtoLess_DoesNotFire()
+        {
+            // A pid-0 legacy-owned recording folded into the proto-less coverage set is covered - no fire.
+            GhostMapPresence.SetLegacyOwnedForTesting("rec-atmo", legacyOwned: true);
+            GhostMapPresence.SetFrameCoverageForTesting("rec-atmo", drawn: true, protoLess: true);
+
+            var uncovered = new List<string>();
+            GhostMapPresence.AssertLegacyOwnedLegsCovered(
+                (recId, doCount, plCount, loCount) => uncovered.Add(recId));
+
+            Assert.Empty(uncovered);
+        }
+
+        [Fact]
+        public void AssertLegacyOwnedLegsCovered_MixedFrame_FiresOnlyForTheBlocker()
+        {
+            // A realistic frame: a director-owned leg, a proto-less leg, and one proto-bearing-not-owned
+            // blocker - all three legacy-owned. Only the blocker fires.
+            GhostMapPresence.SetLegacyOwnedForTesting("rec-director", legacyOwned: true);
+            GhostTrajectoryPolylineRenderer.SetOwnershipPublishForTesting(
+                "rec-director", inDirectorOwnedSet: true, inLegacySet: true);
+
+            GhostMapPresence.SetLegacyOwnedForTesting("rec-atmo", legacyOwned: true);
+            GhostMapPresence.SetFrameCoverageForTesting("rec-atmo", drawn: true, protoLess: true);
+
+            GhostMapPresence.SetLegacyOwnedForTesting("rec-blocker", legacyOwned: true);
+
+            var uncovered = new List<string>();
+            GhostMapPresence.AssertLegacyOwnedLegsCovered(
+                (recId, doCount, plCount, loCount) => uncovered.Add(recId));
+
+            Assert.Single(uncovered);
+            Assert.Equal("rec-blocker", uncovered[0]);
+        }
+
+        [Fact]
+        public void AssertLegacyOwnedLegsCovered_CountsReportSetSizes()
+        {
+            // The callback's counts feed the anomaly body. directorOwned=1, protoLess=1, legacyOwned=3
+            // (the three legacy-owned recordings stamped below).
+            GhostMapPresence.SetLegacyOwnedForTesting("rec-director", legacyOwned: true);
+            GhostTrajectoryPolylineRenderer.SetOwnershipPublishForTesting(
+                "rec-director", inDirectorOwnedSet: true, inLegacySet: true);
+            GhostMapPresence.SetLegacyOwnedForTesting("rec-atmo", legacyOwned: true);
+            GhostMapPresence.SetFrameCoverageForTesting("rec-atmo", drawn: true, protoLess: true);
+            GhostMapPresence.SetLegacyOwnedForTesting("rec-blocker", legacyOwned: true);
+
+            int doCount = -1, plCount = -1, loCount = -1;
+            GhostMapPresence.AssertLegacyOwnedLegsCovered(
+                (recId, d, p, l) => { doCount = d; plCount = p; loCount = l; });
+
+            Assert.Equal(1, doCount);   // director-owned set
+            Assert.Equal(1, plCount);   // proto-less coverage set
+            Assert.Equal(3, loCount);   // legacy-owned set
+        }
+
+        [Fact]
+        public void AssertLegacyOwnedLegsCovered_NothingLegacyOwned_NoOp()
+        {
+            int fires = 0;
+            GhostMapPresence.AssertLegacyOwnedLegsCovered((recId, d, p, l) => fires++);
+            Assert.Equal(0, fires);
+        }
+
+        [Fact]
+        public void NoteLegacyOwnedLeg_PopulatesTheSet_ProtoBearingFires()
+        {
+            // The live producer semantics: NoteLegacyOwnedLeg adds the recId to the legacy-owned set. With
+            // no director-owned publish and no proto-less coverage, the proto-bearing leg is the blocker.
+            GhostMapPresence.NoteLegacyOwnedLeg("rec-blocker");
+
+            var uncovered = new List<string>();
+            GhostMapPresence.AssertLegacyOwnedLegsCovered(
+                (recId, d, p, l) => uncovered.Add(recId));
+            Assert.Contains("rec-blocker", uncovered);
+        }
+
+        [Fact]
+        public void NoteLegacyOwnedLeg_NullOrEmpty_NoOp()
+        {
+            GhostMapPresence.NoteLegacyOwnedLeg(null);
+            GhostMapPresence.NoteLegacyOwnedLeg("");
+            int fires = 0;
+            GhostMapPresence.AssertLegacyOwnedLegsCovered((recId, d, p, l) => fires++);
+            Assert.Equal(0, fires);
+        }
+
+        [Fact]
+        public void ClearFrameCoverageSets_EmptiesTheLegacyOwnedSet()
+        {
+            GhostMapPresence.NoteLegacyOwnedLeg("rec-blocker");
+            GhostMapPresence.ClearFrameCoverageSets();
+
+            int fires = 0;
+            GhostMapPresence.AssertLegacyOwnedLegsCovered((recId, d, p, l) => fires++);
+            Assert.Equal(0, fires); // legacy-owned set empty after the per-frame clear
+        }
+
+        // =====================================================================
+        // WARP-STABLE rate-limit key guard (the #1063 lesson)
+        // =====================================================================
+
+        [Fact]
+        public void PassesPerRecIdRateLimit_WarpAdvancingUtSameRecId_OnePassPerWindow()
+        {
+            // The anomaly's rate-limit KEY is the RecordingId - WARP-STABLE. Across N frames the UT / leg
+            // detail ADVANCE (they live in the anomaly BODY, fed to EmitAnomaly), but the held wall clock
+            // keeps a persistent blocker (same recId) to exactly ONE pass per window. Clock held fixed;
+            // vary the simulated UT every "frame" to mimic warp churn.
+            var lastEmit = new Dictionary<string, double>(StringComparer.Ordinal);
+            double realtime = 5000.0; // wall clock held fixed across the burst
+
+            int passes = 0;
+            for (int frame = 0; frame < 50; frame++)
+            {
+                // The UT advances each frame (warp), but it is NOT the key - only the recId is.
+                double simulatedUT = 1000.0 + frame * 10.0;
+                if (MapRenderProbe.PassesPerRecIdRateLimit(
+                        lastEmit, "rec-persistent-blocker", realtime, minIntervalSeconds: 1.0))
+                {
+                    passes++;
+                }
+                // (simulatedUT is the body content the real callback would format; referenced so the intent
+                // is explicit that it varies while the key does not.)
+                Assert.True(simulatedUT >= 1000.0);
+            }
+
+            // Exactly one pass proves the warp-advancing UT is in the BODY, not the KEY.
+            Assert.Equal(1, passes);
+        }
+
+        [Fact]
+        public void PassesPerRecIdRateLimit_AfterIntervalElapses_PassesAgain()
+        {
+            // Advancing the wall clock past the interval re-opens the gate for the same recId.
+            var lastEmit = new Dictionary<string, double>(StringComparer.Ordinal);
+
+            Assert.True(MapRenderProbe.PassesPerRecIdRateLimit(
+                lastEmit, "rec-blocker", realtime: 100.0, minIntervalSeconds: 1.0));
+            // Still inside the window -> blocked.
+            Assert.False(MapRenderProbe.PassesPerRecIdRateLimit(
+                lastEmit, "rec-blocker", realtime: 100.5, minIntervalSeconds: 1.0));
+            // Past the window -> passes again.
+            Assert.True(MapRenderProbe.PassesPerRecIdRateLimit(
+                lastEmit, "rec-blocker", realtime: 101.5, minIntervalSeconds: 1.0));
+        }
+
+        [Fact]
+        public void PassesPerRecIdRateLimit_DistinctRecIds_EachPassesOncePerWindow()
+        {
+            // Two distinct blockers in the same window each emit once (the key is per-recId, not global).
+            var lastEmit = new Dictionary<string, double>(StringComparer.Ordinal);
+            double realtime = 7000.0;
+
+            Assert.True(MapRenderProbe.PassesPerRecIdRateLimit(lastEmit, "rec-a", realtime, 1.0));
+            Assert.True(MapRenderProbe.PassesPerRecIdRateLimit(lastEmit, "rec-b", realtime, 1.0));
+            // Both re-blocked within the window.
+            Assert.False(MapRenderProbe.PassesPerRecIdRateLimit(lastEmit, "rec-a", realtime, 1.0));
+            Assert.False(MapRenderProbe.PassesPerRecIdRateLimit(lastEmit, "rec-b", realtime, 1.0));
+        }
+
+        [Fact]
+        public void PassesPerRecIdRateLimit_NullDictOrEmptyRecId_NeverPasses()
+        {
+            var lastEmit = new Dictionary<string, double>(StringComparer.Ordinal);
+            Assert.False(MapRenderProbe.PassesPerRecIdRateLimit(null, "rec", 1.0, 1.0));
+            Assert.False(MapRenderProbe.PassesPerRecIdRateLimit(lastEmit, null, 1.0, 1.0));
+            Assert.False(MapRenderProbe.PassesPerRecIdRateLimit(lastEmit, "", 1.0, 1.0));
+        }
+    }
+}

--- a/Source/Parsek/Display/GhostTrajectoryPolylineRenderer.cs
+++ b/Source/Parsek/Display/GhostTrajectoryPolylineRenderer.cs
@@ -269,6 +269,17 @@ namespace Parsek.Display
         }
 
         /// <summary>
+        /// Phase 8e S3a: a read-only view of this frame's director-owned leg set
+        /// (<see cref="directorOwnedLegRecordings"/>), consumed by
+        /// <c>GhostMapPresence.AssertLegacyOwnedLegsCovered</c> to prove every legacy-owned leg is either
+        /// director-owned OR proto-less before the S3b deletion of <see cref="activeLegRecordings"/>.
+        /// Already RecordingId-keyed, so the gate needs NO pid bridge. The set is populated + cleared by
+        /// the Driver's per-frame decide walk on the same lifecycle as the legacy-owned set, so a
+        /// same-frame read pairs correctly. Diagnostic-only; this accessor adds NO live render behavior.
+        /// </summary>
+        internal static ICollection<string> DirectorOwnedLegRecordingsThisFrame => directorOwnedLegRecordings;
+
+        /// <summary>
         /// Test-only accessor: returns the live cache dictionary so the
         /// xUnit suite can assert on cache contents after a refresh.
         /// </summary>
@@ -2195,7 +2206,14 @@ namespace Parsek.Display
                         // COVERAGE set, the Director's genuine accounting of it via this non-proto walk.
                         // Gated on tracing so default play pays nothing; no render/draw effect.
                         if (MapRenderTrace.IsEnabled)
+                        {
                             GhostMapPresence.NoteDrawnRecordingCoverage(rec.RecordingId, ghostPid);
+                            // Phase 8e S3a (PURELY ADDITIVE): mirror the LEGACY ownership-publish (the
+                            // activeLegRecordings.Add directly above) so the S3a gate can prove S3b's
+                            // deletion of activeLegRecordings drops nothing. Same IsEnabled gate; no
+                            // render/draw effect.
+                            GhostMapPresence.NoteLegacyOwnedLeg(rec.RecordingId);
+                        }
                     }
                 }
 

--- a/Source/Parsek/GhostMapPresence.cs
+++ b/Source/Parsek/GhostMapPresence.cs
@@ -961,6 +961,24 @@ namespace Parsek
             new HashSet<string>(StringComparer.Ordinal);
 
         /// <summary>
+        /// Phase 8e S3a (PURELY ADDITIVE diagnostics): every committed recording the autonomous polyline
+        /// walk published into <c>activeLegRecordings</c> (the LEGACY ownership-publish) THIS frame. S3b
+        /// deletes <c>activeLegRecordings</c>, collapsing
+        /// <c>GhostTrajectoryPolylineRenderer.ResolveNonOrbitalLegOwnership</c> to the director-owned set
+        /// only. The DRAW is not at risk (the kept walk draws a pid-0 leg regardless of ownership); the
+        /// only exposure is a PROTO-BEARING leg owned via the legacy set but NOT director-owned, which
+        /// would lose its proto-line/icon SUPPRESSION (a double-draw artifact). This set lets the probe
+        /// PROVE, before the deletion, that every legacy-owned recording is EITHER director-owned OR pid-0
+        /// (proto-less, nothing to suppress). Populated by <see cref="NoteLegacyOwnedLeg"/> from the
+        /// polyline Driver's decide walk at the <c>activeLegRecordings.Add</c> site, gated by the Driver
+        /// on <see cref="MapRenderTrace.IsEnabled"/>; cleared by <see cref="ClearFrameCoverageSets"/> on
+        /// the same per-frame lifecycle as the S0 sets. Diagnostic-only; nothing in the live render path
+        /// reads it.
+        /// </summary>
+        private static readonly HashSet<string> legacyOwnedRecordingIdsThisFrame =
+            new HashSet<string>(StringComparer.Ordinal);
+
+        /// <summary>
         /// Orbit segment time bounds per ghost vessel PID. Used by GhostOrbitArcPatch
         /// to clip the orbit line to only the visible arc (between segment startUT and endUT).
         /// Only populated for segment-based ghosts — terminal-orbit ghosts render the full ellipse.
@@ -9141,6 +9159,9 @@ namespace Parsek
         {
             drawnRecordingIdsThisFrame.Clear();
             protoLessCoverageRecordingIdsThisFrame.Clear();
+            // S3a: the legacy-owned set rides the SAME per-frame lifecycle as the S0 sets, so it reflects
+            // only the recordings this frame's walk published into activeLegRecordings.
+            legacyOwnedRecordingIdsThisFrame.Clear();
         }
 
         /// <summary>
@@ -9163,6 +9184,22 @@ namespace Parsek
             // which keeps the assertion non-vacuous.
             if (ghostPid == 0)
                 protoLessCoverageRecordingIdsThisFrame.Add(recordingId);
+        }
+
+        /// <summary>
+        /// Phase 8e S3a: records that the autonomous polyline walk published
+        /// <paramref name="recordingId"/> into the LEGACY ownership set (<c>activeLegRecordings</c>) this
+        /// frame. Called from the Driver's decide walk at the <c>activeLegRecordings.Add</c> site, already
+        /// gated by the Driver on <see cref="MapRenderTrace.IsEnabled"/>. Distinct from
+        /// <see cref="NoteDrawnRecordingCoverage"/> (S0 DRAWN set): this set mirrors specifically the
+        /// LEGACY-OWNERSHIP publish that S3b deletes, so the S3a gate can prove the deletion drops nothing.
+        /// Diagnostic-only; no render/draw effect.
+        /// </summary>
+        internal static void NoteLegacyOwnedLeg(string recordingId)
+        {
+            if (string.IsNullOrEmpty(recordingId))
+                return;
+            legacyOwnedRecordingIdsThisFrame.Add(recordingId);
         }
 
         /// <summary>
@@ -9228,6 +9265,75 @@ namespace Parsek
             }
         }
 
+        // ---- Phase 8e S3a Gate: legacy-ownership deletion safety (PURELY ADDITIVE) ----
+
+        /// <summary>
+        /// PURE S3a gate predicate: is a LEGACY-owned leg (a recording the autonomous walk published into
+        /// <c>activeLegRecordings</c> this frame) COVERED by the planned S3b deletion of that legacy
+        /// publish? S3b collapses
+        /// <c>GhostTrajectoryPolylineRenderer.ResolveNonOrbitalLegOwnership</c> to the director-owned set
+        /// only. A legacy-owned leg survives the deletion iff it is EITHER in
+        /// <paramref name="directorOwnedRecIds"/> (the same-frame director-owned set still grants the
+        /// proto-line/icon SUPPRESSION the legacy set granted) OR pid-0 / proto-less (in
+        /// <paramref name="protoLessRecIds"/> - there is NO proto to suppress, and the kept walk draws it
+        /// regardless of ownership, so dropping the legacy ownership is invisible). A legacy-owned leg in
+        /// NEITHER set is proto-BEARING AND not director-owned: deleting the legacy ownership would lose
+        /// its suppression and produce the double-draw artifact - the deletion BLOCKER. Expressed entirely
+        /// in the RecordingId domain (both the director-owned set and the legacy set are RecordingId-keyed,
+        /// so NO pid bridge is needed). Unit-testable (all three inputs passed in), so it FIRES for a real
+        /// blocker and PASSES for a covered leg.
+        /// </summary>
+        internal static bool IsLegacyOwnedLegCoveredByDeletion(
+            string legacyOwnedRecId,
+            ICollection<string> directorOwnedRecIds,
+            ICollection<string> protoLessRecIds)
+        {
+            if (string.IsNullOrEmpty(legacyOwnedRecId))
+                return true; // a null/empty id is not a real legacy-owned leg; never flag it
+            if (directorOwnedRecIds != null && directorOwnedRecIds.Contains(legacyOwnedRecId))
+                return true;
+            if (protoLessRecIds != null && protoLessRecIds.Contains(legacyOwnedRecId))
+                return true;
+            return false;
+        }
+
+        /// <summary>
+        /// Runs the S3a deletion-safety assertion over this frame's legacy-owned set, invoking
+        /// <paramref name="onUncovered"/> once per legacy-owned recording that is NEITHER director-owned
+        /// (this frame, via <see cref="Parsek.Display.GhostTrajectoryPolylineRenderer.DirectorOwnedLegRecordingsThisFrame"/>
+        /// - already RecordingId-keyed, no pid bridge) NOR in the proto-less coverage set. Each such
+        /// recording is the deletion BLOCKER: deleting <c>activeLegRecordings</c> (S3b) would drop its
+        /// proto-line/icon suppression. A CLEAN run (zero of these) is the S3b green-light. The callback
+        /// receives <c>(recordingId, directorOwnedCount, protoLessCount, legacyOwnedCount)</c> for the
+        /// anomaly line. Diagnostic-only; the caller gates on <see cref="MapRenderTrace.IsEnabled"/>.
+        /// No-ops when nothing was legacy-owned this frame.
+        /// </summary>
+        internal static void AssertLegacyOwnedLegsCovered(
+            System.Action<string, int, int, int> onUncovered)
+        {
+            if (legacyOwnedRecordingIdsThisFrame.Count == 0)
+                return;
+
+            // The same-frame director-owned set is ALREADY RecordingId-keyed (no pid bridge needed - the
+            // S3a deletion-safety question is purely "is this legacy-owned RecordingId also director-owned
+            // this frame?"). Read it as a read-only view.
+            ICollection<string> directorOwned =
+                Parsek.Display.GhostTrajectoryPolylineRenderer.DirectorOwnedLegRecordingsThisFrame;
+            int directorOwnedCount = directorOwned != null ? directorOwned.Count : 0;
+
+            foreach (string recId in legacyOwnedRecordingIdsThisFrame)
+            {
+                if (IsLegacyOwnedLegCoveredByDeletion(
+                        recId, directorOwned, protoLessCoverageRecordingIdsThisFrame))
+                    continue;
+                onUncovered?.Invoke(
+                    recId,
+                    directorOwnedCount,
+                    protoLessCoverageRecordingIdsThisFrame.Count,
+                    legacyOwnedRecordingIdsThisFrame.Count);
+            }
+        }
+
         /// <summary>Test-only seam: stamp this frame's drawn / proto-less coverage sets so
         /// <see cref="AssertDrawnRecordingsAccounted"/> and the pid-bridge can be exercised end-to-end
         /// from xUnit (the real producer is the Unity-coupled Driver walk). Mirrors the live
@@ -9250,13 +9356,26 @@ namespace Parsek
             else vesselPidToRecordingId[pid] = recordingId;
         }
 
-        /// <summary>Test-only: clear all S0 coverage-closure state (the two frame sets + the scratch),
-        /// so a test starts from a known-empty accounting.</summary>
+        /// <summary>Test-only seam (S3a): stamp this frame's legacy-owned set so
+        /// <see cref="AssertLegacyOwnedLegsCovered"/> can be exercised end-to-end from xUnit (the real
+        /// producer is the Unity-coupled Driver walk). Mirrors the live <see cref="NoteLegacyOwnedLeg"/>
+        /// semantics.</summary>
+        internal static void SetLegacyOwnedForTesting(string recordingId, bool legacyOwned)
+        {
+            if (string.IsNullOrEmpty(recordingId))
+                return;
+            if (legacyOwned) legacyOwnedRecordingIdsThisFrame.Add(recordingId);
+            else legacyOwnedRecordingIdsThisFrame.Remove(recordingId);
+        }
+
+        /// <summary>Test-only: clear all coverage-closure state (the S0 frame sets + the scratch + the
+        /// S3a legacy-owned set), so a test starts from a known-empty accounting.</summary>
         internal static void ResetCoverageSetsForTesting()
         {
             drawnRecordingIdsThisFrame.Clear();
             protoLessCoverageRecordingIdsThisFrame.Clear();
             protoBearingRecordingIdScratch.Clear();
+            legacyOwnedRecordingIdsThisFrame.Clear();
         }
 
         internal static bool TryGetCommittedRecordingById(

--- a/Source/Parsek/InGameTests/ExtendedRuntimeTests.cs
+++ b/Source/Parsek/InGameTests/ExtendedRuntimeTests.cs
@@ -2111,4 +2111,71 @@ namespace Parsek.InGameTests
                 "director drove the icon => None (not a floor frame)");
         }
     }
+
+    // ════════════════════════════════════════════════════════════════
+    //  Phase 8e S3a legacy-ownership deletion gate (PURELY ADDITIVE)
+    // ════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// Exercises the S3a deletion-safety gate under the LIVE KSP runtime/JIT (the pure helper logic is
+    /// covered by xUnit; this proves the static gate + the same-frame director-owned view from
+    /// GhostTrajectoryPolylineRenderer run end-to-end in-game). Drives the seam DETERMINISTICALLY via the
+    /// test stamps - no live ghost / no full Driver frame needed - so it is robust regardless of what is on
+    /// the map. Restores the coverage + ownership state on exit. A full scene-driven assertion (live ghosts
+    /// through the polyline walk, watching for the uncovered-legacy-owned-leg anomaly) is left as a manual
+    /// tracing-on playtest, noted in the S3a report.
+    /// </summary>
+    public class MapRenderS3CoverageInGameTests
+    {
+        [InGameTest(Category = "GhostMapOrbits", Scene = GameScenes.FLIGHT,
+            Description = "S3a: the deletion gate covers director-owned + proto-less legacy legs; fires for a proto-bearing-not-owned blocker")]
+        public void DeletionGateCoversLegacyOwnedSet()
+        {
+            // Snapshot live coverage + ownership state so the synthetic stamps below do not perturb a real
+            // frame. We add synthetic ids and clear them again on exit.
+            GhostMapPresence.ResetCoverageSetsForTesting();
+            try
+            {
+                // A director-owned legacy leg: covered (the director-owned set still grants suppression).
+                GhostMapPresence.SetLegacyOwnedForTesting("s3-ingame-director", legacyOwned: true);
+                Parsek.Display.GhostTrajectoryPolylineRenderer.SetOwnershipPublishForTesting(
+                    "s3-ingame-director", inDirectorOwnedSet: true, inLegacySet: true);
+                // A proto-less legacy leg: covered (nothing to suppress; the kept walk draws it anyway).
+                GhostMapPresence.SetLegacyOwnedForTesting("s3-ingame-atmo", legacyOwned: true);
+                GhostMapPresence.SetFrameCoverageForTesting("s3-ingame-atmo", drawn: true, protoLess: true);
+                // A blocker: legacy-owned, proto-BEARING (NOT in the proto-less set), NOT director-owned.
+                GhostMapPresence.SetLegacyOwnedForTesting("s3-ingame-blocker", legacyOwned: true);
+
+                // Direct predicate exercise under the live JIT (the same-frame director-owned view).
+                var directorOwned =
+                    Parsek.Display.GhostTrajectoryPolylineRenderer.DirectorOwnedLegRecordingsThisFrame;
+                InGameAssert.IsTrue(
+                    GhostMapPresence.IsLegacyOwnedLegCoveredByDeletion(
+                        "s3-ingame-director", directorOwned, null),
+                    "director-owned legacy leg is covered");
+
+                var uncovered = new List<string>();
+                GhostMapPresence.AssertLegacyOwnedLegsCovered(
+                    (recId, doCount, plCount, loCount) => uncovered.Add(recId));
+
+                ParsekLog.Info("TestRunner",
+                    $"S3a gate in-game: uncovered=[{string.Join(",", uncovered)}]");
+
+                InGameAssert.IsFalse(uncovered.Contains("s3-ingame-director"),
+                    "director-owned legacy leg must not fire");
+                InGameAssert.IsFalse(uncovered.Contains("s3-ingame-atmo"),
+                    "proto-less legacy leg must not fire");
+                InGameAssert.IsTrue(uncovered.Contains("s3-ingame-blocker"),
+                    "a proto-bearing-not-owned legacy leg must fire (non-vacuity)");
+                InGameAssert.AreEqual(1, uncovered.Count,
+                    "exactly the blocker is uncovered");
+            }
+            finally
+            {
+                Parsek.Display.GhostTrajectoryPolylineRenderer.SetOwnershipPublishForTesting(
+                    "s3-ingame-director", inDirectorOwnedSet: false, inLegacySet: false);
+                GhostMapPresence.ResetCoverageSetsForTesting();
+            }
+        }
+    }
 }

--- a/Source/Parsek/MapRenderProbe.cs
+++ b/Source/Parsek/MapRenderProbe.cs
@@ -97,6 +97,13 @@ namespace Parsek
         private const double UnaccountedAnomalyMinIntervalSeconds = 1.0;
         private readonly Dictionary<string, double> lastUnaccountedEmitRealtime =
             new Dictionary<string, double>(System.StringComparer.Ordinal);
+        // Phase 8e S3a: soft rate-limit timestamps for the per-RECORDING uncovered-legacy-owned-leg
+        // anomaly (the S3b deletion-safety gate). Keyed by RecordingId (the legacy-owned set is
+        // RecordingId-keyed). A PERSISTENT condition (would fire every frame), so throttled to one line
+        // per recording per second; cleared on scene change. Sibling of lastUnaccountedEmitRealtime.
+        private const double UncoveredAnomalyMinIntervalSeconds = 1.0;
+        private readonly Dictionary<string, double> lastUncoveredEmitRealtime =
+            new Dictionary<string, double>(System.StringComparer.Ordinal);
         // Pids that have already had their Tier-A FirstPosition event emitted on
         // the first end-of-frame truth read for that pid. Cleared on scene change
         // alongside the other per-pid state, so re-entering a scene re-emits a
@@ -158,6 +165,7 @@ namespace Parsek
             lastPolylineOverlapEmitRealtime.Clear();
             firstPositionEmittedPids.Clear();
             lastUnaccountedEmitRealtime.Clear();
+            lastUncoveredEmitRealtime.Clear();
         }
 
         void LateUpdate()
@@ -215,6 +223,17 @@ namespace Parsek
             // LateUpdate is already IsEnabled-gated; the per-recId soft rate-limit below keeps a
             // persistent unaccounted recording from flooding the log (the condition holds every frame).
             AssertDrawnRecordingsAccounted(currentUT, realtime);
+
+            // --- Phase 8e S3a gate: legacy-ownership deletion-safety assertion ---
+            // For EVERY recording the autonomous walk published into the LEGACY ownership set
+            // (activeLegRecordings) this frame, confirm it is COVERED by S3b's planned deletion of that
+            // set: it is EITHER director-owned this frame (the director-owned set still grants the
+            // proto-line/icon suppression) OR proto-less / pid-0 (nothing to suppress; the kept walk draws
+            // it regardless of ownership). A legacy-owned recording in NEITHER is the deletion BLOCKER (a
+            // proto-bearing leg that would lose suppression -> double-draw). A CLEAN run is the S3b
+            // green-light. The whole LateUpdate is IsEnabled-gated; the per-recId soft rate-limit below
+            // keeps a persistent blocker from flooding the log.
+            AssertLegacyOwnedLegsCovered(currentUT, realtime);
         }
 
         private void AssertDrawnRecordingsAccounted(double currentUT, double realtime)
@@ -247,6 +266,58 @@ namespace Parsek
                 && realtime - last < UnaccountedAnomalyMinIntervalSeconds)
                 return false;
             lastUnaccountedEmitRealtime[recId] = realtime;
+            return true;
+        }
+
+        private void AssertLegacyOwnedLegsCovered(double currentUT, double realtime)
+        {
+            GhostMapPresence.AssertLegacyOwnedLegsCovered(
+                (recId, directorOwnedCount, protoLessCount, legacyOwnedCount) =>
+                {
+                    if (!PassesUncoveredRateLimit(recId, realtime))
+                        return;
+                    // Tier-C anomaly (S3a). Keyed (surface=Polyline) by the uncovered legacy-owned
+                    // RecordingId (carried in the prefix pid= slot, the marker-surface convention).
+                    // WARP-STABLE key: recId ONLY - the frame / UT / leg detail lives in the BODY, never
+                    // the key (#1063). A CLEAN run (zero of these) is the S3b deletion green-light: every
+                    // legacy-owned leg is either director-owned or proto-less, so deleting
+                    // activeLegRecordings drops no suppression.
+                    MapRenderTrace.EmitAnomaly(
+                        MapRenderTrace.RenderSurface.Polyline, recId, currentUT, currentUT,
+                        "uncovered-legacy-owned-leg",
+                        string.Format(ic,
+                            "recId={0} legacyOwned=true directorOwned=false protoLess=false "
+                            + "| directorOwnedRecs={1} protoLessRecs={2} legacyOwnedRecs={3}",
+                            recId, directorOwnedCount, protoLessCount, legacyOwnedCount));
+                });
+        }
+
+        private bool PassesUncoveredRateLimit(string recId, double realtime)
+            => PassesPerRecIdRateLimit(
+                lastUncoveredEmitRealtime, recId, realtime, UncoveredAnomalyMinIntervalSeconds);
+
+        /// <summary>
+        /// PURE per-RecordingId soft rate-limit (S3a): returns true at most once per
+        /// <paramref name="minIntervalSeconds"/> wall-clock window for a given
+        /// <paramref name="recId"/>, stamping <paramref name="lastEmitRealtime"/> when it passes. The KEY
+        /// is the RecordingId only - WARP-STABLE: across N frames where the UT / leg detail advance (those
+        /// live in the anomaly BODY), the held wall clock keeps a persistent blocker to ONE line per
+        /// window (#1063). Unit-testable (the dict + clock are passed in), so the warp-stable-key guard
+        /// can be exercised without the Unity probe. Mirrors the S0 PassesUnaccountedRateLimit semantics.
+        /// </summary>
+        internal static bool PassesPerRecIdRateLimit(
+            Dictionary<string, double> lastEmitRealtime,
+            string recId,
+            double realtime,
+            double minIntervalSeconds)
+        {
+            if (lastEmitRealtime == null || string.IsNullOrEmpty(recId))
+                return false;
+            double last;
+            if (lastEmitRealtime.TryGetValue(recId, out last)
+                && realtime - last < minIntervalSeconds)
+                return false;
+            lastEmitRealtime[recId] = realtime;
             return true;
         }
 


### PR DESCRIPTION
## Phase 8e, slice S3a - the sharpened gate before deleting the legacy polyline ownership (additive)

S3 deletes the legacy polyline ownership publish \`activeLegRecordings\`. **S3a (this slice) adds the gate that PROVES the deletion drops nothing, before S3b deletes.** Purely additive: no deletion, no render/draw behavior change (byte-identical path); a new diagnostic gate gated behind \`mapRenderTracing\`, warp-stable key. Mirrors the S0 instruments. Stacked on S0 (#1066).

### Why S0 was not sharp enough
The S0 assertion auto-accounts every pid-0 draw (it builds the proto-less coverage set FROM the walk's own draws), so it confirms a draw *categorization*, not that \`activeLegRecordings\`'s specific contribution to the ownership union is redundant. The real deletion risk is narrow: \`WillLegDraw\` never reads ownership (a pid-0 leg still draws via the kept walk), so the only exposure is a **proto-bearing** leg owned via \`activeLegRecordings\` but NOT in \`directorOwnedLegRecordings\` - it would lose proto-line/icon suppression (the double-draw artifact 8b killed).

### The gate
Proves: every recording in \`activeLegRecordings\` this frame is either in \`directorOwnedLegRecordings\` OR is pid-0 (proto-less). A proto-bearing legacy-owned-but-not-director-owned leg is the **blocker**.
- \`GhostMapPresence.legacyOwnedRecordingIdsThisFrame\` (new per-frame set; populated by the walk via \`NoteLegacyOwnedLeg\`, gated on \`IsEnabled\`).
- Pure \`IsLegacyOwnedLegCoveredByDeletion\` + \`AssertLegacyOwnedLegsCovered\`, reading the same-frame \`DirectorOwnedLegRecordingsThisFrame\` (RecordingId-keyed, read-only; no pid bridge).
- \`MapRenderProbe\` end-of-frame call emitting the Tier-C \`uncovered-legacy-owned-leg\` anomaly (recId-keyed warp-stable, per-recId rate-limited). **Zero across a re-fly = the S3b green-light.**

### Process + tests
Scoping (SPLIT: S3a gate -> S3b delete) -> implement -> last-review read of the crux (predicate fires for the real blocker, same-frame director-owned pairing correct). S0 instruments untouched (complementary). Build clean; full suite **13574 passed** (+17 S3a xUnit: predicate fires for the proto-bearing blocker / passes for director-owned + pid-0, the assert end-to-end via seams, a warp-stable-key guard; + 1 in-game seam test). ERS/ELS GrepAudit clean.

### Validation ask (before S3b deletes)
With \`mapRenderDirectorDrive\` + \`mapRenderTracing\` ON, re-fly s15 "Duna One" (looped re-aim, the historical hot spot) + a non-looped atmospheric mission through landing, in map view. Success = **zero \`uncovered-legacy-owned-leg\`** anomalies (and the S0 \`unaccounted-drawn-recording\` stays zero). That green-lights S3b (delete \`activeLegRecordings\`).