### PR TITLE
Surface changed identities at Info for per-subject science, tech nodes, contracts (audit gaps 1-3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ All notable changes to Parsek are documented here.
 
 - A long career session no longer floods the log with per-frame re-fly settle and per-recording overlap-gate diagnostics. These two traces alone were about two-thirds of a 2026-06-07 career playtest log (roughly 233,000 lines, none of it from an actual re-fly): the floating-origin shift line is now a throttled heartbeat, and the overlap-gate verdict logs only when it actually changes. The per-frame supply-route summary was given the same change-only treatment.
 - The recorder's "sparse sampling" WARN no longer fires during normal coasting or on parked vessels. Its large-gap threshold now scales with the configured sample-density backstop (about 3 seconds at the default Medium) instead of a fixed half-second, so only a genuinely stalled sampler warns; a long career session was logging well over a hundred of these on routine coasts.
+- When Parsek rewrites career state, the default log now names which per-subject science totals, tech-node availability flips, and contracts were changed (a bounded sample on the summary line, full list at Verbose), so a corrupted subject, node, or contract is identifiable from a normal log instead of only a count.
 
 ## 0.10.0
 

--- a/Source/Parsek.Tests/KspStatePatcherTests.cs
+++ b/Source/Parsek.Tests/KspStatePatcherTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Reflection;
+using Contracts;
 using Xunit;
 
 namespace Parsek.Tests
@@ -1119,6 +1120,149 @@ namespace Parsek.Tests
                 l.Contains("[KspStatePatcher]")
                 && l.Contains("RecordsAltitude")
                 && l.Contains("is missing stock record fields"));
+        }
+
+        // ================================================================
+        // Audit gaps 1-3: changed-identity sampling at the Info apply boundary
+        // ================================================================
+
+        [Fact]
+        public void ComposeBoundedIdentitySample_NullOrEmpty_ReturnsEmptyString()
+        {
+            // LOAD-BEARING no-spam contract: a null/empty changed list must append
+            // NOTHING so steady-state Info lines stay byte-identical. Empty string,
+            // never "[]".
+            Assert.Equal(string.Empty,
+                KspStatePatcher.ComposeBoundedIdentitySample(null, 10));
+            Assert.Equal(string.Empty,
+                KspStatePatcher.ComposeBoundedIdentitySample(new List<string>(), 10));
+        }
+
+        [Fact]
+        public void ComposeBoundedIdentitySample_UnderCap_AllEntriesNoMoreSuffix()
+        {
+            var entries = new List<string> { "alpha", "bravo", "charlie" };
+
+            string sample = KspStatePatcher.ComposeBoundedIdentitySample(entries, 10);
+
+            // All three present; no overflow marker because count <= cap.
+            Assert.Contains("alpha", sample);
+            Assert.Contains("bravo", sample);
+            Assert.Contains("charlie", sample);
+            Assert.DoesNotContain("more", sample);
+            Assert.Equal("alpha, bravo, charlie", sample);
+        }
+
+        [Fact]
+        public void ComposeBoundedIdentitySample_OverCap_FirstNThenSingleMoreSuffix()
+        {
+            var entries = new List<string>();
+            for (int i = 0; i < 13; i++)
+                entries.Add("id" + i.ToString());
+
+            string sample = KspStatePatcher.ComposeBoundedIdentitySample(entries, 10);
+
+            // First cap entries present, the rest absent, exactly one "(+3 more)".
+            Assert.Contains("id0", sample);
+            Assert.Contains("id9", sample);
+            Assert.DoesNotContain("id10", sample);
+            Assert.DoesNotContain("id12", sample);
+            Assert.Contains("(+3 more)", sample);
+            // Exactly one overflow marker (no double-append).
+            int markerCount = CountOccurrences(sample, "more)");
+            Assert.Equal(1, markerCount);
+        }
+
+        [Fact]
+        public void ComposeBoundedIdentitySample_ScienceIdentityShape_PreservesOldToNew()
+        {
+            // GAP 1 shape: subjectId:old->new survives the formatter verbatim, with
+            // invariant-culture round-trip floats.
+            float oldScience = 124.8f;
+            float newScience = 1.0f;
+            var entries = new List<string>
+            {
+                $"surfaceSampleMinmus:{oldScience.ToString("R", System.Globalization.CultureInfo.InvariantCulture)}->" +
+                $"{newScience.ToString("R", System.Globalization.CultureInfo.InvariantCulture)}"
+            };
+
+            string sample = KspStatePatcher.ComposeBoundedIdentitySample(entries, 10);
+
+            Assert.Contains("surfaceSampleMinmus", sample);
+            Assert.Contains("->", sample);
+            // The drawdown-corruption shape (124.8 -> 1.0) must be readable. 1.0f
+            // round-trips as "1" under "R"/InvariantCulture, so the new value reads "->1".
+            Assert.Contains("124.8", sample);
+            Assert.Contains("124.8->1", sample);
+        }
+
+        [Fact]
+        public void DescribeRemovedContractIdentities_CurrentBeforeFinished_AllGuidsPresent()
+        {
+            // GAP 3 end-to-end: derive removed identities from two key sets and pass them
+            // through the formatter. Assert membership + current-category-before-finished
+            // ordering, NOT intra-HashSet ordering (the sets are HashSet-sourced).
+            var currentGuid = Guid.Parse("11111111-1111-1111-1111-111111111111");
+            var finishedGuid = Guid.Parse("22222222-2222-2222-2222-222222222222");
+            var currentKeys = new HashSet<KspStatePatcher.ContractRemovalKey>
+            {
+                new KspStatePatcher.ContractRemovalKey
+                {
+                    Id = currentGuid, State = Contract.State.Active
+                }
+            };
+            var finishedKeys = new HashSet<KspStatePatcher.ContractRemovalKey>
+            {
+                new KspStatePatcher.ContractRemovalKey
+                {
+                    Id = finishedGuid, State = Contract.State.Completed
+                }
+            };
+
+            var ids = KspStatePatcher.DescribeRemovedContractIdentities(currentKeys, finishedKeys);
+            string sample = KspStatePatcher.ComposeBoundedIdentitySample(ids, 10);
+
+            Assert.Contains(currentGuid.ToString(), sample);
+            Assert.Contains(finishedGuid.ToString(), sample);
+            // Current-set keys are emitted before finished-set keys.
+            Assert.True(
+                sample.IndexOf(currentGuid.ToString(), StringComparison.Ordinal)
+                    < sample.IndexOf(finishedGuid.ToString(), StringComparison.Ordinal),
+                "current-set removal id must precede finished-set removal id");
+        }
+
+        [Fact]
+        public void DescribeRemovedContractIdentities_OverCap_EmitsMoreSuffix()
+        {
+            // GAP 3 over-cap safety: >cap removal keys must not blow up the Info line.
+            var currentKeys = new HashSet<KspStatePatcher.ContractRemovalKey>();
+            for (int i = 0; i < 13; i++)
+            {
+                currentKeys.Add(new KspStatePatcher.ContractRemovalKey
+                {
+                    Id = Guid.NewGuid(), State = Contract.State.Active
+                });
+            }
+
+            var ids = KspStatePatcher.DescribeRemovedContractIdentities(
+                currentKeys, new HashSet<KspStatePatcher.ContractRemovalKey>());
+            string sample = KspStatePatcher.ComposeBoundedIdentitySample(ids, 10);
+
+            Assert.Equal(13, ids.Count);
+            Assert.Contains("(+3 more)", sample);
+        }
+
+        private static int CountOccurrences(string haystack, string needle)
+        {
+            int count = 0;
+            int index = 0;
+            while ((index = haystack.IndexOf(needle, index, StringComparison.Ordinal)) >= 0)
+            {
+                count++;
+                index += needle.Length;
+            }
+
+            return count;
         }
     }
 }

--- a/Source/Parsek/GameActions/KspStatePatcher.cs
+++ b/Source/Parsek/GameActions/KspStatePatcher.cs
@@ -19,6 +19,12 @@ namespace Parsek
     {
         private const string Tag = "KspStatePatcher";
         private const double RecordStateEpsilon = 0.000001;
+
+        // Max per-identity entries appended to a default-level (Info) apply line.
+        // Keeps the Info aggregate diagnosable without unbounded log growth; the full
+        // list is emitted alongside at Verbose.
+        private const int IdentitySampleCap = 10;
+
         private static readonly CultureInfo IC = CultureInfo.InvariantCulture;
 
         private static void VerboseStablePatchState(string identity, string stateKey, string message)
@@ -360,6 +366,8 @@ namespace Parsek
             int bypassRehydratedNodes = 0, bypassTotalPartsAdded = 0, bypassFallbackNodes = 0;
             var seen = new HashSet<string>(StringComparer.Ordinal);
             List<string> missingTargetIds = null;
+            var madeUnavailableIds = new List<string>();
+            var madeAvailableIds = new List<string>();
 
             foreach (var tech in AssetBase.RnDTechTree.GetTreeTechs())
             {
@@ -375,7 +383,10 @@ namespace Parsek
                 {
                     ProtoTechNode proto = ResearchAndDevelopment.Instance.GetTechState(techId);
                     if (proto == null || proto.state != RDTech.State.Available)
+                    {
                         madeAvailable++;
+                        madeAvailableIds.Add(techId);
+                    }
                     else
                         alreadyAvailable++;
 
@@ -393,7 +404,10 @@ namespace Parsek
                 else
                 {
                     if (currentState == RDTech.State.Available || tech.state == RDTech.State.Available)
+                    {
                         madeUnavailable++;
+                        madeUnavailableIds.Add(techId);
+                    }
                     else
                         alreadyUnavailable++;
 
@@ -422,6 +436,12 @@ namespace Parsek
             string baselineLabel = baselineUt.HasValue
                 ? baselineUt.Value.ToString("R", IC)
                 : "null";
+            // madeUnavailable identities lead (the dangerous direction: a wrongly
+            // re-locked researched node), followed by madeAvailable identities.
+            string madeUnavailableSample =
+                ComposeBoundedIdentitySample(madeUnavailableIds, IdentitySampleCap);
+            string madeAvailableSample =
+                ComposeBoundedIdentitySample(madeAvailableIds, IdentitySampleCap);
             ParsekLog.Info(Tag,
                 $"PatchTechTree: available={target.Count.ToString(IC)}, " +
                 $"madeAvailable={madeAvailable.ToString(IC)}, " +
@@ -429,7 +449,23 @@ namespace Parsek
                 $"alreadyAvailable={alreadyAvailable.ToString(IC)}, " +
                 $"alreadyUnavailable={alreadyUnavailable.ToString(IC)}, " +
                 $"missingTargets={missingTargets.ToString(IC)}, " +
-                $"utCutoff={cutoffLabel}, baselineUt={baselineLabel}");
+                $"utCutoff={cutoffLabel}, baselineUt={baselineLabel}" +
+                (madeUnavailableSample.Length > 0
+                    ? $", madeUnavailableIds=[{madeUnavailableSample}]"
+                    : string.Empty) +
+                (madeAvailableSample.Length > 0
+                    ? $", madeAvailableIds=[{madeAvailableSample}]"
+                    : string.Empty));
+
+            if (madeUnavailableIds.Count > 0)
+                ParsekLog.Verbose(Tag,
+                    $"PatchTechTree: all {madeUnavailableIds.Count.ToString(IC)} made-unavailable tech id(s): " +
+                    string.Join(", ", madeUnavailableIds));
+
+            if (madeAvailableIds.Count > 0)
+                ParsekLog.Verbose(Tag,
+                    $"PatchTechTree: all {madeAvailableIds.Count.ToString(IC)} made-available tech id(s): " +
+                    string.Join(", ", madeAvailableIds));
 
             if (bypassRehydratedNodes > 0)
                 ParsekLog.Verbose(Tag,
@@ -881,6 +917,7 @@ namespace Parsek
             int skippedSubjects = 0;
             int notFoundSubjects = 0;
             int clearedSubjects = 0;
+            var changedSubjects = new List<string>();
 
             foreach (var subjectId in subjectIds)
             {
@@ -896,6 +933,8 @@ namespace Parsek
                 float targetScience = hasCurrentState ? (float)state.CreditedTotal : 0f;
                 if (Math.Abs(kspSubject.science - targetScience) > 0.001f)
                 {
+                    // Read the live value BEFORE the write so the log captures old->new.
+                    float oldScience = kspSubject.science;
                     kspSubject.science = targetScience;
                     if (kspSubject.scienceCap > 0f)
                         kspSubject.scientificValue = 1f - (targetScience / kspSubject.scienceCap);
@@ -905,6 +944,8 @@ namespace Parsek
                     patchedSubjects++;
                     if (!hasCurrentState)
                         clearedSubjects++;
+                    changedSubjects.Add(
+                        $"{subjectId}:{oldScience.ToString("R", IC)}->{targetScience.ToString("R", IC)}");
                 }
                 else
                 {
@@ -912,12 +953,22 @@ namespace Parsek
                 }
             }
 
+            string changedSubjectsSample =
+                ComposeBoundedIdentitySample(changedSubjects, IdentitySampleCap);
             ParsekLog.Info(Tag,
                 $"PatchPerSubjectScience: patched={patchedSubjects.ToString(IC)}, " +
                 $"cleared={clearedSubjects.ToString(IC)}, " +
                 $"skipped={skippedSubjects.ToString(IC)}, " +
                 $"notFound={notFoundSubjects.ToString(IC)}, " +
-                $"totalSubjects={subjectIds.Count}");
+                $"totalSubjects={subjectIds.Count}" +
+                (changedSubjectsSample.Length > 0
+                    ? $", changedSubjects=[{changedSubjectsSample}]"
+                    : string.Empty));
+
+            if (changedSubjects.Count > 0)
+                ParsekLog.Verbose(Tag,
+                    $"PatchPerSubjectScience: all {changedSubjects.Count.ToString(IC)} changed subject(s): " +
+                    string.Join(", ", changedSubjects));
         }
 
         internal static HashSet<string> BuildSubjectIdsForPatch(
@@ -1677,6 +1728,12 @@ namespace Parsek
                 $"{survivingTerminalIds.Count.ToString(IC)} terminal contract(s) preserved in place " +
                 $"(unregisterFailures={unregisterFailures.ToString(IC)})");
 
+            // These are the TARGETED removal keys (pure set): current keys first, then
+            // finished keys. The count can exceed the actually-removed count if a targeted
+            // live contract was already absent from the KSP list.
+            var removedIds = DescribeRemovedContractIdentities(
+                toRemoveCurrentKeys, toRemoveFinishedKeys);
+
             // 2. Rebuild ONLY contracts that are in the ledger but not already present.
             int restored = 0;
             int skippedExisting = 0;
@@ -1685,6 +1742,7 @@ namespace Parsek
             int typeNotFound = 0;
             int loadFailed = 0;
             int registered = 0;
+            var restoredIds = new List<string>();
 
             foreach (string contractId in activeIds)
             {
@@ -1768,6 +1826,7 @@ namespace Parsek
                         }
 
                         restored++;
+                        restoredIds.Add(contractId);
                     }
                     else
                     {
@@ -1799,6 +1858,10 @@ namespace Parsek
 
             int kspTotalAfter = currentContracts != null ? currentContracts.Count : 0;
             int kspFinishedAfter = finishedContracts != null ? finishedContracts.Count : 0;
+            string removedSample =
+                ComposeBoundedIdentitySample(removedIds, IdentitySampleCap);
+            string restoredSample =
+                ComposeBoundedIdentitySample(restoredIds, IdentitySampleCap);
             ParsekLog.Info(Tag,
                 $"PatchContracts: removedStale={removedStale.ToString(IC)}, " +
                 $"removedFinishedTombstoned={removedFinishedTombstoned.ToString(IC)}, " +
@@ -1813,7 +1876,23 @@ namespace Parsek
                 $"ledgerTerminal={terminalIds.Count.ToString(IC)}, " +
                 $"kspTotal={kspTotalAfter.ToString(IC)}, " +
                 $"kspFinished={kspFinishedAfter.ToString(IC)} " +
-                $"(Offered and unrelated finished history preserved; tombstoned terminal filtered)");
+                $"(Offered and unrelated finished history preserved; tombstoned terminal filtered)" +
+                (removedSample.Length > 0
+                    ? $", removedIds=[{removedSample}]"
+                    : string.Empty) +
+                (restoredSample.Length > 0
+                    ? $", restoredIds=[{restoredSample}]"
+                    : string.Empty));
+
+            if (removedIds.Count > 0)
+                ParsekLog.Verbose(Tag,
+                    $"PatchContracts: all {removedIds.Count.ToString(IC)} targeted removed contract id(s): " +
+                    string.Join(", ", removedIds));
+
+            if (restoredIds.Count > 0)
+                ParsekLog.Verbose(Tag,
+                    $"PatchContracts: all {restoredIds.Count.ToString(IC)} restored contract id(s): " +
+                    string.Join(", ", restoredIds));
         }
 
         // ================================================================
@@ -2086,6 +2165,59 @@ namespace Parsek
                 Id = entry.Id,
                 State = entry.State
             };
+        }
+
+        /// <summary>
+        /// Pure helper: composes a bounded, comma-joined sample of changed-identity
+        /// descriptions for a default-level (Info) apply line. Returns string.Empty for a
+        /// null/empty list so the caller appends NOTHING (steady-state Info lines stay
+        /// byte-identical). Under the cap, the full list joins as-is; over the cap, the
+        /// first <paramref name="cap"/> entries join followed by a " (+N more)" overflow
+        /// marker. The full list is emitted separately at Verbose by each caller.
+        /// </summary>
+        internal static string ComposeBoundedIdentitySample(
+            IReadOnlyList<string> changedDescriptions, int cap)
+        {
+            if (changedDescriptions == null || changedDescriptions.Count == 0)
+                return string.Empty;
+
+            int count = changedDescriptions.Count;
+            if (count <= cap)
+                return string.Join(", ", changedDescriptions);
+
+            var head = new List<string>(cap);
+            for (int i = 0; i < cap; i++)
+                head.Add(changedDescriptions[i]);
+
+            return string.Join(", ", head)
+                + " (+" + (count - cap).ToString(IC) + " more)";
+        }
+
+        /// <summary>
+        /// Pure helper: derives the contract identities targeted for removal by the
+        /// per-state removal-key sets — current-set keys first, then finished-set keys.
+        /// Headless-testable because both inputs come from pure key builders. The result
+        /// reflects the TARGETED removal keys, which can exceed the count actually removed
+        /// when a targeted contract was already absent from the live KSP list.
+        /// </summary>
+        internal static List<string> DescribeRemovedContractIdentities(
+            HashSet<ContractRemovalKey> currentKeys,
+            HashSet<ContractRemovalKey> finishedKeys)
+        {
+            var ids = new List<string>();
+            if (currentKeys != null)
+            {
+                foreach (var key in currentKeys)
+                    ids.Add(key.Id.ToString());
+            }
+
+            if (finishedKeys != null)
+            {
+                foreach (var key in finishedKeys)
+                    ids.Add(key.Id.ToString());
+            }
+
+            return ids;
         }
 
         private static bool IsSurvivingTerminalEntry(

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -61,6 +61,20 @@ When referencing prior item numbers from source comments or plans, consult the r
 
 **Status:** Implemented. Full xUnit suite green except the known `InjectAllRecordings` environmental flake (KSP.log lock). In-game validation pending: run `RuntimeTests.RewindReadbackGuard_WarnsOnDivergence_LeavesLiveUnchanged` (Ctrl+Shift+T, FLIGHT) to confirm the WARN fires and live values are untouched; a real healthy rewind should log only within-range / Verbose lines (no FLAGGED DIVERGENCE).
 
+## Done - Per-identity logging at the apply boundary (audit rec #2, gaps 1-3, `docs/dev/ledger-state-reconstruction-audit.md` §4.2)
+
+**Source:** Recommendation #2 of the ledger-state-reconstruction audit: promote the three HIGH-risk per-identity logging gaps from Verbose-only to the default (Info) apply line so a per-subject-science / tech-node / contract corruption is diagnosable from a normal `KSP.log`, not only Verbose.
+
+- ~~**Gap 1 - per-subject science (`KspStatePatcher.PatchPerSubjectScience`):**~~ DONE. The Info summary now carries a bounded `changedSubjects=[subjectId:old->new, ...]` clause (old read before the write), full list at Verbose.
+- ~~**Gap 2 - tech-node availability flips (`KspStatePatcher.PatchTechTree`):**~~ DONE. The Info summary now carries bounded `madeUnavailableIds=[...]` (the dangerous re-lock direction, listed first) and `madeAvailableIds=[...]` clauses, full lists at Verbose. (The `...Ids` suffix keeps the identity-list clauses distinct from the existing `madeAvailable=`/`madeUnavailable=` count fields on the same line.)
+- ~~**Gap 3 - contract remove/restore (`KspStatePatcher.PatchContracts`):**~~ DONE. The Info summary now carries bounded `removedIds=[...]` (targeted removal keys, current set before finished set) and `restoredIds=[...]` clauses, full lists at Verbose.
+
+**Mechanism:** shared pure formatter `KspStatePatcher.ComposeBoundedIdentitySample(list, cap=10)` returns `string.Empty` for a null/empty list (steady-state Info lines stay byte-identical), joins under the cap, and appends ` (+N more)` over the cap; each clause is appended only when the sample is non-empty. Contract removed-identity derivation is the pure `DescribeRemovedContractIdentities`. Logging-only, no schema/serialized-field change.
+
+**Files:** `Source/Parsek/GameActions/KspStatePatcher.cs` (formatter + `DescribeRemovedContractIdentities` + the three Info-line clauses + paired Verbose full-list lines), `Source/Parsek.Tests/KspStatePatcherTests.cs` (6 pure-helper tests).
+
+**Status:** Implemented. Full xUnit suite green except the known `InjectAllRecordings` environmental flake (KSP.log lock).
+
 ## Done 2026-06-07 - BUG-G: tech-purchase affordability gate contradicted the drawdown guard AND blocked destructively (double science loss)
 
 **Source:** 2026-06-07 career playtest, `logs/2026-06-07_2110_tech-purchase-bug/KSP.log` (~lines 13027-13045). Pure-stock play, no Parsek feature used. The player had live science 124.8 but Parsek blocked a 45-cost tech unlock as "insufficient science" AND the science was deducted anyway, twice (`ScienceChanged -45.0 -> 79.8`, block, `ScienceChanged -45.0 -> 34.8`, block; ~90 science lost, no node unlocked). This is the missing OTHER HALF of the drawdown guard above: the guard preserves live above a leaked ledger running balance, but the affordability gate read the leaked ledger value.


### PR DESCRIPTION
Closes the three HIGH-risk per-identity logging gaps at the ledger apply boundary identified in `docs/dev/ledger-state-reconstruction-audit.md` (rec #2, gaps 1-3). Before this, a per-subject-science / tech-node / contract corruption was invisible in a default-level `KSP.log`: only aggregate counts were at Info, the changed identities were Verbose-only.

## What changed

`Source/Parsek/GameActions/KspStatePatcher.cs` now appends a bounded sample of the *changed* identities to the existing Info summary line for each of the three patch methods, only when the changed set is non-empty:

- **Gap 1 - per-subject science (`PatchPerSubjectScience`):** `changedSubjects=[subjectId:old->new, ...]`. The old value is read before the write.
- **Gap 2 - tech-node flips (`PatchTechTree`):** `madeUnavailableIds=[...]` (the dangerous re-lock direction, listed first) and `madeAvailableIds=[...]`.
- **Gap 3 - contract remove/restore (`PatchContracts`):** `removedIds=[...]` (derived from the pure targeted-removal-key sets, current before finished) and `restoredIds=[...]`.

Each gap also emits the full changed list at Verbose. The identity-list tokens carry an `...Ids` suffix so they stay distinct from the existing count fields on the same line.

## Mechanism

A shared pure formatter `ComposeBoundedIdentitySample(list, cap=10)` returns `string.Empty` for a null/empty list (so steady-state Info lines stay byte-identical and there is no per-recalc spam), joins under the cap, and appends ` (+N more)` over the cap. Contract removed-identity derivation is the pure `DescribeRemovedContractIdentities`. Logging-only: no enums, serialized fields, or schema touched.

Per-gap Info-vs-Verbose split is volume-driven: a big rewind can flip many subjects, so the bounded sample caps the Info line while the full set stays at Verbose; the tech tree (~80 nodes) and active contract set are small, so the bounded sample usually shows the whole changed set inline.

## Tests

6 new pure-helper tests in `KspStatePatcherTests.cs` (the production loops early-return under the headless null singletons, so the load-bearing decision/format logic lives in the pure helpers the tests call directly): empty -> `""` (the no-spam invariant), under-cap, over-cap single `(+N more)`, science `old->new` shape, contract key->identity derivation with current-before-finished ordering, and contract over-cap.

Full xUnit suite green: 14655 passed, 0 failed.

Docs: `CHANGELOG.md` (0.10.1 Log Hygiene) and `docs/dev/todo-and-known-bugs.md` updated.