### PR TITLE
docs: ledger/game-actions state-reconstruction audit + follow-up prompts

### DIFF
--- a/docs/dev/ledger-audit-followup-prompts.md
+++ b/docs/dev/ledger-audit-followup-prompts.md
@@ -1,0 +1,312 @@
+# Ledger Audit — Follow-Up Session Prompts
+
+Five self-contained prompts, one per recommendation from
+`docs/dev/ledger-state-reconstruction-audit.md`. Each is meant to be pasted into a
+**fresh session** as the opening instruction to an orchestrator agent. They are ordered
+by the priority in the audit (§8); they are mostly independent, but **Prompt 4
+(LedgerTrace) should land after Prompt 2 (logging gaps)** since the trace lines reuse the
+same per-identity logging, and **Prompt 1** is the highest-leverage standalone win.
+
+Every prompt assumes the agent will:
+- Read `docs/dev/ledger-state-reconstruction-audit.md` and
+  `docs/dev/development-workflow.md` first.
+- Follow the workflow's **plan → review → fix (loop) → implement → review → fix** cycle,
+  dispatching **clean-context subagents** for each stage while the main agent stays the
+  orchestrator (keeps its own context lean, reviews subagent output, decides
+  proceed-vs-iterate).
+- Obey `.claude/CLAUDE.md`: build/test commands, logging requirements (every decision +
+  state transition logged), testing requirements (every new logic method gets unit
+  tests + log-assertion tests), the ERS/ELS routing rule (route reads of
+  `RecordingStore.CommittedRecordings` / `Ledger.Actions` through
+  `EffectiveState.ComputeERS/ComputeELS` unless allowlisted), and the Post-Change
+  Checklist (OnSave/OnLoad, generators, `dotnet test`, CHANGELOG, todo doc).
+- Branch from `origin/main` into a dedicated worktree/branch, and open a PR at the end
+  (no AI attribution / no Co-Authored-By).
+
+---
+
+## Prompt 1 — Rewind read-back divergence guard (production safety)
+
+```
+Implement a rewind-time read-back divergence guard for the Parsek ledger
+reconstruction. Goal: when a rewind reconstructs career state, detect (and loudly log,
+optionally abort) any case where the recalculated target diverges from the ground-truth
+that the RewindPoint quicksave just restored — so a silent career-corruption bug becomes
+a caught, logged event.
+
+START by reading docs/dev/ledger-state-reconstruction-audit.md (esp. §6 "ground-truth
+oracle" and §2 pipeline) and docs/dev/development-workflow.md. Follow the workflow:
+plan -> review -> fix (loop until clean) -> implement -> review -> fix. Use clean-context
+subagents for each stage; you are the orchestrator and keep your own context lean.
+
+KEY FACTS (verify in code, don't trust blindly):
+- On rewind, RewindInvoker loads the RP quicksave (.sfs) = a real KSP save at the rewind
+  UT with actual funds/science/rep/facilities/vessels, THEN calls
+  LedgerOrchestrator.RecalculateAndPatch(double.MaxValue) at RewindInvoker.cs:908. So the
+  live KSP economy *immediately after load, before PatchAll writes* is ground truth.
+- Apply funnel: GameActions/KspStatePatcher.cs:39 (PatchAll) -> PatchScience/PatchFunds/
+  PatchReputation/PatchFacilities/... Each computes a target then writes via
+  AddFunds/AddScience/SetReputation. Funds/Science/Rep already log old->new at Info
+  (:733/:160/:803).
+- The drawdown guard (KspStatePatcher.cs ~:2295) and authoritativeReduction flag
+  (LedgerOrchestrator.cs:1786) already model "is this an authorized drawdown vs a buggy
+  clobber" — integrate with that semantics, don't fight it.
+
+SCOPE: capture the pre-patch live values (funds, science pool, reputation, and ideally
+facility levels) at the rewind apply boundary; compare against the about-to-be-written
+recalc targets; if |divergence| exceeds a tolerance AND the change is NOT an expected
+authoritative rewind drawdown, emit a loud ParsekLog.Warn naming each diverging resource
+with old/groundTruth/target/delta, and gate an optional abort behind a clearly-named
+flag (default: warn-only, do NOT abort, to avoid bricking a legit rewind). Keep the hook
+pure/testable: put the comparison decision in an internal static predicate
+(e.g. ResolveRewindDivergence(...)) so it can be unit-tested without KSP singletons.
+
+DESIGN CONSTRAINTS: this is a guard, not a behavior change — by default it must not alter
+any successful rewind. Make the abort opt-in. Log every branch (no divergence / expected
+authoritative drawdown / flagged divergence). Decide whether this is a small enough
+change to skip the design-doc step (it likely is — it's an instrumentation/guard, single
+subsystem) and note that decision explicitly to the reviewer.
+
+TESTS: unit-test the divergence predicate (matching/diverging/authoritative-drawdown
+cases) and add log-assertion tests via ParsekLog.TestSinkForTesting that the Warn fires
+with the right fields. Consider an in-game Rewind-category test that forces a synthetic
+divergence and asserts the Warn. Run `cd Source/Parsek && dotnet build` and
+`cd Source/Parsek.Tests && dotnet test`.
+
+Update CHANGELOG.md and docs/dev/todo-and-known-bugs.md in the same commit. Open a PR
+targeting main when green; do a clean-context final review first.
+```
+
+---
+
+## Prompt 2 — Close logging gaps 1–3 (per-subject science, tech nodes, contracts)
+
+```
+Close the three HIGH-risk per-identity logging gaps in the Parsek ledger apply boundary
+so a per-subject-science / tech-node / contract corruption is debuggable from a
+default-level KSP.log instead of only Verbose.
+
+START by reading docs/dev/ledger-state-reconstruction-audit.md (§4.1 table + §4.2 gaps
+1-3) and docs/dev/development-workflow.md. Follow plan -> review -> fix (loop) ->
+implement -> review -> fix with clean-context subagents; you orchestrate and stay lean.
+Also read .claude/CLAUDE.md "Logging Requirements" (batch-counting convention: per-item
+decisions get local int counters + ONE summary after the loop; use VerboseRateLimited
+for per-frame, Verbose for one-shot).
+
+THE GAPS (verify each in GameActions/KspStatePatcher.cs):
+- GAP 1 (per-subject science, :871 `kspSubject.science = target`): no per-subject
+  old->new at any level; only aggregate `patched=/cleared=` at Info (:887). Also note
+  this path is left UNCLAMPED by the drawdown guard (~:2295) — extra reason to log it.
+- GAP 2 (tech nodes, :377 SetTechState / :388 protoNodes.Remove): per-node identity only
+  at Verbose ("first 10 missing", :428); Info is counts only (:412).
+- GAP 3 (contracts, :2177 RemoveAt / :1727 currentContracts.Add): contractId only at
+  Verbose/Warn; Info aggregate at :1774.
+
+APPROACH: do NOT spam Info with one line per subject/node/contract on every recalc (there
+can be hundreds). Instead, follow the existing batch-counting convention and surface
+*changed* identities compactly: keep the Info aggregate, but when the changed-set is
+non-empty and bounded, append the changed identity list (or a bounded sample with a
+"+N more" suffix) to the Info line — or emit identities through a change-gated path
+(ParsekLog.VerboseOnChange keyed per subject/node/contract id) so a default log still
+shows WHICH item changed when it changes, without per-frame spam. Match how kerbal roster
+apply already logs per-item at Info (KerbalsModule.cs:1398 etc.) for the bounded cases.
+Decide the Info-vs-change-gated split per gap and justify it to the reviewer (volume is
+the deciding factor).
+
+TESTS: add log-assertion tests (ParsekLog.TestSinkForTesting) proving each gap now emits
+the changed identity + old->new (or changed-id) when a subject/node/contract flips, and
+that steady-state (no change) does NOT spam. These pull double duty as diagnostic-coverage
+guards. Many KspStatePatcher tests run with SuppressUnityCallsForTesting=true and
+null singletons — structure the new logging so the identity/decision logging is reachable
+in that headless mode (log from the target-computation/decision step, not only from the
+post-singleton-write step), so the tests can assert it. Run build + dotnet test.
+
+Update CHANGELOG.md + todo doc in the same commit. Clean-context final review, then PR to
+main.
+```
+
+---
+
+## Prompt 3 — In-game ground-truth verification harness
+
+```
+Build an in-game test harness that verifies Parsek's ledger reconstruction against an
+independent ground-truth KSP save at the same UT, including vessels — the closed
+rewind/recalc-vs-actual-save loop that does NOT exist today.
+
+START by reading docs/dev/ledger-state-reconstruction-audit.md (§5.2 "the critical
+question", §6 oracle, §7 in-game runner capability) and docs/dev/development-workflow.md.
+This is a larger, multi-part feature touching test infrastructure — consider a short
+design doc (workflow step 3) before planning, since it persists a new test category and a
+save-parsing helper. Follow plan -> review -> fix (loop) -> implement -> review -> fix
+with clean-context subagents; you orchestrate.
+
+WHAT EXISTS TO REUSE:
+- InGameTests/ runner: reflection discovery (InGameTestRunner.DiscoverTests:227),
+  [InGameTest] attrs with Category/Scene/RunLast/AllowBatchExecution/
+  RestoreBatchFlightBaselineAfterExecution; multi-frame IEnumerator coroutines;
+  InGameAssert.ApproxEqual (float/double/Vector3 + tolerance) / Skip.
+- Quicksave/quickload already wired: QuickloadResumeHelpers.TriggerQuicksave,
+  ValidateQuicksaveStructure (parses a .sfs without mutating FlightGlobals).
+- Live reads: Funding/ResearchAndDevelopment/Reputation.Instance, FlightGlobals.Vessels,
+  vessel.id/persistentId. SnapshotFinancials/RestoreFinancials helpers at
+  RuntimeTests.cs:14541.
+- LedgerOrchestrator.RecalculateAndPatch is the reconstruction entry.
+
+THE HARNESS (one new [InGameTest] family, Career-only, RestoreBatchFlightBaseline=true so
+it self-cleans):
+1. From a career save at the current UT, capture a quicksave snapshot S (ground truth:
+   economy + the ConfigNode set of VESSEL nodes with their resource totals).
+2. Parse S's .sfs INDEPENDENTLY of the ledger (reuse/extend the ValidateQuicksaveStructure
+   path) to extract: funds, science (pool + per-subject), reputation, facility levels,
+   active contract set, milestone set, and the vessel set (ids/persistentIds + resource
+   totals).
+3. Run LedgerOrchestrator.RecalculateAndPatch and read the reconstructed/live values.
+4. Diff reconstructed vs S with tolerances; InGameAssert each facet; on mismatch produce a
+   structured divergence report (which facet, expected-from-save vs reconstructed).
+   IMPORTANT: this must be a NON-circular comparison — compare recalc output to the
+   INDEPENDENTLY-PARSED save S, NOT module-getter-vs-live-after-patch (that tautology is
+   exactly what TopBarReflectsLedgerAfterRecalc at RuntimeTests.cs:15573 already does and
+   why it proves nothing). Document this distinction in the test's Description.
+5. Skip cleanly (InGameAssert.Skip) when not Career, when singletons are null, or when a
+   live/pending tree would defer patching (mirror the guards in
+   TopBarReflectsLedgerAfterRecalc).
+
+Vessels are NOT touched by the ledger (it reconstructs scalars only) — so the vessel facet
+asserts cross-subsystem consistency: e.g. that a recovered-vessel funds credit in the
+recalc matches whether that vessel is actually present/absent in S after restore. Scope
+the vessel comparison realistically and mark deeper vessel-state checks as v1-deferred if
+needed.
+
+TESTS/VALIDATION: the harness IS the test, but also add pure unit tests for the new
+save-parsing/diff helpers (Source/Parsek.Tests/) with synthetic .sfs fixtures (use the
+Generators/ — ScenarioWriter etc.). Run `dotnet build` + `dotnet test`. For the in-game
+part, document the manual run recipe (Ctrl+Shift+T, the new Category) in the PR.
+
+Update CHANGELOG + todo + .claude/CLAUDE.md (new in-game test category) as needed. Clean
+final review, PR to main.
+```
+
+---
+
+## Prompt 4 — `LedgerTrace`: event-driven ledger state tracer
+
+```
+Build a gated, event-driven "LedgerTrace" observability system for the Parsek ledger
+apply boundary, modeled on the existing render tracer pattern but adapted to discrete
+recalc events (NOT a per-frame probe). It instruments every reconstructed value-change
+and reconciles computed-vs-live (read-back) so career-corruption bugs are traceable.
+
+PREREQUISITE: ideally land after the Prompt-2 logging work (per-identity change lines) so
+LedgerTrace reuses, not duplicates, that logging.
+
+START by reading docs/dev/ledger-state-reconstruction-audit.md (§7 tracer template, §8
+rec 4) and docs/dev/development-workflow.md. Read the templates: MapRenderTrace.cs +
+MapRenderProbe.cs (the pattern), GhostRenderTrace.cs (sibling), and ParsekLog.cs
+(VerboseOnChange:271, RecState:511, test seams). Follow plan -> review -> fix (loop) ->
+implement -> review -> fix with clean-context subagents; you orchestrate and stay lean.
+
+CRITICAL DESIGN NOTE (from the audit): do NOT clone the per-frame MonoBehaviour probe.
+Ledger state changes on discrete recalc/patch events, so a per-frame LateUpdate probe is
+wasted cost. LedgerTrace is EVENT-DRIVEN, hooked at the KspStatePatcher Patch* sites.
+
+REUSE THE PATTERN, THESE LAYERS:
+- Gating: a `ledgerTracing` setting, near-zero cost when off (single bool early-return in
+  every emit), mirroring MapRenderTrace.IsEnabled (:378). Add the flag via the 4-file
+  template: ParsekSettings.cs:56 (field + [CustomParameterUI], default false),
+  UI/SettingsWindowUI.cs:458 (Diagnostics toggle, suffix "(Warning: huge logs)"),
+  ParsekSettingsPersistence.cs:46 (key + record/load/restore), defaults-reset at
+  SettingsWindowUI.cs:195. Add a ForceEnabledForTesting seam.
+- Tier-A structural: a RecState-style (ParsekLog.RecState, :511) grep-stable one-line
+  snapshot per recalc — funds/science/rep/facilities=L.../techNodes=N/contracts=M plus
+  cutoff + authoritativeReduction (the LedgerOrchestrator.cs:1786 decision). Always
+  emitted at Info when enabled.
+- Tier-B change-based truth: per-identity (subject/node/facility/contract id) change
+  lines via VerboseOnChange keyed by id — emit only when that identity's value flips.
+- Tier-C anomaly: a read-back reconcile. At each Patch*, capture the computed target as
+  "intent", and after the live write read the value back; a pure, Unity-free predicate
+  (e.g. IsResourceDrift(target, actual, tol)) decides mismatch -> emit a "ledger-vs-truth"
+  anomaly Warn. Keep predicates pure + unit-tested (like IsIconJump). This is the ledger
+  analogue of MapRenderProbe's ReconcileLineState.
+
+Map the render concepts: "intent" = computed recalc target; "truth" = live
+Funding/RnD/Reputation.Instance + facility level; per-entity key = action/subject/node/
+facility/contract id (NOT a vessel pid). No detailed-window-registry needed unless it
+earns its keep — justify if you add it.
+
+Keep the formatters self-contained (the render tracers deliberately duplicate rather than
+share — do NOT refactor MapRenderTrace/GhostRenderTrace). Respect the ERS/ELS routing
+rule for any CommittedRecordings/Ledger.Actions reads.
+
+TESTS: unit-test every pure predicate + the RecState formatter (matching/diverging/
+boundary), log-assertion tests for each tier (structural snapshot present, change line
+fires only on change, anomaly Warn on injected drift), and a gating test (nothing emitted
+when ledgerTracing off / ForceEnabledForTesting false). Run build + dotnet test. Verify
+OnSave/OnLoad persistence of the new setting (Post-Change Checklist).
+
+Update CHANGELOG + todo + .claude/CLAUDE.md (new LedgerTrace file in the file index).
+Clean final review (serialization + new-subsystem attention), PR to main.
+```
+
+---
+
+## Prompt 5 — xUnit coverage for the live apply boundary
+
+```
+Add headless xUnit coverage for the Parsek KspStatePatcher apply boundary so the
+compute-delta -> write -> read-back loop is actually tested, instead of null-skipped under
+SuppressUnityCallsForTesting.
+
+START by reading docs/dev/ledger-state-reconstruction-audit.md (§5.1 layer (e), §5.3
+risk 1) and docs/dev/development-workflow.md. This is a test-infrastructure change (pure
+refactor for testability + new tests, no gameplay change) — skip the design doc, go
+plan -> implement -> review per the workflow's shortcut, with a clean-context reviewer.
+You orchestrate; use a subagent for the exploration/plan and another for review.
+
+THE PROBLEM (verify): KspStatePatcherTests run with
+KspStatePatcher.SuppressUnityCallsForTesting = true, and the real mutation sites are
+behind `if (Funding.Instance == null) return;` etc. In xUnit those singletons are null,
+so every "apply" test hits the early-return. Only the pure target-computation helpers
+(BuildTargetTechIdsForPatch, AdjustSciencePatchTargetForPending*, BuildSubjectIdsForPatch,
+BuildFacilityPatchTargets) and null-guard logging are covered. The compute-delta ->
+AddFunds/AddScience/SetReputation -> read-back loop is exercised live by only 2 in-game
+tests with synthetic inputs.
+
+APPROACH (pick the lowest-risk that works; justify in the plan):
+Option A — extract the numeric core: refactor each Patch* so the
+"given currentValue + target, produce the delta/clamp decision and the resulting value"
+logic lives in an internal static pure function (taking current as a parameter instead of
+reading Funding.Instance directly). Test those pure functions exhaustively in xUnit
+(matching/clamped/authoritative/seed-missing/no-op/suspicious-drawdown cases), asserting
+the computed delta AND the resulting value AND the log line (TestSinkForTesting). The thin
+Unity-call wrapper stays untested headlessly but becomes trivial.
+Option B — a minimal injectable economy seam: introduce a tiny interface/delegate for
+"read current / write delta" that defaults to the KSP singletons but can be faked in
+xUnit, letting tests drive the full Patch* path headlessly and assert the faked backend
+received the right writes. Higher blast radius — only if Option A can't capture the
+read-back semantics (e.g. the drawdown guard's running-vs-available distinction).
+
+Prefer Option A unless review shows it leaves the dangerous read-back/clamp interaction
+untested. Either way, do NOT change runtime behavior — this is a testability refactor;
+existing tests must still pass unchanged.
+
+COVER THE RISKY PATHS the audit names: per-subject science apply (unclamped!),
+tech-node-set apply, facility-level apply — at least their delta/decision math against a
+provided current value. Add the "what makes it fail" justification to every test (no
+vacuous asserts).
+
+Run `cd Source/Parsek && dotnet build` and `cd Source/Parsek.Tests && dotnet test` — all
+green. Update CHANGELOG + todo doc. Clean-context final review (it touches the
+career-critical apply boundary), PR to main.
+```
+
+---
+
+### Orchestration notes for the human
+
+- **Independence:** 1, 3, 5 are fully independent. 4 depends on 2 (shared per-identity
+  logging). Run 1 first (highest leverage, smallest), then 2, then 3/5 in parallel, then
+  4.
+- Each session's orchestrator should keep the report doc + workflow doc paths in its
+  opening turn and otherwise delegate reading to subagents to stay lean.
+- All five end in a PR to `main`; none should `git merge` into the main checkout locally.

--- a/docs/dev/ledger-state-reconstruction-audit.md
+++ b/docs/dev/ledger-state-reconstruction-audit.md
@@ -1,0 +1,321 @@
+# Audit: Ledger / Game-Actions State-Reconstruction — Logging & Test Coverage
+
+**Status:** investigation report (2026-06-08). No code changed by this audit.
+**Scope:** the ledger / game-actions system that reconstructs **career scalar state**
+(funds, science global + per-subject, reputation, facilities, contracts, milestones,
+strategies, kerbals, tech tree) after rewind / fast-forward / time-warp / save-load.
+**Audience:** future agents implementing the follow-up work (prompts in
+`docs/dev/ledger-audit-followup-prompts.md`).
+
+> **Why this matters.** This subsystem rewrites real KSP career values
+> (`Funding.Instance`, `ResearchAndDevelopment.Instance`, `Reputation.Instance`,
+> facility levels, tech tree, contracts) every time the player rewinds, warps, or
+> reloads. A silent bug here corrupts an entire career save. The two parts of the
+> system that are *most* dangerous — the live **apply boundary** and the **closed
+> rewind→recalc→reapply loop** — are the *least* covered by logging and tests.
+
+---
+
+## 1. Bottom line
+
+- **Logging:** the three headline pools (funds, science pool, reputation) are fully
+  debuggable from a default-level `KSP.log` (`old → new (delta=…, target=…)` at Info).
+  Everything else — per-subject science, tech nodes, facility levels, milestones,
+  contracts, vessel deletion — logs **identities only at Verbose** and surfaces
+  **only aggregate counts at Info**. A corruption in any of those is effectively
+  invisible in a normal log.
+- **Tests:** pure recalc math, serialization, and supersede/tombstone/cutoff topology
+  are genuinely strong (hundreds of focused unit tests). But the **live apply boundary
+  is exercised by only 2 in-game tests with synthetic inputs**, and there is **no
+  end-to-end test that reconstructs state and compares it to a ground-truth save** —
+  and none that touches vessels.
+- **Verdict:** coverage is **sufficient for the recalc math layer** and **insufficient
+  at the apply boundary and the full round-trip level**. A targeted logging upgrade, a
+  lightweight event-driven ledger tracer, and an in-game ground-truth verification
+  harness are all warranted. A full per-frame probe clone (like the render tracer) is
+  **not** warranted — ledger state changes on discrete recalc events, not per-frame.
+
+---
+
+## 2. Pipeline overview (apply boundary)
+
+**Apply funnel:** `KspStatePatcher.PatchAll` (`GameActions/KspStatePatcher.cs:39`) is the
+single entry for career-resource writes. It runs all mutations inside
+`SuppressionGuard.ResourcesAndReplay()` (`:49`) and dispatches:
+`PatchScience` → `PatchTechTree` → `PatchFunds` → `PatchReputation` →
+`PatchFacilities` → `PatchMilestones` → `PatchContracts`.
+
+**Orchestration entry points** (`GameActions/LedgerOrchestrator.cs`):
+- `RecalculateAndPatch` (`:1325`) → `RecalculateAndPatchCore` (`:1705`) is the universal
+  driver — called on **commit, rewind, warp-exit, time-jump, KSP load**.
+- Wrappers funnel into the core: `RecalculateAndPatchForCurrentTimelineUT` (`:1344`,
+  post-rewind/time-jump), `RecalculateAndPatchForTimeJump` (`:1377`),
+  `RecalculateAndPatchForLiveTimelineEvent` (`:1411`),
+  `RecalculateAndPatchAfterTombstones` (`:1439`, supersede tombstone refresh).
+- Core flow: `SeedInitialResourceBalances` → `PurgeGhostOnlyActionsFromLedger` →
+  `BuildRecalculationActions` (ELS via `EffectiveState.ComputeELS`) →
+  `RecalculationEngine.Recalculate` → **patch-deferral gate**
+  (`GetKspPatchDeferralReason`, `:1764` — skips the live KSP write while a live/pending
+  tree exists) → `ApplyRecalculatedStateToKsp` (`:1889`) → `KspStatePatcher.PatchAll`.
+- `kerbalsModule.ApplyToRoster` (`:1903`) runs separately inside
+  `ApplyRecalculatedStateToKsp`, **before** `PatchAll`.
+
+**Recalc engine** (`GameActions/RecalculationEngine.cs`): pure computation, no KSP
+access. Sorts actions by `(UT, earning-before-spending, sequence)`, resets modules,
+walks forward dispatching to tiers (first-tier: Science/Milestones/Contracts/Kerbals;
+strategy transform; second-tier: Funds/Reputation; facilities). Emits a single
+recalc-complete summary via `VerboseOnChange("RecalcEngine", "recalculate-summary", …)`
+(`:214-232`) — counts only, no value-level truth comparison. UT-cutoff filtering
+(`:144-233`) + a shadow projection walk (`RunProjectionWalk`) reserve future spendings.
+
+**Strategies note:** strategies are a ledger-transform tier only — there is **no live
+`StrategySystem` mutation anywhere in production code** (only referenced in UI/tests).
+
+---
+
+## 3. What's already solid (do not rebuild)
+
+- **Recalc math:** `FundsModuleTests` (65), `ScienceModuleTests` (53),
+  `ReputationModuleTests` (48), `ContractsModuleTests` (43), `RecalculationEngineTests`
+  (39), `FullCareerTimelineTests`, `CrossTierIntegrationTests` (7) — thorough,
+  hand-verified constants.
+- **Serialization / migration / supersede topology:** `GameActionSerializationTests`
+  (51), `GameStateEventTests` (102), `RewindSupersedeRollbackTests` (43),
+  `SupersedeCommitTests` (101), `SupersedeCommitTombstoneTests` (23),
+  `RewindUtCutoffTests` (~80), `EffectiveStateTests` (39),
+  `LedgerTombstoneRoundTripTests`, `LedgerRecoveryMigrationTests` (14).
+- **Headline-pool apply logging:** `PatchFunds` (`KspStatePatcher.cs:733`),
+  `PatchScience` (`:160`), `PatchReputation` (`:803`) each log `old → new
+  (delta=…, target=…)` at **Info**, with a loud **Warn** drawdown-guard clamp + session
+  toast (`:2298`) and a >10% suspicious-drawdown Warn (`:723`).
+- **Idempotence:** `DoubleRecalculate_IsIdempotent` proves a repeated walk on the same
+  list is stable.
+- **Kerbal roster apply:** create / recreate / delete / retire log per-kerbal at
+  **Info** (`KerbalsModule.cs:1398/:1384/:1490/:1465/:1477`).
+
+---
+
+## 4. Logging audit
+
+### 4.1 Per-resource apply + logging table
+
+| Resource | Mutation site | old→new at Info? | Identity at Info? | Notes |
+|---|---|---|---|---|
+| **Funds** | `Funding.Instance.AddFunds` `KspStatePatcher.cs:730` | **YES** `:733` | n/a (single pool) | delta + target logged |
+| **Science (pool)** | `AddScience` `:157` | **YES** `:160` | n/a | delta logged |
+| **Reputation** | `SetReputation` `:800` | **YES** `:803` | n/a | uses Set (not Add) to avoid double curve |
+| **Per-subject science** | `kspSubject.science = target` `:871` | **NO (none at any level)** | **NO** | aggregate `patched=/cleared=` only `:887`; **unclamped** by drawdown guard `:2295` |
+| **Tech tree** | `SetTechState` `:377`, `protoNodes.Remove` `:388` | per-node Verbose only | per-node Verbose only | Info aggregate `madeAvailable=/madeUnavailable=` `:412` |
+| **Facility level** | `facility.SetLevel` `FacilityStatePatcher.cs:109` | per-facility Verbose `:112` | per-facility Verbose | Info aggregate `patched=` `:132` |
+| **Facility destruction** | `db.Demolish()`/`db.Repair()` `:231/:239` | per-building Verbose `:233/:240` | Verbose | Info aggregate `:250` |
+| **Milestones (one-shot)** | reflection set `reached/complete` `KspStatePatcher.cs:1088/:1098` | per-node Verbose `:1092/:1104` | Verbose | Info aggregate `credited=/unreached=` `:996` |
+| **Milestones (repeatable)** | reflection field writes `:1363-1391` | single Verbose `synced` `:1418` | Verbose | — |
+| **Contracts** | `currentContracts.Add` `:1727`, `RemoveAt` `:2177` | per-contract Verbose `:1675` | Verbose/Warn | Info aggregate `removedStale=/restored=` `:1774` |
+| **Kerbal roster** | `TryRemove/TryCreate/TryRecreate` | per-kerbal **Info** | **Info** (name + slot) | well-covered |
+| **Strategies** | none (ledger-transform only) | n/a | n/a | no live mutation |
+| **Vessels** (rewind only) | `Vessel.Die()` `PostLoadStripper.cs:280` | n/a | **bare-PID list only** `:213` | see §4.3 |
+
+### 4.2 Logging gaps ranked by career-corruption risk
+
+| # | Risk | Site | Problem |
+|---|------|------|---------|
+| 1 | **HIGH** | `KspStatePatcher.cs:871` per-subject science | No per-subject old→new at *any* level; only aggregate counts at Info. Drawdown guard leaves this **unclamped** (`:2295`). A corrupted subject total is undiagnosable from the log. |
+| 2 | **HIGH** | `:377/:388` tech-node availability flips | Per-node identity only at Verbose ("first 10 missing", `:428`); Info is counts only. A wrongly re-locked researched node shows only `madeUnavailable=N`. |
+| 3 | **HIGH** | `:2177/:1727` contract remove/restore | contractId only at Verbose/Warn; Info is counts. A wrongly-removed active contract (lost advance/reward) is not identifiable. |
+| 4 | MED | `FacilityStatePatcher.cs:109` `SetLevel` | Per-facility old→new only at Verbose. A silently-downgraded launchpad (blocks launches) shows `patched=1`. |
+| 5 | MED | `PostLoadStripper.cs:280` `Vessel.Die()` | No per-vessel Info line; destroyed vessels appear only as a joined **bare-PID list** on `Strip stripped=[…]` `:213`. PID is craft-baked / non-unique → forensically weak. |
+| 6 | MED | `:1088/:1098/:1363` milestone flips | Per-node set/clear only at Verbose. A wrongly-cleared milestone can revoke its reward on the next recalc. |
+| 7 | LOW | `LedgerOrchestrator.cs:1786/:1769` | The single most important branch — `authoritativeReduction` (authorized rewind drawdown vs buggy live clobber) and patch-deferral reason — logged only at Verbose. |
+
+**Helper note:** `VerboseStablePatchState` (`KspStatePatcher.cs:24`) routes skip/no-op
+states through `ParsekLog.VerboseOnChange`; actual-mutation logs use `ParsekLog.Info`.
+
+### 4.3 Vessel reconstruction logging
+
+Vessels are **not** patched by the ledger system (`grep ProtoVessel|FlightGlobals.Vessels`
+in `KspStatePatcher.cs` = zero hits). They are reconstructed only on the
+**Rewind-to-Separation** path: `RewindInvoker.ConsumePostLoad` →
+`ReconciliationBundle.Restore` (repopulates `FlightGlobals.Vessels` from the RP
+quicksave; Info `vesselCount=` `:642`) → `PostLoadStripper.Strip` (vessel destruction via
+`Vessel.Die()` under `SuppressionGuard.Crew()` so deaths don't fan out to the ledger).
+Per-vessel `Die()` is logged at **Verbose** for strict-unmatched strips (`:204`) and
+only as a joined PID list in one Info summary (`:213`); a throwing `Die()` is Warn
+(`:286`). Survivor reconciliation Info `:993`; spawn/respawn routes through
+`ParsekScenario.ReconcileSpawnStateAfterStrip` (`:995`).
+
+---
+
+## 5. Test coverage audit
+
+### 5.1 Inventory by layer
+
+| Layer | Representative tests | Verdict |
+|---|---|---|
+| (a) Pure recalc math (modules) | Funds(65)/Science(53)/Reputation(48)/Contracts(43)/Facilities(22)/Milestones(15)/Strategies(34)/Route(16) module tests, `RecalculationEngineTests`(39), `CrossTierIntegrationTests`(7), `FullCareerTimelineTests`(3) | **Strong** |
+| (b) Serialization / round-trip | `GameActionSerializationTests`(51), `GameStateEventTests`(102), `LedgerTombstoneRoundTripTests`(3), `RecordingSupersedeRelationRoundTripTests` | **Strong** |
+| (c) Load migration | `LedgerRecoveryMigrationTests`(14), `ActionIdMigrationTests`, `MergeJournalForkMigrationTests` | **OK** |
+| (d) Rewind / supersede / tombstone / cutoff | `RewindSupersedeRollbackTests`(43), `SupersedeCommitTests`(101), `SupersedeCommitTombstoneTests`(23), `TombstoneEligibilityTests`(26), `EffectiveStateTests`(39), `RewindUtCutoffTests`(~80) | **Strong on logic, module-state-only** |
+| (e) **KSP-apply (`KspStatePatcher`, 2315 LOC)** | `KspStatePatcherTests`(43), `PatchFundsSanityTests`(7), `ContractAcceptPatchTests`(6), `MilestonePatchingTests`(18), `ScienceSubjectPatchHardeningTests`(5) | **THIN at the real mutation boundary** |
+| (f) Crash recovery | `MergeCrashRecoveryMatrixTests`(5), `MergeJournalOrchestratorTests`, `ParsekScenarioRecoveryRoutingTests` | **OK** |
+| Reconciliation diagnostics | `EarningsReconciliationTests`(112), `PostWalkReconciliationIntegrationTests`(6) | diagnostic-only (WARN on divergence), not a state-diff |
+
+### 5.2 The critical question — is the round trip verified against an actual save (incl. vessels)?
+
+**NO.** There is no test that snapshots a real KSP save at UT X, rewinds, reconstructs,
+and asserts reconstructed funds/science/rep/facilities/kerbals/**vessels** match that
+save. Evidence:
+
+- **`KspStatePatcherTests` run with `SuppressUnityCallsForTesting = true`.** In xUnit the
+  `Funding`/`R&D`/`Reputation` singletons are null, so every real mutation site hits the
+  `if (… == null) return;` early-return. xUnit covers only the **pure target
+  computation** (`BuildTargetTechIdsForPatch`, `AdjustSciencePatchTargetForPending*`,
+  `BuildSubjectIdsForPatch`, `BuildFacilityPatchTargets`) + null-guard logging — never
+  compute-delta → write → read-back.
+- **`FullCareerTimelineTests.FullMunLandingTimeline`** (closest E2E) asserts a full
+  ~20-action timeline reconstructs to hand-computed constants (funds=39700, science=50,
+  facility level 2, …) — but compares against **constants, not a save snapshot**, reads
+  **in-memory module getters, not live `Funding.Instance`**, has **no rewind** (forward
+  walk), and **no vessels**.
+- **`RewindUtCutoffTests`** verify cutoff projection drops future actions correctly —
+  module-state-only, no live singleton, no save, no vessels.
+- **`TopBarReflectsLedgerAfterRecalc`** (`RuntimeTests.cs:15573`, in-game) asserts
+  `Funding.Instance.Funds == FundsModule.GetAvailableFunds()` **after** patching — this
+  is **circular** (the patcher just wrote the live value from the module; it always
+  passes). It proves the write happened, not that the reconstruction is correct.
+- **`GameActionsHealth`** in-game tests (`ExtendedRuntimeTests.cs:710+`) are singleton
+  sanity only (`Funds >= 0`, rep in `[-1000,1000]`).
+- The only live-singleton apply tests are 2 in-game tests (`RuntimeTests.cs:22661+`,
+  drawdown-guard / spending-gate) using **hand-seeded synthetic modules**, not a
+  recalculated ledger.
+
+### 5.3 Riskiest untested paths
+
+1. **`KspStatePatcher` live mutation with a recalculated ledger** — the exact code that
+   writes real funds/science/rep/tech/facilities, only run live by 2 synthetic-input
+   in-game tests. Highest-risk gap.
+2. **Full closed-loop rewind→recalc→reapply numeric equivalence** — no test proves
+   reconstructing at the live tip reproduces pre-rewind balances exactly.
+3. **Per-subject science + tech-tree node-set apply against live R&D** — target-set
+   computation tested; observed effect on `ResearchAndDevelopment.Instance` not.
+4. **Cross-subsystem consistency (ledger scalars ↔ restored vessels)** — a rewind
+   restores both; nothing asserts they agree.
+5. **Facility-level/destruction apply on live `ProtoUpgradeables`** — target computation
+   tested, live level change not.
+
+---
+
+## 6. The ground-truth oracle that already exists (key insight)
+
+On rewind, `RewindInvoker` copies the RewindPoint quicksave
+(`saves/<save>/Parsek/RewindPoints/<rpId>.sfs`) to the save root and calls KSP's
+`GamePersistence.LoadGame` — loading a **real KSP save at the rewind UT**, with the
+actual funds/science/rep/facilities/vessels baked in. **Only then** does
+`RecalculateAndPatch(double.MaxValue)` run (`RewindInvoker.cs:908`), overwriting those
+values with the recalc result.
+
+⇒ The live KSP state **immediately after load, before the patch**, is ground truth.
+Nothing currently reads it back to verify the recalc agrees. This is the natural oracle
+for both a production self-check and an in-game verification harness.
+
+---
+
+## 7. Existing observability infrastructure (the reusable template)
+
+The map/TS render tracer is the proven pattern to copy (selectively).
+
+**Two-file shape:** a pure static trace module (`MapRenderTrace.cs`) + a MonoBehaviour
+truth probe (`MapRenderProbe.cs`); sibling `GhostRenderTrace.cs` mirrors it for flight.
+
+- **Gating (near-zero cost when off):** `MapRenderTrace.IsEnabled` (`:378`) =
+  `ForceEnabledForTesting || ParsekSettings.Current.mapRenderTracing`. Every emit
+  early-returns on `!IsEnabled`; the probe's whole `LateUpdate` is one bool check
+  (`MapRenderProbe.cs:168`).
+- **Three tiers:** Tier-A structural (`EmitStructural` `:719` → `Info`, opens a detailed
+  window); Tier-B change-based truth (`EmitOnChange` `:670`, one Verbose line per
+  *changed* field, caller-owned change detection); Tier-C anomalies (`EmitAnomaly`
+  `:792`, pure Unity-free predicates `IsIconJump`/`IsLineBlink`/`IsIconOffOrbit`,
+  rate-limited).
+- **Intent → truth → reconcile (the core mechanism):** the decision site records its
+  *intent* frame-stamped (`RecordLineIntent` `:861`); the probe runs at
+  `[DefaultExecutionOrder(10000)]` so it reads ACTUAL state after renderers; pure
+  `ReconcileLineState` (`:951`) returns a mismatch token; freshness gating
+  (`IntentFreshnessFrames=0`) drops stale intent instead of false-flagging.
+- **Detailed-window registry:** `detailedUntilByKey` (`:365`) keeps full per-frame detail
+  only around interesting events; `Reset()` clears pid-keyed stores on scene switch.
+
+**`ParsekLog` primitives a tracer builds on** (`ParsekLog.cs`): `Info/Warn/Error/Verbose`;
+`VerboseRateLimited` (`:161`, per-key throttle + suppressed-count); `VerboseOnChange`
+(`:271`, emit only when a caller `stateKey` flips per identity — already used by the
+recalc summary); `WarnRateLimited` (`:404`, not gated on verbose); `RecState` (`:511`,
+structured field-ordered grep-stable snapshot line — closest existing analogue to a
+state tracer); test seams `TestSinkForTesting`/`TestObserverForTesting`/
+`ClockOverrideForTesting`/`SuppressScope`; all `[ThreadStatic]`.
+
+**Settings-flag plumbing template** (to add a `ledgerTracing` flag, mirror
+`mapRenderTracing` across 4 files): `ParsekSettings.cs:56` (field +
+`[CustomParameterUI]`), `UI/SettingsWindowUI.cs:458` (Diagnostics toggle),
+`ParsekSettingsPersistence.cs:46` (key + record/load/restore), defaults-reset path
+(`SettingsWindowUI.cs:195`). Convention suffix for heavy logs: `"(Warning: huge logs)"`.
+
+**In-game test runner capability** (`InGameTests/`): reflection discovery
+(`InGameTestRunner.DiscoverTests:227`), `[InGameTest]` attrs carry
+`Category/Scene/Description/RunLast/AllowBatchExecution/RestoreBatchFlightBaselineAfterExecution`;
+tests can be multi-frame `IEnumerator` coroutines; can quicksave/quickload
+(`QuickloadResumeHelpers.TriggerQuicksave`, `ValidateQuicksaveStructure`), read live
+`Funding/RnD/Reputation.Instance` + `FlightGlobals`, and assert via `InGameAssert`
+(`AreEqual/ApproxEqual/IsGreaterThan/Contains/Skip`). Existing `SnapshotFinancials` /
+`RestoreFinancials` helpers (`RuntimeTests.cs:14541`) snapshot+restore the three pools
+under a `SuppressionGuard`. Precedent for ledger-driven in-game tests:
+`ContractTombstonesAcrossSupersedeTest`, `KerbalRecoveryOnSupersedeTest`.
+
+**Existing ledger-side observability** is ordinary structured logging, not a tracer —
+no intent/truth reconcile loop. Closest existing pattern:
+`KerbalLoadRepairDiagnostics` (accumulate counters → `EmitAndReset` once, bounded
+samples, `HasInterestingChanges` gate), driven from `LedgerOrchestrator.cs:2386`.
+
+---
+
+## 8. Recommendations (priority order)
+
+1. **Rewind read-back guard (production safety).** At the rewind apply boundary, compare
+   the just-loaded quicksave economy (ground truth, §6) against the recalc target
+   *before* patching; fire a loud Warn (and optionally abort the patch) on divergence.
+   Turns silent career corruption into a caught, logged, abortable event. *Highest
+   leverage; most self-contained.*
+2. **Logging gaps 1–3** (per-subject science, tech nodes, contracts): promote per-identity
+   changes to a trace-gated line. HIGH risk, currently invisible.
+3. **In-game ground-truth harness:** from a career save at UT X, capture a quicksave
+   snapshot S, run `RecalculateAndPatch`, and diff the recalc output against S
+   independently (funds, science pool, per-subject science, rep, facility levels,
+   contract/milestone sets, and the **vessel set** parsed from S's `.sfs`). The closed
+   loop that doesn't exist today.
+4. **`LedgerTrace`** behind a `ledgerTracing` flag (event-driven, **not** a per-frame
+   probe): intent capture at each `Patch*`, read-back reconcile → Tier-C `ledger-vs-truth`
+   anomaly, per-identity Tier-B change lines (folds in gaps 4–7), Tier-A `RecState`-style
+   structural snapshot per recalc. Built almost entirely on existing primitives.
+5. **xUnit apply-boundary tests:** add a thin live-singleton fake (or move assertions
+   fully in-game) so the compute-delta → write → read-back loop is covered headlessly,
+   not null-skipped under `SuppressUnityCallsForTesting`.
+
+---
+
+## 9. Key file index
+
+| Concern | File:line |
+|---|---|
+| Apply funnel | `GameActions/KspStatePatcher.cs:39` (`PatchAll`) |
+| Funds/Science/Rep apply (good logs) | `KspStatePatcher.cs:730/:157/:800` |
+| Per-subject science (gap 1) | `KspStatePatcher.cs:871` |
+| Tech tree (gap 2) | `KspStatePatcher.cs:377/:388` |
+| Contracts (gap 3) | `KspStatePatcher.cs:2177/:1727` |
+| Facility level (gap 4) | `FacilityStatePatcher.cs:109` |
+| Vessel strip (gap 5) | `PostLoadStripper.cs:280` |
+| Orchestrator entry | `GameActions/LedgerOrchestrator.cs:1325/:1705/:1889` |
+| Recalc engine | `GameActions/RecalculationEngine.cs:144` |
+| Rewind apply order (oracle) | `RewindInvoker.cs:908` |
+| Tracer template | `MapRenderTrace.cs`, `MapRenderProbe.cs` |
+| Log primitives | `ParsekLog.cs` (`VerboseOnChange:271`, `RecState:511`) |
+| Settings flag template | `ParsekSettings.cs:56`, `UI/SettingsWindowUI.cs:458`, `ParsekSettingsPersistence.cs:46` |
+| In-game runner | `InGameTests/InGameTestRunner.cs`, `RuntimeTests.cs:14541/:15573/:22661` |
+| Closest E2E test | `Source/Parsek.Tests/FullCareerTimelineTests.cs` |
+| ERS/ELS routing rule | `EffectiveState.ComputeERS/ComputeELS`; allowlist `scripts/ers-els-audit-allowlist.txt` |


### PR DESCRIPTION
## What

Two new docs, no code changed:

- **`docs/dev/ledger-state-reconstruction-audit.md`** — audit of logging and test coverage for the ledger / game-actions system that reconstructs career state (funds, science global + per-subject, reputation, facilities, contracts, milestones, kerbals, tech tree) after rewind / fast-forward / time-warp / save-load.
- **`docs/dev/ledger-audit-followup-prompts.md`** — five self-contained session prompts, one per recommendation, each wired to the plan → review → fix → implement → review → fix workflow with clean-context subagents.

## Why

This subsystem rewrites real KSP career values every rewind/warp/reload. A silent bug here corrupts an entire career save, yet the two most dangerous parts — the live **apply boundary** (`KspStatePatcher`) and the **closed rewind→recalc→reapply loop** — are the least covered by logging and tests.

## Key findings

- **Logging:** the three headline pools (funds, science pool, reputation) log `old → new (delta, target)` at Info — fully debuggable. Per-subject science, tech nodes, facility levels, milestones, contracts, and vessel deletion log identities **only at Verbose**; Info shows aggregate counts only. Per-subject science (`KspStatePatcher.cs:871`) is also left **unclamped** by the drawdown guard — the highest-risk single gap.
- **Tests:** recalc math, serialization, and supersede/tombstone/cutoff topology are strong (hundreds of unit tests). But `KspStatePatcherTests` run under `SuppressUnityCallsForTesting` with null singletons, so the real compute-delta → write → read-back loop is exercised live by only **2 synthetic-input in-game tests**. There is **no end-to-end reconstruction-vs-ground-truth-save check**, and none touching vessels. `TopBarReflectsLedgerAfterRecalc` is circular (module-vs-live-after-patch).
- **Unused oracle:** on rewind, the RewindPoint quicksave (`.sfs`) restores a real KSP save at the rewind UT *before* recalc overwrites it (`RewindInvoker.cs:908`) — a natural ground-truth oracle nothing reads back today.

## Recommendations (in priority order, one prompt each)

1. Rewind read-back divergence guard (production safety, highest leverage).
2. Close logging gaps 1–3 (per-subject science / tech nodes / contracts).
3. In-game ground-truth verification harness (recalc vs independently-parsed quicksave at UT, incl. vessels).
4. `LedgerTrace` — event-driven (not per-frame) ledger tracer behind a `ledgerTracing` flag.
5. Headless xUnit coverage for the live apply boundary.

The report includes a file:line index and the existing tracer/`ParsekLog`/in-game-runner templates the follow-ups should reuse.

https://claude.ai/code/session_01Ku9ryS5E9Ed9EdRG42rozK

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ku9ryS5E9Ed9EdRG42rozK)_