### PR TITLE
Improve in-game test runner UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,9 @@ All notable changes to Parsek are documented here.
 - The Logistics window now keeps its size and position across scene changes (for example KSC to flight) instead of resetting to the default each time.
 - The route detail panel, the Create Route summary, and the Candidate row now show the per-run funds cost (net launch cost minus recovered credits) in Career for KSC-origin routes. Recovering the transport at the end of the recorded flight lowers the shown cost; an unrecovered transport shows the full launch cost.
 - Career KSC-origin supply routes now actually pay back the recovered transport cost. The gross launch cost is still charged at dispatch (you front the full build cost), and the recovered amount is credited back one cycle later, so the net funds effect of a steady-state cycle matches the displayed net. The credit reverses correctly on rewind and re-fly.
+- The in-game test runner window is now resizable: drag the bottom-right corner handle like the other Parsek windows. It also opens 100 px taller and will not shrink below that opening height.
+- Manual-only tests (the [single] scenarios you run by hand from the row play button) now show in yellow in the test runner, so they are easy to spot.
+- Removed the test runner's Export Results button. Results already auto-export to parsek-test-results.txt after every run, so the button was redundant.
 
 ### Bug Fixes
 

--- a/Source/Parsek.Tests/TestRunnerPresentationTests.cs
+++ b/Source/Parsek.Tests/TestRunnerPresentationTests.cs
@@ -88,6 +88,49 @@ namespace Parsek.Tests
         }
 
         [Fact]
+        public void IsManualOnly_SingleTest_ReturnsTrue()
+        {
+            // [single]: excluded from batch and not isolated -> must run by hand.
+            var test = new InGameTestInfo
+            {
+                AllowBatchExecution = false,
+                RestoreBatchFlightBaselineAfterExecution = false
+            };
+
+            Assert.True(TestRunnerPresentation.IsManualOnly(test));
+        }
+
+        [Fact]
+        public void IsManualOnly_IsolatedTest_ReturnsFalse()
+        {
+            // [isolated]: can run via Run All + Isolated / Run+, so not manual-only.
+            var test = new InGameTestInfo
+            {
+                AllowBatchExecution = false,
+                RestoreBatchFlightBaselineAfterExecution = true
+            };
+
+            Assert.False(TestRunnerPresentation.IsManualOnly(test));
+        }
+
+        [Fact]
+        public void IsManualOnly_BatchSafeTest_ReturnsFalse()
+        {
+            var test = new InGameTestInfo
+            {
+                AllowBatchExecution = true
+            };
+
+            Assert.False(TestRunnerPresentation.IsManualOnly(test));
+        }
+
+        [Fact]
+        public void IsManualOnly_NullTest_ReturnsFalse()
+        {
+            Assert.False(TestRunnerPresentation.IsManualOnly(null));
+        }
+
+        [Fact]
         public void BuildBatchModeNotice_FiltersOutIneligibleTests()
         {
             var tests = new List<InGameTestInfo>

--- a/Source/Parsek/InGameTests/InGameTestRunner.cs
+++ b/Source/Parsek/InGameTests/InGameTestRunner.cs
@@ -925,7 +925,7 @@ namespace Parsek.InGameTests
             // always reflects the latest state. Multi-scene history lives in
             // InGameTestInfo.ResultsByScene, which ResetResults preserves, so
             // the file accumulates across KSC / Flight / Tracking Station runs.
-            ExportResultsFile(auto: true);
+            ExportResultsFile();
         }
 
         private IEnumerator RestoreBatchFlightBaselineAfterExecution(InGameTestInfo test)
@@ -1855,14 +1855,11 @@ namespace Parsek.InGameTests
         private const string ResultsFileName = "parsek-test-results.txt";
 
         /// <summary>
-        /// Public entry point (manual Export button).
+        /// Writes the results report to the KSP root. Called automatically at
+        /// the end of every batch run (see <see cref="RunBatch"/>), so the file
+        /// always reflects the latest run; there is no manual export button.
         /// </summary>
-        internal void ExportResultsFile()
-        {
-            ExportResultsFile(auto: false);
-        }
-
-        private void ExportResultsFile(bool auto)
+        private void ExportResultsFile()
         {
             try
             {
@@ -1872,7 +1869,7 @@ namespace Parsek.InGameTests
                     exportScene: HighLogic.LoadedScene);
                 File.WriteAllText(path, string.Join("\n", lines) + "\n");
                 ParsekLog.Info(Tag,
-                    $"Test results written to {path} ({(auto ? "auto after run" : "manual export")})");
+                    $"Test results written to {path} (auto after run)");
             }
             catch (Exception ex)
             {

--- a/Source/Parsek/InGameTests/TestRunnerPresentation.cs
+++ b/Source/Parsek/InGameTests/TestRunnerPresentation.cs
@@ -80,6 +80,20 @@ namespace Parsek.InGameTests
             return label;
         }
 
+        /// <summary>
+        /// True for "[single]" tests: scenarios that are skipped by Run All /
+        /// Run category and must be launched by hand from the row play button.
+        /// Used to highlight manual-only checks so they are easy to find.
+        /// [isolated] tests are excluded because they can still run through
+        /// Run All + Isolated / Run+ (see <see cref="BuildTestLabel"/>).
+        /// </summary>
+        internal static bool IsManualOnly(InGameTestInfo test)
+        {
+            return test != null
+                && !test.RestoreBatchFlightBaselineAfterExecution
+                && !test.AllowBatchExecution;
+        }
+
         internal static string BuildBatchModeNotice(
             IReadOnlyList<InGameTestInfo> tests,
             GameScenes loadedScene)

--- a/Source/Parsek/InGameTests/TestRunnerShortcut.cs
+++ b/Source/Parsek/InGameTests/TestRunnerShortcut.cs
@@ -119,7 +119,7 @@ namespace Parsek.InGameTests
                 return;
 
             ParsekUI.HandleResizeDrag(ref windowRect, ref isResizingWindow,
-                MinWindowWidth, MinWindowHeight, "TestRunner window");
+                MinWindowWidth, MinWindowHeight, "TestRunner global window");
 
             windowRect = RunWindowWithNormalizedGuiColors(() =>
                 GUILayout.Window(
@@ -442,7 +442,7 @@ namespace Parsek.InGameTests
                 tooltip.Length > 0 ? wrappedTooltipStyle : zeroHeightLabelStyle,
                 tooltip.Length > 0 ? GUILayout.ExpandWidth(true) : GUILayout.Height(0f));
 
-            ParsekUI.DrawResizeHandle(windowRect, ref isResizingWindow, "TestRunner window");
+            ParsekUI.DrawResizeHandle(windowRect, ref isResizingWindow, "TestRunner global window");
 
             GUI.DragWindow();
         }

--- a/Source/Parsek/InGameTests/TestRunnerShortcut.cs
+++ b/Source/Parsek/InGameTests/TestRunnerShortcut.cs
@@ -21,6 +21,7 @@ namespace Parsek.InGameTests
         private Vector2 scrollPos;
         private InGameTestRunner runner;
         private bool windowHasInputLock;
+        private bool isResizingWindow;
         private const string InputLockId = "Parsek_TestRunnerGlobal";
         private readonly HashSet<string> expandedCategories = new HashSet<string>();
         private List<KeyValuePair<string, List<InGameTestInfo>>> cachedGroups;
@@ -35,7 +36,11 @@ namespace Parsek.InGameTests
         private bool shortcutHeld;
         private static TestRunnerShortcut instance;
         private const float DefaultWindowWidth = 440f;
-        private const float DefaultWindowHeight = 500f;
+        private const float DefaultWindowHeight = 600f;
+        private const float MinWindowWidth = 320f;
+        // Default height is also the minimum: the window opens at this height
+        // and will not shrink below it (matches the Logistics window).
+        private const float MinWindowHeight = DefaultWindowHeight;
         private const float ErrorIndent = 40f;
         private const float ErrorMaxWidth = 380f;
 
@@ -113,6 +118,9 @@ namespace Parsek.InGameTests
             if (!EnsureOpaqueStyle(GUI.skin))
                 return;
 
+            ParsekUI.HandleResizeDrag(ref windowRect, ref isResizingWindow,
+                MinWindowWidth, MinWindowHeight, "TestRunner window");
+
             windowRect = RunWindowWithNormalizedGuiColors(() =>
                 GUILayout.Window(
                     "ParsekTestRunnerGlobal".GetHashCode(),
@@ -120,7 +128,8 @@ namespace Parsek.InGameTests
                     DrawWindow,
                     "Parsek - Test Runner",
                     opaqueStyle,
-                    GUILayout.Width(DefaultWindowWidth)));
+                    GUILayout.Width(windowRect.width),
+                    GUILayout.Height(windowRect.height)));
 
             if (windowRect.Contains(Event.current.mousePosition))
             {
@@ -326,7 +335,7 @@ namespace Parsek.InGameTests
             }
 
             scrollPos = GUILayout.BeginScrollView(scrollPos,
-                GUILayout.MinHeight(200), GUILayout.MaxHeight(500));
+                GUILayout.MinHeight(120), GUILayout.ExpandHeight(true));
 
             foreach (var group in cachedGroups)
             {
@@ -375,11 +384,17 @@ namespace Parsek.InGameTests
                     GUILayout.Label(GetStatusIcon(test.Status), GUILayout.Width(20));
                     GUI.contentColor = prevColor;
 
+                    // Manual-only [single] scenarios are tinted yellow so they
+                    // are easy to find (dimmed when the scene is ineligible).
                     if (!eligible) GUI.enabled = false;
                     string label = TestRunnerPresentation.BuildTestLabel(test);
+                    var prevLabelColor = GUI.contentColor;
+                    if (TestRunnerPresentation.IsManualOnly(test))
+                        GUI.contentColor = Color.yellow;
                     GUILayout.Label(
                         new GUIContent(label, TestRunnerPresentation.BuildTestTooltip(test, eligible)),
                         GUILayout.ExpandWidth(true));
+                    GUI.contentColor = prevLabelColor;
                     GUI.enabled = true;
 
                     GUI.enabled = !running && eligible;
@@ -410,10 +425,9 @@ namespace Parsek.InGameTests
 
             GUILayout.EndScrollView();
 
+            // Results auto-export after every run, so there is no manual export
+            // button (the file always reflects the latest run).
             GUILayout.BeginHorizontal();
-            if (GUILayout.Button(new GUIContent("Export Results",
-                "Auto-exported after every Run All / Run Category / row-play — click to re-write now.")))
-                runner.ExportResultsFile();
             if (GUILayout.Button("Close")) showWindow = false;
             GUILayout.EndHorizontal();
             GUILayout.Label("Results file auto-updates after each run. Multi-scene runs accumulate.",
@@ -427,6 +441,8 @@ namespace Parsek.InGameTests
                 tooltip.Length > 0 ? tooltip : string.Empty,
                 tooltip.Length > 0 ? wrappedTooltipStyle : zeroHeightLabelStyle,
                 tooltip.Length > 0 ? GUILayout.ExpandWidth(true) : GUILayout.Height(0f));
+
+            ParsekUI.DrawResizeHandle(windowRect, ref isResizingWindow, "TestRunner window");
 
             GUI.DragWindow();
         }

--- a/Source/Parsek/UI/TestRunnerUI.cs
+++ b/Source/Parsek/UI/TestRunnerUI.cs
@@ -23,13 +23,18 @@ namespace Parsek
         private readonly HashSet<string> expandedTestCategories = new HashSet<string>();
         private List<KeyValuePair<string, List<InGameTestInfo>>> cachedTestGroups;
         private bool testRunnerWasRunning;
+        private bool isResizingTestRunnerWindow;
         private GUIStyle zeroHeightLabelStyle;
         private GUIStyle wrappedErrorLabelStyle;
         private GUIStyle wrappedTooltipStyle;
 
         private const float SpacingSmall = 3f;
         private const float DefaultWindowWidth = 440f;
-        private const float DefaultWindowHeight = 500f;
+        private const float DefaultWindowHeight = 600f;
+        private const float MinWindowWidth = 320f;
+        // Default height is also the minimum: the window opens at this height
+        // and will not shrink below it (matches the Logistics window).
+        private const float MinWindowHeight = DefaultWindowHeight;
         private const float ErrorIndent = 40f;
         private const float ErrorMaxWidth = 380f;
 
@@ -69,6 +74,9 @@ namespace Parsek
                     DefaultWindowWidth, DefaultWindowHeight);
             }
 
+            ParsekUI.HandleResizeDrag(ref testRunnerWindowRect, ref isResizingTestRunnerWindow,
+                MinWindowWidth, MinWindowHeight, "TestRunner window");
+
             var opaqueWindowStyle = parentUI.GetOpaqueWindowStyle();
             if (opaqueWindowStyle == null)
                 return;
@@ -81,7 +89,8 @@ namespace Parsek
                     DrawTestRunnerWindow,
                     "Parsek - Test Runner",
                     opaqueWindowStyle,
-                    GUILayout.Width(DefaultWindowWidth)
+                    GUILayout.Width(testRunnerWindowRect.width),
+                    GUILayout.Height(testRunnerWindowRect.height)
                 );
             }
             finally
@@ -196,13 +205,18 @@ namespace Parsek
                     GUILayout.Label(icon, GUILayout.Width(20));
                     GUI.contentColor = prevColor;
 
-                    // Test name (dimmed if wrong scene)
+                    // Test name (dimmed if wrong scene). Manual-only [single]
+                    // scenarios are tinted yellow so they are easy to find.
                     if (!eligible) GUI.enabled = false;
                     string testLabel = TestRunnerPresentation.BuildTestLabel(test);
+                    var prevLabelColor = GUI.contentColor;
+                    if (TestRunnerPresentation.IsManualOnly(test))
+                        GUI.contentColor = Color.yellow;
                     GUILayout.Label(
                         new GUIContent(testLabel,
                             TestRunnerPresentation.BuildTestTooltip(test, eligible)),
                         GUILayout.ExpandWidth(true));
+                    GUI.contentColor = prevLabelColor;
                     GUI.enabled = true;
 
                     // Run single button
@@ -338,23 +352,20 @@ namespace Parsek
                 RebuildTestGroupCache();
             testRunnerWasRunning = running;
 
-            // --- Test list ---
+            // --- Test list (fills the resizable window) ---
             GUILayout.Space(SpacingSmall);
             testRunnerScrollPos = GUILayout.BeginScrollView(testRunnerScrollPos,
-                GUILayout.MinHeight(200), GUILayout.MaxHeight(500));
+                GUILayout.MinHeight(120), GUILayout.ExpandHeight(true));
 
             DrawTestCategoryList();
 
             GUILayout.EndScrollView();
 
             // --- Bottom bar ---
+            // Results auto-export after every run, so there is no manual export
+            // button (the file always reflects the latest run).
             GUILayout.Space(SpacingSmall);
             GUILayout.BeginHorizontal();
-            if (GUILayout.Button("Export Results"))
-            {
-                testRunner.ExportResultsFile();
-                ParsekLog.Info("UI", "Test runner: manually exported results file");
-            }
             if (GUILayout.Button("Close"))
             {
                 showTestRunnerWindow = false;
@@ -371,6 +382,9 @@ namespace Parsek
                 tooltip.Length > 0 ? tooltip : string.Empty,
                 tooltip.Length > 0 ? wrappedTooltipStyle : zeroHeightLabelStyle,
                 tooltip.Length > 0 ? GUILayout.ExpandWidth(true) : GUILayout.Height(0f));
+
+            ParsekUI.DrawResizeHandle(testRunnerWindowRect, ref isResizingTestRunnerWindow,
+                "TestRunner window");
 
             GUI.DragWindow();
         }


### PR DESCRIPTION
## Summary

Three quality-of-life changes to the in-game test runner, applied to both windows for consistency: `UI/TestRunnerUI.cs` (Settings > Diagnostics) and `InGameTests/TestRunnerShortcut.cs` (the Ctrl+Shift+T overlay).

- **Highlight manual-only tests in yellow.** `[single]` tests (skipped by Run All / Run Category, launched by hand from the row play button) now render yellow so they are easy to find. Added the pure `TestRunnerPresentation.IsManualOnly(test)` helper (`!AllowBatchExecution && !RestoreBatchFlightBaselineAfterExecution`) so both windows share one definition. `[isolated]` tests are intentionally excluded since they can run via Run All + Isolated / Run+.
- **Resizable window.** Both windows now use the shared `ParsekUI.HandleResizeDrag` / `DrawResizeHandle` chrome (drag the bottom-right corner handle, like Recordings/Logistics). The test list scroll view switched to `ExpandHeight` so it grows with the window, and width/height now track the window rect. The window opens 100 px taller (default height 500 to 600) and its default height is also its minimum, so it will not shrink below its opening height (matches the Logistics window). Width is still freely resizable down to 320 px.
- **Removed the redundant Export Results button.** Results already auto-export to `parsek-test-results.txt` at the end of every run (all run entry points funnel through `RunBatch`), so the manual button was redundant. Also removed the now-dead public `ExportResultsFile()` overload and folded the auto path into one private method.

## Testing

- `dotnet build`: clean (0 warnings, 0 errors).
- `dotnet test`: 50/50 pass, including 4 new `IsManualOnly` cases (single -> true; isolated, batch-safe, null -> false).
- Deployed DLL verified (new resize string present, `Export Results` string absent).

## Docs

- CHANGELOG.md updated under 0.10.0 (UI section). No todo/known-bugs entries referenced this area.