### PR TITLE
Build: deploy to KSP install only on intentional builds

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -9,7 +9,7 @@ cd Source/Parsek.Tests && dotnet test     # all unit tests (does NOT deploy to K
 dotnet test --filter InjectAllRecordings  # inject 8 synthetic recordings into test save
 ```
 
-**KSP deploy is intentional-only:** the post-build copy to `GameData/Parsek/Plugins` runs ONLY when the build is started from `Source/Parsek` itself (the `cd Source/Parsek && dotnet build` flow) or with `-p:ForceKspDeploy=true`. Builds triggered via ProjectReference (`dotnet test`), from the repo root, or by `release.py` print `KSP deploy skipped` instead. `-p:SkipKspDeploy=true` suppresses the deploy even from the project dir. Rationale: with multiple worktrees sharing one KSP install, every sibling test run used to clobber the deployed DLL.
+**KSP deploy is intentional-only:** the post-build copy to `GameData/Parsek/Plugins` runs ONLY when the build is started from the building checkout's own `Source/Parsek` directory, or with `-p:ForceKspDeploy=true`. This works from ANY worktree: `cd Parsek-<branch>/Source/Parsek && dotnet build` deploys that branch's DLL (testing unmerged branches is unchanged). What never deploys: `dotnet test` (builds Parsek via ProjectReference from the Tests dir), builds started from the repo root or elsewhere, and `release.py`; those print `KSP deploy skipped` instead. `-p:SkipKspDeploy=true` suppresses the deploy even from the project dir. Rationale: with multiple worktrees sharing one KSP install, every sibling test run used to clobber the deployed DLL with whatever branch ran tests last.
 
 Post-build copy uses `ContinueOnError="true"` - builds succeed when KSP has DLL locked.
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -5,9 +5,11 @@
 
 ```bash
 cd Source/Parsek && dotnet build          # builds + auto-copies to KSP GameData
-cd Source/Parsek.Tests && dotnet test     # all unit tests
+cd Source/Parsek.Tests && dotnet test     # all unit tests (does NOT deploy to KSP)
 dotnet test --filter InjectAllRecordings  # inject 8 synthetic recordings into test save
 ```
+
+**KSP deploy is intentional-only:** the post-build copy to `GameData/Parsek/Plugins` runs ONLY when the build is started from `Source/Parsek` itself (the `cd Source/Parsek && dotnet build` flow) or with `-p:ForceKspDeploy=true`. Builds triggered via ProjectReference (`dotnet test`), from the repo root, or by `release.py` print `KSP deploy skipped` instead. `-p:SkipKspDeploy=true` suppresses the deploy even from the project dir. Rationale: with multiple worktrees sharing one KSP install, every sibling test run used to clobber the deployed DLL.
 
 Post-build copy uses `ContinueOnError="true"` - builds succeed when KSP has DLL locked.
 
@@ -32,7 +34,7 @@ cp Source/Parsek/bin/Debug/Parsek.dll "$KSPDIR/GameData/Parsek/Plugins/Parsek.dl
 
 From a manual worktree, set `KSPDIR` explicitly because the csproj's relative `Kerbal Space Program/` probe only walks parent directories of the csproj — a sibling-of-the-worktree layout at `C:/Users/vlad3/Documents/Code/Parsek/Kerbal Space Program/` is NOT reachable from `C:/Users/vlad3/Documents/Code/Parsek-<branch>/Source/Parsek/` via ancestor walking.
 
-**If multiple worktrees exist**, any of them can overwrite the shared `GameData/Parsek/Plugins/Parsek.dll`. The deployed file belongs to whichever worktree built most recently. Re-verify after every build if you're switching between worktrees or if a sibling session is also building.
+**If multiple worktrees exist**, any of them can overwrite the shared `GameData/Parsek/Plugins/Parsek.dll` via a direct `cd Source/Parsek && dotnet build` (test runs no longer deploy since the intentional-only deploy gate). The deployed file belongs to whichever worktree deployed most recently. Re-verify (hash-compare, not just mtime) right before every KSP launch if a sibling session is also active.
 
 **Diagnosing which build produced a collected log.** A `collect-logs.py` snapshot can run a clobbered DLL from a *different* branch than you expect (sibling-worktree race). Two cross-checks: (1) read `git-state.txt` in the log folder for the branch/commit the collection captured, but note it reflects the directory the script ran from, not necessarily the deployed DLL; (2) grep `KSP.log` for feature-signature strings to confirm what code actually loaded (e.g. `RouteOriginProof` / `Route proof dock window` for logistics, `OnVesselsUndocking` vs `DeferredHandleTransientUndock` for the undock handler, `Parsek' V<x.y.z>` for the assembly version). If a log lacks the signatures of the feature you're investigating, that session ran the wrong DLL and proves nothing about your change.
 

--- a/Source/Parsek/Parsek.csproj
+++ b/Source/Parsek/Parsek.csproj
@@ -85,13 +85,28 @@
     </Reference>
   </ItemGroup>
 
-  <!-- Post-build: Copy to local KSP GameData -->
-  <Target Name="CopyToGameData" AfterTargets="Build" Condition="Exists('$(KSPDir)')">
+  <!-- Post-build: Copy to local KSP GameData.
+       Deploys ONLY when the build was started from this project directory
+       (cd Source/Parsek && dotnet build) or with -p:ForceKspDeploy=true.
+       Builds triggered via ProjectReference (dotnet test in Parsek.Tests) or from
+       other directories (release.py at repo root) do NOT deploy: with multiple
+       worktrees sharing one KSP install, every test run used to clobber the
+       deployed DLL with whatever branch ran tests last. -->
+  <PropertyGroup>
+    <ParsekDeployToKsp>false</ParsekDeployToKsp>
+    <ParsekDeployToKsp Condition="'$(MSBuildStartupDirectory)' == '$(MSBuildProjectDirectory)'">true</ParsekDeployToKsp>
+    <ParsekDeployToKsp Condition="'$(ForceKspDeploy)' == 'true'">true</ParsekDeployToKsp>
+    <ParsekDeployToKsp Condition="'$(SkipKspDeploy)' == 'true'">false</ParsekDeployToKsp>
+  </PropertyGroup>
+  <Target Name="CopyToGameData" AfterTargets="Build" Condition="Exists('$(KSPDir)') and '$(ParsekDeployToKsp)' == 'true'">
     <MakeDir Directories="$(KSPDir)\GameData\Parsek\Plugins" />
     <Copy SourceFiles="$(OutputPath)Parsek.dll" DestinationFolder="$(KSPDir)\GameData\Parsek\Plugins" ContinueOnError="true" />
     <Copy SourceFiles="$(OutputPath)Parsek.pdb" DestinationFolder="$(KSPDir)\GameData\Parsek\Plugins" Condition="Exists('$(OutputPath)Parsek.pdb')" ContinueOnError="true" />
     <Copy SourceFiles="$(MSBuildProjectDirectory)\..\..\GameData\Parsek\Parsek.version" DestinationFolder="$(KSPDir)\GameData\Parsek" ContinueOnError="true" />
     <Message Text="Copied to $(KSPDir)\GameData\Parsek\Plugins" Importance="high" />
+  </Target>
+  <Target Name="CopyToGameDataSkipped" AfterTargets="Build" Condition="Exists('$(KSPDir)') and '$(ParsekDeployToKsp)' != 'true'">
+    <Message Text="KSP deploy skipped (build not started from Source/Parsek; use -p:ForceKspDeploy=true to override)" Importance="high" />
   </Target>
 
 </Project>

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -197,6 +197,12 @@ A 2026-06-10 online sweep of what KSP players actually fly (stock career contrac
 
 ---
 
+## Done 2026-06-11 - dotnet test clobbered the deployed KSP DLL from every worktree (branch `fix-test-deploy-clobber`)
+
+The `CopyToGameData` post-build target ran `AfterTargets="Build"` unconditionally, so `dotnet test` in ANY worktree (which builds Parsek as a ProjectReference) deployed that branch's DLL to the shared `Kerbal Space Program/GameData/Parsek/Plugins`. With several sessions active, the deployed DLL belonged to whoever ran tests last; during the 2026-06-11 Waterfall validation the install was clobbered twice within minutes of an intentional deploy, and one KSP launch picked up the wrong branch 48 seconds after a sibling's build.
+
+**Fix:** deploy is now intentional-only via a `ParsekDeployToKsp` property: true only when `$(MSBuildStartupDirectory) == $(MSBuildProjectDirectory)` (the documented `cd Source/Parsek && dotnet build` flow) or `-p:ForceKspDeploy=true`; `-p:SkipKspDeploy=true` suppresses it. Skipped builds print `KSP deploy skipped` so the absence of a deploy is visible. `dotnet test`, repo-root builds, and `release.py` (which packages from `bin/Release`, never from the install) no longer touch the install. Sibling worktrees keep clobbering until they rebase past this commit.
+
 ## Done 2026-06-11 - In-game OrbitArcSampler test asserted orbital distance from the floating origin, not the body centre (branch `fix-orbitarc-test-frame`)
 
 `GhostMapPresenceTests.OrbitArcSampler_ClipsLiveOrbitToOpenArc` failed in the 2026-06-11 Run All + Isolated session (`../logs/2026-06-11_1811_m1-ingame-tests/`, "sampled points sit at orbital distance from the body centre (world-frame)") with the active vessel "Jumping Flea" PRELAUNCH on the pad. Root cause is in the TEST, not the sampler: `OrbitArcSampler.SampleSegmentArc` returns WORLD-frame points (`referenceBody.position + relative`), but the assertion checked `buffer[0].magnitude > body.Radius * 0.5` - the distance from the FLOATING ORIGIN, which rides the active vessel. The synthetic orbit's periapsis (720 km from Kerbin's centre, along the Planetarium reference direction in the equatorial plane) passes within ~120 km of a launchpad origin whenever KSC's rotational longitude lines up with the reference direction, so the check failed or passed depending on planet rotation / vessel position. The forward-render review's NIT-6 fixed the sampler doc + assertion message to say "world-frame" but left the origin-relative measurement in place.


### PR DESCRIPTION
## Problem

The `CopyToGameData` post-build target ran `AfterTargets="Build"` unconditionally, so `dotnet test` in ANY worktree (which builds Parsek as a ProjectReference) deployed that branch's DLL to the shared `Kerbal Space Program/GameData/Parsek/Plugins`. With several worktree sessions active, the deployed DLL belonged to whichever branch ran tests last. During the 2026-06-11 Waterfall validation (PR #1124) the install was clobbered twice within minutes of an intentional deploy, and one KSP launch loaded the wrong branch 48 seconds after a sibling session's build, invalidating a whole playtest session.

## Fix

Deploy is gated on a new `ParsekDeployToKsp` property:

- **true** when the build is started from `Source/Parsek` itself (the documented `cd Source/Parsek && dotnet build` flow), or with `-p:ForceKspDeploy=true` from anywhere
- **false** otherwise, and forced off with `-p:SkipKspDeploy=true`

Skipped builds print `KSP deploy skipped (build not started from Source/Parsek; use -p:ForceKspDeploy=true to override)` so the absence of a deploy is visible in build output. `dotnet test`, repo-root builds, and `release.py` (which packages from `bin/Release`, never from the install) no longer touch the install.

## Validation

- `dotnet build` from `Source/Parsek.Tests`: prints the skip message, copies nothing
- `dotnet build` from `Source/Parsek`: deploys as before
- Full `dotnet test` run: 15023 tests green, no deploy in the output
- `release.py` reviewed: builds with repo-root cwd (now skip) and zips from `bin/Release`, unaffected

## Note

Sibling worktrees keep their old csproj until they rebase past this commit, so their test runs can still clobber until then. Docs updated (.claude/CLAUDE.md Build & Test section, todo-and-known-bugs entry).