### PR TITLE
Harden same-parent zero-drift mission reschedule (Phases A-C)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ All notable changes to Parsek are documented here.
 - Fixed a bug where Parsek could wrongly block a tech-node purchase as "insufficient science" while you actually had plenty, and the science was still spent (twice in the reported case) with no node unlocked. The affordability check now respects your real science total in step with the keep-what-you-earned safety net, and a blocked tech or facility purchase no longer deducts anything before the block.
 - Fixed a critical bug where a normal scene change (for example leaving the Space Center for the Editor) could silently refund money you had just spent, such as a facility upgrade, restoring your funds to before the purchase. The keep-what-you-earned safety net now also protects against an unexpected increase: when no rewind or re-fly is active your current funds, science, and reputation are the source of truth, so a bookkeeping gap can no longer hand money back.
 - Fixed a bug where a single contract could be recorded as completing several times in a row (a stock re-fire), multiplying its recorded reward in Parsek's ledger. Duplicate completions of the same contract within the same instant are now ignored, so each contract is recorded once.
+- Looped Mun and Minmus missions no longer show a false off-target warning on the launch-window countdown when the loop is actually relaunching on schedule.
 
 ### Safety
 

--- a/Source/Parsek.Tests/MissionPeriodicityTests.cs
+++ b/Source/Parsek.Tests/MissionPeriodicityTests.cs
@@ -1199,6 +1199,198 @@ namespace Parsek.Tests
         }
 
         [Fact]
+        public void Build_Scheduled_HasNoLoiterCutsOrArrivalHold()
+        {
+            // INV-3 (4.3): the schedule branch of the span clock (TryComputeSpanLoopUT) returns early
+            // BEFORE the loiterCut / arrival-hold remap. That early return is correct ONLY because a
+            // scheduled unit is mutually exclusive with cuts/hold BY CONSTRUCTION: the schedule attaches
+            // exclusively in the same-parent phase-locked block, and the re-aim (cross-parent) block -
+            // the only producer of LoiterCuts / ArrivalHoldSeconds - sets RelaunchSchedule=null. This
+            // test drives the live Build if-chain (NOT the private TryBuildMissionUnit) with a same-parent
+            // drifting Mun config and asserts the mutual-exclusion delta directly on the LoopUnit: a unit
+            // with a non-null schedule carries NO loiter cuts and a zero arrival hold, so the span clock's
+            // bypass can never silently drop a cut/hold. The first three assertions overlap the existing
+            // Build_SupportedSameParentMun.../Build_DriftingLongSpan... tests; the LoiterCuts/ArrivalHold
+            // pair is the new INV-3 delta.
+            var ascent = SurfaceLeg("s", 1000, 1100, "Kerbin");
+            var transfer = OrbitLeg("o", 1100, 1600, "Kerbin");
+            WithSoiEntry(transfer, 1600, 2000, "Mun");
+            ascent.ChainId = "C"; ascent.ChainIndex = 0;
+            transfer.ChainId = "C"; transfer.ChainIndex = 1;
+            var tree = TreeOf("t", ascent, transfer);
+            var committed = new List<Recording>(tree.Recordings.Values);
+
+            double ut0 = 1000.0;
+            double spanEnd = 2000.0;            // last member end = the first play's span end
+            double span = spanEnd - ut0;
+            double anchorEnable = ut0 + 1.5 * MunOrbit;
+            var mission = LoopMissionFor("t", anchorEnable);
+
+            var set = MissionLoopUnitBuilder.Build(
+                new[] { mission }, new[] { tree }, committed, 30.0, StockFake());
+
+            Assert.True(set.TryGetUnitForMember(0, out var unit));
+            // Schedule attached, anchored on its own first launch, throttled to >= the span (overlap
+            // invariant). These overlap the existing same-parent / long-span tests.
+            Assert.NotNull(unit.RelaunchSchedule);
+            Assert.Equal(unit.RelaunchSchedule.FirstLaunchUT, unit.PhaseAnchorUT, 3);
+            Assert.True(unit.RelaunchSchedule.MinIntervalSeconds >= span);
+            // The INV-3 mutual-exclusion delta: a scheduled unit NEVER carries a loiter cut or an arrival
+            // hold (those are re-aim-only, and re-aim nulls the schedule). The span clock's early return
+            // before the cut/hold remap is therefore safe.
+            Assert.Null(unit.LoiterCuts);
+            Assert.Equal(0.0, unit.ArrivalHoldSeconds);
+        }
+
+        [Theory]
+        // configKind drives which same-parent (or unsupported) tree is built; each must attach NO schedule.
+        [InlineData("single-kerbin")]   // single Rotation(Kerbin) constraint - no drift -> fixed cadence
+        [InlineData("tidal-mun")]       // a Mun surface<->orbit handoff (tidally-locked body) - no drift
+        [InlineData("cross-parent")]    // UnsupportedCrossParent (Kerbin -> Duna) - never phase-locks
+        public void Build_NonDriftingOrUnsupportedConfigs_AttachNoSchedule(string configKind)
+        {
+            // Matrix (complements Build_SingleConstraint_NoZeroDriftSchedule... at :1145 and
+            // Build_UnsupportedCrossParent... at :1248, driven through the live Build if-chain): a
+            // single-constraint config, a tidally-locked-body handoff, and an UnsupportedCrossParent
+            // config all leave RelaunchSchedule NULL (only a same-parent DRIFTING multi-constraint config
+            // attaches the zero-drift schedule). Asserting the matrix here pins that the schedule-attach
+            // gate is selective, not "attach for anything supported".
+            RecordingTree tree;
+            switch (configKind)
+            {
+                case "single-kerbin":
+                {
+                    // Kerbin surface ascent + Kerbin orbit handoff = ONE Rotation(Kerbin) constraint.
+                    var surface = SurfaceLeg("s", 1000, 1100, "Kerbin");
+                    var orbit = OrbitLeg("o", 1100, 5000, "Kerbin");
+                    surface.ChainId = "C"; surface.ChainIndex = 0;
+                    orbit.ChainId = "C"; orbit.ChainIndex = 1;
+                    tree = TreeOf("t", surface, orbit);
+                    break;
+                }
+                case "tidal-mun":
+                {
+                    // A Mun-only surface<->orbit handoff: the only constraint is Rotation(Mun) (the body is
+                    // tidally locked, rotationPeriod == orbit period), so there is nothing incommensurate to
+                    // drift against -> no schedule. No Kerbin pad rotation in the included set.
+                    var munSurface = SurfaceLeg("s", 1000, 1100, "Mun");
+                    var munOrbit = OrbitLeg("o", 1100, 5000, "Mun");
+                    munSurface.ChainId = "C"; munSurface.ChainIndex = 0;
+                    munOrbit.ChainId = "C"; munOrbit.ChainIndex = 1;
+                    tree = TreeOf("t", munSurface, munOrbit);
+                    break;
+                }
+                case "cross-parent":
+                {
+                    // Kerbin ascent + a heliocentric Duna SOI entry = UnsupportedCrossParent.
+                    var ascent = SurfaceLeg("s", 1000, 1100, "Kerbin");
+                    var transfer = OrbitLeg("o", 1100, 5000, "Kerbin");
+                    WithSoiEntry(transfer, 5000, 6000, "Duna");
+                    ascent.ChainId = "C"; ascent.ChainIndex = 0;
+                    transfer.ChainId = "C"; transfer.ChainIndex = 1;
+                    tree = TreeOf("t", ascent, transfer);
+                    break;
+                }
+                default:
+                    throw new ArgumentException("unknown configKind " + configKind);
+            }
+
+            var committed = new List<Recording>(tree.Recordings.Values);
+            var mission = LoopMissionFor("t", 123456.0);
+
+            var set = MissionLoopUnitBuilder.Build(
+                new[] { mission }, new[] { tree }, committed, 30.0, StockFake());
+
+            Assert.True(set.TryGetUnitForMember(0, out var unit));
+            Assert.Null(unit.RelaunchSchedule);
+            // No schedule => the cut/hold remap is also absent (re-aim-only), so the mutual-exclusion
+            // delta holds vacuously here too.
+            Assert.Null(unit.LoiterCuts);
+            Assert.Equal(0.0, unit.ArrivalHoldSeconds);
+        }
+
+        [Fact]
+        public void Schedule_SaveLoadRoundTrip_RederivesIdentical()
+        {
+            // INV-4 (4.5): the MissionRelaunchSchedule is NEVER serialized; it is rebuilt on every load
+            // from the persisted Mission.LoopAnchorUT plus the live body geometry (folded into
+            // MissionLoopUnitBuilder.BuildSignature). So a save/reload must re-derive a BYTE-IDENTICAL
+            // launch sequence, or the engine would relaunch at different UTs after a reload than before.
+            //
+            // We model the round-trip with the actually-serialized inputs: Mission.LoopAnchorUT survives
+            // OnSave/OnLoad as a scalar, and the body geometry is re-read each Build from the live
+            // IBodyInfo seam (the same value StockFake() returns on every call). We do NOT drive
+            // ParsekScenario.OnSave/OnLoad in xUnit (Planetarium / GameEvents are unguarded there); the
+            // source-gate / pure equivalent is: persist LoopAnchorUT through a ConfigNode scalar, rebuild
+            // a SECOND Mission from the parsed value, Build both with a freshly-constructed StockFake()
+            // body digest, and assert the resolved launch sequence over k=0..K is identical.
+            var ascent = SurfaceLeg("s", 1000, 1100, "Kerbin");
+            var transfer = OrbitLeg("o", 1100, 1600, "Kerbin");
+            WithSoiEntry(transfer, 1600, 2000, "Mun");
+            ascent.ChainId = "C"; ascent.ChainIndex = 0;
+            transfer.ChainId = "C"; transfer.ChainIndex = 1;
+            var tree = TreeOf("t", ascent, transfer);
+            var committed = new List<Recording>(tree.Recordings.Values);
+
+            double anchorEnable = 1000.0 + 1.5 * MunOrbit;
+
+            // --- PRE-SAVE: build the schedule from the in-memory mission. ---
+            var missionBefore = LoopMissionFor("t", anchorEnable);
+            var setBefore = MissionLoopUnitBuilder.Build(
+                new[] { missionBefore }, new[] { tree }, committed, 30.0, StockFake());
+            Assert.True(setBefore.TryGetUnitForMember(0, out var unitBefore));
+            Assert.NotNull(unitBefore.RelaunchSchedule);
+
+            // --- SAVE: the only persisted schedule INPUT is the LoopAnchorUT scalar (round-tripped via a
+            // ConfigNode value using the project's InvariantCulture "R" contract). ---
+            var node = new ConfigNode("MISSION");
+            node.AddValue("LoopAnchorUT",
+                missionBefore.LoopAnchorUT.ToString("R", System.Globalization.CultureInfo.InvariantCulture));
+
+            // --- LOAD: parse the scalar back and reconstruct a fresh Mission. The body geometry is NOT
+            // persisted; it is re-read from a freshly-constructed StockFake() (the live-seam equivalent). ---
+            double parsedAnchorUT = double.Parse(
+                node.GetValue("LoopAnchorUT"), System.Globalization.CultureInfo.InvariantCulture);
+            Assert.Equal(missionBefore.LoopAnchorUT, parsedAnchorUT, 6); // the scalar survives the trip
+            var missionAfter = LoopMissionFor("t", parsedAnchorUT);
+            var setAfter = MissionLoopUnitBuilder.Build(
+                new[] { missionAfter }, new[] { tree }, committed, 30.0, StockFake());
+            Assert.True(setAfter.TryGetUnitForMember(0, out var unitAfter));
+            Assert.NotNull(unitAfter.RelaunchSchedule);
+
+            // --- ASSERT: the re-derived schedule resolves an IDENTICAL launch sequence. ---
+            var a = unitBefore.RelaunchSchedule;
+            var b = unitAfter.RelaunchSchedule;
+            Assert.Equal(a.FirstLaunchUT, b.FirstLaunchUT, 6);
+            Assert.Equal(unitBefore.PhaseAnchorUT, unitAfter.PhaseAnchorUT, 6);
+            Assert.Equal(a.MinIntervalSeconds, b.MinIntervalSeconds, 6);
+
+            // Resolve over k=0..K through the assembled schedule object: every launch UT + cycle index
+            // matches pre/post. Sweep UTs that step across the first ~K launches (one anchor period per
+            // step easily clears each non-uniform relaunch gap), plus a pre-first-launch parked probe and
+            // a far-future warp probe.
+            const int K = 64;
+            double firstLaunch = a.FirstLaunchUT;
+            var probes = new List<double> { firstLaunch - MunOrbit }; // parked before L_0
+            for (int k = 0; k <= K; k++)
+                probes.Add(firstLaunch + k * MunOrbit);
+            probes.Add(firstLaunch + 5e8); // far-future warp
+
+            foreach (double probe in probes)
+            {
+                bool ra = a.TryResolveActiveLaunch(probe, out double la, out long ca);
+                bool rb = b.TryResolveActiveLaunch(probe, out double lb, out long cb);
+                Assert.Equal(ra, rb);
+                if (ra)
+                {
+                    Assert.Equal(la, lb, 6);
+                    Assert.Equal(ca, cb);
+                }
+                Assert.Equal(a.NextLaunchAfter(probe), b.NextLaunchAfter(probe), 6);
+            }
+        }
+
+        [Fact]
         public void Build_LoopAnchorBeforeFirstPlay_ClampsAnchorToAfterTheFirstPlay()
         {
             // Guards: a looped mission must never relaunch before its first real play completes - the

--- a/Source/Parsek.Tests/MissionScheduleGuardTests.cs
+++ b/Source/Parsek.Tests/MissionScheduleGuardTests.cs
@@ -1,0 +1,300 @@
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    // Phase B + R2/R3 of the zero-drift per-window reschedule HARDENING plan
+    // (docs/dev/plans/zero-drift-reschedule-hardening.md). Three groups:
+    //   (a) INV-3 self-defending guard: TryComputeSpanLoopUT's schedule branch emits a rate-limited
+    //       warning when it is handed a unit that ALSO carries loiterCuts / arrivalHold (a contract
+    //       violation - they are mutually exclusive by construction; the schedule branch silently drops
+    //       the cut/hold). Driven through the public span-clock seam with a contrived misuse unit.
+    //   (b) R3 amber: the extracted pure ShouldTintTMinusAmber helper tints a SCHEDULED unit off the
+    //       SCHEDULE's own worst-launch flag (AllLaunchesWithinTolerance), NOT the fixed m*P-fit
+    //       WithinTolerance (which is false for the in-tolerance stock Mun), so a faithful unit reads
+    //       green while a genuinely over-tolerance bounded-best schedule reads amber.
+    //   (c) R2 (branch ii): a realistic SAME-PARENT config (Kerbin pad + Mun orbit/SOI + Mun-surface
+    //       0.25 deg + Minmus orbit/SOI) IS bounded-best-reachable within ScheduleLookaheadMultiples
+    //       (=4096) using physics-derived tolerances only; the schedule still resolves MONOTONICALLY
+    //       INCREASING launches and surfaces AllLaunchesWithinTolerance==false. This proves INV-1's
+    //       residual oracle must be scoped to the within-tol set (it does NOT bound a bounded-best
+    //       config), and that the R3 flag the amber tint reads is correct on a real over-tolerance case.
+    //
+    // [Collection("Sequential")] because the guard test touches ParsekLog shared static state.
+    [Collection("Sequential")]
+    public class MissionScheduleGuardTests : IDisposable
+    {
+        private readonly List<string> logLines = new List<string>();
+
+        public MissionScheduleGuardTests()
+        {
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = false;
+            // The INV-3 guard emits via VerboseRateLimited, which is gated on IsVerboseEnabled and a
+            // per-key time window. Force verbose on and clear the rate-limit state so the FIRST keyed
+            // occurrence emits deterministically.
+            ParsekLog.VerboseOverrideForTesting = true;
+            ParsekLog.ResetRateLimitsForTesting();
+            ParsekLog.TestSinkForTesting = line => logLines.Add(line);
+            MissionPeriodicity.SuppressLogging = false;
+        }
+
+        public void Dispose()
+        {
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = true;
+            MissionPeriodicity.SuppressLogging = false;
+        }
+
+        // ===================== Stock-like body magnitudes =====================
+        // Kerbin sidereal day, Mun orbit, Minmus orbit (stock).
+        private const double KerbinRotation = 21549.425;
+        private const double MunOrbit = 138984.38;
+        private const double MinmusOrbit = 1077311.0;
+
+        // Physics-derived tolerances (the same forms TryBuildRelaunchSchedule / ToleranceSecondsFor use):
+        //   rotation pad: 0.25 deg of the rotation period;
+        //   orbital: SoiRadius / OrbitalVelocity (the time the body crosses its own SOI);
+        //   transited-body surface rotation (Tight): 0.25 deg of the body's rotation period.
+        private const double PadRotTolerance = KerbinRotation * (0.25 / 360.0);
+        private const double MunSoiTolerance = 2429559.0 / 543.0;          // ~4474 s
+        private const double MinmusSoiTolerance = 2247428.4 / 93.72;       // ~23980 s
+        private const double MunSurfaceRotTolerance = MunOrbit * (0.25 / 360.0); // tidally locked -> period == orbit
+
+        // The synthetic 100/31/tol=2 schedule (launches 900,1300,1800,...) used to drive the span clock
+        // in the guard test. Identical magnitudes to MissionZeroDriftScheduleTests.SyntheticSchedule.
+        private static MissionRelaunchSchedule SyntheticSchedule()
+            => new MissionRelaunchSchedule(
+                0.0, 100.0, new double[] { 31.0 }, new double[] { 2.0 }, floorUT: 0.0,
+                lookaheadMultiples: 100);
+
+        // A realistic SAME-PARENT WITHIN-TOLERANCE schedule (the stock Mun 2-constraint case: pad anchor +
+        // Mun orbit/SOI). Reaches a within-tol window at k~=13, so AllLaunchesWithinTolerance stays true.
+        private static MissionRelaunchSchedule StockMunWithinTolSchedule()
+            => new MissionRelaunchSchedule(
+                0.0, KerbinRotation, new double[] { MunOrbit }, new double[] { MunSoiTolerance },
+                floorUT: 0.0, lookaheadMultiples: MissionPeriodicity.ScheduleLookaheadMultiples);
+
+        // A realistic SAME-PARENT BOUNDED-BEST schedule (R2 branch ii): pad anchor + Mun orbit/SOI +
+        // Mun-surface 0.25 deg + Minmus orbit/SOI. No k in [1,4096] satisfies all three physics-derived
+        // tolerances simultaneously, so EVERY launch falls to bounded-best -> AllLaunchesWithinTolerance
+        // is false. (The Mun appears twice: once as the orbital intercept, once as the tidally-locked
+        // surface rotation, the same way a land-and-return mission's recorder captures both.)
+        private static MissionRelaunchSchedule SameParentBoundedBestSchedule()
+            => new MissionRelaunchSchedule(
+                0.0, KerbinRotation,
+                new double[] { MunOrbit, MunOrbit, MinmusOrbit },
+                new double[] { MunSoiTolerance, MunSurfaceRotTolerance, MinmusSoiTolerance },
+                floorUT: 0.0, lookaheadMultiples: MissionPeriodicity.ScheduleLookaheadMultiples);
+
+        // ===================== (a) INV-3 self-defending guard =====================
+
+        [Fact]
+        public void SpanClock_Scheduled_WithLoiterCuts_EmitsMutexViolationWarning()
+        {
+            // Guards INV-3: a scheduled unit is mutually exclusive with loiter cuts by construction. The
+            // span clock's schedule branch bypasses the cut/hold remap, so it must LOUDLY (but
+            // rate-limited, this is a per-frame hot path) warn if it is ever handed both, instead of
+            // silently dropping the cut. Feed both a schedule AND a loiterCut and assert the keyed
+            // warning fires on the first occurrence.
+            var schedule = SyntheticSchedule();
+            var cuts = new List<GhostPlaybackLogic.LoopCut>
+            {
+                new GhostPlaybackLogic.LoopCut { StartUT = 10.0, LengthSeconds = 5.0 }
+            };
+
+            // currentUT 925 is inside the first scheduled launch's span (launch at 900, span [0,50]).
+            bool ok = GhostPlaybackLogic.TryComputeSpanLoopUT(
+                925.0, phaseAnchorUT: 900.0, spanStartUT: 0.0, spanEndUT: 50.0, cadenceSeconds: 50.0,
+                out _, out _, out _, schedule, cuts);
+            // The schedule branch still resolves (it bypasses, it does not fail).
+            Assert.True(ok);
+
+            Assert.Contains(logLines, l =>
+                l.Contains("[MissionPeriodicity]")
+                && l.Contains("INV-3 contract violation")
+                && l.Contains("loiterCuts=1"));
+        }
+
+        [Fact]
+        public void SpanClock_Scheduled_WithArrivalHold_EmitsMutexViolationWarning()
+        {
+            // Same INV-3 guard, via the arrivalHoldSeconds > 0 disjunct of the predicate.
+            var schedule = SyntheticSchedule();
+
+            bool ok = GhostPlaybackLogic.TryComputeSpanLoopUT(
+                925.0, 900.0, 0.0, 50.0, 50.0, out _, out _, out _,
+                schedule, loiterCuts: null, arrivalHoldSeconds: 30.0);
+            Assert.True(ok);
+
+            Assert.Contains(logLines, l =>
+                l.Contains("[MissionPeriodicity]")
+                && l.Contains("INV-3 contract violation")
+                && l.Contains("arrivalHoldSeconds=30"));
+        }
+
+        [Fact]
+        public void SpanClock_Scheduled_NoCutsNoHold_DoesNotWarn_ShippedPathIsClean()
+        {
+            // Guards that the guard is a NO-OP on the shipped path: a scheduled unit with no cuts and no
+            // hold (the only way the builder ever produces a scheduled unit) emits NO violation line, so
+            // the live build never spams.
+            var schedule = SyntheticSchedule();
+
+            bool ok = GhostPlaybackLogic.TryComputeSpanLoopUT(
+                925.0, 900.0, 0.0, 50.0, 50.0, out _, out _, out _, schedule);
+            Assert.True(ok);
+
+            Assert.DoesNotContain(logLines, l => l.Contains("INV-3 contract violation"));
+        }
+
+        // ===================== (b) R3 amber predicate =====================
+
+        [Fact]
+        public void ShouldTintTMinusAmber_ScheduledWithinTol_StockMun_ReturnsFalse()
+        {
+            // Guards the R3 fix: a SCHEDULED, within-tolerance unit (the stock Mun, whose ACTUAL launches
+            // are within tolerance by construction even though the FIXED m*P fit is over tolerance) must
+            // NOT tint amber. The old predicate (off Solution.WithinTolerance) wrongly ambered it.
+            // We drive the predicate with the schedule's REAL flag to tie it to actual data.
+            var schedule = StockMunWithinTolSchedule();
+            Assert.True(schedule.AllLaunchesWithinTolerance,
+                "stock Mun 2-constraint should be within tolerance");
+
+            bool amber = MissionsWindowUI.ShouldTintTMinusAmber(
+                isPhaseLockedConstrained: true,
+                isScheduled: true,
+                scheduleAllLaunchesWithinTolerance: schedule.AllLaunchesWithinTolerance,
+                // The fixed m*P fit IS over tolerance for the stock Mun (~993 s residual) - the old bug:
+                // tinting off this falsely ambered the faithful unit. Pass false to prove the new
+                // predicate ignores it for a scheduled unit.
+                fixedFitWithinTolerance: false);
+            Assert.False(amber);
+        }
+
+        [Fact]
+        public void ShouldTintTMinusAmber_ScheduledBoundedBest_ReturnsTrue()
+        {
+            // Guards that a REAL over-tolerance schedule is NOT hidden: a bounded-best same-parent
+            // schedule (no within-tol window in 4096) surfaces AllLaunchesWithinTolerance==false, so the
+            // predicate ambers it even though we pass the fixed fit as "within" - the schedule flag, not
+            // the fixed fit, drives a scheduled unit.
+            var schedule = SameParentBoundedBestSchedule();
+            Assert.False(schedule.AllLaunchesWithinTolerance,
+                "the 4-constraint same-parent config should fall to bounded-best (over tolerance)");
+
+            bool amber = MissionsWindowUI.ShouldTintTMinusAmber(
+                isPhaseLockedConstrained: true,
+                isScheduled: true,
+                scheduleAllLaunchesWithinTolerance: schedule.AllLaunchesWithinTolerance,
+                fixedFitWithinTolerance: true);  // even if the fixed fit claims within-tol, amber must fire
+            Assert.True(amber);
+        }
+
+        [Fact]
+        public void ShouldTintTMinusAmber_NonScheduled_TintsOffFixedFit_Unchanged()
+        {
+            // Guards no-regression on the non-scheduled path: a fixed-cadence (non-scheduled) unit tints
+            // off the fixed m*P fit exactly as before. The schedule flag is irrelevant there.
+            Assert.True(MissionsWindowUI.ShouldTintTMinusAmber(
+                isPhaseLockedConstrained: true, isScheduled: false,
+                scheduleAllLaunchesWithinTolerance: true,   // ignored on the non-scheduled path
+                fixedFitWithinTolerance: false));            // over-tolerance fixed fit -> amber
+            Assert.False(MissionsWindowUI.ShouldTintTMinusAmber(
+                isPhaseLockedConstrained: true, isScheduled: false,
+                scheduleAllLaunchesWithinTolerance: false,  // ignored on the non-scheduled path
+                fixedFitWithinTolerance: true));             // within-tolerance fixed fit -> green
+        }
+
+        [Fact]
+        public void ShouldTintTMinusAmber_NotPhaseLocked_NeverTints()
+        {
+            // Guards the gate: continuous / not-aligned / blank states (not phase-locked + constrained)
+            // never tint, regardless of any tolerance flag.
+            Assert.False(MissionsWindowUI.ShouldTintTMinusAmber(
+                isPhaseLockedConstrained: false, isScheduled: true,
+                scheduleAllLaunchesWithinTolerance: false, fixedFitWithinTolerance: false));
+            Assert.False(MissionsWindowUI.ShouldTintTMinusAmber(
+                isPhaseLockedConstrained: false, isScheduled: false,
+                scheduleAllLaunchesWithinTolerance: false, fixedFitWithinTolerance: false));
+        }
+
+        // ===================== (c) R2 branch (ii): bounded-best same-parent fixture =====================
+
+        [Fact]
+        public void R2_SameParentBoundedBest_ResolvesMonotonicallyIncreasing_WithAmberFlagSurfaced()
+        {
+            // R2 branch (ii) (docs/dev/plans/zero-drift-reschedule-hardening.md section 6 R2): a realistic
+            // SAME-PARENT config CAN reach bounded-best within ScheduleLookaheadMultiples using only
+            // physics-derived tolerances (the 4-constraint pad + Mun orbit/SOI + Mun-surface 0.25 deg +
+            // Minmus orbit/SOI case - no k in [1,4096] satisfies all three other-constraints at once).
+            // The schedule must STILL resolve monotonically increasing launches (never throw, never go
+            // backward) and surface AllLaunchesWithinTolerance==false (the R3 amber flag), with a non-zero
+            // worst residual. This is what relaxes INV-1's residual oracle for the bounded-best fixture:
+            // INV-1's "<= m=9 fixed residual" bound is scoped to the WITHIN-TOL set; a bounded-best config
+            // is allowed to exceed it as long as it stays monotonic and surfaces the amber flag.
+            var schedule = SameParentBoundedBestSchedule();
+
+            Assert.False(double.IsNaN(schedule.FirstLaunchUT));
+            // Bounded-best: not within tolerance, and the worst residual exceeds the pad tolerance.
+            Assert.False(schedule.AllLaunchesWithinTolerance);
+            Assert.True(schedule.WorstResidualSeconds > PadRotTolerance,
+                "a bounded-best launch should miss tolerance by more than the pad band, worst residual was "
+                + schedule.WorstResidualSeconds);
+
+            // Resolve a forward sweep through the schedule object and assert STRICTLY INCREASING launches
+            // and a stable, non-decreasing cycle index (never goes backward across the bounded-best path).
+            double prevLaunch = double.NegativeInfinity;
+            long prevCycle = -1;
+            double after = schedule.FirstLaunchUT - 1.0;  // start just before L_0
+            const int n = 16;
+            for (int i = 0; i < n; i++)
+            {
+                double next = schedule.NextLaunchAfter(after);
+                Assert.False(double.IsNaN(next), "a realistic bounded-best schedule must keep resolving future launches");
+                Assert.True(next > after, "NextLaunchAfter must be strictly after the probe");
+
+                Assert.True(schedule.TryResolveActiveLaunch(next, out double active, out long cycle));
+                Assert.Equal(next, active, 3);            // resolving exactly on a launch returns that launch
+                Assert.True(active > prevLaunch, "launches must be strictly increasing");
+                Assert.True(cycle > prevCycle, "the schedule index must increase monotonically");
+
+                prevLaunch = active;
+                prevCycle = cycle;
+                after = next;
+            }
+
+            // The flag never flips back to true as the cache grows (monotonically pessimistic).
+            Assert.False(schedule.AllLaunchesWithinTolerance);
+        }
+
+        [Fact]
+        public void R2_StockMunWithinTol_StaysWithinTolerance_OracleScopeHolds()
+        {
+            // The complement of the bounded-best fixture (INV-1's proven within-tol set): the stock Mun
+            // 2-constraint config DOES reach within-tol windows, so AllLaunchesWithinTolerance stays true
+            // and the worst residual stays within the Mun SOI tolerance. This is the set INV-1's residual
+            // oracle is scoped to; the bounded-best fixture above is explicitly OUT of that scope.
+            var schedule = StockMunWithinTolSchedule();
+
+            Assert.False(double.IsNaN(schedule.FirstLaunchUT));
+            Assert.True(schedule.AllLaunchesWithinTolerance);
+            Assert.True(schedule.WorstResidualSeconds <= MunSoiTolerance + 1e-6,
+                "every stock-Mun launch should be within the Mun SOI tolerance, worst residual was "
+                + schedule.WorstResidualSeconds);
+
+            // And a forward sweep still resolves strictly increasing launches.
+            double prevLaunch = double.NegativeInfinity;
+            double after = schedule.FirstLaunchUT - 1.0;
+            for (int i = 0; i < 8; i++)
+            {
+                double next = schedule.NextLaunchAfter(after);
+                Assert.False(double.IsNaN(next));
+                Assert.True(next > prevLaunch);
+                prevLaunch = next;
+                after = next;
+            }
+        }
+    }
+}

--- a/Source/Parsek.Tests/MissionSpanClockTests.cs
+++ b/Source/Parsek.Tests/MissionSpanClockTests.cs
@@ -579,6 +579,112 @@ namespace Parsek.Tests
             return new GhostPlaybackLogic.LoopUnitSet(unitsByOwner, ownerByIndex);
         }
 
+        // Scheduled sibling of MakeSingleUnitSet: the unit carries a non-null RelaunchSchedule, so the
+        // TS sampler must thread unit.RelaunchSchedule into the shared DecideUnitMemberRender ->
+        // TryComputeSpanLoopUT call (4.2 param-forwarding). A scheduled unit is non-overlapping by
+        // construction, so cadence == overlapCadence == max(span, MinInterval) >= span.
+        private static GhostPlaybackLogic.LoopUnitSet MakeScheduledUnitSet(
+            int ownerIndex, int[] memberIndices,
+            double spanStartUT, double spanEndUT,
+            MissionRelaunchSchedule schedule)
+        {
+            double span = spanEndUT - spanStartUT;
+            double cadence = System.Math.Max(span, schedule.MinIntervalSeconds);
+            var unit = new GhostPlaybackLogic.LoopUnit(
+                ownerIndex, memberIndices, spanStartUT, spanEndUT, cadence,
+                phaseAnchorUT: schedule.FirstLaunchUT,
+                overlapCadenceSeconds: cadence,
+                memberWindows: null, relaunchSchedule: schedule);
+            var unitsByOwner = new Dictionary<int, GhostPlaybackLogic.LoopUnit>
+            {
+                { ownerIndex, unit }
+            };
+            var ownerByIndex = new Dictionary<int, int>();
+            foreach (int m in memberIndices)
+                ownerByIndex[m] = ownerIndex;
+            return new GhostPlaybackLogic.LoopUnitSet(unitsByOwner, ownerByIndex);
+        }
+
+        [Fact]
+        public void Scheduled_FlightTsSampler_AgreeOverSweep()
+        {
+            // 4.2 (INV-2 param-forwarding + INV-8). PARAM-FORWARDING regression test, NOT an
+            // independent-implementation parity proof: both scene paths funnel through the SAME pure
+            // helper (TS ResolveTrackingStationSampleUT -> DecideUnitMemberRender -> TryComputeSpanLoopUT;
+            // flight calls TryComputeSpanLoopUT directly), so the math is f(x) == f(x). The VALUE here
+            // is catching a future regression that drops unit.RelaunchSchedule (or threads a different
+            // schedule) on the TS call - then the TS sampler would resolve the uniform-cadence clock
+            // while flight resolves the scheduled one, and they would diverge across this sweep.
+            //
+            // The unit carries the synthetic 100/31 schedule (launches 900, 1300, 1800, 2200, ...),
+            // span [0,50] (< the ~400 s relaunch interval), member window = the whole span so the
+            // render/tail/parked decision is the schedule's, not a member-window artifact. The sweep
+            // covers the pre-first-launch parked boundary (INV-8), the launch instants, mid-span, and
+            // the inter-cycle tails between launches.
+            var schedule = MissionZeroDriftScheduleTests.SyntheticSchedule();
+            Assert.Equal(900.0, schedule.FirstLaunchUT, 6);
+
+            const int member = 5;
+            double spanStart = 0.0, spanEnd = 50.0;
+            double cadence = System.Math.Max(spanEnd - spanStart, schedule.MinIntervalSeconds);
+            var units = MakeScheduledUnitSet(
+                member, new[] { member }, spanStart, spanEnd, schedule);
+
+            // pre-first-launch (parked / INV-8), launches, mid-span, and inter-cycle tails.
+            double[] sweep =
+            {
+                500, 700, 899.9,           // parked before the first launch
+                900, 925, 949.9,           // first launch + mid-span render
+                950, 970, 1000, 1200,      // first inter-cycle tail
+                1300, 1325, 1349.9,        // second launch render
+                1360, 1700,                // second tail
+                1800, 1850, 2200, 2250,    // third / fourth launch + their tails
+            };
+
+            foreach (double currentUT in sweep)
+            {
+                // FLIGHT path: call the shared span clock directly with the SAME schedule.
+                bool flightOk = GhostPlaybackLogic.TryComputeSpanLoopUT(
+                    currentUT, schedule.FirstLaunchUT, spanStart, spanEnd, cadence,
+                    out double flightLoopUT, out _, out bool flightTail, schedule);
+
+                // TS / map path: the sampler resolves the owning unit's clock, forwarding
+                // unit.RelaunchSchedule. The member window is the whole span, so the only hide reason
+                // is the schedule decision (unresolved / tail), never an out-of-window member.
+                double eff = GhostPlaybackLogic.ResolveTrackingStationSampleUT(
+                    i: member, memberStartUT: spanStart, memberEndUT: spanEnd, liveUT: currentUT,
+                    units, out bool tsHidden);
+
+                // The flight RENDER decision: resolved (ok) and not in the inter-cycle tail.
+                bool flightRenders = flightOk && !flightTail;
+
+                // The hidden/tail/parked decision must AGREE: the TS path hides exactly when the
+                // flight clock does not render (parked-before-first OR inter-cycle tail).
+                Assert.Equal(!flightRenders, tsHidden);
+
+                // When both render, the substituted loopUT must be byte-identical (the param-forwarding
+                // payload). When hidden the TS path returns liveUT (unused by the caller), so loopUT
+                // agreement is only meaningful on the render frames.
+                if (flightRenders)
+                    Assert.Equal(flightLoopUT, eff, 6);
+            }
+
+            // Spot-check the boundary decisions explicitly so a future regression names the frame.
+            // Parked before L_0: hidden (INV-8).
+            GhostPlaybackLogic.ResolveTrackingStationSampleUT(
+                member, spanStart, spanEnd, 500.0, units, out bool h500);
+            Assert.True(h500);
+            // On the first launch: render at spanStart.
+            double eff900 = GhostPlaybackLogic.ResolveTrackingStationSampleUT(
+                member, spanStart, spanEnd, 900.0, units, out bool h900);
+            Assert.False(h900);
+            Assert.Equal(0.0, eff900, 6);
+            // Inter-cycle tail (past the 50 s span, before the next launch): hidden.
+            GhostPlaybackLogic.ResolveTrackingStationSampleUT(
+                member, spanStart, spanEnd, 1000.0, units, out bool h1000);
+            Assert.True(h1000);
+        }
+
         [Fact]
         public void ResolveTrackingStationSampleUT_NonMember_ReturnsLiveUT_NotHidden()
         {

--- a/Source/Parsek.Tests/MissionZeroDriftScheduleTests.cs
+++ b/Source/Parsek.Tests/MissionZeroDriftScheduleTests.cs
@@ -214,6 +214,99 @@ namespace Parsek.Tests
                 "zero-drift worst " + zeroDriftWorst + " should be <= the best fixed multiple " + fixedM9);
         }
 
+        [Fact]
+        public void Schedule_NCycleResolve_ResidualBoundedNoAccumulation()
+        {
+            // 4.1 (INV-1 + INV-8). Phase A hardening: the EXISTING non-accumulation test
+            // (MunCase_ZeroDrift_NeverWorseThanFixedCadence_AndDoesNotAccumulate above) chains the
+            // NextJointNearCoincidenceUT HELPER directly; this test exercises the SAME stock
+            // Kerbin-rotation + Mun-orbit math but THROUGH the assembled MissionRelaunchSchedule
+            // object (TryResolveActiveLaunch / NextLaunchAfter) over many resolves - the gap the
+            // helper chain does not cover (the consumed schedule object across the consumption API).
+            //
+            // The schedule anchors on the Mun orbit and drops the Kerbin pad rotation (the same
+            // shape Schedule_Deterministic_TwoIndependentBuildsResolveIdentically builds). ut0 == 0,
+            // so a resolved launchUT is k*MunOrbit directly; the anchor (Mun) residual is exactly 0
+            // and the OTHER-constraint residual is CircularPhaseError(launchUT, KerbinRotation).
+            //
+            // CAVEAT (plan R2 / INV-1): the "<= the m=9 fixed residual (~993 s)" bound is the
+            // WITHIN-TOLERANCE 2-constraint stock Mun case. That is exactly this fixture: every
+            // resolved launch finds a within-tolerance window (asserted below), so the oracle is
+            // scoped to the proven within-tol set per R2(i). The residual is BOUNDED (stays under
+            // the rotation tolerance, ~15 s) and does NOT monotonically grow like a fixed-cadence
+            // 993, 1986, 2978 s drift.
+            double tolRot = KerbinRotation * (0.25 / 360.0);
+            var schedule = new MissionRelaunchSchedule(
+                ut0: 0.0, anchorPeriod: MunOrbit,
+                otherPeriods: new double[] { KerbinRotation },
+                otherTolerances: new double[] { tolRot },
+                floorUT: 5000.0, lookaheadMultiples: 4096);
+            Assert.False(double.IsNaN(schedule.FirstLaunchUT));
+
+            // INV-8: a resolve at a pre-first-launch UT returns NO active launch. FirstLaunchUT sits
+            // far after ut0 (the first faithful Mun window past the floor), so any UT below it parks.
+            Assert.True(schedule.FirstLaunchUT > 5000.0);
+            Assert.False(schedule.TryResolveActiveLaunch(1000.0, out _, out _));
+            Assert.False(schedule.TryResolveActiveLaunch(5000.0, out _, out _));
+
+            // The best fixed multiple (m=9) residual - the bound the zero-drift schedule must beat.
+            double fixedM9 = MissionPeriodicity.CircularPhaseError(9.0 * MunOrbit, KerbinRotation);
+
+            const int K = 80; // >= 64
+            double worst = 0.0;
+            double prevLaunch = double.NegativeInfinity;
+            long prevIndex = -1;
+            var resids = new List<double>();
+
+            double launchUT = schedule.FirstLaunchUT;
+            for (int k = 0; k < K; k++)
+            {
+                // Resolve THROUGH the schedule object: at the launch instant the active launch is the
+                // launch itself, at the 0-based list index k (NOT a negative dense cycle index).
+                Assert.True(schedule.TryResolveActiveLaunch(launchUT, out double activeUT, out long idx),
+                    "resolve at launch " + k + " (UT " + launchUT + ") should find an active launch");
+                Assert.Equal(launchUT, activeUT, 6);
+                Assert.True(idx >= 0, "list index is 0-based, never negative; was " + idx);
+                Assert.True(idx > prevIndex, "list index strictly increasing");
+                Assert.True(launchUT > prevLaunch, "launches strictly increasing (monotonic schedule)");
+                prevIndex = idx;
+                prevLaunch = launchUT;
+
+                // Anchor (Mun) residual is exactly 0 at every launch: launchUT == k'*MunOrbit (ut0=0).
+                double anchorResid = MissionPeriodicity.CircularPhaseError(launchUT, MunOrbit);
+                Assert.Equal(0.0, anchorResid, 3);
+
+                // Other-constraint (Kerbin rotation) residual: the quantity that must NOT accumulate.
+                double otherResid = MissionPeriodicity.CircularPhaseError(launchUT - 0.0, KerbinRotation);
+                resids.Add(otherResid);
+                if (otherResid > worst) worst = otherResid;
+
+                // Each resolved launch is a WITHIN-TOLERANCE window (the proven 2-constraint set).
+                Assert.True(otherResid <= tolRot + 1e-6,
+                    "launch " + k + " other-residual " + otherResid + " should be within tol " + tolRot);
+
+                // Step to the next scheduled launch via the schedule object's UI/warp target API.
+                launchUT = schedule.NextLaunchAfter(launchUT);
+                Assert.False(double.IsNaN(launchUT), "schedule must produce launch " + (k + 1) + " within the cap");
+            }
+
+            // Bounded: the worst other-residual stays FAR below the fixed-cadence m=9 drift (~993 s),
+            // and below the rotation tolerance the schedule selects on.
+            Assert.True(worst <= fixedM9 + 1e-6,
+                "zero-drift worst residual " + worst + " should be <= the m=9 fixed residual " + fixedM9);
+            Assert.True(worst <= tolRot + 1e-6,
+                "every resolved launch is within tolerance, so worst " + worst + " <= tol " + tolRot);
+
+            // NOT monotonically increasing: a fixed cadence would grow 993, 1986, 2978, ...; the
+            // zero-drift schedule's residual stream rises and falls within the band. At least one
+            // consecutive pair must DECREASE (proves it is not an accumulating ramp).
+            bool sawDecrease = false;
+            for (int i = 1; i < resids.Count; i++)
+                if (resids[i] < resids[i - 1] - 1e-9) { sawDecrease = true; break; }
+            Assert.True(sawDecrease,
+                "the per-launch residual must not monotonically accumulate (a fixed cadence would)");
+        }
+
         // ===================== TryBuildRelaunchSchedule: gating =====================
 
         [Fact]
@@ -443,13 +536,24 @@ namespace Parsek.Tests
             Assert.False(double.IsNaN(schedule.FirstLaunchUT));
 
             // currentUT astronomically beyond what 8192 launches at ~0.001 spacing can reach.
-            Assert.True(schedule.TryResolveActiveLaunch(1e9, out double launchUT, out _));
+            Assert.True(schedule.TryResolveActiveLaunch(1e9, out double launchUT, out long parkedIdx));
             Assert.True(launchUT <= 1e9);
             Assert.False(double.IsNaN(launchUT)); // parked at the last cached launch
 
             Assert.True(double.IsNaN(schedule.NextLaunchAfter(1e9)));
             Assert.Contains(logLines, l =>
                 l.Contains("[MissionPeriodicity]") && l.Contains("MaxScheduleSteps"));
+
+            // 4.6 (INV-5a cap boundedness): once the MaxScheduleSteps cap is reached the cache cannot
+            // grow further, so a SECOND far-future resolve (even further out) parks at the SAME last
+            // cached launch + the SAME 0-based index - the resolver stays bounded and consistent
+            // (no crash, no infinite extend, no past target) rather than churning per call. The
+            // parked index is the last cached launch's 0-based position, which is <= MaxScheduleSteps.
+            Assert.True(schedule.TryResolveActiveLaunch(2e9, out double launchUT2, out long parkedIdx2));
+            Assert.Equal(launchUT, launchUT2, 6);
+            Assert.Equal(parkedIdx, parkedIdx2);
+            Assert.True(parkedIdx >= 0 && parkedIdx < MissionPeriodicity.MaxScheduleSteps,
+                "the parked list index stays within the safety cap; was " + parkedIdx);
         }
 
         [Fact]
@@ -462,6 +566,23 @@ namespace Parsek.Tests
                 0.0, 100.0, new double[] { 31.0 }, new double[] { 2.0 }, 0.0, 100);
 
             Assert.True(schedule.TryResolveActiveLaunch(50000.0, out double aFar, out long cFar));
+
+            // 4.6 (INV-5a, far-future warp): a SINGLE far-future resolve returns the active launch
+            // (the largest launch <= currentUT, idx its 0-based list index) in ONE call - no
+            // per-launch replay catch-up. Synthetic 100/31 launches: 900, 1300, 1800, ...; at 50000
+            // the active launch is 49600 at list index 79. The list index is 0-based, never negative.
+            Assert.Equal(49600.0, aFar, 6);
+            Assert.Equal(79, cFar);
+            Assert.True(cFar >= 0, "list index is 0-based, never negative");
+            Assert.True(aFar <= 50000.0);
+
+            // INV-5a idempotence: a SECOND resolve at a NEARBY UT (still below the next launch, 50500)
+            // returns the SAME active launch + index. The cache already covers this UT, so the
+            // resolve hits the grown cache via binary search and does NOT re-extend.
+            Assert.True(schedule.TryResolveActiveLaunch(50001.0, out double aNear, out long cNear));
+            Assert.Equal(aFar, aNear, 6);
+            Assert.Equal(cFar, cNear);
+
             // Now resolve an earlier time.
             Assert.True(schedule.TryResolveActiveLaunch(1500.0, out double aMid, out long cMid));
             Assert.Equal(1300.0, aMid, 6);
@@ -477,8 +598,9 @@ namespace Parsek.Tests
 
         // A schedule with launches at UT 900, 1300, 1800, ... (synthetic 100/31 case), used to drive
         // the span clock. The span is 50 s, far shorter than the ~400 s relaunch interval, so the
-        // clock parks (inter-cycle tail) between launches.
-        private static MissionRelaunchSchedule SyntheticSchedule()
+        // clock parks (inter-cycle tail) between launches. Internal so the Flight==TS param-forwarding
+        // parity sweep in MissionSpanClockTests reuses this single factory (4.2) instead of cloning it.
+        internal static MissionRelaunchSchedule SyntheticSchedule()
             => new MissionRelaunchSchedule(
                 0.0, 100.0, new double[] { 31.0 }, new double[] { 2.0 }, floorUT: 0.0,
                 lookaheadMultiples: 100);

--- a/Source/Parsek/GhostPlaybackLogic.cs
+++ b/Source/Parsek/GhostPlaybackLogic.cs
@@ -7226,6 +7226,34 @@ namespace Parsek
             // nothing in the gap). Null schedule -> the uniform path below, byte-identical.
             if (schedule != null)
             {
+                // INV-3 self-defending guard (docs/dev/plans/zero-drift-reschedule-hardening.md Phase B):
+                // a scheduled unit is mutually exclusive with loiter cuts / arrival hold BY CONSTRUCTION
+                // (the builder attaches a schedule ONLY in the same-parent phase-locked block; the re-aim
+                // branch that produces cuts/hold sets relaunchSchedule=null). This branch returns early
+                // before the cut/hold remap, so the predicate below is ALWAYS false on the shipped path
+                // (zero behavior change, byte-identical). It is here ONLY to convert a latent silent-drop
+                // (a future same-parent loiter compression or a re-aim unit that ever co-attached a
+                // schedule) into a LOUD contract violation. This is a per-frame hot path with a documented
+                // purity contract (see the summary above), so the warning is RATE-LIMITED + keyed on
+                // mission identity (phaseAnchorUT + spanStartUT), mirroring the per-loop-hold key below -
+                // a raw per-frame Warn / a throw would spam the log across multiple scenes. Degrading, not
+                // crashing: a future misuse stays visible without breaking playback.
+                if (loiterCuts != null || arrivalHoldSeconds > 0.0)
+                {
+                    var gic = CultureInfo.InvariantCulture;
+                    ParsekLog.VerboseRateLimited(
+                        "MissionPeriodicity",
+                        // Mission identity key: distinct missions get distinct keys (no collision); one
+                        // mission keeps ONE key across all frames, so the key set is bounded by mission
+                        // count, not frame count.
+                        $"sched-mutex-violation.{phaseAnchorUT.ToString("R", gic)}.{spanStartUT.ToString("R", gic)}",
+                        "INV-3 contract violation: a scheduled unit carries " +
+                        $"loiterCuts={(loiterCuts != null ? loiterCuts.Count.ToString(gic) : "0")} " +
+                        $"arrivalHoldSeconds={arrivalHoldSeconds.ToString("R", gic)} - the schedule branch " +
+                        "bypasses the cut/hold remap (schedule and cuts/hold are mutually exclusive by " +
+                        "construction). The cut/hold is silently DROPPED; check the builder routing.");
+                }
+
                 if (!schedule.TryResolveActiveLaunch(currentUT, out double launchUT, out long sIdx))
                     return false; // parked before the first scheduled launch
                 double scheduledPhase = currentUT - launchUT;

--- a/Source/Parsek/MissionPeriodicity.cs
+++ b/Source/Parsek/MissionPeriodicity.cs
@@ -1586,6 +1586,17 @@ namespace Parsek
         private long lastK;        // anchor-multiple index of the last cached launch
         private bool capWarned;     // rate-limit the safety-cap Warn
 
+        // R3 tolerance accounting over the cached prefix (docs/dev/plans/zero-drift-reschedule-hardening.md
+        // section 6 R2/R3). TryFindNextScheduleK reports per-launch withinTolerance + the worst
+        // other-constraint residual; ExtendOnce (and the constructor's L_0 resolve) previously dropped
+        // both via `out _`. We now FOLD them into these running aggregates as the cache grows, so the UI
+        // can tint the T- countdown amber off the SCHEDULE's own worst launch (a genuinely over-tolerance
+        // bounded-best launch) instead of the fixed-fit Solution.WithinTolerance (which is false for the
+        // in-tolerance stock Mun). Additive + cheap (two scalar updates per resolved launch); nothing is
+        // serialized (the schedule is always re-derived).
+        private bool allLaunchesWithinTolerance = true;  // true unless some resolved launch was bounded-best
+        private double worstResidualSeconds;             // max worst-other residual over the cached prefix
+
         /// <summary>The first scheduled relaunch UT (= the unit's phase anchor). NaN if none could
         /// be resolved (degenerate inputs).</summary>
         internal double FirstLaunchUT { get; }
@@ -1608,6 +1619,27 @@ namespace Parsek
         /// <summary>The player throttle (the requested relaunch period). 0 = every faithful window
         /// (the maximum attainable cadence).</summary>
         internal double MinSpacingSeconds => minSpacing;
+
+        /// <summary>
+        /// True iff EVERY launch resolved so far (over the lazily-grown cached prefix) found a
+        /// within-tolerance window; false once any launch fell to the bounded-best fallback (no within-tol
+        /// k in <see cref="MissionPeriodicity.ScheduleLookaheadMultiples"/>), i.e. a genuinely
+        /// OVER-tolerance launch. This is the SCHEDULE's own worst-launch tolerance flag (R3): the UI tints
+        /// the T- countdown amber off THIS, not the fixed m*P-fit <c>PeriodicitySolution.WithinTolerance</c>
+        /// (which is false for the stock Mun whose ACTUAL scheduled launches are within tolerance by
+        /// construction). Grows monotonically more pessimistic as the cache extends (it can only flip
+        /// true -&gt; false, never back), so a far-future warp that uncovers a bounded-best launch keeps the
+        /// flag false. See docs/dev/plans/zero-drift-reschedule-hardening.md section 6 R2/R3.
+        /// </summary>
+        internal bool AllLaunchesWithinTolerance => allLaunchesWithinTolerance;
+
+        /// <summary>
+        /// The worst other-constraint phase residual (seconds) over the cached prefix - the largest amount
+        /// any non-anchor constraint missed its recorded position by, across the launches resolved so far.
+        /// 0 when no launch has been resolved or every residual was 0. Diagnostic companion to
+        /// <see cref="AllLaunchesWithinTolerance"/>; grows monotonically as the cache extends.
+        /// </summary>
+        internal double WorstResidualSeconds => worstResidualSeconds;
 
         internal MissionRelaunchSchedule(
             double ut0, double anchorPeriod,
@@ -1636,11 +1668,12 @@ namespace Parsek
                 kFloor = 1;
             if (!MissionPeriodicity.TryFindNextScheduleK(
                     anchorPeriod, this.otherPeriods, this.otherTolerances,
-                    kFloor, lookaheadMultiples, out long k0, out _, out _))
+                    kFloor, lookaheadMultiples, out long k0, out double r0, out bool w0))
                 return;
             launches.Add(ut0 + k0 * anchorPeriod);
             lastK = k0;
             FirstLaunchUT = launches[0];
+            FoldLaunchTolerance(r0, w0);  // R3: account L_0's tolerance
 
             // Eager prefix to determine BOTH the min interval (defensive gate, see MinIntervalSeconds)
             // and the MEAN interval (the user-facing display cadence). Min often coincides across
@@ -1690,11 +1723,26 @@ namespace Parsek
             long kStart = Math.Max(lastK + 1, throttleK);
             if (!MissionPeriodicity.TryFindNextScheduleK(
                     anchorPeriod, otherPeriods, otherTolerances,
-                    kStart, lookaheadMultiples, out long k, out _, out _))
+                    kStart, lookaheadMultiples, out long k, out double resid, out bool within))
                 return false;
             launches.Add(ut0 + k * anchorPeriod);
             lastK = k;
+            FoldLaunchTolerance(resid, within);  // R3: account this launch's tolerance
             return true;
+        }
+
+        // R3: fold one resolved launch's tolerance into the running aggregates. AllLaunchesWithinTolerance
+        // can only flip true -> false (a single bounded-best launch makes the whole schedule "amber"); the
+        // worst residual is the running max. Cheap: two scalar updates per launch, no allocation. A NaN
+        // residual (degenerate) is ignored for the worst-residual max but a non-within launch still clears
+        // the all-within flag. See docs/dev/plans/zero-drift-reschedule-hardening.md section 6 R2/R3.
+        private void FoldLaunchTolerance(double residualSeconds, bool withinTolerance)
+        {
+            if (!withinTolerance)
+                allLaunchesWithinTolerance = false;
+            if (!double.IsNaN(residualSeconds) && !double.IsInfinity(residualSeconds)
+                && residualSeconds > worstResidualSeconds)
+                worstResidualSeconds = residualSeconds;
         }
 
         /// <summary>

--- a/Source/Parsek/UI/MissionsWindowUI.cs
+++ b/Source/Parsek/UI/MissionsWindowUI.cs
@@ -1162,6 +1162,14 @@ namespace Parsek
             // hit the same short anchor-step gap). NaN when not scheduled.
             public double ScheduledTypicalIntervalSeconds;
 
+            // R3: the SCHEDULE's own worst-launch tolerance flag - true iff every resolved scheduled
+            // launch found a within-tolerance window, false once any fell to bounded-best (a genuinely
+            // over-tolerance launch). The T- amber tint reads THIS for a scheduled unit, not the fixed
+            // m*P-fit Solution.WithinTolerance (which is false for the in-tolerance stock Mun). True (the
+            // benign default) when not scheduled, so the non-scheduled amber path is unchanged. See
+            // docs/dev/plans/zero-drift-reschedule-hardening.md section 6 R2/R3.
+            public bool ScheduleAllLaunchesWithinTolerance;
+
             // Supported + constrained: the loop is phase-locked to a real period P (not the free
             // MinCycleDuration). This is the state where the period cell shows P + basis label and
             // the T- cell shows a live countdown.
@@ -1256,6 +1264,11 @@ namespace Parsek
             result.ScheduledTypicalIntervalSeconds = result.IsScheduled
                 ? unit.RelaunchSchedule.AverageIntervalSeconds
                 : double.NaN;
+            // R3: surface the schedule's OWN worst-launch tolerance for the amber tint. Benign default
+            // true when not scheduled (the non-scheduled amber path then reads Solution.WithinTolerance,
+            // unchanged). For a scheduled unit this reflects whether any cached launch fell to bounded-best.
+            result.ScheduleAllLaunchesWithinTolerance = !result.IsScheduled
+                || unit.RelaunchSchedule.AllLaunchesWithinTolerance;
 
             // Re-aim (cross-parent interplanetary): the unit carries a synodic schedule the faithful
             // periodicity Solve cannot represent (it reports UnsupportedCrossParent). Surface it so the
@@ -1326,10 +1339,16 @@ namespace Parsek
                 periodicity.NowUT,
                 periodicity.IsReaim);
 
-            // Tint a live countdown amber when the best-effort window misses its physics tolerance
-            // (over-constrained config - the user may want to re-trim), matching the design's
-            // green/amber readout intent. Continuous / not-aligned / blank states read plain.
-            bool amber = periodicity.IsPhaseLockedConstrained && !periodicity.Solution.WithinTolerance;
+            // Tint a live countdown amber when the actual relaunch alignment misses its physics tolerance
+            // (over-constrained config - the user may want to re-trim), matching the design's green/amber
+            // readout intent. Continuous / not-aligned / blank states read plain. For a SCHEDULED
+            // (zero-drift) unit this reads the SCHEDULE's own worst-launch flag, NOT the fixed m*P-fit
+            // Solution.WithinTolerance (R3 fix, see ShouldTintTMinusAmber).
+            bool amber = ShouldTintTMinusAmber(
+                periodicity.IsPhaseLockedConstrained,
+                periodicity.IsScheduled,
+                periodicity.ScheduleAllLaunchesWithinTolerance,
+                periodicity.Solution.WithinTolerance);
             Color prev = GUI.contentColor;
             if (amber)
                 GUI.contentColor = LoopPeriodClampColor;
@@ -1338,6 +1357,41 @@ namespace Parsek
         }
 
         // ----- Pure display helpers (unit-tested; the IMGUI layout above is playtest-verified) -----
+
+        /// <summary>
+        /// Whether the "Time to launch" countdown cell should tint amber (R3, see
+        /// docs/dev/plans/zero-drift-reschedule-hardening.md section 6). The cell tints amber when the
+        /// loop's ACTUAL relaunch alignment misses its physics tolerance - the user may want to re-trim.
+        /// The amber source DIFFERS between scheduled and non-scheduled units:
+        /// - A SCHEDULED (zero-drift) unit relaunches at NON-UNIFORM, within-tolerance-when-reachable
+        ///   windows; its real tolerance is the SCHEDULE's own worst launch
+        ///   (<paramref name="scheduleAllLaunchesWithinTolerance"/>), NOT the fixed m*P-fit
+        ///   <paramref name="fixedFitWithinTolerance"/>. The fixed fit is FALSE for the stock Mun (~993 s
+        ///   residual at m=9) even though every ACTUAL scheduled launch is within tolerance by construction,
+        ///   so tinting off the fixed fit wrongly ambers a faithful unit. Tinting off the schedule flag
+        ///   correctly ambers only a genuinely over-tolerance (bounded-best) schedule and stays green for
+        ///   the in-tolerance stock Mun.
+        /// - A NON-scheduled (fixed-cadence) unit has no schedule; its tolerance IS the fixed m*P fit, so it
+        ///   tints off <paramref name="fixedFitWithinTolerance"/> exactly as before (no behavior change).
+        /// In BOTH cases the unit must be phase-locked + constrained
+        /// (<paramref name="isPhaseLockedConstrained"/>) to tint at all; continuous / not-aligned / blank
+        /// states read plain. NOT tinted unconditionally off <paramref name="isScheduled"/> - that would
+        /// hide a real over-tolerance schedule. Pure (no Unity); unit-tested.
+        /// </summary>
+        internal static bool ShouldTintTMinusAmber(
+            bool isPhaseLockedConstrained,
+            bool isScheduled,
+            bool scheduleAllLaunchesWithinTolerance,
+            bool fixedFitWithinTolerance)
+        {
+            if (!isPhaseLockedConstrained)
+                return false;
+            // Scheduled: amber iff some scheduled launch was over tolerance (bounded-best).
+            // Non-scheduled: amber iff the fixed m*P fit missed tolerance (unchanged behavior).
+            return isScheduled
+                ? !scheduleAllLaunchesWithinTolerance
+                : !fixedFitWithinTolerance;
+        }
 
         /// <summary>
         /// The engine's ACTUAL next relaunch UT for a built loop unit, derived from the SAME schedule

--- a/docs/dev/plans/mission-periodicity-phases.md
+++ b/docs/dev/plans/mission-periodicity-phases.md
@@ -122,9 +122,12 @@ circular phase error over one step `m*P`, preferring the smallest `m` on a tie. 
 `joint-best-fit` (`m>1`); the residual is the per-cycle drift, surfaced via `WithinTolerance` (the
 existing amber readout). Kerbal X (rotation 21549.425s + Mun 138984.38s) -> `m=9` (~14.5 days),
 pad residual `9688s -> ~993s`. Helpers `FindBestJointMultiple` / `JointStepResidual` are pure +
-unit-tested. The remaining accumulating-drift limitation (a fixed cadence cannot hold incommensurate
-periods aligned forever) is the deferred **zero-drift per-window reschedule** task in
-`todo-and-known-bugs.md` (needs a non-uniform-cadence span clock, a larger engine change).
+unit-tested. The accumulating-drift limitation of THIS fixed-cadence variant (a fixed cadence cannot
+hold incommensurate periods aligned forever) was the motivation for the **zero-drift per-window
+reschedule**, which has since SHIPPED and is now hardened: the loop re-solves each relaunch
+independently to the true next joint near-coincidence (the non-uniform-cadence span clock + larger
+engine change this note once deferred), so the pad error stays bounded instead of accumulating. See
+`docs/dev/done/plans/zero-drift-reschedule.md` for the shipped spec.
 
 **Goal:** correct `P` for any number of constraints, with an honest residual.
 

--- a/docs/dev/plans/zero-drift-reschedule-hardening.md
+++ b/docs/dev/plans/zero-drift-reschedule-hardening.md
@@ -1,0 +1,595 @@
+# Plan: Zero-drift per-window reschedule - verify-and-harden (same-parent Mun / Minmus)
+
+NOTE (2026-06-09): Phases A-C shipped on branch `zero-drift-harden`; the Phase D in-game VISUAL-parity tier (per-frame ghost activation, scheduled debris render, three-scene visual parity) is deferred to a follow-up.
+
+Status: HARDENING. This is NOT a from-scratch design. The mechanism is ALREADY SHIPPED
+and wired into every scene. The job here is to lift the shipped SAME-PARENT
+(Kerbin -> Mun / Minmus, including land-and-return) looped-mission reschedule to a FLAWLESS
+bar: close the test-coverage and verification gaps, add the missing self-defending guards,
+and fix the stale docs so the tree of truth matches HEAD.
+
+SCOPE LOCK (maintainer, 2026-06-09): SAME-PARENT ONLY. The cross-parent "Duna-One-class"
+single-moon arrival hold is a different subsystem (re-aim, `UnsupportedCrossParent`) and is a
+SEPARATE sibling pass, not part of this plan. See section 6, Decision 1.
+
+Branch: TBD (off origin/main, fresh sibling worktree per the worktree rule).
+
+All `file.cs:NNN` cites in this plan are HEAD-at-authoring and may drift a few lines; re-grep
+the named symbols rather than trusting the line numbers (see the line-number caveat in
+section 4).
+
+References (read before implementing):
+- `docs/dev/done/plans/zero-drift-reschedule.md` (the AUTHORITATIVE shipped spec: section
+  2.1 offset-cancellation, 2.2 anchor-on-tightest-band, 2.3 minSpacing throttle, 3.1
+  schedule-provider object, 4 structural-drift gating, 7-8 test/phase plan).
+- `Source/Parsek/MissionPeriodicity.cs` (solver + `MissionRelaunchSchedule`).
+- `Source/Parsek/MissionLoopUnitBuilder.cs` (routing + schedule attach).
+- `Source/Parsek/GhostPlaybackLogic.cs` (the span clock + scene-shared resolvers).
+- `Source/Parsek.Tests/MissionZeroDriftScheduleTests.cs`,
+  `Source/Parsek.Tests/MissionPeriodicityTests.cs`,
+  `Source/Parsek.Tests/MissionSpanClockTests.cs`,
+  `Source/Parsek.Tests/MapRender/ChainSamplerTests.cs`.
+
+---
+
+## 1. Status banner - authoritative ground-truth verdict
+
+**The feature is BUILT, wired, and pure-unit-tested. It is NOT deferred.** All six
+ground-truth reports agree.
+
+The doc/code contradiction the prompt flagged resolves IN FAVOR OF THE CODE:
+
+- **STALE DOC** `docs/dev/plans/mission-periodicity-phases.md:116-127` still labels the
+  zero-drift per-window reschedule "the deferred ... task ... (needs a non-uniform-cadence
+  span clock, a larger engine change)" and headers Phase 2 "DONE - fixed-cadence variant".
+- **CODE REALITY (HEAD):** the non-uniform-cadence span clock is the active path. It is the
+  `if (schedule != null)` branch at `GhostPlaybackLogic.cs:7227-7238` (verified: resolves
+  the largest scheduled launch <= currentUT via `schedule.TryResolveActiveLaunch`, measures
+  phase from it, parks at spanEnd between launches via `isInInterCycleTail`, returns early
+  before any loiterCut / arrival-hold logic). The schedule is built by
+  `MissionPeriodicity.TryBuildRelaunchSchedule` (`MissionPeriodicity.cs:1049-1138`), held by
+  the `MissionRelaunchSchedule` class (`MissionPeriodicity.cs:1565-1756`), and attached by
+  `MissionLoopUnitBuilder.cs:296-315`.
+- The in-code comment at `MissionPeriodicity.cs:502` already says zero-drift is "now
+  implemented", and the plan doc was archived as DONE at
+  `docs/dev/done/plans/zero-drift-reschedule.md`, with the v6 archive
+  `docs/dev/done/todo-and-known-bugs-v6.md:10` listing it among shipped Missions work. Only
+  the live `mission-periodicity-phases.md` Phase 2 note was not updated.
+
+**What is built (same-parent / single-moon path):**
+- The pure periodicity solver, anchor-on-tightest-duty-cycle, zero-drift residual that is an
+  absolute function of `k` (non-accumulating by construction, not by comment).
+- The lazily-generated `MissionRelaunchSchedule` + `TryResolveActiveLaunch` /
+  `NextLaunchAfter` (binary search), the `MaxScheduleSteps=8192` safety cap.
+- Builder routing: schedule attaches ONLY in the same-parent phase-locked block; the
+  re-aim (cross-parent) block sets `relaunchSchedule=null` (`MissionLoopUnitBuilder.cs:431`).
+  Schedule and loiterCuts/arrivalHold are MUTUALLY EXCLUSIVE by construction.
+- Consumption wired into every scene: flight engine, KSC, Tracking Station, flight map,
+  Missions UI countdown / Warp-to, logistics RouteLoopClock.
+
+**What live coverage ALREADY exists (do not re-author this):**
+- `RuntimeTests.cs:5383` `TrackingStationSpanClock_ZeroDriftSchedule_ResolvesScheduledLaunch`
+  (Category=TrackingStation) constructs a REAL `MissionRelaunchSchedule` (synthetic 100/31,
+  launches at 900/1300/1800) and drives `ResolveTrackingStationSampleUT` through the TS/map
+  seam at the non-uniform launches, including inter-launch-tail-hide and parked-before-first.
+- `RuntimeTests.cs:5432` `FlightSpanClock_ZeroDriftSchedule_EngineResolvesScheduledLaunches`
+  (Category=Flight) builds a live `GhostPlaybackEngine`, feeds it a non-null-schedule LoopUnit
+  via `SetLoopUnits`, asserts it takes the span-clock (not overlap) branch, and resolves
+  `TryResolveUnitMemberPlaybackUT` + `DecideUnitMemberRender` at the same non-uniform launches
+  plus the parked-before-first case.
+
+These two tests already prove the RESOLVER-LEVEL live path for a scheduled unit. They
+honestly scope OUT (at `RuntimeTests.cs:5443-5457`) the genuinely-uncovered piece: the
+per-frame ghost `GameObject` `SetActive`/spawn/destroy in
+`GhostPlaybackEngine.UpdateUnitMemberPlayback`, the warp single-fire rebuild count, ride-along
+debris live render, and three-scene VISUAL parity. The flawless gap below is exactly that
+carve-out plus the missing pure tests, NOT a zero-coverage void.
+
+**What is incomplete (the flawless gap, all in-scope):**
+- No pure "N-cycle non-accumulation through the assembled `MissionRelaunchSchedule` object"
+  test (the existing non-accumulation test chains the `NextJointNearCoincidenceUT` helper, not
+  the assembled schedule object across many resolves).
+- The existing `MissionPeriodicityTests.cs` already drives `MissionLoopUnitBuilder.Build` with
+  a `StockFake()` bodyInfo and asserts `RelaunchSchedule == null` for single-constraint
+  (`:1161`) and `!= null` + `MinIntervalSeconds >= span` for a drifting config (`:1193-1195`).
+  The genuinely-missing builder delta is only the explicit
+  `LoiterCuts == null && ArrivalHoldSeconds == 0` (INV-3) mutual-exclusion assertion.
+- No xUnit test pins the flight resolver and the TS/map sampler agree on `loopUT` for a
+  scheduled unit at the PARAM-FORWARDING level (a regression dropping `unit.RelaunchSchedule`
+  from the TS call would go uncaught). NOTE both scene paths funnel through the same pure
+  helper (`ResolveTrackingStationSampleUT` -> `DecideUnitMemberRender` -> `TryComputeSpanLoopUT`),
+  so this is a param-threading regression test, not an independent-implementation parity proof.
+- No save/load re-derive test tying schedule determinism to an OnSave/OnLoad round-trip.
+- The schedule branch in `TryComputeSpanLoopUT` silently bypasses loiterCuts/arrivalHold and
+  does NOT assert the upstream mutual-exclusion invariant (latent foot-gun).
+- The per-frame ghost `GameObject` activation + the three-scene visual render parity are
+  playtest-verified only, not covered by a live in-game test (the existing two scheduled
+  in-game tests stop at the resolver, by their own scope comment).
+- Two TS playtest verifications were left "confirm in next playtest" /
+  "playtest log-grep pending" in `todo-and-known-bugs.md` for the same-parent TS render path.
+
+**What is explicitly NOT built and is a NON-GOAL of this plan:**
+- The single-moon CROSS-PARENT re-aim arrival (the "Duna-One-class" captured-then-land arrival
+  hold). SCOPE DECISION (maintainer, confirmed 2026-06-09): this pass is SAME-PARENT ONLY. That
+  arrival hold is a cross-parent re-aim construct (`ArrivalHoldPlanner`, classified
+  `UnsupportedCrossParent`) hardened in a SEPARATE sibling pass, not here. So "single-moon" in
+  this plan means same-parent Mun / Minmus only.
+- 2+ constrained moons (Jool-class).
+- Multi-hop / gravity-assist chains.
+- Atmo-direct interplanetary.
+- The broader cross-parent Phase-4 generalization (`UnsupportedCrossParent`). The periodicity
+  solver correctly DETECTS cross-parent and hands off to the re-aim subsystem; that subsystem
+  is audited elsewhere, not here.
+
+---
+
+## 2. Done vs Remaining (Remaining strictly scoped to the flawless bar)
+
+| Area | Done (HEAD) | Remaining (flawless) |
+|------|-------------|----------------------|
+| Pure solver math | `TryBuildRelaunchSchedule`, `TryFindNextScheduleK`, `SelectAnchorConstraintIndex`, tolerance model, bounded-best fallback, NaN guards, safety cap - all unit-tested (`MissionZeroDriftScheduleTests.cs`) | none (math is sound) |
+| Schedule object | `MissionRelaunchSchedule` resolve/next/extend, lazy cache, determinism test | N-cycle non-accumulation test THROUGH the object; live-warp single-frame cost spot-check |
+| Builder routing | schedule attach gate + mutual exclusion by construction (`MissionLoopUnitBuilder.cs:296-431`); `Build` already attach/no-attach tested with `StockFake()` bodyInfo (`MissionPeriodicityTests.cs:1161/1193-1195`) | builder-level mutual-exclusion (`LoiterCuts==null && ArrivalHoldSeconds==0`) assertion via `MissionLoopUnitBuilder.Build` (the private `TryBuildMissionUnit` is not test-reachable) |
+| Span clock consumption | `if (schedule != null)` branch + null-byte-identical regression; resolver-level scheduled-unit live tests already exist for Flight + TS (`RuntimeTests.cs:5383/5432`) | Flight==TS param-forwarding regression test for a SCHEDULED unit; self-defending invariant guard |
+| Scene wiring | flight / KSC / TS / map / UI / logistics all thread `unit.RelaunchSchedule`; resolver-level live coverage shipped | new in-game tests for per-frame ghost activation, scheduled debris render, three-scene VISUAL parity (resolver level already covered) |
+| Save/load | schedule derived from persisted inputs + signature rebuild; determinism test | OnSave/OnLoad round-trip re-derive test (source-gate or in-game) |
+| TS render | startup loop-aware create, same-body carry fix (shipped + unit-tested) | close 2 playtest-pending TS verifications (todo lines ~527, ~529) |
+| Docs | done-plan archived, code comments updated | fix `mission-periodicity-phases.md:116-127`; close playtest-pending todo lines |
+
+---
+
+## 3. The flawless bar - correctness INVARIANTS, each with a proving test
+
+These are the properties that MUST hold for the shipped same-parent / single-moon path to be
+flawless. Each names the test that proves it (new tests are built in section 4).
+
+- **INV-1 Zero accumulating drift.** For a stock same-parent config (Kerbin rotation + Mun
+  orbit), successive scheduled launches resolved THROUGH the `MissionRelaunchSchedule` object
+  keep every other-constraint residual within its physics tolerance and never grow like
+  993, 1986, 2978 s (bounded, not monotonically increasing). The anchor residual is exactly 0 at
+  every launch. CAVEAT (see R2): the "<= the m=9 fixed residual" bound holds for the
+  WITHIN-TOLERANCE branch (the stock 2-constraint Mun case); a bounded-best 3-constraint config
+  can exceed it, so scope this oracle to the proven within-tol set per R2(i) or relax it for an
+  explicit bounded-best fixture per R2(ii).
+  Proof: new `Schedule_NCycleResolve_ResidualBoundedNoAccumulation` (section 4.1).
+
+- **INV-2 Flight and TS thread the schedule into the SAME shared resolver.** For a unit
+  carrying a non-null `RelaunchSchedule`, the flight engine path (`TryComputeSpanLoopUT`) and
+  the map/TS path (`ResolveTrackingStationSampleUT` -> `DecideUnitMemberRender`) resolve the
+  SAME `loopUT`, `cycleIndex`, and `renderHidden` for the same currentUT, across a UT sweep
+  that includes the pre-first-launch (parked) boundary, the launch instants, and the
+  inter-cycle tails. STRUCTURAL CAVEAT: both scene paths funnel through the same pure helper
+  (`ResolveTrackingStationSampleUT` -> `DecideUnitMemberRender` -> `TryComputeSpanLoopUT` at
+  `GhostPlaybackLogic.cs:7471/7520`; flight `UpdateUnitMemberPlayback` -> `DecideUnitMemberRender`
+  at `GhostPlaybackEngine.cs:2280`), so the xUnit "agreement" is `f(x) == f(x)` at the math
+  level - its real value is a PARAM-FORWARDING regression test (does
+  `ResolveTrackingStationSampleUT` thread schedule + cuts + hold + anchor into the shared
+  helper, so a future regression dropping `unit.RelaunchSchedule` from the TS call is caught).
+  The genuinely-independent three-scene parity (different per-frame machinery) is the in-game
+  visual test (4.9), which carries the INV-2-live weight.
+  Proof: new `Scheduled_FlightTsSampler_AgreeOverSweep` (section 4.2, param-forwarding) +
+  in-game 4.9 (independent visual parity).
+
+- **INV-3 Mutual exclusion is enforced, not merely true.** A unit with a non-null
+  `RelaunchSchedule` always has `LoiterCuts == null` and `ArrivalHoldSeconds == 0`; the span
+  clock's schedule branch is correct to bypass the cut/hold logic.
+  Proof: new builder test `Build_Scheduled_HasNoLoiterCutsOrArrivalHold` (4.3) + a fail-loud
+  guard at the consumption point (section 4.4).
+
+- **INV-4 Schedule survives save/load and config re-snap.** A reload re-derives a
+  byte-identical launch sequence (the schedule is never serialized; it is rebuilt from
+  persisted `Mission.LoopAnchorUT` (`Mission.cs:85/116`) + live body geometry, folded into
+  `BuildSignature` at `MissionLoopUnitBuilder.cs`). A tolerance-affecting body change rebuilds.
+  Proof: existing determinism test PLUS new `Schedule_SaveLoadRoundTrip_RederivesIdentical`
+  (4.5).
+
+- **INV-5a Warp resolves the active launch in one call (resolver, pure-testable).** A single
+  far-future currentUT (past many scheduled launches) resolves the correct active launch
+  directly in one `TryResolveActiveLaunch` call (no per-launch replay catch-up). The cache
+  lazily extends to cover the jump bounded by `MaxScheduleSteps=8192`, and a second resolve at
+  a nearby UT is idempotent (does not re-extend, hits the grown cache via binary search at
+  `MissionPeriodicity.cs:1714-1721`).
+  Proof: new `Schedule_FarFutureWarp_ResolvesActiveOnce_WithinCap` (4.6).
+- **INV-5b Warp triggers exactly one ghost rebuild (engine, in-game-only).** Across a live
+  multi-launch TimeWarp jump the engine changes `cycleIndex` once and triggers exactly one
+  ghost rebuild. This is a property of `GhostPlaybackEngine.UpdateUnitMemberPlayback`, not of
+  the pure resolver, so a pure xUnit test cannot observe it.
+  Proof: in-game warp spot-check folded into the flight render test (4.7).
+
+- **INV-6 Faithful-instance-per-launch, nothing in the gap (live).** In live FLIGHT a looped
+  same-parent multi-constraint mission renders exactly one faithful instance per scheduled
+  launch and nothing in the inter-cycle tail; ride-along debris ride their scheduled parent.
+  Note the resolver-level faithful-launch path is already covered by the two existing
+  in-game tests (`RuntimeTests.cs:5383/5432`); this invariant's NEW weight is the per-frame
+  ghost `GameObject` `SetActive`/spawn/destroy in `UpdateUnitMemberPlayback` plus the live
+  ride-along debris render, which those tests scope out at `RuntimeTests.cs:5443-5457`.
+  Proof: new in-game tests (4.7, 4.8).
+
+- **INV-8 Pre-first-launch / future-dated anchor parks cleanly.** When currentUT is before
+  the first scheduled launch (`FirstLaunchUT`, which may sit after a future-dated UT0 so the
+  dense index `k` is negative), `schedule.TryResolveActiveLaunch` returns false
+  (`GhostPlaybackLogic.cs:7229-7230` returns false -> `SpanClockUnresolved`), the render
+  decision is the parked/hidden decision, and the flight resolver and TS sampler AGREE on the
+  parked decision. The existing in-game tests exercise this incidentally; pin it as an
+  explicit assertion target.
+  Proof: folded into the 4.2 sweep (assert the parked decision at a pre-L0 UT, both paths
+  agree) and the 4.1 N-cycle test (resolve at a pre-first-launch UT returns no active launch).
+
+- **INV-7 (RESOLVED VACUOUS - same-parent scope).** The maintainer confirmed this pass is
+  SAME-PARENT ONLY (section 6, Decision 1). The "Duna-One-class single-moon captured-then-land
+  arrival hold" is a CROSS-PARENT re-aim construct (`ArrivalHoldPlanner`, `UnsupportedCrossParent`)
+  NOT served by the zero-drift schedule, so it is a SEPARATE sibling pass, not part of this
+  flawless bar. On the in-scope path (same-parent Mun / Minmus, including land-and-return) there
+  is NO arrival hold, so INV-7 is vacuous and INV-1 / INV-2 / INV-6 fully cover the in-scope
+  single-moon cases. No arrival-hold unit is attached in any Phase-D fixture.
+
+---
+
+## 4. Phased work items
+
+Ordered by dependency and risk. Phases A-C are the SHIPPABLE CORE: they close INV-1, INV-2
+(param-forwarding), INV-3, INV-4, INV-5a, and INV-8 plus the builder/guard work with ZERO live
+dependency, and each is independently shippable and testable. Phase D is an OPTIONAL
+live-verification tier gated on live KSP and a new fixture (see Phase D for the fallback if the
+fixture is blocked). Review checkpoints are placed at the math-core verification milestone and
+the wiring milestone, not per commit (per the project workflow).
+
+LINE-NUMBER CAVEAT: all `file.cs:NNN` cites below are HEAD-at-authoring and may drift a few
+lines. Implementers should re-grep the named symbols (`TryComputeSpanLoopUT`,
+`TryResolveActiveLaunch`, `relaunchSchedule = sched` / `= null`, `parentUnit.RelaunchSchedule`,
+`ResolveTrackingStationSampleUT`, `DecideUnitMemberRender`) rather than trusting the cites; the
+symbol names are stable.
+
+### Phase A - Pure schedule-object hardening tests (lowest risk, no production change)
+
+**Scope:** prove the SHIPPED math holds through the assembled schedule object over many
+cycles, and prove Flight==TS at the resolver layer. No source changes; pure xUnit only.
+
+**Files:**
+- `Source/Parsek.Tests/MissionZeroDriftScheduleTests.cs` (add tests)
+- `Source/Parsek.Tests/MissionSpanClockTests.cs` (add the scheduled-unit parity test;
+  reuse its `MakeSingleUnitSet` / `ThreeMemberUnit` helpers). REUSE the EXISTING
+  `SyntheticSchedule()` factory at `MissionZeroDriftScheduleTests.cs:481` (do NOT author a
+  parallel one that could drift)
+- Read-only confirms: `MissionPeriodicity.cs:1565-1756`, `GhostPlaybackLogic.cs:7227-7238`,
+  `GhostPlaybackLogic.cs:7461-7535` (`DecideUnitMemberRender` + `ResolveTrackingStationSampleUT`).
+
+**Gap closed:** the existing non-accumulation test (`MissionZeroDriftScheduleTests.cs:174-215`)
+chains `NextJointNearCoincidenceUT` 12 times - it proves the HELPER, not the consumed schedule
+object across many resolves (INV-1). And while the live resolver path for a scheduled unit IS
+covered in-game (`RuntimeTests.cs:5383/5432`), no PURE xUnit test pins that
+`ResolveTrackingStationSampleUT` forwards `unit.RelaunchSchedule` (+ cuts/hold/anchor) into the
+shared helper, so a param-dropping regression on the TS call would go uncaught at the unit
+level (INV-2, param-forwarding).
+
+**Tests to add:**
+1. **4.1 `Schedule_NCycleResolve_ResidualBoundedNoAccumulation`** (INV-1, + INV-8 pre-L0): build
+   the stock Kerbin-rotation + Mun-orbit schedule; loop `k=0..K` (K>=64) calling
+   `schedule.TryResolveActiveLaunch` / `NextLaunchAfter`; at each resolved launchUT recompute
+   `CircularPhaseError(launchUT - ut0, otherPeriod)` and assert it stays <= the m=9 fixed
+   residual (~993 s) and never monotonically grows. Also assert that a resolve at a
+   pre-first-launch UT returns no active launch (INV-8).
+2. **4.2 `Scheduled_FlightTsSampler_AgreeOverSweep`** (INV-2 param-forwarding, + INV-8): build a
+   unit WITH a synthetic schedule; over a currentUT sweep covering the pre-first-launch parked
+   boundary, several launches, and inter-cycle tails, assert
+   `TryComputeSpanLoopUT(...schedule)` and `ResolveTrackingStationSampleUT(...unit-with-schedule)`
+   agree on `loopUT` and the hidden/tail/parked decision. Frame this as a PARAM-FORWARDING
+   regression test: both scene paths share the same pure helper, so the assertion's value is
+   that the schedule + cuts + hold + anchor are threaded into the shared call (a dropped
+   `unit.RelaunchSchedule` on the TS call is what this catches), NOT an independent
+   cross-implementation parity proof. The independent visual parity is in-game 4.9.
+3. **4.6 `Schedule_FarFutureWarp_ResolvesActiveOnce_WithinCap`** (INV-5a): resolve at a single
+   far-future currentUT (past many launches) in one call; assert it returns the correct active
+   launch + dense index, the cache stayed bounded (<= `MaxScheduleSteps`), and a second resolve
+   at a nearby UT does not re-extend (idempotent cache). This is the PURE half of warp; the
+   "exactly one rebuild / cycleIndex changes once" half (INV-5b) is in-game-only (4.7).
+
+**Validation / exit:** `dotnet test` green; the three new tests fail if the schedule-object
+resolve drifts or the two scene resolvers disagree. **REVIEW CHECKPOINT (math core):** a
+clean-context review that the N-cycle residual oracle is measuring the right quantity (the
+other-constraint phase error in the same frame the solver uses) and that the parity sweep
+covers the tail boundaries, not just mid-span.
+
+### Phase B - Builder-level mutual-exclusion test + self-defending guard
+
+**Scope:** add the one genuinely-missing builder assertion (schedule => no cuts/hold), and make
+the span-clock bypass fail-loud instead of silent.
+
+**Files:**
+- `Source/Parsek.Tests/MissionPeriodicityTests.cs` (ADD the mutual-exclusion assertion here -
+  this file ALREADY drives `MissionLoopUnitBuilder.Build` with a `StockFake()` bodyInfo and
+  asserts `RelaunchSchedule == null` for single-constraint (`:1161`) and `!= null` +
+  `MinIntervalSeconds >= span` for the drifting config (`:1193-1195`)). NOTE (corrected per the
+  clean review): a `MissionLoopUnitBuilderTests.cs` DOES exist, but its `Build` helper uses the
+  NO-bodyInfo overload and never drives the schedule path, so the schedule-attach assertions
+  belong in `MissionPeriodicityTests.cs` (which calls `Build(..., StockFake())`), not there.
+  Route the new test
+  through the internal `MissionLoopUnitBuilder.Build` entrypoint
+  (`MissionLoopUnitBuilder.cs:38`); the schedule-attach if-chain's `TryBuildMissionUnit`
+  (`MissionLoopUnitBuilder.cs:111`) is PRIVATE static and is NOT test-reachable even with
+  `InternalsVisibleTo`, so `Build` is the only seam that drives the live if-chain.
+- `Source/Parsek/GhostPlaybackLogic.cs:7227-7238` (add the guard)
+- `Source/Parsek/MissionPeriodicity.cs` (R3, corrected fix: surface the schedule's worst-launch
+  `AllLaunchesWithinTolerance` / `WorstResidualSeconds` from `TryFindNextScheduleK` through
+  `ExtendOnce` onto `MissionRelaunchSchedule`, instead of dropping it via `out _` at `:1693`)
+- `Source/Parsek/UI/MissionsWindowUI.cs:1332` (R3: tint amber off the surfaced schedule flag, NOT
+  the fixed-fit `WithinTolerance` and NOT unconditionally off `IsScheduled`)
+- Read-only confirms: `MissionLoopUnitBuilder.cs:267-315` (phaseLocked attach),
+  `MissionLoopUnitBuilder.cs:431` (re-aim null), `:561-565` (LoopUnit construction).
+
+**Gap closed:** (INV-3) the schedule branch returns early before the loiterCut /
+arrival-hold remap and trusts an UPSTREAM, undocumented-at-the-consumption-point invariant
+(schedule => phaseLocked => no cuts/hold). Safe today, but a future same-parent loiter
+compression or a re-aim unit that ever co-attached a schedule would silently drop the
+cut/hold with no warning. The existing `Build`-driven tests already pin schedule
+attach/no-attach; the only missing builder delta is the explicit
+`LoiterCuts == null && ArrivalHoldSeconds == 0` mutual-exclusion assertion.
+
+**Production change (minimal, fail-loud, RATE-LIMITED):** `TryComputeSpanLoopUT` is a per-frame
+HOT path called every frame from the flight engine (`GhostPlaybackEngine.cs:359/1878/2280`),
+the TS seam (`ResolveTrackingStationSampleUT`), KSC, the map, and logistics `RouteLoopClock`
+(`RouteLoopClock.cs:107`). Its doc contract (`GhostPlaybackLogic.cs:7184-7185`) states it is
+pure on the common path "except a single rate-limited Verbose line". A raw `ParsekLog.Warn`
+would therefore fire EVERY FRAME for EVERY scheduled-with-cuts unit across multiple scenes -
+log spam that violates the project's per-frame logging convention. So: in the
+`if (schedule != null)` block, before the early return, when
+`loiterCuts != null || arrivalHoldSeconds > 0`, emit a RATE-LIMITED / keyed warning - either
+`ParsekLog.VerboseRateLimited` or a Warn-once keyed on mission identity
+(`phaseAnchorUT + spanStartUT`), mirroring the existing per-loop-hold key at
+`GhostPlaybackLogic.cs:7298`. This is belt-and-suspenders: it changes no behavior on the shipped
+path (the predicate is always false there) but converts a latent silent-drop into a loud
+contract violation WITHOUT per-frame spam, and stays consistent with the function's documented
+purity contract. Keep it rate-limited and degrading, not a per-frame throw, so a future misuse
+degrades visibly rather than crashing playback. (A debug-only `Assert` - Open Decision 2 - is
+acceptable as an additional CI catch, but the live-build path must not spam.)
+
+**Tests to add:**
+1. **4.3 `Build_Scheduled_HasNoLoiterCutsOrArrivalHold`** (INV-3): drive
+   `MissionLoopUnitBuilder.Build` (NOT the private `TryBuildMissionUnit`) with a same-parent
+   drifting config + non-null `StockFake()` bodyInfo; assert `RelaunchSchedule != null`,
+   `PhaseAnchorUT == FirstLaunchUT`, `MinIntervalSeconds >= span`, AND `LoiterCuts == null` &&
+   `ArrivalHoldSeconds == 0`. The first three assertions overlap the existing
+   `Build_DriftingLongSpan...` test (`MissionPeriodicityTests.cs:1193-1195`); the
+   `LoiterCuts`/`ArrivalHold` pair is the new delta. (May be folded into the existing test
+   rather than a new method.)
+2. **`Build_SingleConstraint_TidalCollapse_Unsupported_NoSchedule`** (matrix): single /
+   tidally-locked / `UnsupportedCrossParent` configs attach NO schedule and do not regress the
+   anchor (complements the existing `MissionPeriodicityTests.cs:1145/1248`, driven through
+   `MissionLoopUnitBuilder.Build`).
+3. **Guard log test:** a log-capture test (per `RewindLoggingTests` pattern) that feeds the
+   span clock a contrived unit with both a schedule AND loiterCuts and asserts the rate-limited
+   warning fires (on the first frame / first key occurrence).
+
+**Validation / exit:** `dotnet test` green; the guard log line appears only on the contrived
+misuse. **REVIEW CHECKPOINT (wiring):** review the guard wording/level and that the builder
+tests actually exercise the live if-chain (not a hand-built LoopUnit shortcut).
+
+### Phase C - Save/load re-derive coverage
+
+**Scope:** tie schedule determinism to an actual persistence round-trip (INV-4).
+
+**Files:**
+- `Source/Parsek.Tests/MissionPeriodicityTests.cs` (or a focused new test class)
+- Read-only confirms: `Mission.cs:85/116` (`LoopAnchorUT` serialized),
+  `MissionLoopUnitBuilder.cs` `BuildSignature` (folds `LoopAnchorUT` +
+  `SoiRadius`/`OrbitalVelocity` + `TransitedBodyRotationMode`).
+
+**Gap closed:** the existing `Schedule_Deterministic_TwoIndependentBuilds...` proves two builds
+from the SAME in-memory inputs match; nothing ties that to OnSave/OnLoad of a looped Mission.
+Per the `ParsekScenario` xUnit limitation (Planetarium/GameEvents unguarded), use the
+source-gate pattern (`ChainSaveLoadTests.ChainStateNotPersistedInScenario` style) OR a focused
+in-game test if a live save round-trip is needed.
+
+**Tests to add:**
+1. **4.5 `Schedule_SaveLoadRoundTrip_RederivesIdentical`** (INV-4): serialize the persisted
+   inputs (`LoopAnchorUT` + the body-geometry digest), rebuild, and assert the resolved launch
+   sequence over `k=0..K` is identical pre/post. If a true OnLoad round-trip is required, add
+   it as the in-game variant in Phase D.
+
+**Validation / exit:** `dotnet test` green.
+
+### Phase D - In-game scene coverage + the synthetic-recording fixture (OPTIONAL live tier, highest cost, last)
+
+**Scope:** close the genuinely-uncovered live piece (the per-frame ghost `GameObject`
+activation, ride-along debris render, three-scene VISUAL parity for INV-6) and the warp
+single-fire rebuild spot-check (INV-5b). This is NEW coverage BEYOND the existing
+resolver-level scheduled in-game tests (`RuntimeTests.cs:5383/5432`), not the filling of a
+zero-coverage void. It is the only phase that needs live KSP and a new fixture, and is the
+OPTIONAL live-verification tier: Phases A-C ship a fully-verified resolver/builder/save-load
+tier independently of it.
+
+**Sub-phase D0 - the fixture (a hard prerequisite; make its cost visible before D1-D3):**
+- `Source/Parsek.Tests/Generators/RecordingBuilder.cs` (+ `ScenarioWriter.cs`): add a
+  looped same-parent Mun mission fixture. Today no generator produces a looped same-parent Mun
+  mission tree, which is WHY the live gaps cannot be cheaply closed; the fixture unlocks all
+  three in-game tests below. If the fixture proves expensive or blocked, the honest close is
+  doc-hygiene task 3 (annotate the done-plan that the in-game tier was carried forward); do NOT
+  leave D1-D3 half-done.
+
+**Files (D1-D3):**
+- `Source/Parsek/InGameTests/RuntimeTests.cs` (add the three tests, `Category = "Periodicity"`,
+  `Scene = GameScenes.FLIGHT`)
+- Read-only confirms: `GhostPlaybackEngine.cs:368` (single-instance), `:1881` (the easy-to-miss
+  ride-along-debris `parentUnit.RelaunchSchedule` site), `:2283`; `ParsekKSC.cs:1189`;
+  `ParsekTrackingStation.cs` -> `GhostMapPresence.cs:6494`.
+
+**Gap closed (INV-6 / INV-5b):** the existing scheduled in-game tests
+(`RuntimeTests.cs:5383/5432`) cover the RESOLVER level for a scheduled same-parent unit (TS
+sampler + live `GhostPlaybackEngine` member-UT/render decision), but by their own scope comment
+(`RuntimeTests.cs:5443-5457`) they do NOT cover the per-frame ghost `GameObject`
+`SetActive`/spawn/destroy in `GhostPlaybackEngine.UpdateUnitMemberPlayback`, the warp
+single-fire rebuild count, the live ride-along debris render, or the three-scene VISUAL parity
+(flight-map / TS ProtoVessel repositioning in `GhostMapPresence` + the KSC mesh path). Those
+remain playtest-verified only. (The Periodicity-category in-game tests
+`CrossParentReaimCanaryInGameTest` / `ReaimEndToEndInGameTest` are cross-parent Kerbin->Duna and
+attach no schedule; they are NOT scheduled-path coverage, but the scheduled-path resolver IS
+covered by the two tests named above.)
+
+**Tests to add:**
+1. **4.7 Flight render** (INV-6, + INV-5b warp): a looped same-parent multi-constraint mission
+   renders exactly one faithful instance per scheduled launch and nothing in the inter-cycle
+   tail; include a warp step across >=2 launches and assert exactly one rebuild (the
+   engine-internal single-fire property the pure 4.6 cannot observe).
+2. **4.8 Ride-along debris** (INV-6): debris of a scheduled member launches in lockstep with
+   its scheduled parent (the `GhostPlaybackEngine.cs:1881` site). At minimum add a PURE test
+   that the debris branch resolves the SAME launchUT/cycle as the parent member for a scheduled
+   unit (the inputs are available); the live render is the in-game follow-up.
+3. **4.9 Three-scene parity** (INV-2 live): the same scheduled member renders identically in
+   flight, KSC, and TS for the same UT.
+
+**Validation / playtest exit:**
+- All new in-game tests pass via Ctrl+Shift+T; results in `parsek-test-results.txt`.
+- A single-moon (Mun) TS-entry + orbit-gap playtest closes the two pending TS verifications
+  (section 5): grep `KSP.log` for `source=None reason=before-terminal-orbit` at a loop-mapped
+  UT (todo startup-flash line) and zero `destroy reason=gap-between-orbit-segments` recreate
+  churn across the orbit-segment gap (todo 1-2 s line).
+- **DLL verification before the playtest** (CLAUDE.md hard rule): grep the deployed
+  `GameData/Parsek/Plugins/Parsek.dll` for a distinctive UTF-16 string from the new guard /
+  test before launching, because sibling worktrees share the deployed DLL.
+
+**Fallback if the D0 fixture is blocked:** Phases A-C are the shippable core and close
+INV-1/2/3/4/5a/8 with zero live dependency. If the looped same-parent Mun fixture proves
+expensive or blocked, the honest close is doc-hygiene task 3: annotate the done-plan that the
+in-game tier (4.7-4.9) was carried forward to a follow-up rather than leaving Phase D
+half-done. The two existing scheduled in-game tests (`RuntimeTests.cs:5383/5432`) already keep
+the resolver-level live path covered in the interim.
+
+---
+
+## 5. Doc-hygiene tasks (match docs to HEAD)
+
+1. **`docs/dev/plans/mission-periodicity-phases.md:116-127`** - the one real doc/code
+   contradiction. Update the Phase 2 body to state the zero-drift per-window reschedule
+   SHIPPED, drop "deferred" / "a larger engine change", and link
+   `docs/dev/done/plans/zero-drift-reschedule.md`. Do not delete the fixed-cadence-variant
+   history; just correct the forward-looking "deferred" claim.
+2. **`docs/dev/todo-and-known-bugs.md`** (the "Done - Missions: looped inter-body
+   launch-window phase-lock" block, ~lines 527 and 529-530) - the TS startup wrong-position
+   icon flash (`source=None reason=before-terminal-orbit`) and the TS 1-2 s render gap across
+   recorded orbit-segment gaps are marked FIXED / Subsumed but close with "playtest log-grep
+   pending" / "Confirm in the next TS playtest". After the Phase-D Mun TS playtest, update
+   these to closed with the grep evidence (or, if the grep does NOT show the expected lines,
+   reopen with the captured frame - do not mark closed on faith, per the
+   confirm-diagnosis-against-evidence rule).
+3. **`docs/dev/done/plans/zero-drift-reschedule.md`** - this done-plan's test plan
+   (lines 519-527) lists three in-game tests as delivered scope. The done-plan is only PARTLY
+   overstated: two scheduled resolver-level in-game tests DO exist
+   (`RuntimeTests.cs:5383/5432`), but the per-frame ghost activation / ride-along debris render
+   / three-scene visual parity tier does NOT. After Phase D lands those, the done-plan is
+   accurate; if Phase D is deferred, add a one-line note in that done-plan that the per-frame
+   visual in-game tier was carried to this hardening plan so the archive does not over-state
+   delivered validation (the resolver-level tier is already shipped).
+4. This hardening plan moves to `docs/dev/done/plans/` when all phases land.
+
+---
+
+## 6. Highest residual risks + open DECISIONS for the maintainer
+
+**Open decisions:**
+
+1. **Scope of "single-moon" - RESOLVED 2026-06-09: SAME-PARENT ONLY.** The maintainer confirmed
+   this hardening pass covers the SAME-PARENT zero-drift schedule path (Kerbin -> Mun / Minmus,
+   including land-and-return) only. The cross-parent "Duna-One-class" single-moon arrival hold
+   (`ArrivalHoldPlanner`, `MissionLoopUnitBuilder.cs:527`, classified `UnsupportedCrossParent`
+   at `MissionPeriodicity.cs:451-457`) is a DIFFERENT subsystem and is hardened in a separate
+   sibling pass, NOT here. Consequence: INV-7 is vacuous, no Phase-D fixture attaches an
+   arrival-hold unit, and every Phase-D fixture is same-parent Mun. (Recorded so a later reader
+   does not reopen the reader disagreement that originally flagged this.)
+
+2. **Guard severity at the span-clock bypass.** The live-build path is FIXED as a rate-limited
+   warning (not a raw per-frame Warn) because `TryComputeSpanLoopUT` is a per-frame hot path
+   with a documented purity contract - see Phase B. The remaining maintainer call is only
+   whether to ADD a debug-only `Assert` (throws in test builds, catches the misuse harder in
+   CI) ON TOP of the rate-limited live warning, or rely on the warning + the Phase-B guard log
+   test alone. A debug assert risks nothing in live playback (compiled out) but adds a CI trip.
+
+3. **Same-parent loiter compression (parity gap, out of scope but worth a yes/no).** A
+   same-parent Mun/Minmus land-and-return with a long parking loiter takes the schedule path
+   and replays the FULL recorded span (loiter included) at each relaunch -
+   `ReaimLoiterCompressor.ComputeCuts` runs ONLY in the re-aim branch
+   (`MissionLoopUnitBuilder.cs:441`). Geometry stays faithful; only supply-route density is
+   affected. Is full-faithful-span replay the intended same-parent behavior indefinitely, or a
+   future item? Flag, do not design.
+
+**Highest residual risks:**
+
+- **R1 - Live-warp single-frame cache cost is unverified.** On a very large single-frame
+  TimeWarp jump, `TryResolveActiveLaunch`'s while-extend loop
+  (`MissionPeriodicity.cs:1711-1713`) can call `ExtendOnce` many times in one frame, each an
+  O(lookahead <= `ScheduleLookaheadMultiples = 4096`) `TryFindNextScheduleK` /
+  `CircularPhaseError` scan (`MissionPeriodicity.cs:526`), bounded only by
+  `MaxScheduleSteps = 8192` (`:533`). So the absolute single-frame worst case is doubly bounded
+  at ~8192 extends * up to a 4096-multiple scan - large but finite, and the cache persists in
+  `cachedLoopUnits` so it is a one-time cost per far jump. The pure tests warp to ~1e9 in xUnit
+  time, NOT a single live frame. Likely fine, but the worst-case live-frame cost is unmeasured;
+  the two constants above let the maintainer judge the paper bound before deciding whether the
+  Phase-D warp spot-check (4.7) is necessary - it remains the cheapest empirical confirm.
+
+- **R2 - Over-tolerance (bounded-best) launches replay silently (PROMOTED: it has teeth in two
+  places).** `TryResolveActiveLaunch` returns only launchUT + index; the per-launch residual /
+  withinTolerance from `TryFindNextScheduleK` are dropped (`out _` in `ExtendOnce`,
+  `MissionPeriodicity.cs:1693`). The stock Mun 2-constraint case always finds within-tol windows,
+  but a 3-constraint same-parent config (e.g. pad rotation + a Mun intercept + a second body
+  constraint) that falls to bounded-best within `ScheduleLookaheadMultiples = 4096` would replay
+  genuinely over-tolerance launches. This is NOT just a diagnostic nicety: (a) it falsifies the
+  "within tolerance by construction" premise (so the R3 fix surfaces the worst-launch flag and
+  tints off it); and (b) INV-1's oracle asserts the per-launch residual stays `<=` the m=9 fixed
+  residual (~993 s), which a bounded-best config could EXCEED. REQUIRED for the flawless bar:
+  EITHER (i) prove + assert that no in-scope same-parent config reaches bounded-best within the
+  lookahead, and scope INV-1's oracle to that proven set; OR (ii) add a bounded-best same-parent
+  fixture and assert the schedule still resolves MONOTONICALLY INCREASING launches with the
+  worst-launch amber flag surfaced (R3), relaxing INV-1's residual bound for that fixture. The
+  surfaced flag from the R3 fix is the shared mechanism. The implementing agent picks (i) or (ii)
+  after determining whether such a same-parent config is even constructible.
+
+- **R3 - UI amber-while-faithful tint is a CONFIRMED shipping mismatch (small fix + test, in
+  the flawless-bar scope).** This is no longer an open verify-item: the CODE-REALITY review
+  traced it. `MissionsWindowUI.cs:1332` computes
+  `bool amber = periodicity.IsPhaseLockedConstrained && !periodicity.Solution.WithinTolerance`.
+  `IsPhaseLockedConstrained` (`:1168`) is true for a scheduled drifting same-parent unit
+  (`Solved && ShouldPhaseLock && P > MinCycleDuration` - the exact gate the schedule attaches
+  under at `MissionLoopUnitBuilder.cs:267`), and `Solution.WithinTolerance` reflects the FIXED
+  m*P fit and is FALSE for the stock Mun (~993 s residual). So the T- countdown cell tints
+  AMBER for a scheduled unit whose ACTUAL scheduled launches ARE within tolerance by
+  construction - exactly the display-vs-reality mismatch. (The PERIOD cell is fine: it reads
+  `RelaunchSchedule.AverageIntervalSeconds` with a "varies" label at
+  `MissionsWindowUI.cs:1250-1258`.)
+  FIX (corrected per the clean review - do NOT just force `amber=false` for `IsScheduled`): a
+  scheduled unit is within tolerance ONLY when EVERY scheduled launch found a within-tolerance
+  window. The BOUNDED-BEST path (`TryFindNextScheduleK` returns `withinTolerance=false` at
+  `MissionPeriodicity.cs:949-953` when no within-tol k exists in the lookahead) can still produce
+  genuinely over-tolerance launches, and that flag is currently DROPPED (`out _` at
+  `MissionPeriodicity.cs:1693`). So the honest fix is to SURFACE the schedule's own worst-launch
+  tolerance (a new `MissionRelaunchSchedule.AllLaunchesWithinTolerance` / `WorstResidualSeconds`
+  over the cached prefix, threaded up from `TryFindNextScheduleK` through `ExtendOnce`) and tint
+  amber off THAT for a scheduled unit, NOT off the fixed-fit `WithinTolerance` and NOT
+  unconditionally off `IsScheduled`. This closes R2 in the same stroke. Tests: `amber == false`
+  for a within-tol scheduled unit (stock Mun) AND `amber == true` for a contrived bounded-best
+  scheduled unit (so a real over-tolerance schedule is NOT silently hidden). This now touches
+  `MissionPeriodicity` (surface the flag), not only the UI file; fold into Phase B. Re-grep the
+  cites before editing - they are HEAD-at-authoring.
+
+- **R4 - Deployed-DLL drift.** Sibling `Parsek-*` worktrees share
+  `GameData/Parsek/Plugins/Parsek.dll`; an in-game playtest can silently run a different
+  branch's build. Always grep the deployed DLL for a distinctive UTF-16 string from this work
+  before any Phase-D playtest.
+
+---
+
+## Open verification items (readers disagreed or could not confirm in a read-only pass)
+
+- (RESOLVED 2026-06-09) The single-moon scope is SAME-PARENT ONLY (section 6, Decision 1); the
+  cross-parent Duna arrival hold is a separate sibling pass. No longer an open item.
+- Whether the per-launch residual/withinTolerance is logged at schedule-EXTEND time at all
+  (the done-doc section 6 specs Verbose-per-relaunch logging; the out params are dropped via
+  `out _` at `MissionPeriodicity.cs:1693`) - confirm by grep on a live run before assuming the
+  diagnostic exists (R2). This is the only diagnostic-surface question left open; if no shipped
+  same-parent config falls to bounded-best (verify per R2) the surface is moot.
+- The three-scene VISUAL parity (4.9) is the one INV-2 property a read-only pass cannot
+  confirm: flight, KSC, and TS each run independent per-frame ghost-placement machinery, so
+  whether they render the scheduled member identically can only be shown live in Phase D, not
+  by the shared-helper xUnit test (which is param-forwarding only, see INV-2).
+
+NOTE: R3 (UI amber-while-faithful tint) was an open verify-item in earlier drafts; the
+CODE-REALITY review traced it to a confirmed shipping mismatch at `MissionsWindowUI.cs:1332`,
+so it is now a concrete fix in section 6 R3, no longer an open verification question.

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -13,6 +13,14 @@ When referencing prior item numbers from source comments or plans, consult the r
 
 ---
 
+## Done 2026-06-09 - Zero-drift per-window reschedule: same-parent (Mun / Minmus) verify-and-harden (branch `zero-drift-harden`, Phases A-C)
+
+**Scope:** SAME-PARENT only (Kerbin -> Mun / Minmus, including land-and-return). The cross-parent "Duna-One-class" single-moon arrival hold is a different subsystem (re-aim, `UnsupportedCrossParent`) and is a separate sibling pass, not part of this work. The mechanism (`MissionPeriodicity` `NextJointNearCoincidenceUT` / `TryBuildRelaunchSchedule` / `MissionRelaunchSchedule`, attached in `MissionLoopUnitBuilder.TryBuildMissionUnit` and consumed by the shared `GhostPlaybackLogic` span clock across flight / KSC / Tracking Station) was already SHIPPED; this work lifted it to a flawless bar by closing the test-coverage / verification gaps, adding the missing self-defending guards, and fixing the stale docs.
+
+**Done:** the same-parent zero-drift hardening (tests + span-clock guard + the R3 amber-tint fix that stops the launch-window status showing a false amber warning when the schedule is actually on target). Plan + per-phase breakdown: `docs/dev/plans/zero-drift-reschedule-hardening.md`; shipped spec: `docs/dev/done/plans/zero-drift-reschedule.md`.
+
+**Carried forward (deferred to a follow-up):** the Phase D in-game VISUAL-parity tier (per-frame ghost activation, scheduled debris render, and three-scene visual parity) is NOT closed by this work and is deferred to a follow-up; Phases A-C shipped on branch `zero-drift-harden`. The two Tracking-Station playtest-pending lines below also remain open (they need a live playtest, not closed here).
+
 ## Done 2026-06-08 - Bug 1 (funds-economy-divergence): a stock contract re-fire baked N copies of the reward into the ledger
 
 **Symptom (log-verified):** a single contract completion fired the stock award sequence 4 times within 22 ms (and a second contract 3 times), and Parsek recorded a `ContractCompleted` row per fire. Evidence: `logs/2026-06-08_2110_funds-bug/KSP.log`. `KSP.log:17201, 17227, 17250, 17271` (19:15:43.089-.111): four `Awarding 63250 funds to player for contract completion` STOCK lines for ONE contract (`1eb2baf9-afce-48c7-82d6-364dae85f57a`, "Science data from surface of The Mun"), live funds 305131 -> 494881. `KSP.log:17225, 17247, 17269, 17289` (`AddEvent: ContractCompleted ... total=33..36`): four store rows, same contractId / UT 475409.6 / recordingId tag. At commit those convert to four `ContractComplete` ledger rows (4 x 63250 = 253000).


### PR DESCRIPTION
## Summary

Verify-and-harden pass over the same-parent zero-drift per-window mission reschedule (Kerbin to Mun / Minmus looped missions). The non-uniform relaunch schedule was already shipped but under-tested and carried a UI mismatch; this lifts it to a flawless bar without changing the shipped behavior.

Scope is same-parent only. The cross-parent "Duna-One-class" arrival hold (re-aim) and multi-moon / Jool-class are explicit non-goals.

## Changes

Production (all minimal; the shipped path stays byte-identical):

- Span clock: a rate-limited self-defending guard in the schedule branch of `TryComputeSpanLoopUT`. No-op on the shipped path (a scheduled unit never carries loiter cuts / arrival hold); it only fires if a future change ever co-attaches them, turning a latent silent-drop into a visible contract violation.
- `MissionRelaunchSchedule` now surfaces its own worst-launch tolerance (`AllLaunchesWithinTolerance` / `WorstResidualSeconds`), which the solver previously computed and dropped.
- The Missions "Time to launch" cell tints amber off the schedule's real alignment instead of the fixed m*P fit, via a pure `ShouldTintTMinusAmber` helper. An in-tolerance Mun schedule no longer shows a false amber warning; a genuinely over-tolerance (bounded-best) schedule still does.

Tests: N-cycle non-accumulation through the schedule object, far-future warp single-resolve plus cache bound and idempotence, Flight and Tracking-Station param-forwarding agreement, builder schedule-vs-cuts/hold mutual exclusion, save/load re-derive, and a same-parent bounded-best fixture (a 4-constraint Kerbin + Mun + Minmus config that drives every launch to bounded-best).

Docs: CHANGELOG (0.10.1); corrected the stale "deferred" claim in `mission-periodicity-phases.md`; added a scope-locked Done entry. Plan: `docs/dev/plans/zero-drift-reschedule-hardening.md`.

## Validation

- Build clean; full xUnit suite 14739 passed / 1 failed, the single failure being the documented `InjectAllRecordings` environmental flake (KSP held the install lock), unrelated to this change.
- Clean-context review: GO, zero must-fixes.

## Deferred

Phase D (the live in-game visual-parity tier: per-frame ghost activation, scheduled debris render, three-scene visual parity) is deferred to a follow-up, per the plan's fallback. The two Tracking-Station playtest-pending lines remain open.
