### PR TITLE
Match test runner Close button to other windows

### DIFF
--- a/Source/Parsek/InGameTests/TestRunnerShortcut.cs
+++ b/Source/Parsek/InGameTests/TestRunnerShortcut.cs
@@ -426,10 +426,9 @@ namespace Parsek.InGameTests
             GUILayout.EndScrollView();
 
             // Results auto-export after every run, so there is no manual export
-            // button (the file always reflects the latest run).
-            GUILayout.BeginHorizontal();
+            // button (the file always reflects the latest run). Full-width Close
+            // (matches the Logistics / Kerbals / Settings windows).
             if (GUILayout.Button("Close")) showWindow = false;
-            GUILayout.EndHorizontal();
             GUILayout.Label("Results file auto-updates after each run. Multi-scene runs accumulate.",
                 GUI.skin.label);
             GUILayout.Label("Ctrl+Shift+T to toggle from any scene", GUI.skin.label);

--- a/Source/Parsek/UI/TestRunnerUI.cs
+++ b/Source/Parsek/UI/TestRunnerUI.cs
@@ -363,15 +363,14 @@ namespace Parsek
 
             // --- Bottom bar ---
             // Results auto-export after every run, so there is no manual export
-            // button (the file always reflects the latest run).
+            // button (the file always reflects the latest run). Full-width Close
+            // (matches the Logistics / Kerbals / Settings windows).
             GUILayout.Space(SpacingSmall);
-            GUILayout.BeginHorizontal();
             if (GUILayout.Button("Close"))
             {
                 showTestRunnerWindow = false;
                 ParsekLog.Verbose("UI", "Test runner window closed");
             }
-            GUILayout.EndHorizontal();
             GUILayout.Label("Ctrl+Shift+T to toggle from any scene", GUI.skin.label);
 
             // Always render tooltip label — conditional rendering causes


### PR DESCRIPTION
Small cosmetic follow-up to #1080.

After the Export Results button was removed, the test runner's Close button was left inside a `BeginHorizontal()/EndHorizontal()` wrapper (leftover from when Export sat beside it). A lone `GUILayout.Button` already stretches to full width, so the button rendered full-width either way; this just drops the now-redundant wrapper so both test runner windows match the idiom the other full-width-Close windows use (Logistics / Kerbals / Settings call `GUILayout.Button("Close")` directly).

**No visual or behavioral change** - the Close button looked and behaved identically before and after.

Applies to both `Source/Parsek/UI/TestRunnerUI.cs` (Settings > Diagnostics) and `Source/Parsek/InGameTests/TestRunnerShortcut.cs` (Ctrl+Shift+T overlay).

Build clean (0 warnings, 0 errors).