### PR TITLE
Bump version to 0.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Parsek are documented here.
 
 ---
 
+## 0.10.1
+
+- Maintenance and bug-fix release following up on issues found in post-0.10.0 career playtesting.
+
 ## 0.10.0
 
 ### Defaults

--- a/GameData/Parsek/Parsek.version
+++ b/GameData/Parsek/Parsek.version
@@ -1,7 +1,7 @@
 {
     "NAME": "Parsek",
     "URL": "https://raw.githubusercontent.com/vl3c/Parsek/main/GameData/Parsek/Parsek.version",
-    "VERSION": { "MAJOR": 0, "MINOR": 10, "PATCH": 0 },
+    "VERSION": { "MAJOR": 0, "MINOR": 10, "PATCH": 1 },
     "KSP_VERSION": { "MAJOR": 1, "MINOR": 12, "PATCH": 5 },
     "KSP_VERSION_MIN": { "MAJOR": 1, "MINOR": 12, "PATCH": 0 },
     "KSP_VERSION_MAX": { "MAJOR": 1, "MINOR": 12, "PATCH": 99 }

--- a/Source/Parsek/Properties/AssemblyInfo.cs
+++ b/Source/Parsek/Properties/AssemblyInfo.cs
@@ -17,7 +17,7 @@ using System.Runtime.InteropServices;
 
 [assembly: Guid("a1b2c3d4-e5f6-7890-abcd-ef1234567890")]
 
-[assembly: AssemblyVersion("0.10.0.0")]
-[assembly: AssemblyFileVersion("0.10.0.0")]
+[assembly: AssemblyVersion("0.10.1.0")]
+[assembly: AssemblyFileVersion("0.10.1.0")]
 
 [assembly: KSPAssembly("Parsek", 0, 10)]


### PR DESCRIPTION
Opens the 0.10.1 maintenance cycle so the post-0.10.0 career-playtest fixes have a version to file under.

## Changes
- `GameData/Parsek/Parsek.version`: VERSION PATCH 0 -> 1
- `Source/Parsek/Properties/AssemblyInfo.cs`: `AssemblyVersion` and `AssemblyFileVersion` 0.10.0.0 -> 0.10.1.0
- `CHANGELOG.md`: new `## 0.10.1` section (maintenance opener; the individual fix PRs add their own entries here)

Version-only change: no behavior change, no code paths touched. `AssemblyVersion` matches `release.py`'s expected `0.10.1.0`, so the release version-consistency check passes.