### PR TITLE
Test runner UI: blue [single] tints + pin footer to window bottom

### DIFF
--- a/Source/Parsek/InGameTests/TestRunnerShortcut.cs
+++ b/Source/Parsek/InGameTests/TestRunnerShortcut.cs
@@ -384,13 +384,14 @@ namespace Parsek.InGameTests
                     GUILayout.Label(GetStatusIcon(test.Status), GUILayout.Width(20));
                     GUI.contentColor = prevColor;
 
-                    // Manual-only [single] scenarios are tinted yellow so they
+                    // Manual-only [single] scenarios are tinted blue so they
                     // are easy to find (dimmed when the scene is ineligible).
+                    // Readable light blue: Color.blue is too dark on KSP's dark window.
                     if (!eligible) GUI.enabled = false;
                     string label = TestRunnerPresentation.BuildTestLabel(test);
                     var prevLabelColor = GUI.contentColor;
                     if (TestRunnerPresentation.IsManualOnly(test))
-                        GUI.contentColor = Color.yellow;
+                        GUI.contentColor = new Color(0.45f, 0.65f, 1f);
                     GUILayout.Label(
                         new GUIContent(label, TestRunnerPresentation.BuildTestTooltip(test, eligible)),
                         GUILayout.ExpandWidth(true));

--- a/Source/Parsek/InGameTests/TestRunnerShortcut.cs
+++ b/Source/Parsek/InGameTests/TestRunnerShortcut.cs
@@ -334,8 +334,13 @@ namespace Parsek.InGameTests
                 GUILayout.Label(batchModeNotice, GUI.skin.label);
             }
 
+            // Bare ExpandHeight (no MinHeight) so the scroll view stretches to
+            // fill the fixed-height window, pinning the Close button + info
+            // labels to the bottom. A MinHeight option clears stretchHeight and
+            // leaves the footer floating with dead space below it. Matches the
+            // Kerbals / Real Spawn Control / Logistics windows.
             scrollPos = GUILayout.BeginScrollView(scrollPos,
-                GUILayout.MinHeight(120), GUILayout.ExpandHeight(true));
+                GUILayout.ExpandHeight(true));
 
             foreach (var group in cachedGroups)
             {

--- a/Source/Parsek/UI/TestRunnerUI.cs
+++ b/Source/Parsek/UI/TestRunnerUI.cs
@@ -206,12 +206,13 @@ namespace Parsek
                     GUI.contentColor = prevColor;
 
                     // Test name (dimmed if wrong scene). Manual-only [single]
-                    // scenarios are tinted yellow so they are easy to find.
+                    // scenarios are tinted blue so they are easy to find.
+                    // Readable light blue: Color.blue is too dark on KSP's dark window.
                     if (!eligible) GUI.enabled = false;
                     string testLabel = TestRunnerPresentation.BuildTestLabel(test);
                     var prevLabelColor = GUI.contentColor;
                     if (TestRunnerPresentation.IsManualOnly(test))
-                        GUI.contentColor = Color.yellow;
+                        GUI.contentColor = new Color(0.45f, 0.65f, 1f);
                     GUILayout.Label(
                         new GUIContent(testLabel,
                             TestRunnerPresentation.BuildTestTooltip(test, eligible)),

--- a/Source/Parsek/UI/TestRunnerUI.cs
+++ b/Source/Parsek/UI/TestRunnerUI.cs
@@ -355,8 +355,13 @@ namespace Parsek
 
             // --- Test list (fills the resizable window) ---
             GUILayout.Space(SpacingSmall);
+            // Bare ExpandHeight (no MinHeight) so the scroll view stretches to
+            // fill the fixed-height window, pinning the Close button + info
+            // labels to the bottom. A MinHeight option clears stretchHeight and
+            // leaves the footer floating with dead space below it. Matches the
+            // Kerbals / Real Spawn Control / Logistics windows.
             testRunnerScrollPos = GUILayout.BeginScrollView(testRunnerScrollPos,
-                GUILayout.MinHeight(120), GUILayout.ExpandHeight(true));
+                GUILayout.ExpandHeight(true));
 
             DrawTestCategoryList();
 


### PR DESCRIPTION
## What

Two small in-game test runner UI fixes (both windows: the global Ctrl+Shift+T window and the in-flight Parsek sub-window).

### 1. Tint manual-only `[single]` tests blue instead of yellow
- `IsManualOnly(test)` label tint changes from `Color.yellow` to `new Color(0.45f, 0.65f, 1f)` in [TestRunnerShortcut.cs](Source/Parsek/InGameTests/TestRunnerShortcut.cs) and [TestRunnerUI.cs](Source/Parsek/UI/TestRunnerUI.cs).
- Pure `Color.blue` (0,0,1) is nearly invisible on KSP's dark window, so a legible light blue is used. The `Running`-status yellow icon is left unchanged.

### 2. Pin the footer (Close + info labels) to the window bottom
- The scroll view used `GUILayout.MinHeight(120), GUILayout.ExpandHeight(true)`. The `MinHeight` option clears `stretchHeight`, so the scroll view did not actually stretch to fill the fixed-height window: the Close button and info labels floated up with dead space below them.
- Fix: drop `MinHeight` and use bare `GUILayout.ExpandHeight(true)` so the scroll view fills the window and the footer pins to the bottom. The 600px minimum window height guarantees room. Matches the Kerbals / Real Spawn Control / Logistics windows.

## Testing
- `dotnet build` succeeds (0 warnings, 0 errors).
- Cosmetic IMGUI layout/tint only, no new logic, so no unit tests added. The footer-pin matches the established working-window pattern (bare `ExpandHeight` scroll view).