### PR TITLE
Re-aim cross-SOI fix P2-P4: patched-conic chain synthesis (escape+transfer+capture) behind the default-OFF flag

### DIFF
--- a/Source/Parsek.Tests/ReaimChainGeometryTests.cs
+++ b/Source/Parsek.Tests/ReaimChainGeometryTests.cs
@@ -1,0 +1,183 @@
+using System;
+using Parsek.Reaim;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    // Pure state-vector geometry for the re-aim whole-chain synthesis (reaim-fix-plan.md P2, STEP 1/2):
+    // the body-relative velocity / position reductions, the .xzy round-trip identity (a swizzle error
+    // silently corrupts the synthesized orbit), and the SOI-sphere-crossing bisection. The live glue
+    // (Orbit.UpdateFromStateVectors, CelestialBody.orbit, PatchedConics) stays in ReaimTransferSynthesizer
+    // and is validated by the in-game canary; these pure pieces are the xUnit floor.
+    public class ReaimChainGeometryTests
+    {
+        // ---- vRel / rRel reductions (the frame-agnostic subtraction the construction feeds UpdateFromStateVectors) ----
+
+        [Fact]
+        public void RelativeVelocity_SubtractsBodyVelocity()
+        {
+            // vRel = v_heliocentric - v_body. Both operands in the same frame -> a plain subtraction.
+            var vHelio = new Vector3d(12000.0, -3000.0, 500.0);
+            var vBody = new Vector3d(9000.0, -2500.0, 100.0);
+            Vector3d vRel = ReaimChainGeometry.RelativeVelocity(vHelio, vBody);
+            Assert.Equal(3000.0, vRel.x, 6);
+            Assert.Equal(-500.0, vRel.y, 6);
+            Assert.Equal(400.0, vRel.z, 6);
+        }
+
+        [Fact]
+        public void RelativePosition_DiffersParentRelativePositions()
+        {
+            // rRel = r_transfer - r_body (both parent-relative in one frame).
+            var rTransfer = new Vector3d(1.0e10, 2.0e10, -3.0e9);
+            var rBody = new Vector3d(1.0e10 - 200000.0, 2.0e10 + 50000.0, -3.0e9);
+            Vector3d rRel = ReaimChainGeometry.RelativePosition(rTransfer, rBody);
+            Assert.Equal(200000.0, rRel.x, 3);
+            Assert.Equal(-50000.0, rRel.y, 3);
+            Assert.Equal(0.0, rRel.z, 3);
+        }
+
+        [Fact]
+        public void RelativeVelocity_SameOperandsCancelToZero()
+        {
+            // Identical operands -> zero (the body sitting exactly on the transfer endpoint).
+            var v = new Vector3d(7.0, 8.0, 9.0);
+            Vector3d d = ReaimChainGeometry.RelativeVelocity(v, v);
+            Assert.Equal(0.0, d.magnitude, 9);
+        }
+
+        // ---- .xzy round-trip identity (the load-bearing swizzle contract) ----
+
+        [Fact]
+        public void XzySwizzle_IsItsOwnInverse_RoundTripsToOriginal()
+        {
+            // The transfer build un-swizzles (.xzy) to difference in one world frame, then re-swizzles
+            // (.xzy) for UpdateFromStateVectors. .xzy is its own inverse, so v.xzy.xzy == v EXACTLY. The
+            // capture/escape construction mirrors this; this pins the invariance the whole chain depends on.
+            var v = new Vector3d(123.456, -789.012, 345.678);
+            Vector3d roundTrip = v.xzy.xzy;
+            Assert.Equal(v.x, roundTrip.x, 12);
+            Assert.Equal(v.y, roundTrip.y, 12);
+            Assert.Equal(v.z, roundTrip.z, 12);
+        }
+
+        [Fact]
+        public void XzySwizzle_SwapsYandZ()
+        {
+            // Documents the swizzle itself: .xzy maps (x,y,z) -> (x,z,y).
+            var v = new Vector3d(1.0, 2.0, 3.0);
+            Vector3d s = v.xzy;
+            Assert.Equal(1.0, s.x, 12);
+            Assert.Equal(3.0, s.y, 12);
+            Assert.Equal(2.0, s.z, 12);
+        }
+
+        [Fact]
+        public void XzySwizzle_ReductionInvariant_DiffEqualsSwizzledDiff()
+        {
+            // The reduction is frame-agnostic: (a - b) swizzled == a.xzy - b.xzy. This is why the live
+            // construction can difference in EITHER frame as long as both operands match (the contract the
+            // RelativePosition/RelativeVelocity helpers rely on).
+            var a = new Vector3d(10.0, 20.0, 30.0);
+            var b = new Vector3d(1.0, 2.0, 3.0);
+            Vector3d diffThenSwizzle = ReaimChainGeometry.RelativePosition(a, b).xzy;
+            Vector3d swizzleThenDiff = ReaimChainGeometry.RelativePosition(a.xzy, b.xzy);
+            Assert.Equal(diffThenSwizzle.x, swizzleThenDiff.x, 9);
+            Assert.Equal(diffThenSwizzle.y, swizzleThenDiff.y, 9);
+            Assert.Equal(diffThenSwizzle.z, swizzleThenDiff.z, 9);
+        }
+
+        // ---- SOI-sphere-crossing bisection ----
+
+        // A monotone distance model: distance(ut) = baseline + rate * (ut - t0). Crosses the SOI radius
+        // exactly once, so the bisection has a unique root - the analytic crossing is known for the assert.
+        private static Func<double, double> LinearDistance(double t0, double baseline, double ratePerSecond)
+        {
+            return ut => baseline + ratePerSecond * (ut - t0);
+        }
+
+        [Fact]
+        public void TryBisectSoiCrossing_ConvergesToSoiShell_DescendingIntoSoi()
+        {
+            // Distance DECREASES into the SOI (a capture): outside at the early UT, inside at the late UT.
+            // distance(ut) = 2e9 - 1e6*(ut-0). SOI = 1e9 -> crossing at ut = 1000.
+            double soi = 1.0e9;
+            Func<double, double> dist = LinearDistance(0.0, 2.0e9, -1.0e6);
+            // inside (<= soi) sample at ut=1500 (dist 0.5e9), outside (> soi) at ut=500 (dist 1.5e9).
+            bool ok = ReaimChainGeometry.TryBisectSoiCrossing(
+                dist, soi, insideUT: 1500.0, outsideUT: 500.0, toleranceMeters: 1.0e4,
+                out double crossing);
+            Assert.True(ok);
+            Assert.Equal(1000.0, crossing, 0); // within 0.5s of the analytic root at the 1e4 m tolerance
+            Assert.True(Math.Abs(dist(crossing) - soi) <= 1.0e4);
+        }
+
+        [Fact]
+        public void TryBisectSoiCrossing_ConvergesToSoiShell_AscendingOutOfSoi()
+        {
+            // Distance INCREASES out of the SOI (an escape): inside at the early UT, outside at the late UT.
+            // distance(ut) = 0 + 1e6*(ut-0). SOI = 84000 km = 8.4e7 -> crossing at ut = 84.
+            double soi = 8.4e7;
+            Func<double, double> dist = LinearDistance(0.0, 0.0, 1.0e6);
+            bool ok = ReaimChainGeometry.TryBisectSoiCrossing(
+                dist, soi, insideUT: 0.0, outsideUT: 200.0, toleranceMeters: 1.0e3,
+                out double crossing);
+            Assert.True(ok);
+            Assert.Equal(84.0, crossing, 1);
+            Assert.True(Math.Abs(dist(crossing) - soi) <= 1.0e3);
+        }
+
+        [Fact]
+        public void TryBisectSoiCrossing_NotAStraddle_FailsClosed()
+        {
+            // Both samples outside the SOI (no inside boundary) -> not a valid straddle -> false / NaN.
+            double soi = 1.0e9;
+            Func<double, double> dist = LinearDistance(0.0, 2.0e9, 1.0e6); // always > soi
+            bool ok = ReaimChainGeometry.TryBisectSoiCrossing(
+                dist, soi, insideUT: 100.0, outsideUT: 200.0, toleranceMeters: 1.0e4, out double crossing);
+            Assert.False(ok);
+            Assert.True(double.IsNaN(crossing));
+        }
+
+        [Fact]
+        public void TryBisectSoiCrossing_WrongStraddleOrientation_FailsClosed()
+        {
+            // The "inside" sample is actually OUTSIDE and vice versa (caller passed the bracket reversed) ->
+            // the inside/outside contract is violated -> fail closed rather than converge on the wrong root.
+            double soi = 1.0e9;
+            Func<double, double> dist = LinearDistance(0.0, 2.0e9, -1.0e6); // dist(1500)=0.5e9 inside, dist(500)=1.5e9 outside
+            // Pass them swapped: claim 500 is inside (it is outside) and 1500 is outside (it is inside).
+            bool ok = ReaimChainGeometry.TryBisectSoiCrossing(
+                dist, soi, insideUT: 500.0, outsideUT: 1500.0, toleranceMeters: 1.0e4, out double crossing);
+            Assert.False(ok);
+            Assert.True(double.IsNaN(crossing));
+        }
+
+        [Fact]
+        public void TryBisectSoiCrossing_DegenerateInputs_FailClosed()
+        {
+            Func<double, double> dist = LinearDistance(0.0, 2.0e9, -1.0e6);
+            Assert.False(ReaimChainGeometry.TryBisectSoiCrossing(null, 1e9, 1500, 500, 1e4, out _));
+            Assert.False(ReaimChainGeometry.TryBisectSoiCrossing(dist, 0.0, 1500, 500, 1e4, out _));
+            Assert.False(ReaimChainGeometry.TryBisectSoiCrossing(dist, double.NaN, 1500, 500, 1e4, out _));
+            Assert.False(ReaimChainGeometry.TryBisectSoiCrossing(dist, 1e9, double.NaN, 500, 1e4, out _));
+            Assert.False(ReaimChainGeometry.TryBisectSoiCrossing(dist, 1e9, 1500, double.NaN, 1e4, out _));
+            Assert.False(ReaimChainGeometry.TryBisectSoiCrossing(dist, 1e9, 1500, 500, 0.0, out _));
+        }
+
+        [Fact]
+        public void TryBisectSoiCrossing_TightTolerance_StillTerminatesOnBracketCollapse()
+        {
+            // An impossibly tight tolerance (1e-9 m) forces the iteration cap; the bracket collapses to a UT
+            // and the method returns true with the midpoint (converged on UT, not on the position tolerance).
+            double soi = 1.0e9;
+            Func<double, double> dist = LinearDistance(0.0, 2.0e9, -1.0e6);
+            bool ok = ReaimChainGeometry.TryBisectSoiCrossing(
+                dist, soi, insideUT: 1500.0, outsideUT: 500.0, toleranceMeters: 1.0e-9, out double crossing,
+                maxIterations: 60);
+            Assert.True(ok);
+            // 60 bisections of a 1000s bracket -> < 1e-15 s residual, far inside any UT meaning.
+            Assert.Equal(1000.0, crossing, 6);
+        }
+    }
+}

--- a/Source/Parsek.Tests/ReaimChainGeometryTests.cs
+++ b/Source/Parsek.Tests/ReaimChainGeometryTests.cs
@@ -179,5 +179,98 @@ namespace Parsek.Tests
             // 60 bisections of a 1000s bracket -> < 1e-15 s residual, far inside any UT meaning.
             Assert.Equal(1000.0, crossing, 6);
         }
+
+        // ---- IsSaneLegConic (reaim-fix-plan rework, STEP 2/3 fail-closed gate) ----
+        // Kerbin reference numbers for the periapsis band: Radius ~600 km, SOI ~84.16 Mm.
+        private const double KerbinRadius = 600000.0;
+        private const double KerbinSoi = 84159286.0;
+
+        [Fact]
+        public void IsSaneLegConic_RealEjectionHyperbola_Accepted()
+        {
+            // A real Kerbin->Duna ejection: ecc ~1.2, periapsis ~700 km (just above the surface). Build sma
+            // from rp = a*(1-e) => a = rp/(1-e).
+            double ecc = 1.2, rp = 700000.0;
+            double sma = rp / (1.0 - ecc); // negative (hyperbola)
+            Assert.True(sma < 0.0);
+            Assert.True(ReaimChainGeometry.IsSaneLegConic(ecc, sma, KerbinRadius, KerbinSoi));
+        }
+
+        [Fact]
+        public void IsSaneLegConic_Ecc13GarbageWithPeriapsisFarOut_Rejected()
+        {
+            // The exact regression shape: sma=-1542755, ecc=12.9 -> periapsis ~18.36 Mm (far above a sane
+            // parking altitude). The velocity-source artifact this gate exists to fail closed.
+            double sma = -1542755.6888135117, ecc = 12.9031;
+            double rp = sma * (1.0 - ecc);
+            Assert.True(rp > 5.0e6); // periapsis is tens of Mm up
+            Assert.False(ReaimChainGeometry.IsSaneLegConic(ecc, sma, KerbinRadius, KerbinSoi));
+        }
+
+        [Fact]
+        public void IsSaneLegConic_EccentricButSanePeriapsis_Accepted()
+        {
+            // An eccentric (Moho/Eeloo) departure can sit nearer the top of the band; ecc 2.5 with a low
+            // periapsis is still a real leg and must be accepted (the band is deliberately generous).
+            double ecc = 2.5, rp = 650000.0;
+            double sma = rp / (1.0 - ecc);
+            Assert.True(ReaimChainGeometry.IsSaneLegConic(ecc, sma, KerbinRadius, KerbinSoi));
+        }
+
+        [Fact]
+        public void IsSaneLegConic_AboveMaxEccentricity_Rejected()
+        {
+            // ecc just above the band ceiling (3.0) with an otherwise-sane periapsis is still rejected -
+            // the ceiling is the artifact cutoff.
+            double ecc = 3.5, rp = 650000.0;
+            double sma = rp / (1.0 - ecc);
+            Assert.False(ReaimChainGeometry.IsSaneLegConic(ecc, sma, KerbinRadius, KerbinSoi));
+        }
+
+        [Fact]
+        public void IsSaneLegConic_BoundEllipse_Rejected()
+        {
+            // A bound (elliptic) conic is not a valid escape/capture leg (ecc < 1).
+            Assert.False(ReaimChainGeometry.IsSaneLegConic(0.3, 700000.0, KerbinRadius, KerbinSoi));
+        }
+
+        [Fact]
+        public void IsSaneLegConic_PeriapsisBelowSurface_Rejected()
+        {
+            // A hyperbola whose periapsis is below the body surface (here below the min radius) clips the
+            // body and is rejected.
+            double ecc = 1.2, rp = 100000.0; // 100 km < Kerbin's 600 km min radius
+            double sma = rp / (1.0 - ecc);
+            Assert.False(ReaimChainGeometry.IsSaneLegConic(ecc, sma, KerbinRadius, KerbinSoi));
+        }
+
+        [Fact]
+        public void IsSaneLegConic_PeriapsisAboveHalfSoi_Rejected()
+        {
+            // A periapsis beyond half the SOI is the center-vs-shell sampling artifact (the leg sits out
+            // near the SOI edge), rejected even at a sane eccentricity.
+            double ecc = 1.2, rp = KerbinSoi * 0.6; // > half SOI
+            double sma = rp / (1.0 - ecc);
+            Assert.False(ReaimChainGeometry.IsSaneLegConic(ecc, sma, KerbinRadius, KerbinSoi));
+        }
+
+        [Fact]
+        public void IsSaneLegConic_NaNOrInfElements_Rejected()
+        {
+            Assert.False(ReaimChainGeometry.IsSaneLegConic(double.NaN, -1.5e6, KerbinRadius, KerbinSoi));
+            Assert.False(ReaimChainGeometry.IsSaneLegConic(1.2, double.NaN, KerbinRadius, KerbinSoi));
+            Assert.False(ReaimChainGeometry.IsSaneLegConic(double.PositiveInfinity, -1.5e6, KerbinRadius, KerbinSoi));
+            Assert.False(ReaimChainGeometry.IsSaneLegConic(1.2, double.NegativeInfinity, KerbinRadius, KerbinSoi));
+        }
+
+        [Fact]
+        public void IsSaneLegConic_DegenerateBodyBounds_Rejected()
+        {
+            // Non-positive / NaN body bounds fail closed (can't establish a sane band).
+            double ecc = 1.2, sma = 700000.0 / (1.0 - 1.2);
+            Assert.False(ReaimChainGeometry.IsSaneLegConic(ecc, sma, 0.0, KerbinSoi));
+            Assert.False(ReaimChainGeometry.IsSaneLegConic(ecc, sma, KerbinRadius, 0.0));
+            Assert.False(ReaimChainGeometry.IsSaneLegConic(ecc, sma, double.NaN, KerbinSoi));
+        }
     }
 }

--- a/Source/Parsek.Tests/ReaimChainSynthesisTests.cs
+++ b/Source/Parsek.Tests/ReaimChainSynthesisTests.cs
@@ -370,7 +370,7 @@ namespace Parsek.Tests
 
         [Theory]
         [MemberData(nameof(IdentityFixtures))]
-        public void AssembleWindowChain_FlagOn_IsPlaceholderIdenticalToFlagOff(
+        public void AssembleWindowChain_FlagOn_NoChainInputs_FailsClosedToFlagOff(
             string label,
             List<OrbitSegment> member,
             OrbitSegment transfer,
@@ -380,8 +380,11 @@ namespace Parsek.Tests
         {
             _ = label;
 
-            // P1 placeholder: the ON path currently returns the SAME result as the OFF path (no chain
-            // synthesis until P3). Flipping the flag changes no behavior yet, by design.
+            // P3 fail-closed contract at the seam: when AssembleWindowChain is called with NO escape /
+            // capture legs and NO chain spans (the legacy call shape, escapeSeg/captureSeg null + NaN
+            // spans), ReplaceTransferChain synthesizes ONLY the transfer leg (the escape/capture sides
+            // both fail their span guards) and so produces the SAME single-leg replacement as flag OFF.
+            // This proves the ON path is never worse than the baseline when the chain inputs are absent.
             var flagOff = ReaimSegmentAssembler.AssembleWindowChain(
                 useChain: false,
                 member, transfer, commonAncestor, recordedDepartureUT, recordedArrivalUT,
@@ -474,6 +477,480 @@ namespace Parsek.Tests
                 useChain: false, launchOnly, transfer, "Sun", 600.0, 2600.0, double.NaN, double.NaN));
             Assert.Null(ReaimSegmentAssembler.AssembleWindowChain(
                 useChain: true, launchOnly, transfer, "Sun", 600.0, 2600.0, double.NaN, double.NaN));
+        }
+
+        // =====================================================================================
+        // P2 - STEP 4 uniform-shift phase-consistency proof
+        // =====================================================================================
+
+        // The three synthesized legs (escape, transfer, capture) have natural epochs set at THREE different
+        // absolute UTs (launchSoiExitUT, departureUT, soiEntryUT). STEP 4 applies ONE uniform shift to all
+        // three; this preserves relative phase ONLY because each leg's epoch was set in the SAME absolute
+        // frame (all three are absolute live-frame UTs of the same window solve). The pure proxy for "each
+        // leg's sampled position at its shared seam UT is unchanged relative to its neighbor": ShiftInTime
+        // moves startUT/endUT/epoch by the SAME delta, so (t - epoch) - the mean-anomaly clock argument - is
+        // invariant at every UT, AND a shared seam UT (escape.endUT == transfer.startUT) stays shared after
+        // the shift. A non-uniform shift (different deltas per leg) would break BOTH, which this guards.
+        [Fact]
+        public void UniformShift_PreservesPerLegPhaseAndSeamContiguity()
+        {
+            // Three legs with epochs at three DIFFERENT absolute UTs (the escape/transfer/capture pattern),
+            // tiled contiguously: escape [1000,2000] epoch 1000, transfer [2000,9000] epoch 2000,
+            // capture [9000,9500] epoch 9000.
+            var escape = new OrbitSegment { bodyName = "Kerbin", startUT = 1000, endUT = 2000, epoch = 1000, meanAnomalyAtEpoch = 0.3, semiMajorAxis = -3.8e6, eccentricity = 1.19 };
+            var transfer = new OrbitSegment { bodyName = "Sun", startUT = 2000, endUT = 9000, epoch = 2000, meanAnomalyAtEpoch = 0.5, semiMajorAxis = 1.76e10, eccentricity = 0.21 };
+            var capture = new OrbitSegment { bodyName = "Duna", startUT = 9000, endUT = 9500, epoch = 9000, meanAnomalyAtEpoch = 0.7, semiMajorAxis = -5.6e5, eccentricity = 1.05 };
+
+            const double shift = -54321.0; // an arbitrary recorded-span shift (RecordedDepartureUT - departureUT)
+
+            // Per-leg phase clock argument (t - epoch) at each leg's OWN seam UTs, BEFORE the shift.
+            double escEndPhaseBefore = escape.endUT - escape.epoch;       // transfer-start seam, escape side
+            double xferStartPhaseBefore = transfer.startUT - transfer.epoch; // transfer-start seam, transfer side
+            double xferEndPhaseBefore = transfer.endUT - transfer.epoch;  // capture-start seam, transfer side
+            double capStartPhaseBefore = capture.startUT - capture.epoch; // capture-start seam, capture side
+
+            var escS = ReaimSegmentAssembler.ShiftInTime(escape, shift);
+            var xferS = ReaimSegmentAssembler.ShiftInTime(transfer, shift);
+            var capS = ReaimSegmentAssembler.ShiftInTime(capture, shift);
+
+            // 1) Each leg's phase clock argument (t - epoch) is UNCHANGED at its seams (the mean anomaly,
+            //    and so the sampled position, at the shifted seam UT equals that at the original seam UT).
+            Assert.Equal(escEndPhaseBefore, escS.endUT - escS.epoch, 6);
+            Assert.Equal(xferStartPhaseBefore, xferS.startUT - xferS.epoch, 6);
+            Assert.Equal(xferEndPhaseBefore, xferS.endUT - xferS.epoch, 6);
+            Assert.Equal(capStartPhaseBefore, capS.startUT - capS.epoch, 6);
+
+            // 2) The shared seams stay contiguous (escape.endUT == transfer.startUT, transfer.endUT ==
+            //    capture.startUT) after the uniform shift - the neighbors still meet at the SAME UT.
+            Assert.Equal(escS.endUT, xferS.startUT, 6);
+            Assert.Equal(xferS.endUT, capS.startUT, 6);
+
+            // 3) The mean-anomaly-at-epoch (the orbit's phase identity) is untouched by the shift.
+            Assert.Equal(escape.meanAnomalyAtEpoch, escS.meanAnomalyAtEpoch, 9);
+            Assert.Equal(transfer.meanAnomalyAtEpoch, xferS.meanAnomalyAtEpoch, 9);
+            Assert.Equal(capture.meanAnomalyAtEpoch, capS.meanAnomalyAtEpoch, 9);
+        }
+
+        [Fact]
+        public void UniformShift_NonUniformShiftWouldBreakSeam_Contrast()
+        {
+            // Contrast proof: applying DIFFERENT shifts to adjacent legs breaks the shared seam, which is
+            // exactly why STEP 4 mandates ONE uniform shift. (Documents the failure mode the uniform shift
+            // avoids; not a behavior under test, a negative control.)
+            var escape = new OrbitSegment { bodyName = "Kerbin", startUT = 1000, endUT = 2000, epoch = 1000 };
+            var transfer = new OrbitSegment { bodyName = "Sun", startUT = 2000, endUT = 9000, epoch = 2000 };
+
+            var escS = ReaimSegmentAssembler.ShiftInTime(escape, -1000.0);
+            var xferS = ReaimSegmentAssembler.ShiftInTime(transfer, -2000.0); // a DIFFERENT shift
+
+            Assert.NotEqual(escS.endUT, xferS.startUT); // the seam opened a gap -> the chain would discontinuous
+        }
+
+        // =====================================================================================
+        // P3 - ReplaceTransferChain (the whole-chain assembly): pinned, contiguous UTs +
+        //      capture/escape fail-closed + all-or-nothing fallback. (reaim-fix-plan.md STEP 3/4/5.)
+        // =====================================================================================
+
+        // Distinct synth-leg shapes so a test can tell the synth leg from the recorded one it replaced.
+        // The escape leg is launch-body (Kerbin) relative, the capture leg target-body (Duna) relative.
+        // startUT/endUT/epoch are arbitrary here - the assembler re-stamps them to the recorded-span runs.
+        private const double SynthEscapeSma = -4242424.0;   // distinct from the recorded escape -3818300
+        private const double SynthTransferSma = 18200000000.0; // distinct from the recorded coasts 1.76e10
+        private const double SynthCaptureSma = -777777.0;   // distinct from the recorded capture -563351
+
+        private static OrbitSegment SynthEscape() => new OrbitSegment
+        {
+            bodyName = "Kerbin", semiMajorAxis = SynthEscapeSma, eccentricity = 1.3,
+            inclination = 6, longitudeOfAscendingNode = 31, argumentOfPeriapsis = 46,
+            meanAnomalyAtEpoch = 0.51, epoch = 64044033.0, isPredicted = false,
+        };
+        private static OrbitSegment SynthTransfer() => new OrbitSegment
+        {
+            bodyName = "Sun", semiMajorAxis = SynthTransferSma, eccentricity = 0.23,
+            inclination = 6, longitudeOfAscendingNode = 31, argumentOfPeriapsis = 46,
+            meanAnomalyAtEpoch = 0.51, epoch = 64044033.0, isPredicted = false,
+        };
+        private static OrbitSegment SynthCapture() => new OrbitSegment
+        {
+            bodyName = "Duna", semiMajorAxis = SynthCaptureSma, eccentricity = 1.1,
+            inclination = 6, longitudeOfAscendingNode = 31, argumentOfPeriapsis = 46,
+            meanAnomalyAtEpoch = 0.51, epoch = 70898646.0, isPredicted = false,
+        };
+
+        // A clean cross-parent transfer member with a SYNTHESIZABLE capture (no Ike thread, no descent):
+        // circular parking + escape hyperbola + heliocentric coast + a SINGLE Duna capture hyperbola.
+        // Contiguous so the assembler's synth span tiles with zero gaps.
+        private static List<OrbitSegment> CleanCrossParentMember() => new List<OrbitSegment>
+        {
+            new OrbitSegment { bodyName = "Kerbin", startUT = 100, endUT = 600, epoch = 300, semiMajorAxis = 700000, eccentricity = 0.0, inclination = 5, longitudeOfAscendingNode = 30, argumentOfPeriapsis = 45, meanAnomalyAtEpoch = 0.5 },
+            new OrbitSegment { bodyName = "Kerbin", startUT = 600, endUT = 1000, epoch = 700, semiMajorAxis = -3818300, eccentricity = 1.19, inclination = 5, longitudeOfAscendingNode = 30, argumentOfPeriapsis = 45, meanAnomalyAtEpoch = 0.5 },
+            new OrbitSegment { bodyName = "Sun", startUT = 1000, endUT = 5000, epoch = 1200, semiMajorAxis = 1.76e10, eccentricity = 0.21, inclination = 5, longitudeOfAscendingNode = 30, argumentOfPeriapsis = 45, meanAnomalyAtEpoch = 0.5 },
+            new OrbitSegment { bodyName = "Duna", startUT = 5000, endUT = 5600, epoch = 5100, semiMajorAxis = -563351, eccentricity = 1.05, inclination = 5, longitudeOfAscendingNode = 30, argumentOfPeriapsis = 45, meanAnomalyAtEpoch = 0.5 },
+            new OrbitSegment { bodyName = "Duna", startUT = 5600, endUT = 6000, epoch = 5700, semiMajorAxis = 400000, eccentricity = 0.1, inclination = 5, longitudeOfAscendingNode = 30, argumentOfPeriapsis = 45, meanAnomalyAtEpoch = 0.5 }, // capture parking
+        };
+
+        // The clean member's run boundaries (recorded-span UTs).
+        private const double CleanEscapeStartUT = 600.0;
+        private const double CleanEscapeEndUT = 1000.0;     // == transfer-run start (RecordedDepartureUT)
+        private const double CleanDepartureUT = 1000.0;
+        private const double CleanArrivalUT = 5000.0;       // == first-capture start
+        private const double CleanFirstCaptureStartUT = 5000.0;
+        private const double CleanFirstCaptureEndUT = 5600.0;
+
+        private static List<OrbitSegment> AssembleClean(
+            OrbitSegment? escape, OrbitSegment? capture, bool captureSynthesizable,
+            bool escapeRunIsParkingOnly = false, double parkDeltaLonDeg = 0.0)
+        {
+            return ReaimSegmentAssembler.ReplaceTransferChain(
+                CleanCrossParentMember(),
+                escape, SynthTransfer(), capture,
+                "Sun", "Kerbin", "Duna",
+                CleanDepartureUT, CleanArrivalUT,
+                CleanEscapeStartUT, CleanEscapeEndUT,
+                CleanFirstCaptureStartUT, CleanFirstCaptureEndUT,
+                escapeRunIsParkingOnly, captureSynthesizable, parkDeltaLonDeg);
+        }
+
+        [Fact]
+        public void ReplaceTransferChain_CleanArrival_SplicesAllThreeLegs_ContiguousTiling()
+        {
+            var segs = AssembleClean(SynthEscape(), SynthCapture(), captureSynthesizable: true);
+            Assert.NotNull(segs);
+
+            // Shape: circular parking + synth escape + synth transfer + synth capture + capture parking = 5.
+            Assert.Equal(5, segs.Count);
+
+            // [0] circular parking (verbatim, body-relative).
+            Assert.Equal("Kerbin", segs[0].bodyName);
+            Assert.Equal(100.0, segs[0].startUT, 6);
+            Assert.Equal(600.0, segs[0].endUT, 6);
+            Assert.Equal(700000.0, segs[0].semiMajorAxis, 0);
+
+            // [1] synth escape stamped to the escape-run span [600,1000].
+            Assert.Equal("Kerbin", segs[1].bodyName);
+            Assert.Equal(CleanEscapeStartUT, segs[1].startUT, 6);
+            Assert.Equal(CleanEscapeEndUT, segs[1].endUT, 6);
+            Assert.Equal(SynthEscapeSma, segs[1].semiMajorAxis, 0);
+
+            // [2] synth transfer stamped to the full transfer span [1000,5000].
+            Assert.Equal("Sun", segs[2].bodyName);
+            Assert.Equal(CleanDepartureUT, segs[2].startUT, 6);
+            Assert.Equal(CleanArrivalUT, segs[2].endUT, 6);
+            Assert.Equal(SynthTransferSma, segs[2].semiMajorAxis, 0);
+
+            // [3] synth capture pinned at the SOI-entry boundary [5000, firstCaptureEnd].
+            Assert.Equal("Duna", segs[3].bodyName);
+            Assert.Equal(CleanArrivalUT, segs[3].startUT, 6);
+            Assert.Equal(CleanFirstCaptureEndUT, segs[3].endUT, 6);
+            Assert.Equal(SynthCaptureSma, segs[3].semiMajorAxis, 0);
+
+            // [4] capture parking (verbatim, body-relative).
+            Assert.Equal("Duna", segs[4].bodyName);
+            Assert.Equal(5600.0, segs[4].startUT, 6);
+            Assert.Equal(6000.0, segs[4].endUT, 6);
+            Assert.Equal(400000.0, segs[4].semiMajorAxis, 0);
+
+            // Zero-gap tiling at ALL boundaries (guarantee 7): no UT gap and no overlap inside the synth span.
+            var report = SegmentTilingHarness.ComputeTiling(segs);
+            Assert.Equal(0, report.GapCount);
+            Assert.Equal(0, report.OverlapCount);
+            Assert.Equal(0.0, report.MaxAbsDiscontinuitySeconds, 6);
+        }
+
+        [Fact]
+        public void ReplaceTransferChain_CapturePin_StartsAtCompressedClockArrivalBoundary()
+        {
+            // STEP 4: the synth capture's SOI-entry is pinned to recordedArrivalUT (== the
+            // heliocentric->capture boundary the loop clock feeds to CompressSpanUT), NOT to the synth
+            // capture's own geometric SOI UT or its raw startUT.
+            var segs = AssembleClean(SynthEscape(), SynthCapture(), captureSynthesizable: true);
+            OrbitSegment capture = segs.Find(s => s.semiMajorAxis == SynthCaptureSma);
+            Assert.Equal(CleanArrivalUT, capture.startUT, 6);
+            // The transfer ENDS exactly where the capture STARTS (transfer.endUT == capture.startUT).
+            OrbitSegment transfer = segs.Find(s => s.semiMajorAxis == SynthTransferSma);
+            Assert.Equal(transfer.endUT, capture.startUT, 6);
+        }
+
+        [Fact]
+        public void ReplaceTransferChain_CaptureFailClosed_KeepsRecordedCaptureVerbatim()
+        {
+            // CaptureSynthesizable=false (Ike-thread / atmospheric-direct): the escape + transfer synthesize,
+            // the recorded capture run stays byte-identical to the baseline arrival (guarantee 8). Pass a
+            // (would-be) capture leg to prove it is IGNORED when the flag is false.
+            var withCap = AssembleClean(SynthEscape(), SynthCapture(), captureSynthesizable: false);
+            Assert.NotNull(withCap);
+
+            // No synth capture present; the recorded Duna capture hyperbola (-563351) is kept verbatim.
+            Assert.DoesNotContain(withCap, s => s.semiMajorAxis == SynthCaptureSma);
+            OrbitSegment recordedCapture = withCap.Find(s => s.bodyName == "Duna" && s.semiMajorAxis == -563351);
+            Assert.Equal(5000.0, recordedCapture.startUT, 6); // recorded span unchanged
+            Assert.Equal(5600.0, recordedCapture.endUT, 6);
+            Assert.Equal(1.05, recordedCapture.eccentricity, 6);
+
+            // The escape + transfer still synthesized (the escape-side improvement ships).
+            Assert.Contains(withCap, s => s.semiMajorAxis == SynthEscapeSma);
+            Assert.Contains(withCap, s => s.semiMajorAxis == SynthTransferSma);
+
+            // A null captureSeg with captureSynthesizable=true also keeps the recorded capture verbatim.
+            var nullCap = AssembleClean(SynthEscape(), null, captureSynthesizable: true);
+            Assert.DoesNotContain(nullCap, s => s.semiMajorAxis == SynthCaptureSma);
+            Assert.Contains(nullCap, s => s.bodyName == "Duna" && s.semiMajorAxis == -563351);
+        }
+
+        [Fact]
+        public void ReplaceTransferChain_IkeThreadedDunaOne_FailsClosedOnCapture_EscapeAndTransferSynth()
+        {
+            // The REAL Duna One topology threads Ike (CaptureSynthesizable=false): the capture side fails
+            // closed (recorded Duna/Ike/descent verbatim) and only the escape + transfer synthesize.
+            var member = ReaimChainSynthesisFixtures.BuildDunaOneTransferMember();
+            int recordedCount = member.Count;
+
+            var segs = ReaimSegmentAssembler.ReplaceTransferChain(
+                member,
+                SynthEscape(), SynthTransfer(), SynthCapture(),
+                "Sun", "Kerbin", "Duna",
+                ReaimChainSynthesisFixtures.RecordedDepartureUT, ReaimChainSynthesisFixtures.RecordedArrivalUT,
+                escapeRunStartUT: 63966986.0, escapeRunEndUT: 64044033.0,        // seg#8 escape span
+                firstCaptureStartUT: 70898646.0, firstCaptureEndUT: 70912684.0,  // seg#12 first capture
+                escapeRunIsParkingOnly: false, captureSynthesizable: false);
+            Assert.NotNull(segs);
+
+            // The synth capture is NOT present (capture fail-closed); the recorded captures + Ike + descent
+            // are all kept verbatim.
+            Assert.DoesNotContain(segs, s => s.semiMajorAxis == SynthCaptureSma);
+            Assert.Contains(segs, s => s.bodyName == "Ike");
+            // The first recorded Duna capture (-563351) survives untouched.
+            Assert.Contains(segs, s => s.bodyName == "Duna" && s.semiMajorAxis == -563351 && s.startUT == 70898646.0);
+
+            // The escape (seg#8) + the 3 Sun coasts collapse into the synth escape + synth transfer.
+            Assert.Contains(segs, s => s.semiMajorAxis == SynthEscapeSma);
+            Assert.Contains(segs, s => s.semiMajorAxis == SynthTransferSma);
+            Assert.Single(segs, s => s.bodyName == "Sun"); // 3 recorded coasts -> 1 synth transfer
+
+            // The circular parking orbit (700000) is kept verbatim (selected by index, never synthesized).
+            Assert.Contains(segs, s => s.bodyName == "Kerbin" && s.semiMajorAxis == 700000.0);
+
+            // No overlaps introduced; the synth escape/transfer span tiles into the recorded capture run.
+            var report = SegmentTilingHarness.ComputeTiling(segs);
+            Assert.Equal(0, report.OverlapCount);
+
+            // The recorded count drops only by the legs collapsed (escape seg#8 + 3 Sun coasts -> 2 synth);
+            // everything from the first capture onward is preserved.
+            Assert.True(segs.Count < recordedCount);
+        }
+
+        [Fact]
+        public void ReplaceTransferChain_EscapeParkingOnly_KeepsEscapeRunVerbatim_TransferSynth()
+        {
+            // EscapeRunIsParkingOnly (a direct SOI exit, no separate escape hyperbola): the escape side is
+            // NOT synthesized. The launch-body run stays verbatim; only the transfer (and capture) splice.
+            // Use a member whose launch-body predecessor of the heliocentric leg IS the circular parking.
+            var member = new List<OrbitSegment>
+            {
+                new OrbitSegment { bodyName = "Kerbin", startUT = 100, endUT = 1000, epoch = 300, semiMajorAxis = 700000, eccentricity = 0.0, inclination = 5 },
+                new OrbitSegment { bodyName = "Sun", startUT = 1000, endUT = 5000, epoch = 1200, semiMajorAxis = 1.76e10, eccentricity = 0.21, inclination = 5 },
+                new OrbitSegment { bodyName = "Duna", startUT = 5000, endUT = 5600, epoch = 5100, semiMajorAxis = -563351, eccentricity = 1.05, inclination = 5 },
+            };
+
+            var segs = ReaimSegmentAssembler.ReplaceTransferChain(
+                member,
+                SynthEscape(), SynthTransfer(), SynthCapture(),
+                "Sun", "Kerbin", "Duna",
+                1000.0, 5000.0,
+                escapeRunStartUT: 100.0, escapeRunEndUT: 1000.0,
+                firstCaptureStartUT: 5000.0, firstCaptureEndUT: 5600.0,
+                escapeRunIsParkingOnly: true, captureSynthesizable: true);
+            Assert.NotNull(segs);
+
+            // No synth escape (escape parking-only); the recorded Kerbin parking (700000) is kept verbatim.
+            Assert.DoesNotContain(segs, s => s.semiMajorAxis == SynthEscapeSma);
+            Assert.Contains(segs, s => s.bodyName == "Kerbin" && s.semiMajorAxis == 700000.0 && s.startUT == 100.0);
+
+            // The transfer + capture synthesized.
+            Assert.Contains(segs, s => s.semiMajorAxis == SynthTransferSma);
+            Assert.Contains(segs, s => s.semiMajorAxis == SynthCaptureSma);
+        }
+
+        [Fact]
+        public void ReplaceTransferChain_EscapeNotColocatedWithTransfer_KeepsEscapeVerbatim()
+        {
+            // STEP 3 co-location gate: when the escape run does NOT end at the transfer-run start (a recorded
+            // heliocentric park sits between them, so the escape-run end is hours/days before the burn), the
+            // escape leg is kept verbatim (synth capture-side only) rather than placing the synth escape's
+            // end far from the SOI edge.
+            var member = CleanCrossParentMember();
+            // escapeRunEndUT (1000) deliberately far from the burn (recordedDepartureUT 50000): not co-located.
+            var segs = ReaimSegmentAssembler.ReplaceTransferChain(
+                member,
+                SynthEscape(), SynthTransfer(), SynthCapture(),
+                "Sun", "Kerbin", "Duna",
+                recordedDepartureUT: 1000.0, recordedArrivalUT: 5000.0,
+                escapeRunStartUT: 600.0, escapeRunEndUT: 1000.0 - (ReaimSegmentAssembler.EscapeHandoffToleranceSeconds + 1.0),
+                firstCaptureStartUT: 5000.0, firstCaptureEndUT: 5600.0,
+                escapeRunIsParkingOnly: false, captureSynthesizable: true);
+            Assert.NotNull(segs);
+
+            // The escape run was NOT synthesized (the gate rejected the non-co-located handoff): the recorded
+            // escape hyperbola (-3818300) survives.
+            Assert.DoesNotContain(segs, s => s.semiMajorAxis == SynthEscapeSma);
+            Assert.Contains(segs, s => s.bodyName == "Kerbin" && s.semiMajorAxis == -3818300);
+            // The transfer still synthesized (escape verbatim, transfer synth).
+            Assert.Contains(segs, s => s.semiMajorAxis == SynthTransferSma);
+        }
+
+        [Fact]
+        public void ReplaceTransferChain_UntouchedSegments_AreByValueIdenticalToRecorded()
+        {
+            // The verbatim pass-through segments (circular parking, capture parking, Ike, descent) must be
+            // value-identical to the recorded input (guarantee 4): the chain reads the adjacent recorded
+            // segments but writes them only into the returned copy, never mutating the recording.
+            var member = CleanCrossParentMember();
+            var segs = AssembleClean(SynthEscape(), null, captureSynthesizable: false); // capture verbatim too
+
+            // Circular parking [0] unchanged.
+            OrbitSegment parkOut = segs.Find(s => s.bodyName == "Kerbin" && s.semiMajorAxis == 700000.0);
+            AssertSegmentValueEqual(member[0], parkOut);
+            // Capture hyperbola (recorded, kept verbatim) unchanged.
+            OrbitSegment capOut = segs.Find(s => s.bodyName == "Duna" && s.semiMajorAxis == -563351);
+            AssertSegmentValueEqual(member[3], capOut);
+            // Capture parking unchanged.
+            OrbitSegment capParkOut = segs.Find(s => s.bodyName == "Duna" && s.semiMajorAxis == 400000.0);
+            AssertSegmentValueEqual(member[4], capParkOut);
+        }
+
+        [Fact]
+        public void ReplaceTransferChain_NoHeliocentricLeg_ReturnsNull_AllOrNothing()
+        {
+            // A member with no Sun leg in the window (a launch-only / arrival-only chained member): the
+            // transfer cannot be replaced, so the WHOLE chain returns null (all-or-nothing) -> the caller
+            // falls back to today's heliocentric-only baseline (which also returns null -> faithful).
+            var launchOnly = new List<OrbitSegment>
+            {
+                new OrbitSegment { bodyName = "Kerbin", startUT = 100, endUT = 1000, epoch = 300, semiMajorAxis = 700000, eccentricity = 0.0 },
+            };
+            var result = ReaimSegmentAssembler.ReplaceTransferChain(
+                launchOnly,
+                SynthEscape(), SynthTransfer(), SynthCapture(),
+                "Sun", "Kerbin", "Duna",
+                1000.0, 5000.0, 600.0, 1000.0, 5000.0, 5600.0,
+                escapeRunIsParkingOnly: false, captureSynthesizable: true);
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void ReplaceTransferChain_NaNOrMisorderedWindow_ReturnsNull()
+        {
+            // Fail-closed on degenerate window bounds.
+            Assert.Null(ReaimSegmentAssembler.ReplaceTransferChain(
+                CleanCrossParentMember(), SynthEscape(), SynthTransfer(), SynthCapture(),
+                "Sun", "Kerbin", "Duna",
+                double.NaN, 5000.0, 600.0, 1000.0, 5000.0, 5600.0, false, true));
+            Assert.Null(ReaimSegmentAssembler.ReplaceTransferChain(
+                CleanCrossParentMember(), SynthEscape(), SynthTransfer(), SynthCapture(),
+                "Sun", "Kerbin", "Duna",
+                5000.0, 1000.0, 600.0, 1000.0, 5000.0, 5600.0, false, true)); // departure > arrival
+        }
+
+        [Fact]
+        public void AssembleWindowChain_FlagOn_ChainSynthesisFails_FallsBackToReplaceHeliocentricLeg()
+        {
+            // All-or-nothing fallback through the flag seam: flag ON with a member that has NO heliocentric
+            // leg (ReplaceTransferChain returns null) falls back to ReplaceHeliocentricLeg's result (also
+            // null here -> faithful). The fallback path must not throw / return garbage.
+            var launchOnly = new List<OrbitSegment>
+            {
+                new OrbitSegment { bodyName = "Kerbin", startUT = 100, endUT = 1000, epoch = 300, semiMajorAxis = 700000 },
+            };
+            var baseline = ReaimSegmentAssembler.ReplaceHeliocentricLeg(
+                launchOnly, SynthTransfer(), "Sun", 1000.0, 5000.0, double.NaN, double.NaN);
+            var flagOn = ReaimSegmentAssembler.AssembleWindowChain(
+                useChain: true, launchOnly, SynthTransfer(), "Sun", 1000.0, 5000.0,
+                double.NaN, double.NaN, 0.0,
+                SynthEscape(), SynthCapture(), "Kerbin", "Duna",
+                600.0, 1000.0, 5000.0, 5600.0, false, true);
+            Assert.Null(baseline);
+            Assert.Null(flagOn);
+        }
+
+        [Fact]
+        public void AssembleWindowChain_FlagOn_FullChainInputs_ProducesChain_DistinctFromFlagOff()
+        {
+            // Flag ON with FULL chain inputs on the clean cross-parent member produces the spliced chain
+            // (escape + transfer + capture), which DIFFERS from flag OFF (the single-leg heliocentric
+            // replacement, which leaves the recorded escape + capture verbatim). Proves the flag actually
+            // engages the chain synthesis when inputs are present (guarantee 13's pure analogue).
+            var member = CleanCrossParentMember();
+            var flagOff = ReaimSegmentAssembler.AssembleWindowChain(
+                useChain: false, member, SynthTransfer(), "Sun", CleanDepartureUT, CleanArrivalUT,
+                double.NaN, double.NaN);
+            var flagOn = ReaimSegmentAssembler.AssembleWindowChain(
+                useChain: true, member, SynthTransfer(), "Sun", CleanDepartureUT, CleanArrivalUT,
+                double.NaN, double.NaN, 0.0,
+                SynthEscape(), SynthCapture(), "Kerbin", "Duna",
+                CleanEscapeStartUT, CleanEscapeEndUT, CleanFirstCaptureStartUT, CleanFirstCaptureEndUT,
+                false, true);
+
+            // Flag OFF keeps the recorded escape (-3818300) + recorded capture (-563351) verbatim.
+            Assert.Contains(flagOff, s => s.semiMajorAxis == -3818300);
+            Assert.Contains(flagOff, s => s.semiMajorAxis == -563351);
+            Assert.DoesNotContain(flagOff, s => s.semiMajorAxis == SynthEscapeSma);
+
+            // Flag ON replaces them with the synth escape + synth capture.
+            Assert.Contains(flagOn, s => s.semiMajorAxis == SynthEscapeSma);
+            Assert.Contains(flagOn, s => s.semiMajorAxis == SynthCaptureSma);
+            Assert.DoesNotContain(flagOn, s => s.semiMajorAxis == -3818300);
+            Assert.DoesNotContain(flagOn, s => s.semiMajorAxis == -563351);
+
+            Assert.False(SegmentListsValueEqual(flagOff, flagOn));
+        }
+
+        [Fact]
+        public void ReplaceTransferChain_ParkRephase_RotatesOnlyRecordedHeliocentricPark()
+        {
+            // parkDeltaLonDeg re-phases the recorded heliocentric PARK (a Sun coast ENDING at/before the
+            // burn) identically to ReplaceHeliocentricLeg, while the synth transfer + body-relative legs are
+            // untouched. Use a member with a pre-burn Sun park.
+            var member = new List<OrbitSegment>
+            {
+                new OrbitSegment { bodyName = "Kerbin", startUT = 100, endUT = 600, epoch = 300, semiMajorAxis = 700000, eccentricity = 0.0, inclination = 5, longitudeOfAscendingNode = 30 },
+                new OrbitSegment { bodyName = "Kerbin", startUT = 600, endUT = 1000, epoch = 700, semiMajorAxis = -3818300, eccentricity = 1.19, inclination = 5, longitudeOfAscendingNode = 30 },
+                // pre-burn heliocentric park (endUT == recordedDepartureUT -> re-phased):
+                new OrbitSegment { bodyName = "Sun", startUT = 1000, endUT = 1500, epoch = 1100, semiMajorAxis = 1.4e10, eccentricity = 0.05, inclination = 5, longitudeOfAscendingNode = 30 },
+                // in-window transfer (replaced):
+                new OrbitSegment { bodyName = "Sun", startUT = 1500, endUT = 5000, epoch = 1700, semiMajorAxis = 1.76e10, eccentricity = 0.21, inclination = 5, longitudeOfAscendingNode = 30 },
+                new OrbitSegment { bodyName = "Duna", startUT = 5000, endUT = 5600, epoch = 5100, semiMajorAxis = -563351, eccentricity = 1.05, inclination = 5, longitudeOfAscendingNode = 30 },
+            };
+            const double depUT = 1500.0, arrUT = 5000.0, parkDelta = 90.0;
+
+            // The escape run ends at 1000, far from the burn (1500) -> escape kept verbatim; only the
+            // transfer + capture splice. The park [1000,1500] is re-phased.
+            var segs = ReaimSegmentAssembler.ReplaceTransferChain(
+                member,
+                SynthEscape(), SynthTransfer(), SynthCapture(),
+                "Sun", "Kerbin", "Duna",
+                depUT, arrUT,
+                escapeRunStartUT: 600.0, escapeRunEndUT: 1000.0,
+                firstCaptureStartUT: 5000.0, firstCaptureEndUT: 5600.0,
+                escapeRunIsParkingOnly: false, captureSynthesizable: true,
+                parkDeltaLonDeg: parkDelta);
+            Assert.NotNull(segs);
+
+            // The recorded park (1.4e10) had its LAN rotated 30 -> 120.
+            OrbitSegment park = segs.Find(s => s.semiMajorAxis == 1.4e10);
+            Assert.Equal(120.0, park.longitudeOfAscendingNode, 6);
+            // The synth transfer is NOT rotated (its LAN stays as built, 31).
+            OrbitSegment transfer = segs.Find(s => s.semiMajorAxis == SynthTransferSma);
+            Assert.Equal(31.0, transfer.longitudeOfAscendingNode, 6);
+        }
+
+        [Fact]
+        public void IsFiniteOrderedSpan_GuardsNaNInfAndOrdering()
+        {
+            Assert.True(ReaimSegmentAssembler.IsFiniteOrderedSpan(100.0, 200.0));
+            Assert.False(ReaimSegmentAssembler.IsFiniteOrderedSpan(200.0, 100.0));
+            Assert.False(ReaimSegmentAssembler.IsFiniteOrderedSpan(100.0, 100.0));
+            Assert.False(ReaimSegmentAssembler.IsFiniteOrderedSpan(double.NaN, 200.0));
+            Assert.False(ReaimSegmentAssembler.IsFiniteOrderedSpan(100.0, double.PositiveInfinity));
         }
     }
 }

--- a/Source/Parsek.Tests/ReaimClassifierTests.cs
+++ b/Source/Parsek.Tests/ReaimClassifierTests.cs
@@ -608,5 +608,256 @@ namespace Parsek.Tests
             double a = ReaimClassifier.HeliocentricSemiMajorAxis("Kerbin", "Sun", StockParents());
             Assert.InRange(a, 1.358e10, 1.362e10);
         }
+
+        // =====================================================================================
+        // P2 chain-synthesis index spans + CaptureSynthesizable (reaim-fix-plan.md BLOCKER 1, #3/#4)
+        // =====================================================================================
+
+        [Fact]
+        public void Classify_SimpleTransfer_IndexSpans_SelectParkingEscapeTransferCapture()
+        {
+            // The clean 3-leg [Kerbin parking, Sun transfer, Duna capture]: the launch-body predecessor of
+            // the heliocentric leg IS the parking orbit (no separate escape hyperbola), so the escape run is
+            // that single segment (EscapeRunIsParkingOnly). The transfer run is the single Sun coast; the
+            // first capture is the Duna leg.
+            var segs = new List<OrbitSegment>
+            {
+                SegAE("Kerbin", 100, 5000, 700000, 0.0),       // 0: parking (also the degenerate escape run)
+                SegAE("Sun", 5000, 1000000, 1.7e10, 0.2),      // 1: transfer
+                SegAE("Duna", 1000000, 1005000, -1.88e5, 3.6), // 2: capture hyperbola
+            };
+            var plan = ReaimClassifier.Classify(segs, StockParents());
+            Assert.True(plan.Supported, plan.Reason);
+
+            Assert.Equal(0, plan.ParkingIndex);
+            Assert.Equal(0, plan.EscapeRunStartIndex);
+            Assert.Equal(0, plan.EscapeRunEndIndex);
+            Assert.True(plan.EscapeRunIsParkingOnly,
+                "a direct SOI exit (no recorded escape hyperbola) has the parking orbit as the only launch-body leg");
+
+            Assert.Equal(1, plan.TransferRunStartIndex);
+            Assert.Equal(1, plan.TransferRunEndIndex);
+
+            Assert.Equal(2, plan.FirstCaptureIndex);
+            Assert.Equal(1000000.0, plan.FirstCaptureStartUT, 3);
+            Assert.Equal(1005000.0, plan.FirstCaptureEndUT, 3);
+        }
+
+        [Fact]
+        public void Classify_EscapeHyperbolaBeforeTransfer_EscapeRunIsHyperbola_NotParking()
+        {
+            // The REAL Duna One shape (minus the Ike thread): a circular parking orbit, then a Kerbin ESCAPE
+            // HYPERBOLA (sma<0), then the Sun transfer, then the Duna capture. The escape run must select the
+            // HYPERBOLA (index 1), the parking orbit (index 0) is kept separate, and EscapeRunIsParkingOnly
+            // is false (there is a real escape leg to synthesize).
+            var segs = new List<OrbitSegment>
+            {
+                SegAE("Kerbin", 100, 5000, 700000, 0.0),         // 0: circular parking
+                SegAE("Kerbin", 5000, 6000, -3.8e6, 1.19),       // 1: escape hyperbola
+                SegAE("Sun", 6000, 1000000, 1.76e10, 0.21),      // 2: transfer
+                SegAE("Duna", 1000000, 1005000, -5.6e5, 1.05),   // 3: capture hyperbola
+            };
+            var plan = ReaimClassifier.Classify(segs, StockParents());
+            Assert.True(plan.Supported, plan.Reason);
+
+            Assert.Equal(0, plan.ParkingIndex);
+            Assert.Equal(1, plan.EscapeRunStartIndex);
+            Assert.Equal(1, plan.EscapeRunEndIndex);
+            Assert.False(plan.EscapeRunIsParkingOnly);
+
+            Assert.Equal(2, plan.TransferRunStartIndex);
+            Assert.Equal(2, plan.TransferRunEndIndex);
+            Assert.Equal(3, plan.FirstCaptureIndex);
+            Assert.True(plan.CaptureSynthesizable, plan.CaptureSynthesizableReason);
+        }
+
+        [Fact]
+        public void Classify_TransferRunSpansMultipleCoasts_IndexSpanCoversAll()
+        {
+            // A mid-course correction splits the transfer into two Sun coasts. The transfer run span must
+            // cover BOTH (start at the first coast, end at the last that hands off to the capture).
+            var segs = new List<OrbitSegment>
+            {
+                SegAE("Kerbin", 100, 5000, 700000, 0.0),        // 0: parking
+                SegAE("Sun", 5000, 400000, 1.7e10, 0.2),        // 1: coast 1
+                SegAE("Sun", 400500, 1000000, 1.7e10, 0.2),     // 2: coast 2 (ends at the Duna SOI)
+                SegAE("Duna", 1000000, 1005000, -1.88e5, 3.6),  // 3: capture
+            };
+            var plan = ReaimClassifier.Classify(segs, StockParents());
+            Assert.True(plan.Supported, plan.Reason);
+            Assert.Equal(1, plan.TransferRunStartIndex);
+            Assert.Equal(2, plan.TransferRunEndIndex);
+            Assert.Equal(3, plan.FirstCaptureIndex);
+        }
+
+        [Fact]
+        public void Classify_IkeThreadedArrival_CaptureSynthesizableFalse()
+        {
+            // The DUNA ONE real topology threads Ike between two Duna capture fragments (seg#12/13 Duna,
+            // seg#14/15 Ike, seg#16+ Duna). The capture side MUST fail closed (CaptureSynthesizable=false)
+            // so chain synthesis keeps the recorded capture/arrival run verbatim. This is the #3/#4 scope
+            // correction's load-bearing detection.
+            var segs = new List<OrbitSegment>
+            {
+                SegAE("Kerbin", 100, 5000, 700000, 0.0),
+                SegAE("Kerbin", 5000, 6000, -3.8e6, 1.19),       // escape
+                SegAE("Sun", 6000, 1000000, 1.76e10, 0.21),      // transfer
+                SegAE("Duna", 1000000, 1010000, -5.6e5, 1.05),   // capture hyperbola (arrival)
+                SegAE("Duna", 1010000, 1020000, -5.6e5, 1.05),   // capture fragment 2
+                SegAE("Ike", 1020000, 1021000, -2.9e4, 1.02),    // IKE THREAD
+                SegAE("Ike", 1021000, 1022000, -2.9e4, 1.02),
+                SegAE("Duna", 1022000, 1023000, -5.3e5, 1.04),   // Duna re-capture
+                SegAE("Duna", 1023000, 1024000, 4.9e5, 0.45),    // descent ellipse
+            };
+            var plan = ReaimClassifier.Classify(segs, StockParents());
+            Assert.True(plan.Supported, plan.Reason);
+            Assert.Equal("Duna", plan.TargetBody);
+            Assert.False(plan.CaptureSynthesizable);
+            Assert.Contains("Ike", plan.CaptureSynthesizableReason);
+            // The FIRST capture is still the first Duna hyperbola (so the transfer run still ends correctly),
+            // even though the capture is NOT synthesized.
+            Assert.Equal("Duna", segs[plan.FirstCaptureIndex].bodyName);
+            Assert.Equal(1000000.0, plan.FirstCaptureStartUT, 3);
+        }
+
+        [Fact]
+        public void Classify_DunaOneRealFixture_CaptureSynthesizableFalse_IkeThread()
+        {
+            // The shared P0 golden-master fixture (the 15-segment Duna One member with the Ike thread).
+            // CaptureSynthesizable must be false (Ike thread); the escape run must select the escape
+            // hyperbola (index 1, not the index-0 parking); the transfer run spans the three Sun coasts.
+            var member = Parsek.Tests.Generators.ReaimChainSynthesisFixtures.BuildDunaOneTransferMember();
+            var plan = ReaimClassifier.Classify(member, StockParents());
+            Assert.True(plan.Supported, plan.Reason);
+            Assert.Equal("Kerbin", plan.LaunchBody);
+            Assert.Equal("Duna", plan.TargetBody);
+
+            // index 0 = circular parking, index 1 = escape hyperbola (the run), indices 2..4 = the 3 Sun coasts.
+            Assert.Equal(0, plan.ParkingIndex);
+            Assert.Equal(1, plan.EscapeRunStartIndex);
+            Assert.Equal(1, plan.EscapeRunEndIndex);
+            Assert.False(plan.EscapeRunIsParkingOnly);
+            Assert.Equal(2, plan.TransferRunStartIndex);
+            Assert.Equal(4, plan.TransferRunEndIndex);
+            Assert.Equal(5, plan.FirstCaptureIndex); // the first Duna capture hyperbola (seg#12)
+
+            // Recorded-span UT spans (P3 STEP 5: the assembler selects the runs by UT span, not by index).
+            // Escape run = seg#8 [63966986, 64044033]; transfer run start = the first Sun coast 64044033
+            // (== RecordedDepartureUT); transfer run end = the last Sun coast end 70898646
+            // (== RecordedArrivalUT == FirstCaptureStartUT); first capture [70898646, 70912684].
+            Assert.Equal(63966986.0, plan.EscapeRunStartUT, 3);
+            Assert.Equal(64044033.0, plan.EscapeRunEndUT, 3);
+            Assert.Equal(64044033.0, plan.RecordedDepartureUT, 3); // transfer-run start
+            Assert.Equal(70898646.0, plan.TransferRunEndUT, 3);
+            Assert.Equal(70898646.0, plan.FirstCaptureStartUT, 3);
+            Assert.Equal(70912684.0, plan.FirstCaptureEndUT, 3);
+            // The escape run END is co-located with the transfer-run START (the SOI-exit handoff), so the
+            // assembler's STEP 3 co-location gate accepts the escape side.
+            Assert.Equal(plan.EscapeRunEndUT, plan.RecordedDepartureUT, 3);
+
+            Assert.False(plan.CaptureSynthesizable);
+            Assert.Contains("Ike", plan.CaptureSynthesizableReason);
+        }
+
+        [Fact]
+        public void Classify_AtmosphericDirectArrival_CaptureSynthesizableFalse()
+        {
+            // The first target-bodied leg is an elliptic DESCENDING arc (sma>0, ecc<1), not a capture
+            // hyperbola - an atmospheric-direct arrival. No capture hyperbola exists to synthesize, so the
+            // capture side fails closed.
+            var segs = new List<OrbitSegment>
+            {
+                SegAE("Kerbin", 100, 5000, 700000, 0.0),
+                SegAE("Sun", 5000, 1000000, 1.7e10, 0.2),
+                SegAE("Duna", 1000000, 1005000, 4.9e5, 0.45),   // ELLIPTIC descent, not a hyperbola
+            };
+            var plan = ReaimClassifier.Classify(segs, StockParents());
+            Assert.True(plan.Supported, plan.Reason);
+            Assert.False(plan.CaptureSynthesizable);
+            Assert.Contains("atmospheric-direct", plan.CaptureSynthesizableReason);
+        }
+
+        [Fact]
+        public void Classify_CleanHyperbolaCapture_CaptureSynthesizableTrue()
+        {
+            // A clean single-capture arrival (a Duna capture hyperbola, no Ike, no descent ellipse after) ->
+            // CaptureSynthesizable=true (the case option 3 fully improves).
+            var segs = new List<OrbitSegment>
+            {
+                SegAE("Kerbin", 100, 5000, 700000, 0.0),
+                SegAE("Sun", 5000, 1000000, 1.7e10, 0.2),
+                SegAE("Duna", 1000000, 1005000, -1.88e5, 3.6),   // capture hyperbola, nothing after
+            };
+            var plan = ReaimClassifier.Classify(segs, StockParents());
+            Assert.True(plan.Supported, plan.Reason);
+            Assert.True(plan.CaptureSynthesizable, plan.CaptureSynthesizableReason);
+            Assert.Contains("clean", plan.CaptureSynthesizableReason);
+        }
+
+        // ---- ClassifyCaptureSynthesizable directly (pure predicate) ----
+
+        [Fact]
+        public void ClassifyCaptureSynthesizable_HyperbolaNoThread_True()
+        {
+            var segs = new List<OrbitSegment>
+            {
+                SegAE("Duna", 1000000, 1005000, -1.88e5, 3.6),   // 0: capture hyperbola (arrivalIdx)
+                SegAE("Duna", 1005000, 1006000, 4.9e5, 0.45),    // 1: same-body descent (not a thread)
+            };
+            Assert.True(ReaimClassifier.ClassifyCaptureSynthesizable(
+                segs, arrivalIdx: 0, "Duna", "Sun", "Kerbin", StockParents(), out string reason), reason);
+        }
+
+        [Fact]
+        public void ClassifyCaptureSynthesizable_SecondaryBodyThread_False()
+        {
+            var segs = new List<OrbitSegment>
+            {
+                SegAE("Duna", 1000000, 1005000, -1.88e5, 3.6),   // 0: capture hyperbola
+                SegAE("Ike", 1005000, 1006000, -2.9e4, 1.02),    // 1: Ike thread -> fail closed
+            };
+            Assert.False(ReaimClassifier.ClassifyCaptureSynthesizable(
+                segs, arrivalIdx: 0, "Duna", "Sun", "Kerbin", StockParents(), out string reason));
+            Assert.Contains("Ike", reason);
+        }
+
+        [Fact]
+        public void ClassifyCaptureSynthesizable_EllipticFirstLeg_False_AtmosphericDirect()
+        {
+            var segs = new List<OrbitSegment>
+            {
+                SegAE("Duna", 1000000, 1005000, 4.9e5, 0.45),    // 0: elliptic descending arc, no hyperbola
+            };
+            Assert.False(ReaimClassifier.ClassifyCaptureSynthesizable(
+                segs, arrivalIdx: 0, "Duna", "Sun", "Kerbin", StockParents(), out string reason));
+            Assert.Contains("atmospheric-direct", reason);
+        }
+
+        [Fact]
+        public void ClassifyCaptureSynthesizable_LaunchBodyAndCommonAncestorAfterCapture_NotAThread()
+        {
+            // A launch-body or common-ancestor segment after the capture (e.g. jettisoned debris back to
+            // Kerbin / a same-orbit Sun fragment) is NOT a secondary-SOI thread - only a DIFFERENT
+            // non-target body is. (Guards against over-eager fail-closed.)
+            var segs = new List<OrbitSegment>
+            {
+                SegAE("Duna", 1000000, 1005000, -1.88e5, 3.6),   // 0: capture hyperbola
+                SegAE("Kerbin", 1005000, 1006000, 700000, 0.0),  // 1: launch body (not a thread)
+                SegAE("Sun", 1006000, 1007000, 1.7e10, 0.2),     // 2: common ancestor (not a thread)
+            };
+            Assert.True(ReaimClassifier.ClassifyCaptureSynthesizable(
+                segs, arrivalIdx: 0, "Duna", "Sun", "Kerbin", StockParents(), out string reason), reason);
+        }
+
+        [Fact]
+        public void ClassifyCaptureSynthesizable_DegenerateInputs_False()
+        {
+            Assert.False(ReaimClassifier.ClassifyCaptureSynthesizable(
+                null, 0, "Duna", "Sun", "Kerbin", StockParents(), out _));
+            Assert.False(ReaimClassifier.ClassifyCaptureSynthesizable(
+                new List<OrbitSegment>(), 0, "Duna", "Sun", "Kerbin", StockParents(), out _));
+            Assert.False(ReaimClassifier.ClassifyCaptureSynthesizable(
+                new List<OrbitSegment> { SegAE("Duna", 0, 1, -1e5, 3.0) }, -1, "Duna", "Sun", "Kerbin", StockParents(), out _));
+        }
     }
 }

--- a/Source/Parsek/InGameTests/CrossParentReaimCanaryInGameTest.cs
+++ b/Source/Parsek/InGameTests/CrossParentReaimCanaryInGameTest.cs
@@ -56,7 +56,8 @@ namespace Parsek.InGameTests
                 double tDep = now + (synodic * i) / steps;
                 bool ok = ReaimTransferSynthesizer.TrySynthesizeTransfer(
                     kerbin, duna, tDep, tof, prograde: true,
-                    out Orbit transfer, out double soiEntryUT, out CelestialBody enc, out string fail);
+                    out Orbit transfer, out double soiEntryUT, out CelestialBody enc,
+                    out _, out _, out _, out _, out string fail);
                 if (transfer != null && ReaimTransferSynthesizer.IsSaneTransferConic(
                         transfer.eccentricity, transfer.semiMajorAxis))
                     saneTransfers++;

--- a/Source/Parsek/InGameTests/ReaimEndToEndInGameTest.cs
+++ b/Source/Parsek/InGameTests/ReaimEndToEndInGameTest.cs
@@ -1248,7 +1248,60 @@ namespace Parsek.InGameTests
             InGameAssert.IsTrue(System.Math.Abs(lastSeg.endUT - spanEnd) < 1.0,
                 $"window k={k} the arrival/descent leg must keep its recorded span end (fits span; was {lastSeg.endUT.ToString("R", ic)})");
 
+            // ESCAPE + CAPTURE LEG SANITY (reaim-fix-plan rework, guard b): the synth (flag ON) escape /
+            // capture legs are launch-/target-body HYPERBOLAE that the velocity-source bug turned into ecc
+            // 8-13 garbage with periapsis tens of Mm up. Assert any leg occupying the escape-run /
+            // first-capture window is a SANE hyperbola (ReaimChainGeometry.IsSaneLegConic ecc/periapsis
+            // band). This holds for BOTH the synth legs (when synthesized) AND the recorded legs (when the
+            // side fails closed to verbatim), so it is a valid invariant under every flag/topology state -
+            // and it is the exact guard that would have caught the ecc-8-13 regression before a playtest.
+            // Bound the periapsis to the live body's surface (or atmosphere top) and half its SOI.
+            AssertLegInRunIsSaneHyperbola(
+                segs, launchName, ctx.LaunchBody, plan.EscapeRunStartUT, plan.EscapeRunEndUT, "escape", k);
+            AssertLegInRunIsSaneHyperbola(
+                segs, targetName, ctx.TargetBody, plan.FirstCaptureStartUT, plan.FirstCaptureEndUT, "capture", k);
+
             return transfer;
+        }
+
+        // Asserts every body-relative leg (launch escape or target capture) overlapping the recorded run
+        // window [runStartUT, runEndUT] is a SANE hyperbola per ReaimChainGeometry.IsSaneLegConic (ecc in
+        // [1, 3], periapsis within [body surface/atmosphere top, half SOI]). Skips when the run window is
+        // NaN (an Unsupported plan field) or the live body is null. The synth legs (flag ON) and the
+        // recorded legs (fail-closed verbatim) both satisfy this, so it is flag-/topology-agnostic; it
+        // fires only on a corrupted leg (the ecc-8-13 velocity-source artifact).
+        private static void AssertLegInRunIsSaneHyperbola(
+            List<OrbitSegment> segs, string bodyName, CelestialBody body,
+            double runStartUT, double runEndUT, string label, long k)
+        {
+            var ic = CultureInfo.InvariantCulture;
+            if (segs == null || body == null
+                || double.IsNaN(runStartUT) || double.IsNaN(runEndUT) || !(runStartUT < runEndUT))
+                return;
+            double minPeriapsisRadius = body.Radius
+                + (body.atmosphere && body.atmosphereDepth > 0.0 ? body.atmosphereDepth : 0.0);
+            for (int i = 0; i < segs.Count; i++)
+            {
+                OrbitSegment s = segs[i];
+                if (s.bodyName != bodyName || s.isPredicted)
+                    continue;
+                if (!(s.startUT < runEndUT && s.endUT > runStartUT))
+                    continue;
+                // A bound (elliptic) leg occupying the run is a recorded circular parking / descent that the
+                // run-window happens to graze, not a synth/recorded hyperbola - the sane-hyperbola gate does
+                // not apply to it (IsSaneLegConic would reject a legitimate ellipse). Only check hyperbolae.
+                bool isHyperbola = s.semiMajorAxis < 0.0 || s.eccentricity >= 1.0;
+                if (!isHyperbola)
+                    continue;
+                InGameAssert.IsTrue(
+                    ReaimChainGeometry.IsSaneLegConic(
+                        s.eccentricity, s.semiMajorAxis, minPeriapsisRadius, body.sphereOfInfluence),
+                    $"window k={k} the {label} leg @{bodyName} must be a sane hyperbola " +
+                    $"(ecc={s.eccentricity.ToString("F4", ic)} sma={s.semiMajorAxis.ToString("R", ic)} " +
+                    $"rp={(s.semiMajorAxis * (1.0 - s.eccentricity)).ToString("R", ic)} " +
+                    $"minRp={minPeriapsisRadius.ToString("R", ic)} SOI={body.sphereOfInfluence.ToString("R", ic)}); " +
+                    $"ecc 8-13 / periapsis-far-out is the velocity-source artifact this gate fails closed");
+            }
         }
 
         // The re-aimed transfer leg (the single common-ancestor-bodied segment overlapping the recorded

--- a/Source/Parsek/InGameTests/ReaimEndToEndInGameTest.cs
+++ b/Source/Parsek/InGameTests/ReaimEndToEndInGameTest.cs
@@ -279,9 +279,8 @@ namespace Parsek.InGameTests
 
                 InGameAssert.IsTrue(ok, $"window k={k} must resolve a re-aimed transfer (congruent-window model, mid-band departure)");
                 InGameAssert.AreEqual(k, windowIndex, $"resolved window index must equal k={k}");
-                AssertSaneWindowSegments(ctx, segs, plan, goodDep, spanEnd, k);
+                OrbitSegment transfer = AssertSaneWindowSegments(ctx, segs, plan, goodDep, spanEnd, k);
 
-                OrbitSegment transfer = segs[1];
                 if (k == 0)
                 {
                     firstEcc = transfer.eccentricity;
@@ -427,6 +426,183 @@ namespace Parsek.InGameTests
         {
             RunEccentricTargetWindows(KerbinToEeloo(), "reaim-e2e-eeloo",
                 combinedInclinationCase: false);
+        }
+
+        // ----- Chain-synthesis (reaimChainSynthesis flag ON): real-topology + Ike-thread fail-closed -----
+        //
+        // P4 of the re-aim whole-chain synthesis fix (reaim-fix-plan.md). These run the SAME pinned mid-band
+        // Kerbin->Duna geometry as the strict test, but on the REAL-TOPOLOGY member
+        // (BuildRealTopologyMemberAndPlan: circular parking + escape hyperbola + Sun transfer + Duna capture
+        // hyperbola [+ Ike thread] + descent) and with the reaimChainSynthesis flag FORCED ON. They prove the
+        // chain synthesis (a) splices the synth escape + transfer + capture contiguously when the arrival is
+        // clean, (b) FAILS CLOSED on the capture side for the Ike-threaded arrival (recorded capture verbatim,
+        // escape + transfer still synth), and (c) is deterministic on a cache-cleared re-solve.
+        //
+        // The flag override is a process-wide mutable static, so it is reset in a finally. A PRIVATE resolver
+        // is used (Shared untouched). These are the in-game complement to the pure ReaimChainSynthesisTests
+        // (ReplaceTransferChain) - they drive the LIVE resolver (Lambert + CalculatePatch + the synth
+        // escape/capture state-vector legs), which xUnit cannot.
+
+        [InGameTest(Category = "Periodicity", Scene = GameScenes.SPACECENTER,
+            Description = "Re-aim chain synthesis (flag ON, clean Kerbin->Duna arrival): the synth escape + transfer + capture splice contiguously; the recorded escape/capture hyperbolae are REPLACED; deterministic on re-solve")]
+        public void Reaim_ChainSynthesis_CleanArrival_SplicesEscapeTransferCapture()
+        {
+            DriveChainSynthesisWindows(ikeThread: false, "reaim-e2e-chain-clean");
+        }
+
+        [InGameTest(Category = "Periodicity", Scene = GameScenes.SPACECENTER,
+            Description = "Re-aim chain synthesis (flag ON, Ike-threaded Kerbin->Duna arrival): the capture side FAILS CLOSED (recorded Duna capture verbatim), the escape + transfer still synthesize; deterministic on re-solve")]
+        public void Reaim_ChainSynthesis_IkeThreadedArrival_CaptureFailsClosed()
+        {
+            DriveChainSynthesisWindows(ikeThread: true, "reaim-e2e-chain-ike");
+        }
+
+        // Drives the chain-synthesis path under the flag ON for the real-topology member. ikeThread selects
+        // the clean single-capture arrival (capture synthesized) vs the Ike-threaded arrival (capture fails
+        // closed). Asserts the chain shape + the synth-vs-verbatim contract per window, plus the cache-cleared
+        // determinism re-solve. The flag override is reset in finally; the resolver is private (Shared safe).
+        private static void DriveChainSynthesisWindows(bool ikeThread, string memberIdPrefix)
+        {
+            var ic = CultureInfo.InvariantCulture;
+            ScanContext ctx = BuildPinnedScanOrSkip(KerbinToDuna());
+            if (ctx == null)
+                return;
+
+            int midIdx = ReaimFeasibilityScan.CenterOfLongestRunIndex(ctx.Scan, cyclic: true);
+            if (midIdx < 0)
+            {
+                InGameAssert.Skip("no good Kerbin->Duna departure found in the pinned synodic scan (unexpected on stock)");
+                return;
+            }
+            double goodDep = ctx.ScanDepartureUTs[midIdx];
+
+            bool? savedFlag = ReaimChainSynthesis.ForceEnabledForTesting;
+            try
+            {
+                ReaimChainSynthesis.ForceEnabledForTesting = true;
+                InGameAssert.IsTrue(ReaimChainSynthesis.IsEnabled,
+                    "the chain-synthesis flag must read ON for this test (forced via ForceEnabledForTesting)");
+
+                BuildRealTopologyMemberAndPlan(ctx, goodDep, ikeThread,
+                    out List<OrbitSegment> memberSegments, out ReaimMissionPlan plan,
+                    out double spanStart, out double spanEnd);
+                ReaimWindowPlanner.ReaimWindowSchedule sched = ReaimWindowPlanner.Plan(
+                    ctx.LaunchBody.orbit.period, ctx.TargetBody.orbit.period, goodDep, ctx.TofSeconds,
+                    spanStart, spanEnd, referenceUT: goodDep - 1.0);
+                InGameAssert.IsTrue(sched.Valid, "window schedule must be valid: " + (sched.Reason ?? ""));
+
+                var resolver = new ReaimPlaybackResolver();
+                string memberId = memberIdPrefix + "-" + midIdx.ToString(ic);
+                double span = spanEnd - spanStart;
+                int resolved = 0, captureSynthCount = 0, captureVerbatimCount = 0;
+                for (long k = 0; k < WindowsToCheck; k++)
+                {
+                    double currentUT = sched.PhaseAnchorUT + k * sched.CadenceSeconds + 0.5 * span;
+                    bool ok = resolver.TryResolveWindowSegments(
+                        memberId, memberSegments, plan, sched,
+                        sched.PhaseAnchorUT, spanStart, spanEnd, sched.CadenceSeconds, currentUT,
+                        out List<OrbitSegment> segs, out long windowIndex);
+                    InGameAssert.AreEqual(k, windowIndex, $"window index must equal k={k}");
+
+                    // Window 0 (the recorded departure) must resolve; later windows may decline cleanly
+                    // (the separate eccentric-drift mode), which is a clean fail-closed fall-back.
+                    if (k == 0)
+                        InGameAssert.IsTrue(ok,
+                            "window k=0 (the recorded departure) must resolve the chain (flag ON, real topology)");
+                    if (!ok)
+                    {
+                        InGameAssert.IsTrue(segs == null, $"window k={k} decline must return null segments");
+                        continue;
+                    }
+                    resolved++;
+
+                    // Shape-agnostic sanity (launch leg / re-aimed transfer / target arrival, recorded-span).
+                    AssertSaneWindowSegments(ctx, segs, plan, goodDep, spanEnd, k);
+
+                    // The chain must FULLY COVER its synth span with NO UT overlap (guarantee 7's in-game
+                    // counterpart; the recorder's sub-tolerance sampling gaps may persist outside the synth
+                    // span, but the synth legs themselves must not overlap a neighbor).
+                    AssertNoOverlaps(segs, k);
+
+                    // Capture side: VERBATIM for the Ike thread (a deterministic assembler contract given
+                    // CaptureSynthesizable=false), best-effort SYNTH for the clean arrival (the synth capture
+                    // leg is built from v2 + a state-vector construction the live geometry may decline; the
+                    // assembler then keeps the recorded capture verbatim - a clean fail-closed, never worse
+                    // than the baseline). So the Ike fail-closed is HARD; the clean-arrival capture synth is
+                    // OBSERVATIONAL (logged), tracked by the captureSynth / captureVerbatim counters.
+                    bool recordedCaptureVerbatim = segs.Exists(
+                        s => s.bodyName == ctx.TargetBodyName && s.semiMajorAxis == -563351.0
+                             && System.Math.Abs(s.startUT - plan.FirstCaptureStartUT) < 1.0);
+                    if (ikeThread)
+                    {
+                        // CAPTURE FAIL-CLOSED (HARD): the recorded Duna capture hyperbola (-563351) stays
+                        // verbatim, pinned at the recorded SOI-entry boundary, and the Ike thread is preserved.
+                        // This is byte-identical to today's arrival (guarantee 8), so it never renders worse.
+                        InGameAssert.IsTrue(recordedCaptureVerbatim,
+                            $"window k={k} the Ike-threaded arrival must keep the recorded Duna capture (-563351) verbatim (capture fail-closed)");
+                        InGameAssert.IsTrue(segs.Exists(s => s.bodyName == "Ike"),
+                            $"window k={k} the recorded Ike thread must be preserved when the capture side fails closed");
+                        captureVerbatimCount++;
+                    }
+                    else
+                    {
+                        // CLEAN ARRIVAL: count whether the synth capture engaged (recorded capture replaced) vs
+                        // fell back to verbatim. Both are valid (fail-closed); the count is the P6 measurement
+                        // surface. When the synth engaged, the capture leg is target-RELATIVE and starts at the
+                        // recorded SOI-entry boundary - that is what makes the line enter the SOI + icon follow.
+                        if (recordedCaptureVerbatim)
+                            captureVerbatimCount++;
+                        else
+                            captureSynthCount++;
+                    }
+
+                    // Cache-cleared determinism: the SAME window must re-solve to the SAME chain shape +
+                    // transfer conic (knife-edge windows are floored by the fail-closed-to-faithful contract).
+                    resolver.Clear();
+                    bool ok2 = resolver.TryResolveWindowSegments(
+                        memberId, memberSegments, plan, sched,
+                        sched.PhaseAnchorUT, spanStart, spanEnd, sched.CadenceSeconds, currentUT,
+                        out List<OrbitSegment> segs2, out long windowIndex2);
+                    InGameAssert.IsTrue(ok2, $"window k={k} cache-cleared re-solve must reproduce the resolve");
+                    InGameAssert.AreEqual(windowIndex, windowIndex2, $"window k={k} re-solve index must match");
+                    InGameAssert.AreEqual(segs.Count, segs2.Count,
+                        $"window k={k} re-solved chain must have the same segment count");
+                    OrbitSegment a = FindReaimedTransfer(segs, plan);
+                    OrbitSegment b = FindReaimedTransfer(segs2, plan);
+                    InGameAssert.IsTrue(
+                        NearlyEqual(a.semiMajorAxis, b.semiMajorAxis) && NearlyEqual(a.eccentricity, b.eccentricity)
+                        && NearlyEqual(a.inclination, b.inclination)
+                        && NearlyEqual(a.longitudeOfAscendingNode, b.longitudeOfAscendingNode)
+                        && NearlyEqual(a.argumentOfPeriapsis, b.argumentOfPeriapsis),
+                        $"window k={k} re-solved transfer conic must match the first solve");
+                }
+
+                ParsekLog.Info("ReaimE2E",
+                    $"Kerbin->Duna chain synthesis (flag ON, ikeThread={ikeThread}): scanIdx={midIdx} goodDep={goodDep.ToString("F1", ic)} " +
+                    $"checked={WindowsToCheck} resolved={resolved} captureSynth={captureSynthCount} captureVerbatim={captureVerbatimCount} " +
+                    $"(clean=capture replaced by synth target-relative leg; ike=capture fail-closed verbatim)");
+            }
+            finally
+            {
+                ReaimChainSynthesis.ForceEnabledForTesting = savedFlag;
+            }
+        }
+
+        // Asserts the assembled segment list has NO UT overlaps (a later segment starting before its
+        // predecessor ends): the synth legs must tile, never overlap (reaim-fix-plan.md guarantee 7). Small
+        // FORWARD recorder sampling gaps are allowed (the raw recording carries them); overlaps are not.
+        private static void AssertNoOverlaps(List<OrbitSegment> segs, long k)
+        {
+            var ic = CultureInfo.InvariantCulture;
+            if (segs == null)
+                return;
+            for (int i = 1; i < segs.Count; i++)
+            {
+                double overlap = segs[i - 1].endUT - segs[i].startUT;
+                InGameAssert.IsTrue(overlap <= 1.0,
+                    $"window k={k} segment {i.ToString(ic)} overlaps its predecessor by {overlap.ToString("F1", ic)}s " +
+                    $"(prev endUT={segs[i - 1].endUT.ToString("R", ic)} start={segs[i].startUT.ToString("R", ic)})");
+            }
         }
 
         // The shared eccentric-target driver. Picks the band CENTER departure (the stable mid-band pick, like
@@ -643,9 +819,10 @@ namespace Parsek.InGameTests
                     sched.PhaseAnchorUT, spanStart, spanEnd, sched.CadenceSeconds, currentUT,
                     out List<OrbitSegment> segs, out long windowIndex);
                 InGameAssert.AreEqual(k, windowIndex, $"window index must equal k={k} on resolve AND on decline");
+                OrbitSegment firstSolveTransfer = default;
                 if (ok)
                 {
-                    AssertSaneWindowSegments(ctx, segs, plan, departureUT, spanEnd, k);
+                    firstSolveTransfer = AssertSaneWindowSegments(ctx, segs, plan, departureUT, spanEnd, k);
                     resolvedCount++;
                     map.Append('R');
                 }
@@ -675,7 +852,10 @@ namespace Parsek.InGameTests
                 InGameAssert.AreEqual(windowIndex, windowIndex2, $"window k={k} re-solve index must match");
                 if (ok && ok2)
                 {
-                    OrbitSegment a = segs[1], b = segs2[1];
+                    // Compare the RE-AIMED TRANSFER conic across the two solves, found by body (the chain
+                    // shape can vary with the flag/topology, so segs[1] is no longer reliably the transfer).
+                    OrbitSegment a = firstSolveTransfer;
+                    OrbitSegment b = FindReaimedTransfer(segs2, plan);
                     InGameAssert.IsTrue(
                         NearlyEqual(a.semiMajorAxis, b.semiMajorAxis) && NearlyEqual(a.eccentricity, b.eccentricity)
                         && NearlyEqual(a.inclination, b.inclination)
@@ -830,7 +1010,7 @@ namespace Parsek.InGameTests
                 depUTs[i] = tDep;
                 scan[i] = ReaimTransferSynthesizer.TrySynthesizeTransfer(
                     ctx.LaunchBody, ctx.TargetBody, tDep, ctx.TofSeconds, prograde: true,
-                    out _, out _, out _, out _);
+                    out _, out _, out _, out _, out _, out _, out _, out _);
                 if (scan[i])
                     hits++;
             }
@@ -883,20 +1063,159 @@ namespace Parsek.InGameTests
             };
         }
 
-        // The shared per-window sanity assertions: 3 segments (launch parking / re-aimed
-        // common-ancestor transfer / target arrival), sane elliptic transfer conic, recorded-span
-        // placement. Reads the launch/target body names from the fixture so it is target-agnostic.
-        private static void AssertSaneWindowSegments(
+        // Builds the REAL-TOPOLOGY synthetic member + plan for the chain-synthesis path (reaim-fix-plan.md
+        // P4 / "CRITICAL SCOPE CORRECTION"): NOT the 3-leg [parking, helio, arrival] idealization, but the
+        // shape the chain synthesis ships for - a circular launch-body PARKING orbit, a launch-body ESCAPE
+        // HYPERBOLA (sma<0), the common-ancestor TRANSFER coast [departureUT, recordedArrivalUT], a
+        // target-body CAPTURE HYPERBOLA (sma<0), and a target-body DESCENT ellipse. The heliocentric leg
+        // stays at [departureUT, recordedArrivalUT] (so the resolver's transfer placement / window mapping
+        // is unchanged from BuildMemberAndPlan) and RecordedDepartureUT/RecordedArrivalUT keep the values
+        // the schedule expects.
+        //
+        // <para>The escape run ends co-located with departureUT (within EscapeHandoffToleranceSeconds) and
+        // the first capture begins at recordedArrivalUT, so the assembler's STEP 3 co-location gate accepts
+        // the escape handoff and the STEP 4 capture pin lands on the recorded arrival boundary.</para>
+        //
+        // <para>When <paramref name="ikeThread"/> is true an Ike SOI thread (two short Ike hyperbolae) is
+        // inserted between the Duna capture and the descent - the secondary-moon / Phase-4 case the capture
+        // side FAILS CLOSED for (CaptureSynthesizable=false), so the synth escape + transfer ship but the
+        // recorded capture/Ike/descent run stays verbatim.</para>
+        //
+        // The plan's chain index spans + recorded-span run UTs are wired to match the member so the live
+        // resolver (BuildWindowSegments) splices by span; the indices are into THIS list (no predicted tails,
+        // already sorted) so they align with the classifier's contract.
+        private static void BuildRealTopologyMemberAndPlan(
+            ScanContext ctx, double departureUT, bool ikeThread,
+            out List<OrbitSegment> memberSegments, out ReaimMissionPlan plan,
+            out double spanStart, out double spanEnd)
+        {
+            ReaimFixture fx = ctx.Fixture;
+            string launchName = fx.LaunchBodyName;
+            string targetName = fx.TargetBodyName;
+            string parent = ctx.LaunchBody.referenceBody.bodyName;
+
+            double recordedArrivalUT = departureUT + ctx.TofSeconds;
+            // Launch-body legs BEFORE the transfer: circular parking [parkStart, escapeStart] then the escape
+            // hyperbola [escapeStart, departureUT]. The escape run ends exactly at departureUT (co-located).
+            double escapeRunSeconds = 60.0;          // a short recorded escape hyperbola (sub-tolerance handoff)
+            double escapeStartUT = departureUT - escapeRunSeconds;
+            double parkStartUT = escapeStartUT - 600.0;
+            spanStart = parkStartUT;
+            // Target-body legs AFTER the transfer: a capture hyperbola [recordedArrivalUT, captureEndUT],
+            // optionally an Ike thread, then a descent ellipse ending at spanEnd.
+            double captureSeconds = 200.0;
+            double captureEndUT = recordedArrivalUT + captureSeconds;
+
+            memberSegments = new List<OrbitSegment>();
+            // [0] circular launch-body parking orbit (kept verbatim; the escape leg is selected by index).
+            memberSegments.Add(new OrbitSegment { bodyName = launchName, startUT = parkStartUT, endUT = escapeStartUT,
+                semiMajorAxis = fx.ParkingSma, eccentricity = fx.ParkingEcc, epoch = parkStartUT });
+            // [1] launch-body ESCAPE HYPERBOLA (sma<0, ecc>1) - the leg chain synthesis replaces.
+            memberSegments.Add(new OrbitSegment { bodyName = launchName, startUT = escapeStartUT, endUT = departureUT,
+                semiMajorAxis = -3818300.0, eccentricity = 1.19, epoch = escapeStartUT });
+            // [2] common-ancestor (Sun) TRANSFER coast [departureUT, recordedArrivalUT].
+            memberSegments.Add(new OrbitSegment { bodyName = parent, startUT = departureUT, endUT = recordedArrivalUT,
+                semiMajorAxis = fx.HeliocentricSma, eccentricity = fx.HeliocentricEcc, epoch = departureUT });
+            int firstCaptureIndex = memberSegments.Count;
+            // [3] target-body CAPTURE HYPERBOLA (sma<0, ecc>1) - the first capture leg.
+            memberSegments.Add(new OrbitSegment { bodyName = targetName, startUT = recordedArrivalUT, endUT = captureEndUT,
+                semiMajorAxis = -563351.0, eccentricity = 1.05, epoch = recordedArrivalUT });
+            double tailStartUT = captureEndUT;
+            if (ikeThread)
+            {
+                // Ike SOI thread (two short Ike hyperbolae) - the secondary-moon case (capture fails closed).
+                double ikeEndUT = tailStartUT + 100.0;
+                memberSegments.Add(new OrbitSegment { bodyName = "Ike", startUT = tailStartUT, endUT = tailStartUT + 50.0,
+                    semiMajorAxis = -29873.0, eccentricity = 1.02, epoch = tailStartUT });
+                memberSegments.Add(new OrbitSegment { bodyName = "Ike", startUT = tailStartUT + 50.0, endUT = ikeEndUT,
+                    semiMajorAxis = -29873.0, eccentricity = 1.02, epoch = tailStartUT + 50.0 });
+                tailStartUT = ikeEndUT;
+            }
+            // descent ellipse (sma>0, ecc<1), ending at the span end.
+            spanEnd = tailStartUT + 600.0;
+            memberSegments.Add(new OrbitSegment { bodyName = targetName, startUT = tailStartUT, endUT = spanEnd,
+                semiMajorAxis = fx.ArrivalSma, eccentricity = fx.ArrivalEcc, epoch = tailStartUT });
+
+            // CaptureSynthesizable mirrors the classifier's decision: false when the Ike thread is present
+            // (secondary-SOI), true for the clean single-capture arrival.
+            bool captureSynthesizable = !ikeThread;
+
+            plan = new ReaimMissionPlan
+            {
+                Supported = true,
+                LaunchBody = launchName,
+                TargetBody = targetName,
+                CommonAncestor = parent,
+                ParkingOrbit = memberSegments[0],
+                HeliocentricLeg = memberSegments[2],
+                ArrivalLeg = memberSegments[firstCaptureIndex],
+                RecordedDepartureUT = departureUT,
+                RecordedArrivalUT = recordedArrivalUT,
+                RecordedTransferTofSeconds = ctx.TofSeconds,
+
+                // Chain-synthesis index spans (into THIS member list; no predicted tails, already ordered).
+                ParkingIndex = 0,
+                EscapeRunStartIndex = 1,
+                EscapeRunEndIndex = 1,
+                EscapeRunIsParkingOnly = false,
+                TransferRunStartIndex = 2,
+                TransferRunEndIndex = 2,
+                FirstCaptureIndex = firstCaptureIndex,
+                // Recorded-span run boundary UTs the assembler tiles the synth legs against.
+                EscapeRunStartUT = escapeStartUT,
+                EscapeRunEndUT = departureUT,                 // co-located with the transfer-run start
+                TransferRunEndUT = recordedArrivalUT,
+                FirstCaptureStartUT = recordedArrivalUT,      // == the target SOI-entry the capture pins to
+                FirstCaptureEndUT = captureEndUT,
+                CaptureSynthesizable = captureSynthesizable,
+                CaptureSynthesizableReason = ikeThread ? "secondary-SOI thread (Ike)" : "clean single-capture arrival",
+            };
+        }
+
+        // The shared per-window sanity assertions, REWRITTEN for the re-aim whole-chain synthesis fix
+        // (reaim-fix-plan.md P4): the assembled list is NO LONGER a 3-segment [parking, transfer, arrival]
+        // idealization. It is a GENERIC chain whose shape depends on the member topology and the
+        // reaimChainSynthesis flag state:
+        //   - flag OFF (the byte-identical baseline path the existing tests run under): today's single-leg
+        //     heliocentric replacement - the recorded launch-body leg(s), ONE re-aimed common-ancestor
+        //     transfer, the recorded target-body leg(s). For the simple 3-leg fixture this is still 3
+        //     segments; for the real-topology fixture (BuildRealTopologyMemberAndPlan) it is the full
+        //     recorded chain with only the Sun leg replaced.
+        //   - flag ON, real topology: the synth escape + transfer + (when synthesizable) capture spliced
+        //     contiguously into the verbatim recorded parking / Ike / descent.
+        // So the assertions are shape-AGNOSTIC: find the re-aimed transfer by BODY (not by index segs[1]),
+        // validate the sane prograde elliptic conic + the recorded-span placement, and confirm the chain is
+        // bracketed by a launch-body leg before the transfer and a target-body leg after it that keeps the
+        // span end. Returns the re-aimed transfer segment so the caller can read its per-window orientation
+        // (the strict test's longitude-of-periapsis rotation), which used to be the hard-coded segs[1].
+        private static OrbitSegment AssertSaneWindowSegments(
             ScanContext ctx, List<OrbitSegment> segs, ReaimMissionPlan plan, double departureUT, double spanEnd, long k)
         {
             var ic = CultureInfo.InvariantCulture;
             string launchName = ctx.LaunchBodyName;
             string targetName = ctx.TargetBodyName;
-            InGameAssert.IsTrue(segs != null && segs.Count == 3,
-                $"window k={k} must keep 3 segments ({launchName} parking / re-aimed transfer / {targetName} arrival)");
-            OrbitSegment transfer = segs[1];
-            InGameAssert.AreEqual(plan.CommonAncestor, transfer.bodyName,
-                $"window k={k} transfer must be common-ancestor-bodied");
+            InGameAssert.IsTrue(segs != null && segs.Count >= 3,
+                $"window k={k} must have at least 3 segments (a {launchName} launch leg / re-aimed transfer / {targetName} arrival leg); was {(segs == null ? "null" : segs.Count.ToString(ic))}");
+
+            // The re-aimed transfer: the common-ancestor-bodied leg overlapping the recorded transfer window
+            // [departureUT, recordedArrivalUT]. There must be EXACTLY ONE (any further in-window heliocentric
+            // coasts collapse into the one re-aimed arc), found by body, not by a fixed index.
+            int transferIdx = -1;
+            int transferCount = 0;
+            for (int i = 0; i < segs.Count; i++)
+            {
+                OrbitSegment s = segs[i];
+                if (s.bodyName == plan.CommonAncestor
+                    && s.startUT < plan.RecordedArrivalUT && s.endUT > plan.RecordedDepartureUT)
+                {
+                    transferCount++;
+                    transferIdx = i;
+                }
+            }
+            InGameAssert.AreEqual(1, transferCount,
+                $"window k={k} must have exactly one re-aimed {plan.CommonAncestor}-bodied transfer leg in the recorded window (any extra heliocentric coasts collapse into one arc)");
+            OrbitSegment transfer = segs[transferIdx];
+
             InGameAssert.IsTrue(
                 ReaimTransferSynthesizer.IsSaneTransferConic(transfer.eccentricity, transfer.semiMajorAxis),
                 $"window k={k} transfer must be a sane elliptic conic (ecc={transfer.eccentricity.ToString("R", ic)} sma={transfer.semiMajorAxis.ToString("R", ic)})");
@@ -909,14 +1228,45 @@ namespace Parsek.InGameTests
             InGameAssert.IsTrue(
                 !ReaimTransferSynthesizer.IsRetrogradeTransfer(transfer.inclination),
                 $"window k={k} transfer must be prograde (inc={transfer.inclination.ToString("F2", ic)} deg < 90; a retrograde result declines to faithful, never resolves)");
-            // Per-member: only the heliocentric leg is re-aimed (placed at [departure, recordedArrival]);
-            // the launch parking + target arrival legs keep their recorded UTs + bodies.
-            InGameAssert.AreEqual(launchName, segs[0].bodyName, $"window k={k} must keep the {launchName} parking leg");
-            InGameAssert.AreEqual(targetName, segs[2].bodyName, $"window k={k} must keep the {targetName} arrival leg");
-            InGameAssert.IsTrue(System.Math.Abs(segs[1].startUT - departureUT) < 1.0,
-                $"window k={k} transfer must start at the recorded departure (recorded-span)");
-            InGameAssert.IsTrue(System.Math.Abs(segs[2].endUT - spanEnd) < 1.0,
-                $"window k={k} arrival must keep its recorded span end (fits span)");
+            // The re-aimed transfer is placed at the recorded departure (recorded-span); only the
+            // common-ancestor leg is re-aimed, so its start anchors the loop's replay of the departure.
+            InGameAssert.IsTrue(System.Math.Abs(transfer.startUT - departureUT) < 1.0,
+                $"window k={k} transfer must start at the recorded departure (recorded-span; was {transfer.startUT.ToString("R", ic)})");
+
+            // The chain is bracketed by the recorded body-relative legs that follow their LIVE body: a
+            // launch-body leg (circular parking and/or escape) BEFORE the transfer, and a target-body leg
+            // (capture and/or descent) AFTER it. These pass through verbatim (flag OFF) or surround the synth
+            // escape/capture (flag ON); either way the chain must START launch-bodied and the LAST segment
+            // must be target-bodied and keep the recorded span end.
+            InGameAssert.IsTrue(transferIdx >= 1,
+                $"window k={k} the re-aimed transfer must be preceded by a recorded {launchName} launch leg");
+            InGameAssert.AreEqual(launchName, segs[0].bodyName,
+                $"window k={k} the chain must start with the {launchName} launch leg (body-relative, follows its body)");
+            OrbitSegment lastSeg = segs[segs.Count - 1];
+            InGameAssert.AreEqual(targetName, lastSeg.bodyName,
+                $"window k={k} the chain must end on the {targetName} arrival/descent leg (body-relative)");
+            InGameAssert.IsTrue(System.Math.Abs(lastSeg.endUT - spanEnd) < 1.0,
+                $"window k={k} the arrival/descent leg must keep its recorded span end (fits span; was {lastSeg.endUT.ToString("R", ic)})");
+
+            return transfer;
+        }
+
+        // The re-aimed transfer leg (the single common-ancestor-bodied segment overlapping the recorded
+        // transfer window), found by BODY - the chain shape can vary with the flag / topology, so a fixed
+        // index is unreliable. Used by the determinism re-solve comparison. Returns default(OrbitSegment)
+        // if none is found (the caller only reaches here on a resolved window, so one always exists).
+        private static OrbitSegment FindReaimedTransfer(List<OrbitSegment> segs, ReaimMissionPlan plan)
+        {
+            if (segs == null)
+                return default;
+            for (int i = 0; i < segs.Count; i++)
+            {
+                OrbitSegment s = segs[i];
+                if (s.bodyName == plan.CommonAncestor
+                    && s.startUT < plan.RecordedArrivalUT && s.endUT > plan.RecordedDepartureUT)
+                    return s;
+            }
+            return default;
         }
 
         // Identical-solve comparison: the re-solve runs the same FP path on the same inputs, so

--- a/Source/Parsek/Reaim/ReaimChainGeometry.cs
+++ b/Source/Parsek/Reaim/ReaimChainGeometry.cs
@@ -1,0 +1,114 @@
+using System;
+
+namespace Parsek.Reaim
+{
+    // PURE state-vector geometry for the re-aim whole-chain synthesis (reaim-fix-plan.md, STEP 1/2).
+    // These are the pieces of the escape / capture leg construction that DON'T need a live Unity scene -
+    // the SOI-sphere-crossing bisection (driven by a sampled-distance delegate the live caller supplies),
+    // the body-relative velocity conversion (vRel = v_heliocentric - v_body), and the .xzy round-trip
+    // identity. The live glue (Orbit.UpdateFromStateVectors, CelestialBody.orbit, PatchedConics) stays in
+    // ReaimTransferSynthesizer and is exercised by the in-game canary; the math below is xUnit-tested.
+    //
+    // Frame contract (the load-bearing detail, mirrored from ReaimTransferSynthesizer): a body's orbit
+    // relative position/velocity come back YZ-swizzled (AliceWorld). The transfer is built in the same
+    // swizzled frame as the bodies, so the difference rEntry = transfer.relPos - body.relPos and the
+    // velocity difference vRel = v - body.orbitalVel are taken in ONE consistent frame and then fed to
+    // Orbit.UpdateFromStateVectors verbatim. Re-aim's transfer build does its differencing on the
+    // UN-swizzled (.xzy) vectors and re-swizzles (.xzy is its own inverse) for UpdateFromStateVectors; the
+    // capture / escape construction MUST mirror that exactly. RelativeVelocity below performs only the
+    // subtraction (a frame-agnostic operation: if both operands are in the same frame the result is too),
+    // so the live caller controls the swizzling around it identically to the transfer build.
+    internal static class ReaimChainGeometry
+    {
+        /// <summary>
+        /// Body-relative velocity at a SOI crossing: <c>vRel = vHeliocentric - vBody</c>. Pure vector
+        /// subtraction. BOTH operands must already be in the SAME frame (the caller supplies them either
+        /// both swizzled or both un-swizzled - the subtraction is frame-agnostic). This is the
+        /// <c>v2 - targetBody.orbit.getOrbitalVelocityAtUT(...)</c> (capture) and
+        /// <c>v1 - launchBody.orbit.getOrbitalVelocityAtUT(...)</c> (escape) reduction the state-vector
+        /// construction feeds to <c>Orbit.UpdateFromStateVectors</c>.
+        /// </summary>
+        internal static Vector3d RelativeVelocity(Vector3d vHeliocentric, Vector3d vBody)
+        {
+            return vHeliocentric - vBody;
+        }
+
+        /// <summary>
+        /// Body-relative position at a SOI crossing: <c>rRel = rTransfer - rBody</c> (both parent-relative
+        /// in the same frame). Pure. This is the <c>transfer.relPos - targetBody.relPos</c> reduction
+        /// (parent-relative positions differenced in one frame) the state-vector construction feeds to
+        /// <c>Orbit.UpdateFromStateVectors</c>.
+        /// </summary>
+        internal static Vector3d RelativePosition(Vector3d rTransfer, Vector3d rBody)
+        {
+            return rTransfer - rBody;
+        }
+
+        // Default bisection control for the SOI-sphere crossing refinement. The proximity scan
+        // (ReaimTransferSynthesizer.TryFindTargetEncounterByProximity) has ~span/96 UT resolution; bisecting
+        // to the SOI shell tightens the seam to well under the in-SOI handoff residual the playtest already
+        // tolerates (the Ike/Duna seams log ~0.3-2.6 Mm). 60 iterations halves the bracket ~1e18x, far below
+        // any meaningful UT, so it terminates on the position tolerance long before the iteration cap.
+        internal const int DefaultBisectionIterations = 60;
+
+        /// <summary>
+        /// Refines a SOI-sphere crossing UT by bisection. <paramref name="distanceAtUT"/> returns the
+        /// vessel-to-body distance (metres) at a UT; <paramref name="soiRadius"/> is the body's SOI radius.
+        /// The bracket [<paramref name="insideUT"/>, <paramref name="outsideUT"/>] must straddle the shell:
+        /// <c>distance(insideUT) &lt;= soiRadius</c> (inside the SOI) and
+        /// <c>distance(outsideUT) &gt; soiRadius</c> (outside). Returns the UT where the sampled distance is
+        /// within <paramref name="toleranceMeters"/> of the SOI radius, or the bracket midpoint at the
+        /// iteration cap. Pure (given the delegate); the delegate is the only Unity-bound dependency and the
+        /// live caller wires it to <c>(transfer.relPos - body.relPos).magnitude</c>.
+        /// </summary>
+        /// <remarks>
+        /// Returns false (with <paramref name="crossingUT"/> = NaN) when the inputs are degenerate (NaN
+        /// bracket, non-positive SOI, the bracket is NOT a valid inside/outside straddle, or the delegate is
+        /// null) so the caller fails closed to the raw scanned UT rather than a corrupted refinement.
+        /// </remarks>
+        internal static bool TryBisectSoiCrossing(
+            Func<double, double> distanceAtUT, double soiRadius,
+            double insideUT, double outsideUT, double toleranceMeters,
+            out double crossingUT,
+            int maxIterations = DefaultBisectionIterations)
+        {
+            crossingUT = double.NaN;
+            if (distanceAtUT == null
+                || double.IsNaN(soiRadius) || double.IsInfinity(soiRadius) || soiRadius <= 0.0
+                || double.IsNaN(insideUT) || double.IsInfinity(insideUT)
+                || double.IsNaN(outsideUT) || double.IsInfinity(outsideUT)
+                || double.IsNaN(toleranceMeters) || toleranceMeters <= 0.0)
+                return false;
+
+            double dIn = distanceAtUT(insideUT);
+            double dOut = distanceAtUT(outsideUT);
+            if (double.IsNaN(dIn) || double.IsNaN(dOut))
+                return false;
+            // Require a genuine inside (<= soi) / outside (> soi) straddle so the sign convention is sound.
+            if (!(dIn <= soiRadius && dOut > soiRadius))
+                return false;
+
+            double lo = insideUT;   // distance(lo) <= soi  (inside)
+            double hi = outsideUT;  // distance(hi)  > soi  (outside)
+            double mid = 0.5 * (lo + hi);
+            for (int i = 0; i < maxIterations; i++)
+            {
+                mid = 0.5 * (lo + hi);
+                double dMid = distanceAtUT(mid);
+                if (double.IsNaN(dMid))
+                    return false;
+                if (Math.Abs(dMid - soiRadius) <= toleranceMeters)
+                {
+                    crossingUT = mid;
+                    return true;
+                }
+                if (dMid <= soiRadius)
+                    lo = mid;   // mid still inside -> push the inside boundary out
+                else
+                    hi = mid;   // mid outside -> pull the outside boundary in
+            }
+            crossingUT = mid; // converged on UT (bracket collapsed) even if not on the position tolerance
+            return true;
+        }
+    }
+}

--- a/Source/Parsek/Reaim/ReaimChainGeometry.cs
+++ b/Source/Parsek/Reaim/ReaimChainGeometry.cs
@@ -44,6 +44,55 @@ namespace Parsek.Reaim
             return rTransfer - rBody;
         }
 
+        // Upper bound on a sane escape/capture-leg eccentricity (reaim-fix-plan.md STEP 2/3 fail-closed
+        // gate). A real interplanetary ejection / capture hyperbola from a low parking orbit sits at ecc
+        // ~1.05-1.5 (Kerbin->Duna v-infinity ~0.9-1.2 km/s over a ~700 km periapsis); anything above ~3 is
+        // a state-vector reconstruction artifact (the ecc 8-13 garbage the velocity-source bug produced),
+        // never a real leg. The band is deliberately generous (it must accept eccentric Moho/Eeloo
+        // departures) but well below the artifact regime so a corrupted leg fails closed.
+        internal const double MaxSaneLegEccentricity = 3.0;
+
+        /// <summary>
+        /// PURE leg-conic sanity gate (reaim-fix-plan.md STEP 2/3 "MEASURE and fail-closed"). True when a
+        /// synthesized escape/capture leg is a real hyperbola anchored at a sane periapsis altitude, so the
+        /// caller may splice it; false (FAIL CLOSED to the recorded leg verbatim / the baseline) when the
+        /// reduced state produced a degenerate or wrong-altitude conic.
+        ///
+        /// <para>Rejects, in order: NaN/Inf elements; a non-hyperbolic conic (<paramref name="eccentricity"/>
+        /// &lt; 1, i.e. a bound ellipse - a real escape/capture leg is hyperbolic); an absurd eccentricity
+        /// (&gt; <see cref="MaxSaneLegEccentricity"/> - the ecc 8-13 garbage from an inconsistent
+        /// position/velocity state); and a periapsis radius <c>rp = a*(1-e)</c> outside the sane band
+        /// [<paramref name="minPeriapsisRadius"/>, <c>soiRadius * <paramref name="maxPeriapsisSoiFraction"/></c>].
+        /// The lower bound is the body's surface (or atmosphere top) radius - a periapsis below it is a leg
+        /// that clips the body; the upper bound (default half the SOI) rejects a leg whose periapsis sits out
+        /// near the SOI shell (the center-vs-shell sampling artifact: periapsis tens of Mm up).</para>
+        ///
+        /// <para>For a KSP hyperbola sma &lt; 0 and ecc &gt; 1, so <c>rp = a*(1-e)</c> = (negative)*(negative)
+        /// = positive. Pure (scalar arithmetic); the live caller passes the body's Radius/atmosphere/SOI.</para>
+        /// </summary>
+        internal static bool IsSaneLegConic(
+            double eccentricity, double semiMajorAxis,
+            double minPeriapsisRadius, double soiRadius,
+            double maxLegEccentricity = MaxSaneLegEccentricity,
+            double maxPeriapsisSoiFraction = 0.5)
+        {
+            if (double.IsNaN(eccentricity) || double.IsInfinity(eccentricity)
+                || double.IsNaN(semiMajorAxis) || double.IsInfinity(semiMajorAxis))
+                return false;
+            // Real escape/capture leg is hyperbolic; a bound ellipse (ecc < 1) is not a valid leg here.
+            if (eccentricity < 1.0 || eccentricity > maxLegEccentricity)
+                return false;
+            if (double.IsNaN(minPeriapsisRadius) || minPeriapsisRadius <= 0.0
+                || double.IsNaN(soiRadius) || soiRadius <= 0.0)
+                return false;
+            // Periapsis radius of the hyperbola (sma < 0, ecc > 1 => a*(1-e) > 0).
+            double rp = semiMajorAxis * (1.0 - eccentricity);
+            if (double.IsNaN(rp) || double.IsInfinity(rp) || rp <= 0.0)
+                return false;
+            double maxPeriapsis = soiRadius * maxPeriapsisSoiFraction;
+            return rp >= minPeriapsisRadius && rp <= maxPeriapsis;
+        }
+
         // Default bisection control for the SOI-sphere crossing refinement. The proximity scan
         // (ReaimTransferSynthesizer.TryFindTargetEncounterByProximity) has ~span/96 UT resolution; bisecting
         // to the SOI shell tightens the seam to well under the in-SOI handoff residual the playtest already

--- a/Source/Parsek/Reaim/ReaimClassifier.cs
+++ b/Source/Parsek/Reaim/ReaimClassifier.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 
 namespace Parsek.Reaim
 {
@@ -40,9 +41,79 @@ namespace Parsek.Reaim
         // is purely diagnostic so the ReaimDiag log shows WHY a Sun-predecessor mission engaged.
         public bool DepartedFromHeliocentricPark;
 
+        // ---- Chain-synthesis index spans (reaim-fix-plan.md P2, BLOCKER 1) ----
+        // The recorded transfer member is NOT a clean 3-leg [parking, helio, arrival] shape: the real
+        // Duna One is a 14+-segment chain with a recorded Kerbin ESCAPE HYPERBOLA, THREE Sun coasts, a
+        // Duna CAPTURE HYPERBOLA, an Ike thread, and a descent. Chain synthesis (P3) must replace the
+        // escape RUN, the transfer RUN, and the FIRST capture leg by INDEX (never the misnamed
+        // ParkingOrbit field, the post-capture parking, the Ike segs, the descent, or chained debris).
+        // These indices are into the SORTED non-predicted segment list the classifier walked.
+
+        // The launch-body segment(s) between the circular parking orbit and the heliocentric leg - the
+        // ESCAPE RUN. [EscapeRunStartIndex, EscapeRunEndIndex] inclusive. When the launch-body predecessor
+        // of the heliocentric leg is the circular parking orbit itself (a direct SOI-exit with no recorded
+        // escape hyperbola), the run is a single index (== ParkingIndex) and EscapeRunIsParkingOnly is
+        // true (no separate escape leg to synthesize). -1 when not applicable.
+        public int EscapeRunStartIndex;
+        public int EscapeRunEndIndex;
+        public bool EscapeRunIsParkingOnly;   // the launch-body predecessor IS the circular parking orbit (no escape hyperbola)
+
+        // The circular-parking-orbit index (the last launch-body orbit before the escape run), kept
+        // VERBATIM. == ParkingIndex below when the escape run is a separate hyperbola; == EscapeRunStartIndex
+        // when EscapeRunIsParkingOnly. -1 when not applicable.
+        public int ParkingIndex;
+
+        // The common-ancestor (Sun) transfer RUN: [TransferRunStartIndex, TransferRunEndIndex] inclusive
+        // (transferStartIdx..lastCoastIdx). All collapse into the one re-aimed arc. -1 when not applicable.
+        public int TransferRunStartIndex;
+        public int TransferRunEndIndex;
+
+        // ---- Recorded-span UT spans of the chain runs (reaim-fix-plan.md P3/STEP 5) ----
+        // The pure assembler (ReaimSegmentAssembler.ReplaceTransferChain) selects the escape / transfer /
+        // capture runs out of the member's OWN recorded segment list by recorded-span UT span, NOT by the
+        // classifier's segment INDICES: the classifier filters predicted segments and SORTS, so its indices
+        // do not align with the caller's raw memberSegments (which can carry predicted tails / a different
+        // order). These are the recorded-span boundary UTs the assembler tiles the synth legs against:
+        //   - escape run  [EscapeRunStartUT, EscapeRunEndUT]  (launch-body hyperbola run; the synth escape
+        //     replaces this span; == ParkingIndex's own span when EscapeRunIsParkingOnly, in which case the
+        //     escape side is NOT synthesized).
+        //   - transfer run [RecordedDepartureUT, TransferRunEndUT]  (the Sun coasts; the synth transfer
+        //     replaces them; RecordedDepartureUT is the run start, == HeliocentricLeg.startUT).
+        //   - first capture [FirstCaptureStartUT, FirstCaptureEndUT]  (the first target hyperbola).
+        // NaN when not applicable (an Unsupported plan).
+        public double EscapeRunStartUT;
+        public double EscapeRunEndUT;
+        public double TransferRunEndUT;
+
+        // The FIRST target-bodied capture leg (the first Duna hyperbola), kept its own index. The only
+        // capture leg chain synthesis replaces (when CaptureSynthesizable); everything after it (Ike,
+        // re-capture, descent) stays verbatim. -1 when not applicable.
+        public int FirstCaptureIndex;
+
+        // The target SOI-entry UT (== ArrivalLeg.startUT == RecordedArrivalUT) the synth capture leg's
+        // SOI-entry is pinned to (in recorded-span time). Convenience copy for the assembler.
+        public double FirstCaptureStartUT;
+        public double FirstCaptureEndUT;
+
+        // FALSE when the capture side must FAIL CLOSED (reaim-fix-plan.md CRITICAL SCOPE CORRECTION #3/#4):
+        // a SECONDARY-body SOI segment (e.g. Ike) threads between the heliocentric leg and the destination
+        // capture, OR the arrival is atmospheric-direct (the first target-bodied leg is an elliptic
+        // descending arc, no capture hyperbola to synthesize). The Duna One real topology threads Ike, so
+        // CaptureSynthesizable = false there: chain synthesis synthesizes escape + transfer only and keeps
+        // the recorded capture/arrival run VERBATIM. CaptureSynthesizableReason records why (diagnostic).
+        public bool CaptureSynthesizable;
+        public string CaptureSynthesizableReason;
+
         internal static ReaimMissionPlan Unsupported(string launchBody, string reason)
         {
-            return new ReaimMissionPlan { Supported = false, LaunchBody = launchBody, Reason = reason };
+            return new ReaimMissionPlan
+            {
+                Supported = false, LaunchBody = launchBody, Reason = reason,
+                EscapeRunStartIndex = -1, EscapeRunEndIndex = -1, ParkingIndex = -1,
+                TransferRunStartIndex = -1, TransferRunEndIndex = -1, FirstCaptureIndex = -1,
+                EscapeRunStartUT = double.NaN, EscapeRunEndUT = double.NaN, TransferRunEndUT = double.NaN,
+                FirstCaptureStartUT = double.NaN, FirstCaptureEndUT = double.NaN,
+            };
         }
     }
 
@@ -247,6 +318,60 @@ namespace Parsek.Reaim
             if (sunPredecessor && !parkingDeparture)
                 return ReaimMissionPlan.Unsupported(launchBody,
                     "transfer departs from a heliocentric parking orbit or mid-course correction (deferred); staying faithful");
+
+            // ESCAPE RUN (reaim-fix-plan.md P2/STEP 2/STEP 3, BLOCKER 1). The launch-body segment(s)
+            // immediately before the heliocentric leg are the recorded escape (a real Kerbin HYPERBOLA in
+            // the Duna One case, seg#8) - the leg chain synthesis replaces by INDEX, not the misnamed
+            // ParkingOrbit field. The discriminator between the escape leg and the circular PARKING orbit is
+            // the conic shape: the parking orbit is a BOUND (elliptic, ecc < 1, sma > 0) launch-body orbit,
+            // the escape leg is HYPERBOLIC (ecc >= 1 / sma < 0). Walk back from helioIdx-1 over CONTIGUOUS
+            // launch-body HYPERBOLAE; the first BOUND launch-body orbit hit is the parking orbit (kept
+            // verbatim, never synthesized). When the launch-body predecessor of the heliocentric leg is
+            // itself BOUND (a direct SOI exit with no separately-recorded escape hyperbola), the escape run
+            // is that single parking segment and there is nothing to synthesize on the escape side
+            // (EscapeRunIsParkingOnly).
+            int escapeRunEndIdx = helioIdx - 1;             // last launch-body seg before helio
+            bool lastLaunchBodyIsHyperbolic = IsHyperbolicConic(segs[escapeRunEndIdx]);
+            int escapeRunStartIdx;
+            int parkingOrbitIdx;
+            bool escapeRunIsParkingOnly;
+            if (!lastLaunchBodyIsHyperbolic)
+            {
+                // Direct SOI exit: the launch-body predecessor of helio IS the bound circular parking orbit.
+                // The escape run is that single segment; no escape hyperbola to synthesize.
+                escapeRunStartIdx = escapeRunEndIdx;
+                parkingOrbitIdx = escapeRunEndIdx;
+                escapeRunIsParkingOnly = true;
+            }
+            else
+            {
+                // Walk back over contiguous launch-body HYPERBOLAE; stop at the first non-launch-body seg or
+                // the first BOUND launch-body orbit (the circular parking).
+                escapeRunStartIdx = escapeRunEndIdx;
+                parkingOrbitIdx = -1;
+                for (int i = escapeRunEndIdx - 1; i >= 0; i--)
+                {
+                    if (segs[i].bodyName != launchBody)
+                        break;                              // hit a non-launch-body seg -> run ends
+                    if (!IsHyperbolicConic(segs[i]))
+                    {
+                        parkingOrbitIdx = i;                // the bound circular parking orbit
+                        break;
+                    }
+                    escapeRunStartIdx = i;                  // another launch-body escape hyperbola segment
+                }
+                // If no bound parking orbit was found before the escape run (recording started already on the
+                // escape hyperbola), fall back to the escape-run start as the parking anchor.
+                if (parkingOrbitIdx < 0)
+                    parkingOrbitIdx = escapeRunStartIdx;
+                escapeRunIsParkingOnly = false;
+            }
+
+            // CAPTURE-SIDE FAIL-CLOSED detection (reaim-fix-plan.md CRITICAL SCOPE CORRECTION #3/#4).
+            bool captureSynthesizable = ClassifyCaptureSynthesizable(
+                segs, arrivalIdx, targetBody, commonAncestor, launchBody, bodyInfo,
+                out string captureReason);
+
             return new ReaimMissionPlan
             {
                 Supported = true,
@@ -260,8 +385,97 @@ namespace Parsek.Reaim
                 RecordedDepartureUT = transferStart.startUT,            // transfer-run start (SOI exit, or the heliocentric-park burn)
                 RecordedArrivalUT = arrival.startUT,                    // target SOI entry
                 RecordedTransferTofSeconds = arrival.startUT - transferStart.startUT,
-                DepartedFromHeliocentricPark = parkingDeparture
+                DepartedFromHeliocentricPark = parkingDeparture,
+
+                // Chain-synthesis index spans (into the sorted non-predicted segs list).
+                EscapeRunStartIndex = escapeRunStartIdx,
+                EscapeRunEndIndex = escapeRunEndIdx,
+                EscapeRunIsParkingOnly = escapeRunIsParkingOnly,
+                ParkingIndex = parkingOrbitIdx,
+                TransferRunStartIndex = transferStartIdx,
+                TransferRunEndIndex = lastCoastIdx,
+                EscapeRunStartUT = segs[escapeRunStartIdx].startUT,
+                EscapeRunEndUT = segs[escapeRunEndIdx].endUT,
+                TransferRunEndUT = lastCoast.endUT,
+                FirstCaptureIndex = arrivalIdx,
+                FirstCaptureStartUT = arrival.startUT,
+                FirstCaptureEndUT = arrival.endUT,
+                CaptureSynthesizable = captureSynthesizable,
+                CaptureSynthesizableReason = captureReason,
             };
+        }
+
+        /// <summary>
+        /// True when an OrbitSegment's conic is HYPERBOLIC (an escape / capture leg) rather than BOUND
+        /// (a circular / elliptic parking orbit). A KSP hyperbola has sma &lt; 0 (and ecc &gt;= 1); a bound
+        /// orbit has sma &gt; 0 and ecc &lt; 1. Used to separate the escape hyperbola from the circular
+        /// parking orbit. Pure. NaN sma/ecc reads as NOT hyperbolic (fail safe toward treating it as a
+        /// bound parking boundary).
+        /// </summary>
+        internal static bool IsHyperbolicConic(OrbitSegment seg)
+        {
+            if (double.IsNaN(seg.semiMajorAxis) || double.IsNaN(seg.eccentricity))
+                return false;
+            return seg.semiMajorAxis < 0.0 || seg.eccentricity >= 1.0;
+        }
+
+        /// <summary>
+        /// Decides whether the FIRST target-bodied capture leg (<paramref name="arrivalIdx"/>) can be
+        /// synthesized, or whether the capture side must FAIL CLOSED to the recorded capture verbatim
+        /// (reaim-fix-plan.md CRITICAL SCOPE CORRECTION #3/#4). Returns false when:
+        /// <list type="bullet">
+        /// <item>ATMOSPHERIC-DIRECT: the first target-bodied leg is already an elliptic DESCENDING arc
+        /// (sma &gt; 0, ecc &lt; 1) rather than a capture hyperbola - there is no capture hyperbola to
+        /// synthesize.</item>
+        /// <item>SECONDARY-SOI THREAD (e.g. Ike): a segment in the arrival window after the first capture
+        /// is bodied as a DIFFERENT body that is neither the target nor the common ancestor nor the launch
+        /// body (a secondary moon SOI the arrival threads). The Duna One real topology threads Ike, so this
+        /// fires and the capture side fails closed.</item>
+        /// </list>
+        /// Pure (scans the segment bodies + the first capture's conic sign). <paramref name="reason"/>
+        /// records the decision for the diagnostic log.
+        /// </summary>
+        internal static bool ClassifyCaptureSynthesizable(
+            IReadOnlyList<OrbitSegment> segs, int arrivalIdx, string targetBody,
+            string commonAncestor, string launchBody, IBodyInfo bodyInfo, out string reason)
+        {
+            reason = null;
+            if (segs == null || arrivalIdx < 0 || arrivalIdx >= segs.Count)
+            {
+                reason = "no first-capture leg";
+                return false;
+            }
+
+            // ATMOSPHERIC-DIRECT: the first target leg is an elliptic descending arc, not a capture
+            // hyperbola (a hyperbola is sma < 0 / ecc >= 1). No capture hyperbola exists to synthesize.
+            OrbitSegment firstCapture = segs[arrivalIdx];
+            bool isHyperbola = firstCapture.semiMajorAxis < 0.0 || firstCapture.eccentricity >= 1.0;
+            if (!isHyperbola)
+            {
+                reason = $"atmospheric-direct arrival (first '{targetBody}' leg is elliptic ecc=" +
+                         $"{firstCapture.eccentricity.ToString("F3", CultureInfo.InvariantCulture)} " +
+                         $"sma={firstCapture.semiMajorAxis.ToString("R", CultureInfo.InvariantCulture)}); capture verbatim";
+                return false;
+            }
+
+            // SECONDARY-SOI THREAD: a body other than the target / common ancestor / launch body appears
+            // after the first capture (e.g. Ike between two Duna captures). Scan forward from the segment
+            // after the first capture; stop at the next heliocentric leg (none here - the multi-hop guard
+            // already rejected those) or the end of the member.
+            for (int i = arrivalIdx + 1; i < segs.Count; i++)
+            {
+                string b = segs[i].bodyName;
+                if (string.IsNullOrEmpty(b))
+                    continue;
+                if (b != targetBody && b != commonAncestor && b != launchBody)
+                {
+                    reason = $"secondary-SOI thread ('{b}' between '{targetBody}' captures, e.g. Ike via Duna); capture verbatim";
+                    return false;
+                }
+            }
+
+            reason = "clean single-capture arrival";
+            return true;
         }
 
         // A heliocentric phasing park is admissible for re-aim only when it is near-circular (ecc <=

--- a/Source/Parsek/Reaim/ReaimPlaybackResolver.cs
+++ b/Source/Parsek/Reaim/ReaimPlaybackResolver.cs
@@ -197,15 +197,25 @@ namespace Parsek.Reaim
             Orbit transferOrbit = null;
             double soiEntryUT = double.NaN;
             CelestialBody encounterBody = null;
+            Orbit escapeOrbit = null;
+            Orbit captureOrbit = null;
+            double launchSoiExitUT = double.NaN;
+            double targetSoiEntryUT = double.NaN;
             double usedTofSeconds = double.NaN;
             string failReason = null;
             for (int c = 0; c < candidateTofs.Count; c++)
             {
                 double tof = candidateTofs[c];
                 // ReaimTofSearch drops non-positive tofs already; keep the positivity guard as a backstop.
+                // STEP 0 widened TrySynthesizeTransfer to also emit the escape/capture legs + their SOI UTs;
+                // P3 consumes them below (the chain assembly). The legs are best-effort: a leg that cannot
+                // build leaves its Orbit null and the assembler fails that SIDE closed (escape/capture
+                // verbatim), or the whole chain falls back to the heliocentric-only baseline.
                 if (tof > 0.0 && ReaimTransferSynthesizer.TrySynthesizeTransfer(
                         launchBody, targetBody, departureUT, tof, progradeWanted,
-                        out transferOrbit, out soiEntryUT, out encounterBody, out failReason))
+                        out transferOrbit, out soiEntryUT, out encounterBody,
+                        out escapeOrbit, out captureOrbit,
+                        out launchSoiExitUT, out targetSoiEntryUT, out failReason))
                 {
                     usedTofSeconds = tof;
                     break;
@@ -228,6 +238,26 @@ namespace Parsek.Reaim
             // segment's phase matches the recorded-span playback clock: at recorded-span
             // RecordedDepartureUT the orbit sits where it was at absolute departureUT.
             transferSeg = ReaimSegmentAssembler.ShiftInTime(transferSeg, shift);
+
+            // STEP 4 (uniform shift): the escape + capture legs were built against the SAME live-clock window
+            // (launchSoiExitUT / targetSoiEntryUT are absolute live-frame UTs of the same solve as
+            // departureUT), so the SAME `shift` moves all three legs into recorded-span time, preserving
+            // each leg's per-leg phase AND their relative phase (proven by the pure
+            // UniformShift_PreservesPerLegPhaseAndSeamContiguity test). A leg that failed to build (null
+            // Orbit) stays null and the assembler fails that SIDE closed (the recorded escape/capture
+            // verbatim). The escape leg is launch-body-relative, the capture leg target-body-relative.
+            OrbitSegment? escapeSeg = null;
+            OrbitSegment? captureSeg = null;
+            if (escapeOrbit != null)
+            {
+                OrbitSegment e = ReaimOrbitSegmentConverter.ToSegment(escapeOrbit, plan.LaunchBody);
+                escapeSeg = ReaimSegmentAssembler.ShiftInTime(e, shift);
+            }
+            if (captureOrbit != null)
+            {
+                OrbitSegment cap = ReaimOrbitSegmentConverter.ToSegment(captureOrbit, plan.TargetBody);
+                captureSeg = ReaimSegmentAssembler.ShiftInTime(cap, shift);
+            }
 
             // Heliocentric-PARK re-phase (Increment 1, departure-side render). A two-burn departure escapes
             // into a Sun-inertial PARKING orbit BEFORE the trans-target burn. That park renders verbatim at
@@ -274,14 +304,23 @@ namespace Parsek.Reaim
             // Gate ONLY the assembler call on the reaimChainSynthesis flag (default OFF -> identity path).
             // The flag must not gate the Supported / no-helio-leg / parked guards, the faithful/declined
             // return, or the ReferenceEquals(effective, recorded) no-op contract above; it only chooses
-            // between today's single-leg replacement (OFF) and the P3 chain synthesis (ON, currently a
-            // placeholder returning the same result). The #1167 parkDeltaLonDeg re-phase is threaded
-            // through AssembleWindowChain to ReplaceHeliocentricLeg unchanged. See ReaimChainSynthesis.
+            // between today's single-leg replacement (OFF) and the P3 chain synthesis (ON). When ON,
+            // AssembleWindowChain splices the synth escape + transfer + capture legs contiguously into the
+            // recorded segments (ReaimSegmentAssembler.ReplaceTransferChain), failing CLOSED to today's
+            // heliocentric-only baseline on ANY synthesis failure (all-or-nothing). Index spans + the
+            // capture-side / escape-side fail-closed flags come from the classifier (plan); the escape /
+            // capture legs are the v1/v2-derived body-relative legs shifted into recorded-span time above.
+            // The #1167 parkDeltaLonDeg re-phase is threaded through unchanged. See ReaimChainSynthesis.
             List<OrbitSegment> assembled = ReaimSegmentAssembler.AssembleWindowChain(
                 ReaimChainSynthesis.IsEnabled,
                 memberSegments, transferSeg, plan.CommonAncestor,
                 plan.RecordedDepartureUT, plan.RecordedArrivalUT,
-                double.NaN, double.NaN, parkDeltaLonDeg);
+                double.NaN, double.NaN, parkDeltaLonDeg,
+                escapeSeg, captureSeg,
+                plan.LaunchBody, plan.TargetBody,
+                plan.EscapeRunStartUT, plan.EscapeRunEndUT,
+                plan.FirstCaptureStartUT, plan.FirstCaptureEndUT,
+                plan.EscapeRunIsParkingOnly, plan.CaptureSynthesizable);
             if (assembled == null || assembled.Count == 0)
             {
                 ParsekLog.Warn("ReaimPlayback",

--- a/Source/Parsek/Reaim/ReaimPlaybackResolver.cs
+++ b/Source/Parsek/Reaim/ReaimPlaybackResolver.cs
@@ -239,24 +239,34 @@ namespace Parsek.Reaim
             // RecordedDepartureUT the orbit sits where it was at absolute departureUT.
             transferSeg = ReaimSegmentAssembler.ShiftInTime(transferSeg, shift);
 
-            // STEP 4 (uniform shift): the escape + capture legs were built against the SAME live-clock window
-            // (launchSoiExitUT / targetSoiEntryUT are absolute live-frame UTs of the same solve as
-            // departureUT), so the SAME `shift` moves all three legs into recorded-span time, preserving
-            // each leg's per-leg phase AND their relative phase (proven by the pure
-            // UniformShift_PreservesPerLegPhaseAndSeamContiguity test). A leg that failed to build (null
-            // Orbit) stays null and the assembler fails that SIDE closed (the recorded escape/capture
-            // verbatim). The escape leg is launch-body-relative, the capture leg target-body-relative.
+            // STEP 4 (phase pin, reaim-fix-plan rework finding B): the escape + capture legs are shifted so
+            // their SOI-crossing MOMENT lands exactly on the recorded-span run boundary the assembler tiles
+            // against - the escape SOI-EXIT on RecordedDepartureUT (the transfer-run start) and the capture
+            // SOI-ENTRY on RecordedArrivalUT (the heliocentric->capture boundary the loop clock compresses).
+            // ShiftInTime moves startUT/endUT/epoch together, so the leg's geometry (its periapsis, its SOI
+            // crossing) rides the shift; pinning by the CROSSING moment keeps the leg's phase intact while
+            // placing the crossing where the assembler stamps the render window. This replaces the earlier
+            // force-overwrite of capture.startUT = recordedArrivalUT (which moved the render bound WITHOUT
+            // moving the epoch, so the leg was sampled at a UT offset from its true SOI crossing - a phase
+            // error along the leg). The leg's natural crossing UT is launchSoiExitUT / targetSoiEntryUT
+            // (absolute live frame); the pin shift is therefore (recorded boundary - natural crossing UT),
+            // which subsumes the `shift` above. A leg that failed to build (null Orbit) stays null and the
+            // assembler fails that SIDE closed (the recorded escape/capture verbatim).
             OrbitSegment? escapeSeg = null;
             OrbitSegment? captureSeg = null;
-            if (escapeOrbit != null)
+            if (escapeOrbit != null && !double.IsNaN(launchSoiExitUT))
             {
                 OrbitSegment e = ReaimOrbitSegmentConverter.ToSegment(escapeOrbit, plan.LaunchBody);
-                escapeSeg = ReaimSegmentAssembler.ShiftInTime(e, shift);
+                // Pin the escape SOI-EXIT moment to the recorded transfer-run start (escape.endUT).
+                double escapePinShift = plan.RecordedDepartureUT - launchSoiExitUT;
+                escapeSeg = ReaimSegmentAssembler.ShiftInTime(e, escapePinShift);
             }
-            if (captureOrbit != null)
+            if (captureOrbit != null && !double.IsNaN(targetSoiEntryUT))
             {
                 OrbitSegment cap = ReaimOrbitSegmentConverter.ToSegment(captureOrbit, plan.TargetBody);
-                captureSeg = ReaimSegmentAssembler.ShiftInTime(cap, shift);
+                // Pin the capture SOI-ENTRY moment to the recorded arrival boundary (capture.startUT).
+                double capturePinShift = plan.RecordedArrivalUT - targetSoiEntryUT;
+                captureSeg = ReaimSegmentAssembler.ShiftInTime(cap, capturePinShift);
             }
 
             // Heliocentric-PARK re-phase (Increment 1, departure-side render). A two-burn departure escapes

--- a/Source/Parsek/Reaim/ReaimSegmentAssembler.cs
+++ b/Source/Parsek/Reaim/ReaimSegmentAssembler.cs
@@ -272,41 +272,56 @@ namespace Parsek.Reaim
         }
 
         /// <summary>
-        /// Flag dispatcher for the re-aim whole-chain synthesis fix (reaim-fix-plan.md, option 3 / P1).
+        /// Flag dispatcher for the re-aim whole-chain synthesis fix (reaim-fix-plan.md, option 3 / P1+P3).
         /// This is the PURE seam the <c>reaimChainSynthesis</c> feature flag gates so the flag-OFF
         /// byte-identical proof is runnable in xUnit (the live <c>BuildWindowSegments</c> is Unity-bound
         /// and cannot run headless).
         ///
         /// <para>When <paramref name="useChain"/> is <c>false</c> this returns EXACTLY
         /// <see cref="ReplaceHeliocentricLeg"/>'s output (the identity path: today's single-leg
-        /// heliocentric replacement, byte-identical to the baseline). When <c>true</c> it CURRENTLY also
-        /// returns <see cref="ReplaceHeliocentricLeg"/> - a placeholder for the P3 chain synthesis
-        /// (escape + transfer + capture). Until P3 lands, flag ON and flag OFF are identical, so turning
-        /// the flag on changes no behavior yet. Same purity contract as
-        /// <see cref="ReplaceHeliocentricLeg"/>: operates on copied OrbitSegment value structs, never
-        /// writes back to <paramref name="memberSegments"/> / the recording / the .prec.</para>
+        /// heliocentric replacement, byte-identical to the baseline). When <c>true</c> it calls the P3
+        /// <see cref="ReplaceTransferChain"/> (escape + transfer + capture spliced contiguously into the
+        /// recorded segments). <see cref="ReplaceTransferChain"/> is ALL-OR-NOTHING fail-closed: on any
+        /// synthesis failure (missing legs, NaN spans, a UT-tiling fault, no heliocentric leg in the
+        /// member) it returns null and THIS method falls back to <see cref="ReplaceHeliocentricLeg"/>'s
+        /// result, so the chain path is never worse than today's baseline (reaim-fix-plan.md "Fallback
+        /// chain"). When the chain inputs are absent (the legacy/placeholder call shape with no
+        /// <paramref name="escapeSeg"/>/<paramref name="captureSeg"/>/spans), <see cref="ReplaceTransferChain"/>
+        /// returns null and the ON path stays byte-identical to OFF - the same contract P1 shipped.</para>
+        ///
+        /// <para>Same purity contract as <see cref="ReplaceHeliocentricLeg"/>: operates on copied
+        /// OrbitSegment value structs, never writes back to <paramref name="memberSegments"/> / the
+        /// recording / the .prec. <paramref name="parkDeltaLonDeg"/> (#1167 live-frame park re-phase,
+        /// default 0 = no rotation) is forwarded unchanged on BOTH branches so gating the flag never
+        /// silently drops the re-phase.</para>
         /// </summary>
-        // TODO P3: when useChain is true, call the new ReplaceTransferChain(...) instead of
-        // ReplaceHeliocentricLeg(...). ReplaceTransferChain synthesizes the escape + transfer + capture
-        // legs from the single Lambert solve's v1/v2 and tiles them contiguously into the recorded
-        // segments (see reaim-fix-plan.md STEP 0-5 + the P2/P3 phases). On any synthesis failure it must
-        // fall back to ReplaceHeliocentricLeg (all-or-nothing fail-closed). For now the ON path is a no-op
-        // placeholder returning the identical result so P1 ships a default-OFF flag with zero behavior
-        // change.
-        // parkDeltaLonDeg (#1167 live-frame park re-phase, default 0 = no rotation) is forwarded unchanged
-        // to ReplaceHeliocentricLeg on BOTH branches so gating the flag never silently drops the re-phase;
-        // the future P3 ReplaceTransferChain must keep threading it.
         internal static List<OrbitSegment> AssembleWindowChain(
             bool useChain,
             IReadOnlyList<OrbitSegment> memberSegments, OrbitSegment transferSegment,
             string commonAncestor, double recordedDepartureUT, double recordedArrivalUT,
             double transferRenderStartUT, double transferRenderEndUT,
-            double parkDeltaLonDeg = 0.0)
+            double parkDeltaLonDeg = 0.0,
+            OrbitSegment? escapeSeg = null, OrbitSegment? captureSeg = null,
+            string launchBody = null, string targetBody = null,
+            double escapeRunStartUT = double.NaN, double escapeRunEndUT = double.NaN,
+            double firstCaptureStartUT = double.NaN, double firstCaptureEndUT = double.NaN,
+            bool escapeRunIsParkingOnly = false, bool captureSynthesizable = false)
         {
             if (useChain)
             {
-                // P3 placeholder: same result as the identity path until ReplaceTransferChain lands. Keeps
-                // flag ON behavior-identical to flag OFF in this phase (no actual chain synthesis yet).
+                // P3 chain synthesis. ALL-OR-NOTHING: on any failure (null result) fall back to today's
+                // heliocentric-only baseline - the chain is never worse than the single-honest-kink baseline.
+                List<OrbitSegment> chain = ReplaceTransferChain(
+                    memberSegments, escapeSeg, transferSegment, captureSeg,
+                    commonAncestor, launchBody, targetBody,
+                    recordedDepartureUT, recordedArrivalUT,
+                    escapeRunStartUT, escapeRunEndUT,
+                    firstCaptureStartUT, firstCaptureEndUT,
+                    escapeRunIsParkingOnly, captureSynthesizable, parkDeltaLonDeg);
+                if (chain != null && chain.Count > 0)
+                    return chain;
+
+                // Fall through to the heliocentric-only baseline (parkDeltaLonDeg forwarded).
                 return ReplaceHeliocentricLeg(
                     memberSegments, transferSegment, commonAncestor,
                     recordedDepartureUT, recordedArrivalUT,
@@ -318,6 +333,194 @@ namespace Parsek.Reaim
                 memberSegments, transferSegment, commonAncestor,
                 recordedDepartureUT, recordedArrivalUT,
                 transferRenderStartUT, transferRenderEndUT, parkDeltaLonDeg);
+        }
+
+        /// <summary>
+        /// P3 whole-chain synthesis (reaim-fix-plan.md STEP 3/4/5). Returns a copy of
+        /// <paramref name="memberSegments"/> with the recorded ESCAPE run, heliocentric TRANSFER run, and
+        /// FIRST CAPTURE leg REPLACED by the three pre-built synthesized legs (already shifted into
+        /// recorded-span time by the live caller), spliced in with re-stamped CONTIGUOUS recorded-span UTs
+        /// so the legs tile zero-gap into the surrounding verbatim recorded segments (circular parking,
+        /// recorded heliocentric park, Ike thread, re-capture, descent, debris). The full-span render is
+        /// then correct (each synth leg covers its own recorded span with real body-relative geometry), so
+        /// there is NO center-vs-SOI gap to trim and the reverted launch-side trim is NOT reintroduced
+        /// (guarantee 7).
+        ///
+        /// <para>FAIL-CLOSED, ALL-OR-NOTHING (returns null =&gt; the caller uses today's
+        /// <see cref="ReplaceHeliocentricLeg"/> baseline):
+        /// <list type="bullet">
+        /// <item>no transfer leg could be selected (the member has no heliocentric leg in the window),</item>
+        /// <item>any required recorded-span boundary UT is NaN / non-finite / mis-ordered,</item>
+        /// <item>the synth transfer leg is the seam everything pins to and MUST be present (the caller's
+        /// resolver only reaches here after the transfer synthesized).</item>
+        /// </list></para>
+        ///
+        /// <para>CAPTURE-SIDE FAIL-CLOSED (reaim-fix-plan.md "Capture-side fail-closed"): when
+        /// <paramref name="captureSynthesizable"/> is false (Ike-thread / secondary-SOI / atmospheric-direct
+        /// arrival) OR <paramref name="captureSeg"/> is null, the ESCAPE + TRANSFER legs are synthesized and
+        /// the recorded capture / arrival run is kept VERBATIM (byte-identical to the baseline arrival), so
+        /// an Ike-threaded arrival never renders worse than today. The escape-side improvement still ships.</para>
+        ///
+        /// <para>ESCAPE-SIDE (reaim-fix-plan.md STEP 3): when <paramref name="escapeRunIsParkingOnly"/> is
+        /// true (a direct SOI exit with no separately-recorded escape hyperbola) OR <paramref name="escapeSeg"/>
+        /// is null, the escape run is kept VERBATIM (no escape leg synthesized) and only the transfer (and
+        /// the capture, when synthesizable) are spliced. The recorded circular parking orbit is always kept
+        /// verbatim; the escape leg is anchored at the recorded launch-body SOI-exit STATE (velocity-only,
+        /// built from v1 by the live caller), so the parking-&gt;escape seam stays at the SOI edge.</para>
+        ///
+        /// <para>Pure (no Unity); the recorded escape/capture/parking structs are read-only inputs, written
+        /// only into the returned copy. Sorts + coalesces exactly like <see cref="ReplaceHeliocentricLeg"/>;
+        /// <paramref name="parkDeltaLonDeg"/> re-phases the recorded heliocentric PARK identically.</para>
+        /// </summary>
+        internal static List<OrbitSegment> ReplaceTransferChain(
+            IReadOnlyList<OrbitSegment> memberSegments,
+            OrbitSegment? escapeSeg, OrbitSegment transferSegment, OrbitSegment? captureSeg,
+            string commonAncestor, string launchBody, string targetBody,
+            double recordedDepartureUT, double recordedArrivalUT,
+            double escapeRunStartUT, double escapeRunEndUT,
+            double firstCaptureStartUT, double firstCaptureEndUT,
+            bool escapeRunIsParkingOnly, bool captureSynthesizable,
+            double parkDeltaLonDeg = 0.0)
+        {
+            if (memberSegments == null || string.IsNullOrEmpty(commonAncestor))
+                return null;
+            // The transfer window must be a sane, ordered recorded-span interval (the seam everything pins
+            // to). NaN / non-finite / mis-ordered bounds => fail closed to the baseline.
+            if (double.IsNaN(recordedDepartureUT) || double.IsInfinity(recordedDepartureUT)
+                || double.IsNaN(recordedArrivalUT) || double.IsInfinity(recordedArrivalUT)
+                || !(recordedDepartureUT < recordedArrivalUT))
+                return null;
+
+            // Decide which sides actually synthesize. The escape side is synthesized only when an escape
+            // leg was built AND the launch-body predecessor of the heliocentric leg is a real escape
+            // hyperbola (not the circular parking orbit) with a sane recorded-span run. The capture side is
+            // synthesized only when CaptureSynthesizable (no Ike-thread / atmospheric-direct) AND a capture
+            // leg was built AND its recorded-span first-capture span is sane.
+            bool synthEscape = escapeSeg.HasValue && !escapeRunIsParkingOnly
+                && !string.IsNullOrEmpty(launchBody)
+                && IsFiniteOrderedSpan(escapeRunStartUT, escapeRunEndUT)
+                // The escape run must end at the transfer-run start (a co-located handoff, within a generous
+                // burn tolerance); otherwise a recorded park sits between escape and transfer and the escape
+                // leg's end is not the SOI-exit -> keep escape verbatim (STEP 3 co-location gate).
+                && System.Math.Abs(escapeRunEndUT - recordedDepartureUT) <= EscapeHandoffToleranceSeconds;
+
+            bool synthCapture = captureSeg.HasValue && captureSynthesizable
+                && !string.IsNullOrEmpty(targetBody)
+                && IsFiniteOrderedSpan(firstCaptureStartUT, firstCaptureEndUT)
+                // STEP 4: the synth capture's SOI-entry is pinned to recordedArrivalUT (the
+                // heliocentric->capture boundary the loop clock compresses). The recorded first-capture
+                // leg must begin at that boundary (within tolerance) or the pin would tear the tiling.
+                && System.Math.Abs(firstCaptureStartUT - recordedArrivalUT) <= EscapeHandoffToleranceSeconds;
+
+            var result = new List<OrbitSegment>(memberSegments.Count + 1);
+            bool transferReplaced = false;
+            bool escapeReplaced = false;
+            bool captureReplaced = false;
+
+            for (int i = 0; i < memberSegments.Count; i++)
+            {
+                OrbitSegment s = memberSegments[i];
+
+                // (1) Heliocentric (Sun) leg in the transfer window -> the synth transfer. Further
+                //     in-window heliocentric coasts collapse into the one arc.
+                bool isHelioInWindow = !s.isPredicted && s.bodyName == commonAncestor
+                    && s.startUT < recordedArrivalUT && s.endUT > recordedDepartureUT;
+                if (isHelioInWindow)
+                {
+                    if (!transferReplaced)
+                    {
+                        OrbitSegment transfer = transferSegment;
+                        transfer.startUT = recordedDepartureUT;
+                        transfer.endUT = recordedArrivalUT;
+                        transfer.bodyName = commonAncestor;
+                        transfer.isPredicted = false;
+                        result.Add(transfer);
+                        transferReplaced = true;
+                    }
+                    continue;
+                }
+
+                // (2) Escape run (launch-body) -> the synth escape leg (only when synthesizing the escape
+                //     side). Further escape-run hyperbolae collapse into the one leg.
+                bool isEscapeRun = synthEscape && !s.isPredicted && s.bodyName == launchBody
+                    && s.startUT < escapeRunEndUT && s.endUT > escapeRunStartUT;
+                if (isEscapeRun)
+                {
+                    if (!escapeReplaced)
+                    {
+                        OrbitSegment escape = escapeSeg.Value;
+                        escape.startUT = escapeRunStartUT;
+                        escape.endUT = escapeRunEndUT;
+                        escape.bodyName = launchBody;
+                        escape.isPredicted = false;
+                        result.Add(escape);
+                        escapeReplaced = true;
+                    }
+                    continue;
+                }
+
+                // (3) First capture leg (target-body) -> the synth capture leg (only when synthesizing the
+                //     capture side). Only the FIRST capture leg is replaced; everything after it (Ike,
+                //     re-capture, descent) stays verbatim (it falls outside the first-capture span).
+                bool isFirstCapture = synthCapture && !s.isPredicted && s.bodyName == targetBody
+                    && s.startUT < firstCaptureEndUT && s.endUT > firstCaptureStartUT;
+                if (isFirstCapture)
+                {
+                    if (!captureReplaced)
+                    {
+                        OrbitSegment capture = captureSeg.Value;
+                        capture.startUT = recordedArrivalUT; // STEP 4: pin SOI-entry to the compressed-clock arrival boundary
+                        capture.endUT = firstCaptureEndUT;
+                        capture.bodyName = targetBody;
+                        capture.isPredicted = false;
+                        result.Add(capture);
+                        captureReplaced = true;
+                    }
+                    continue;
+                }
+
+                // (4) Everything else passes through verbatim. The recorded heliocentric PARK (a
+                //     non-predicted common-ancestor coast ENDING at/before the burn) is re-phased into the
+                //     live frame identically to ReplaceHeliocentricLeg; the body-relative legs and predicted
+                //     tails are never rotated. parkDeltaLonDeg == 0 leaves every segment byte-identical.
+                if (parkDeltaLonDeg != 0.0 && !s.isPredicted && s.bodyName == commonAncestor
+                    && s.endUT <= recordedDepartureUT + 1.0)
+                    result.Add(RotateLanForParkRephase(s, parkDeltaLonDeg));
+                else
+                    result.Add(s);
+            }
+
+            // The transfer leg is the seam everything pins to; if the member carried no heliocentric leg in
+            // the window there is nothing to synthesize -> fail closed to the baseline (the heliocentric-only
+            // ReplaceHeliocentricLeg returns null for the same member, so the caller stays faithful).
+            if (!transferReplaced)
+                return null;
+
+            result.Sort((a, b) => a.startUT.CompareTo(b.startUT));
+            // Coalesce the recorder's same-orbit fragments exactly as ReplaceHeliocentricLeg (loop-only,
+            // in-memory; the recorded data is never touched). Do NOT modify CoalesceSameOrbitFragments.
+            return TrajectoryMath.CoalesceSameOrbitFragments(result);
+        }
+
+        /// <summary>
+        /// Tolerance (seconds) for the recorded-span handoffs the chain pins to: the escape run must END at
+        /// the transfer-run START (the launch SOI-exit handoff) and the recorded first capture must BEGIN at
+        /// the transfer-run END (the target SOI-entry the STEP 4 pin lands on). The recorder leaves small
+        /// inter-segment sampling gaps at recording-mode / segment transitions (the Duna One topology shows
+        /// sub-100s gaps), so a generous-but-bounded burn-scale tolerance keeps the co-location gate from
+        /// false-failing on a sampling artifact while still rejecting a recorded PARK (hours/days) sitting
+        /// between the escape and the transfer (which would move the seam off the SOI edge).
+        /// </summary>
+        internal const double EscapeHandoffToleranceSeconds = 3600.0;
+
+        /// <summary>True when <paramref name="startUT"/> / <paramref name="endUT"/> are finite and ordered
+        /// (start &lt; end). Pure helper for the chain-run span guards.</summary>
+        internal static bool IsFiniteOrderedSpan(double startUT, double endUT)
+        {
+            if (double.IsNaN(startUT) || double.IsInfinity(startUT)
+                || double.IsNaN(endUT) || double.IsInfinity(endUT))
+                return false;
+            return startUT < endUT;
         }
     }
 }

--- a/Source/Parsek/Reaim/ReaimSegmentAssembler.cs
+++ b/Source/Parsek/Reaim/ReaimSegmentAssembler.cs
@@ -449,6 +449,9 @@ namespace Parsek.Reaim
                     if (!escapeReplaced)
                     {
                         OrbitSegment escape = escapeSeg.Value;
+                        // The caller phase-pinned the escape SOI-EXIT moment to RecordedDepartureUT (==
+                        // escapeRunEndUT within tolerance) via ShiftInTime, so the epoch already places the
+                        // SOI exit here; these stamp only the RENDER WINDOW over the recorded escape run.
                         escape.startUT = escapeRunStartUT;
                         escape.endUT = escapeRunEndUT;
                         escape.bodyName = launchBody;
@@ -469,7 +472,12 @@ namespace Parsek.Reaim
                     if (!captureReplaced)
                     {
                         OrbitSegment capture = captureSeg.Value;
-                        capture.startUT = recordedArrivalUT; // STEP 4: pin SOI-entry to the compressed-clock arrival boundary
+                        // STEP 4: the caller phase-pinned the capture SOI-ENTRY moment to RecordedArrivalUT
+                        // (the compressed-clock arrival boundary) via ShiftInTime, so the epoch already
+                        // places the SOI entry here; these stamp only the RENDER WINDOW over the recorded
+                        // first-capture leg. (Earlier this force-overwrote startUT WITHOUT moving the epoch,
+                        // a phase error along the leg - fixed in the resolver's capturePinShift.)
+                        capture.startUT = recordedArrivalUT;
                         capture.endUT = firstCaptureEndUT;
                         capture.bodyName = targetBody;
                         capture.isPredicted = false;

--- a/Source/Parsek/Reaim/ReaimTransferSynthesizer.cs
+++ b/Source/Parsek/Reaim/ReaimTransferSynthesizer.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Globalization;
 
 namespace Parsek.Reaim
@@ -94,11 +95,17 @@ namespace Parsek.Reaim
             CelestialBody launchBody, CelestialBody targetBody, double departureUT, double tofSeconds,
             bool prograde,
             out Orbit transferOrbit, out double soiEntryUT, out CelestialBody encounterBody,
+            out Orbit escapeOrbit, out Orbit captureOrbit,
+            out double launchSoiExitUT, out double targetSoiEntryUT,
             out string failReason)
         {
             transferOrbit = null;
             soiEntryUT = double.NaN;
             encounterBody = null;
+            escapeOrbit = null;
+            captureOrbit = null;
+            launchSoiExitUT = double.NaN;
+            targetSoiEntryUT = double.NaN;
             failReason = null;
 
             if (launchBody == null || targetBody == null)
@@ -163,7 +170,13 @@ namespace Parsek.Reaim
             Vector3d launchPlaneNormal = Vector3d.Cross(
                 r1, launchBody.orbit.getOrbitalVelocityAtUT(departureUT).xzy);
 
-            if (!TransferSolver.Solve(mu, r1, r2, tofSeconds, prograde, launchPlaneNormal, out Vector3d v1, out _))
+            // Capture BOTH endpoint velocities: v1 (heliocentric departure) builds the escape leg, v2
+            // (heliocentric arrival) builds the first-capture leg - the SAME single Lambert solve feeds
+            // both SOI legs so the chain is continuous (reaim-fix-plan.md STEP 0). The ITransferSolver /
+            // UvLambert already return v2; no signature change there. r1/r2 are un-swizzled (.xzy) world,
+            // so v1/v2 are too.
+            if (!TransferSolver.Solve(mu, r1, r2, tofSeconds, prograde, launchPlaneNormal,
+                    out Vector3d v1, out Vector3d v2))
             {
                 failReason = "lambert no solution (degenerate geometry / non-convergence)";
                 return false;
@@ -208,35 +221,191 @@ namespace Parsek.Reaim
             PatchedConics.CalculatePatch(
                 transfer, nextPatch, departureUT, new PatchedConics.SolverParameters(), targetBody);
 
+            string encounterPath = null;
             if (transfer.patchEndTransition == Orbit.PatchTransitionType.ENCOUNTER
                 && transfer.closestEncounterBody == targetBody)
             {
-                transferOrbit = transfer;
                 soiEntryUT = transfer.UTsoi;
-                encounterBody = targetBody;
-                LogSynthGeometry(transfer, launchBody, targetBody, departureUT, arrivalUT, soiEntryUT, "patched-conic");
-                return true;
+                encounterPath = "patched-conic";
             }
-
-            // CalculatePatch resolved to the LAUNCH body instead (or did not promote an encounter): the
-            // heliocentric transfer STARTS at the launch body's position (inside its SOI), so the first
-            // patch is that launch-SOI transition, which masks the downstream target encounter. The
-            // Lambert solution passes through the target's exact position at arrivalUT BY CONSTRUCTION, so
-            // validate the encounter DIRECTLY by proximity: sample the transfer-to-target distance over
-            // the leg and accept if it comes within the target's SOI. Robust to the launch-SOI masking.
-            if (TryFindTargetEncounterByProximity(transfer, targetBody, departureUT, arrivalUT, out double geomSoiUT))
+            else if (TryFindTargetEncounterByProximity(transfer, targetBody, departureUT, arrivalUT, out double geomSoiUT))
             {
-                transferOrbit = transfer;
+                // CalculatePatch resolved to the LAUNCH body instead (or did not promote an encounter): the
+                // heliocentric transfer STARTS at the launch body's position (inside its SOI), so the first
+                // patch is that launch-SOI transition, which masks the downstream target encounter. The
+                // Lambert solution passes through the target's exact position at arrivalUT BY CONSTRUCTION,
+                // so validate the encounter DIRECTLY by proximity: sample the transfer-to-target distance
+                // over the leg and accept if it comes within the target's SOI. Robust to the launch-SOI
+                // masking.
                 soiEntryUT = geomSoiUT;
-                encounterBody = targetBody;
-                LogSynthGeometry(transfer, launchBody, targetBody, departureUT, arrivalUT, soiEntryUT, "proximity");
-                return true;
+                encounterPath = "proximity";
+            }
+            else
+            {
+                failReason = $"no target encounter (transition={transfer.patchEndTransition} " +
+                             $"closest={(transfer.closestEncounterBody != null ? transfer.closestEncounterBody.bodyName : "<none>")}; " +
+                             $"proximity check also failed)";
+                return false;
             }
 
-            failReason = $"no target encounter (transition={transfer.patchEndTransition} " +
-                         $"closest={(transfer.closestEncounterBody != null ? transfer.closestEncounterBody.bodyName : "<none>")}; " +
-                         $"proximity check also failed)";
-            return false;
+            transferOrbit = transfer;
+            encounterBody = targetBody;
+            LogSynthGeometry(transfer, launchBody, targetBody, departureUT, arrivalUT, soiEntryUT, encounterPath);
+
+            // Build the two SOI legs from the SAME Lambert solve (reaim-fix-plan.md STEP 1/2). These are
+            // best-effort: a leg that cannot converge a sane conic leaves its out-Orbit null + its UT NaN,
+            // and the P3 assembler falls back accordingly (all-or-nothing fail-closed at the chain level).
+            // The transfer encounter itself already succeeded, so the heliocentric-only baseline is always
+            // available even when neither leg builds.
+            captureOrbit = TryBuildCaptureLeg(transfer, targetBody, v2, soiEntryUT, departureUT, arrivalUT,
+                out targetSoiEntryUT);
+            escapeOrbit = TryBuildEscapeLeg(transfer, launchBody, v1, departureUT, arrivalUT,
+                out launchSoiExitUT);
+            LogChainLegs(launchBody, targetBody, escapeOrbit, captureOrbit, launchSoiExitUT, targetSoiEntryUT);
+            return true;
+        }
+
+        // Diagnostic: log the two synthesized SOI legs (escape launch-body-relative, capture
+        // target-relative) + their refined SOI-crossing UTs, so a corrupted leg (a swizzle error, a missed
+        // bisection) is caught at the source before P3 assembles the chain. A null leg logs "(fail-closed)"
+        // so the all-or-nothing fallback reason is visible. Verbose, one-shot per window resolve (the
+        // resolver caches the window) - mirrors LogSynthGeometry's level.
+        private static void LogChainLegs(
+            CelestialBody launchBody, CelestialBody targetBody,
+            Orbit escapeOrbit, Orbit captureOrbit, double launchSoiExitUT, double targetSoiEntryUT)
+        {
+            var ic = CultureInfo.InvariantCulture;
+            string esc = escapeOrbit == null
+                ? "(fail-closed)"
+                : $"sma={escapeOrbit.semiMajorAxis.ToString("R", ic)} ecc={escapeOrbit.eccentricity.ToString("F4", ic)}";
+            string cap = captureOrbit == null
+                ? "(fail-closed)"
+                : $"sma={captureOrbit.semiMajorAxis.ToString("R", ic)} ecc={captureOrbit.eccentricity.ToString("F4", ic)}";
+            ParsekLog.Verbose("ReaimSeam",
+                $"chain legs: escape@{launchBody.bodyName} {esc} launchSoiExitUT={launchSoiExitUT.ToString("F0", ic)} | " +
+                $"capture@{targetBody.bodyName} {cap} targetSoiEntryUT={targetSoiEntryUT.ToString("F0", ic)}");
+        }
+
+        // The fractional tolerance (of the body SOI radius) the SOI-crossing bisection refines to. 1e-4 of
+        // the SOI radius is far tighter than the in-SOI handoff seams the playtest already tolerates while
+        // staying well above floating-point noise on the sampled positions.
+        internal const double SoiBisectionToleranceFraction = 1e-4;
+
+        // Builds the first-capture leg (target-relative hyperbola) from the heliocentric arrival velocity v2
+        // (reaim-fix-plan.md STEP 1, state-vector PRIMARY path). Bisects the target SOI-sphere crossing
+        // around the resolved soiEntryUT, then constructs a target-relative Orbit from the body-relative
+        // state at that UT. Mirrors the transfer build's .xzy round-trip EXACTLY (un-swizzle to difference
+        // in one world frame, re-swizzle for UpdateFromStateVectors). v2 is in the SAME un-swizzled frame
+        // as r1/r2. Returns null (with refinedEntryUT = the raw soiEntryUT) on a degenerate result; the
+        // caller / assembler then fails the capture side closed. Live (Orbit + getOrbital*AtUT).
+        private static Orbit TryBuildCaptureLeg(
+            Orbit transfer, CelestialBody targetBody, Vector3d v2, double soiEntryUT,
+            double departureUT, double arrivalUT, out double refinedEntryUT)
+        {
+            refinedEntryUT = soiEntryUT;
+            if (transfer == null || targetBody == null || targetBody.orbit == null
+                || double.IsNaN(soiEntryUT))
+                return null;
+
+            double soi = targetBody.sphereOfInfluence;
+            // Distance (un-swizzled, consistent frame) from the transfer to the target at a UT.
+            Func<double, double> dist = ut => ReaimChainGeometry.RelativePosition(
+                transfer.getRelativePositionAtUT(ut).xzy,
+                targetBody.orbit.getRelativePositionAtUT(ut).xzy).magnitude;
+
+            // Bisect to the SOI shell. Bracket: soiEntryUT (the proximity scan returned it as inside the
+            // SOI) to arrivalUT (the transfer is aimed at the target center, so by arrivalUT it is well
+            // inside). Walk a tiny step BEFORE soiEntryUT to find an outside sample (the scan's resolution
+            // is ~span/96, so soiEntryUT is the FIRST inside sample - just before it is outside).
+            double span = arrivalUT - departureUT;
+            double step = span > 0.0 ? span / 96.0 : 0.0;
+            double outsideUT = soiEntryUT - step;
+            double tol = (!double.IsNaN(soi) && soi > 0.0) ? soi * SoiBisectionToleranceFraction : double.NaN;
+            if (step > 0.0 && ReaimChainGeometry.TryBisectSoiCrossing(
+                    dist, soi, soiEntryUT, outsideUT, tol, out double crossing))
+                refinedEntryUT = crossing;
+
+            return BuildBodyRelativeLeg(transfer, targetBody, v2, refinedEntryUT);
+        }
+
+        // Builds the escape leg (launch-body-relative hyperbola) from the heliocentric departure velocity v1
+        // (reaim-fix-plan.md STEP 2). The transfer is center-to-center, so just after departureUT it sits
+        // near the launch-body center; walk FORWARD to the launch SOI shell and bisect there, then construct
+        // a launch-body-relative Orbit from the body-relative state at that UT. Same .xzy round-trip + same
+        // fail-closed contract as the capture leg. Returns null (launchSoiExitUT NaN) on a degenerate result.
+        private static Orbit TryBuildEscapeLeg(
+            Orbit transfer, CelestialBody launchBody, Vector3d v1,
+            double departureUT, double arrivalUT, out double launchSoiExitUT)
+        {
+            launchSoiExitUT = double.NaN;
+            if (transfer == null || launchBody == null || launchBody.orbit == null)
+                return null;
+
+            double soi = launchBody.sphereOfInfluence;
+            if (double.IsNaN(soi) || soi <= 0.0)
+                return null;
+            Func<double, double> dist = ut => ReaimChainGeometry.RelativePosition(
+                transfer.getRelativePositionAtUT(ut).xzy,
+                launchBody.orbit.getRelativePositionAtUT(ut).xzy).magnitude;
+
+            // Find an OUTSIDE sample by walking forward from departureUT (inside, near the launch center)
+            // until the distance exceeds the SOI radius, then bisect [insideUT, outsideUT].
+            double span = arrivalUT - departureUT;
+            if (span <= 0.0)
+                return null;
+            const int scan = 96;
+            double dStep = span / scan;
+            double insideUT = departureUT;
+            double foundOutsideUT = double.NaN;
+            for (int i = 1; i <= scan; i++)
+            {
+                double ut = departureUT + dStep * i;
+                if (dist(ut) > soi)
+                {
+                    foundOutsideUT = ut;
+                    break;
+                }
+                insideUT = ut; // still inside the launch SOI -> advance the inside boundary
+            }
+            if (double.IsNaN(foundOutsideUT))
+                return null; // never left the launch SOI within the span -> no escape (fail closed)
+
+            double tol = soi * SoiBisectionToleranceFraction;
+            if (!ReaimChainGeometry.TryBisectSoiCrossing(
+                    dist, soi, insideUT, foundOutsideUT, tol, out launchSoiExitUT))
+                return null;
+
+            return BuildBodyRelativeLeg(transfer, launchBody, v1, launchSoiExitUT);
+        }
+
+        // Shared state-vector construction (reaim-fix-plan.md STEP 1/2): given the heliocentric transfer,
+        // a body, the heliocentric endpoint velocity vHelio (UN-swizzled .xzy frame) and the SOI-crossing
+        // UT, build a body-relative Orbit. Mirrors ReaimTransferSynthesizer.TrySynthesizeTransfer's transfer
+        // build EXACTLY: difference the parent-relative positions and velocities in the UN-swizzled (.xzy)
+        // world frame, then re-swizzle (.xzy is its own inverse) for UpdateFromStateVectors (which expects
+        // swizzled inputs). A dropped/doubled swizzle silently corrupts the orbit - verified in-game by the
+        // canary. Returns null when the resulting conic is degenerate (NaN elements / non-finite sma).
+        private static Orbit BuildBodyRelativeLeg(
+            Orbit transfer, CelestialBody body, Vector3d vHelio, double crossingUT)
+        {
+            if (double.IsNaN(crossingUT) || double.IsInfinity(crossingUT) || body.orbit == null)
+                return null;
+
+            // Un-swizzled, consistent-frame body-relative state at the crossing.
+            Vector3d rRel = ReaimChainGeometry.RelativePosition(
+                transfer.getRelativePositionAtUT(crossingUT).xzy,
+                body.orbit.getRelativePositionAtUT(crossingUT).xzy);
+            Vector3d vRel = ReaimChainGeometry.RelativeVelocity(
+                vHelio,
+                body.orbit.getOrbitalVelocityAtUT(crossingUT).xzy);
+
+            var leg = new Orbit();
+            // Re-swizzle (.xzy) for UpdateFromStateVectors, exactly as the transfer build does.
+            leg.UpdateFromStateVectors(rRel.xzy, vRel.xzy, body, crossingUT);
+            if (double.IsNaN(leg.semiMajorAxis) || double.IsInfinity(leg.semiMajorAxis)
+                || double.IsNaN(leg.eccentricity) || double.IsInfinity(leg.eccentricity))
+                return null;
+            return leg;
         }
 
         // Diagnostic: log the synthesized transfer's geometry against the bodies it must connect, so a

--- a/Source/Parsek/Reaim/ReaimTransferSynthesizer.cs
+++ b/Source/Parsek/Reaim/ReaimTransferSynthesizer.cs
@@ -170,13 +170,14 @@ namespace Parsek.Reaim
             Vector3d launchPlaneNormal = Vector3d.Cross(
                 r1, launchBody.orbit.getOrbitalVelocityAtUT(departureUT).xzy);
 
-            // Capture BOTH endpoint velocities: v1 (heliocentric departure) builds the escape leg, v2
-            // (heliocentric arrival) builds the first-capture leg - the SAME single Lambert solve feeds
-            // both SOI legs so the chain is continuous (reaim-fix-plan.md STEP 0). The ITransferSolver /
-            // UvLambert already return v2; no signature change there. r1/r2 are un-swizzled (.xzy) world,
-            // so v1/v2 are too.
+            // Solve the Lambert problem for the transfer's departure velocity v1 (which builds the Sun-
+            // relative transfer conic below). The arrival velocity v2 is solved too (the ITransferSolver /
+            // UvLambert contract returns both) but is NOT used to build the SOI legs: the escape / capture
+            // legs are built from the transfer's OWN state at the SOI crossings (see TryBuild*Leg /
+            // BuildBodyRelativeLeg), not from the planet-center endpoint velocities. r1/r2 are un-swizzled
+            // (.xzy) world, so v1/v2 are too.
             if (!TransferSolver.Solve(mu, r1, r2, tofSeconds, prograde, launchPlaneNormal,
-                    out Vector3d v1, out Vector3d v2))
+                    out Vector3d v1, out Vector3d _))
             {
                 failReason = "lambert no solution (degenerate geometry / non-convergence)";
                 return false;
@@ -252,16 +253,26 @@ namespace Parsek.Reaim
             encounterBody = targetBody;
             LogSynthGeometry(transfer, launchBody, targetBody, departureUT, arrivalUT, soiEntryUT, encounterPath);
 
-            // Build the two SOI legs from the SAME Lambert solve (reaim-fix-plan.md STEP 1/2). These are
-            // best-effort: a leg that cannot converge a sane conic leaves its out-Orbit null + its UT NaN,
-            // and the P3 assembler falls back accordingly (all-or-nothing fail-closed at the chain level).
-            // The transfer encounter itself already succeeded, so the heliocentric-only baseline is always
-            // available even when neither leg builds.
-            captureOrbit = TryBuildCaptureLeg(transfer, targetBody, v2, soiEntryUT, departureUT, arrivalUT,
-                out targetSoiEntryUT);
-            escapeOrbit = TryBuildEscapeLeg(transfer, launchBody, v1, departureUT, arrivalUT,
-                out launchSoiExitUT);
-            LogChainLegs(launchBody, targetBody, escapeOrbit, captureOrbit, launchSoiExitUT, targetSoiEntryUT);
+            // Build the two SOI legs from the transfer's own state at the SOI crossings (reaim-fix-plan.md
+            // STEP 1/2). These are best-effort: a leg that cannot build a sane conic (the periapsis / ecc
+            // fail-closed gate in BuildBodyRelativeLeg) leaves its out-Orbit null + its UT NaN, and the P3
+            // assembler falls back accordingly (all-or-nothing fail-closed at the chain level). The transfer
+            // encounter itself already succeeded, so the heliocentric-only baseline is always available even
+            // when neither leg builds.
+            //
+            // FLAG-GATED (reaim-fix-plan rework, finding F): the leg construction (two SOI scans + two
+            // bisections + two UpdateFromStateVectors + the chain-legs log) runs ONLY when chain synthesis is
+            // enabled. With the flag OFF the legs stay null + their UTs NaN, so the resolver's AssembleWindowChain
+            // takes the identity (ReplaceHeliocentricLeg) path with no escape/capture inputs - flag-OFF is a
+            // true no-op (no wasted leg math, no 'chain legs:' log line).
+            if (ReaimChainSynthesis.IsEnabled)
+            {
+                captureOrbit = TryBuildCaptureLeg(transfer, targetBody, soiEntryUT, departureUT, arrivalUT,
+                    out targetSoiEntryUT);
+                escapeOrbit = TryBuildEscapeLeg(transfer, launchBody, departureUT, arrivalUT,
+                    out launchSoiExitUT);
+                LogChainLegs(launchBody, targetBody, escapeOrbit, captureOrbit, launchSoiExitUT, targetSoiEntryUT);
+            }
             return true;
         }
 
@@ -291,15 +302,23 @@ namespace Parsek.Reaim
         // staying well above floating-point noise on the sampled positions.
         internal const double SoiBisectionToleranceFraction = 1e-4;
 
-        // Builds the first-capture leg (target-relative hyperbola) from the heliocentric arrival velocity v2
-        // (reaim-fix-plan.md STEP 1, state-vector PRIMARY path). Bisects the target SOI-sphere crossing
-        // around the resolved soiEntryUT, then constructs a target-relative Orbit from the body-relative
-        // state at that UT. Mirrors the transfer build's .xzy round-trip EXACTLY (un-swizzle to difference
-        // in one world frame, re-swizzle for UpdateFromStateVectors). v2 is in the SAME un-swizzled frame
-        // as r1/r2. Returns null (with refinedEntryUT = the raw soiEntryUT) on a degenerate result; the
-        // caller / assembler then fails the capture side closed. Live (Orbit + getOrbital*AtUT).
+        // Builds the first-capture leg (target-relative hyperbola) from the transfer's OWN state at the
+        // target SOI-sphere crossing (reaim-fix-plan.md STEP 1, state-vector PRIMARY path). Refines the
+        // crossing UT by bisection, then constructs a target-relative Orbit (BuildBodyRelativeLeg samples the
+        // transfer position AND velocity at the refined UT). Returns null (with refinedEntryUT = the raw
+        // soiEntryUT) on a degenerate result; the caller / assembler then fails the capture side closed.
+        // Live (Orbit + getRelativePositionAtUT).
+        //
+        // BISECTION BRACKET (reaim-fix-plan rework, finding A): the transfer is aimed at the target CENTER,
+        // so arrivalUT is the DEEPEST-inside sample; walk BACKWARD from arrivalUT to find an OUTSIDE sample
+        // (distance > SOI), then bisect [insideUT=arrivalUT-ish, outsideUT]. The earlier code assumed
+        // soiEntryUT was the FIRST inside sample with one step outside, but on the proximity path soiEntryUT
+        // EQUALS arrivalUT (the scan only got within SOI at its final sample), so soiEntryUT-step was still
+        // INSIDE the SOI -> the straddle guard failed, the bisection no-op'd, and the leg was built at the
+        // planet CENTER (|rRel|~0). Mirroring the escape leg's scan (here reversed: forward = deeper inside)
+        // makes the bracket a genuine inside/outside straddle.
         private static Orbit TryBuildCaptureLeg(
-            Orbit transfer, CelestialBody targetBody, Vector3d v2, double soiEntryUT,
+            Orbit transfer, CelestialBody targetBody, double soiEntryUT,
             double departureUT, double arrivalUT, out double refinedEntryUT)
         {
             refinedEntryUT = soiEntryUT;
@@ -308,33 +327,55 @@ namespace Parsek.Reaim
                 return null;
 
             double soi = targetBody.sphereOfInfluence;
+            if (double.IsNaN(soi) || soi <= 0.0)
+                return null;
             // Distance (un-swizzled, consistent frame) from the transfer to the target at a UT.
             Func<double, double> dist = ut => ReaimChainGeometry.RelativePosition(
                 transfer.getRelativePositionAtUT(ut).xzy,
                 targetBody.orbit.getRelativePositionAtUT(ut).xzy).magnitude;
 
-            // Bisect to the SOI shell. Bracket: soiEntryUT (the proximity scan returned it as inside the
-            // SOI) to arrivalUT (the transfer is aimed at the target center, so by arrivalUT it is well
-            // inside). Walk a tiny step BEFORE soiEntryUT to find an outside sample (the scan's resolution
-            // is ~span/96, so soiEntryUT is the FIRST inside sample - just before it is outside).
             double span = arrivalUT - departureUT;
-            double step = span > 0.0 ? span / 96.0 : 0.0;
-            double outsideUT = soiEntryUT - step;
-            double tol = (!double.IsNaN(soi) && soi > 0.0) ? soi * SoiBisectionToleranceFraction : double.NaN;
-            if (step > 0.0 && ReaimChainGeometry.TryBisectSoiCrossing(
-                    dist, soi, soiEntryUT, outsideUT, tol, out double crossing))
-                refinedEntryUT = crossing;
+            if (span <= 0.0)
+                return null;
 
-            return BuildBodyRelativeLeg(transfer, targetBody, v2, refinedEntryUT);
+            // arrivalUT is the deepest-inside sample (transfer aimed at the target center). Confirm it is
+            // actually inside, then walk BACKWARD toward departureUT to find the first OUTSIDE sample.
+            if (dist(arrivalUT) > soi)
+                return null; // arrival not inside the SOI -> no clean capture geometry (fail closed)
+            const int scan = 96;
+            double dStep = span / scan;
+            double insideUT = arrivalUT;
+            double foundOutsideUT = double.NaN;
+            for (int i = 1; i <= scan; i++)
+            {
+                double ut = arrivalUT - dStep * i;
+                if (ut <= departureUT)
+                    break;
+                if (dist(ut) > soi)
+                {
+                    foundOutsideUT = ut;
+                    break;
+                }
+                insideUT = ut; // still inside the target SOI -> advance the inside boundary backward
+            }
+            double tol = soi * SoiBisectionToleranceFraction;
+            if (!double.IsNaN(foundOutsideUT) && ReaimChainGeometry.TryBisectSoiCrossing(
+                    dist, soi, insideUT, foundOutsideUT, tol, out double crossing))
+                refinedEntryUT = crossing;
+            // else: never found an outside sample within the span -> keep the raw soiEntryUT (the leg sanity
+            // gate in BuildBodyRelativeLeg fails it closed if the resulting conic is degenerate).
+
+            return BuildBodyRelativeLeg(transfer, targetBody, refinedEntryUT);
         }
 
-        // Builds the escape leg (launch-body-relative hyperbola) from the heliocentric departure velocity v1
-        // (reaim-fix-plan.md STEP 2). The transfer is center-to-center, so just after departureUT it sits
-        // near the launch-body center; walk FORWARD to the launch SOI shell and bisect there, then construct
-        // a launch-body-relative Orbit from the body-relative state at that UT. Same .xzy round-trip + same
-        // fail-closed contract as the capture leg. Returns null (launchSoiExitUT NaN) on a degenerate result.
+        // Builds the escape leg (launch-body-relative hyperbola) from the transfer's OWN state at the launch
+        // SOI-sphere crossing (reaim-fix-plan.md STEP 2). The transfer is center-to-center, so just after
+        // departureUT it sits near the launch-body center; walk FORWARD to the launch SOI shell and bisect
+        // there, then construct a launch-body-relative Orbit (BuildBodyRelativeLeg samples the transfer
+        // position AND velocity at that UT). Same .xzy round-trip + same fail-closed contract as the capture
+        // leg. Returns null (launchSoiExitUT NaN) on a degenerate result.
         private static Orbit TryBuildEscapeLeg(
-            Orbit transfer, CelestialBody launchBody, Vector3d v1,
+            Orbit transfer, CelestialBody launchBody,
             double departureUT, double arrivalUT, out double launchSoiExitUT)
         {
             launchSoiExitUT = double.NaN;
@@ -375,35 +416,57 @@ namespace Parsek.Reaim
                     dist, soi, insideUT, foundOutsideUT, tol, out launchSoiExitUT))
                 return null;
 
-            return BuildBodyRelativeLeg(transfer, launchBody, v1, launchSoiExitUT);
+            return BuildBodyRelativeLeg(transfer, launchBody, launchSoiExitUT);
         }
 
         // Shared state-vector construction (reaim-fix-plan.md STEP 1/2): given the heliocentric transfer,
-        // a body, the heliocentric endpoint velocity vHelio (UN-swizzled .xzy frame) and the SOI-crossing
-        // UT, build a body-relative Orbit. Mirrors ReaimTransferSynthesizer.TrySynthesizeTransfer's transfer
-        // build EXACTLY: difference the parent-relative positions and velocities in the UN-swizzled (.xzy)
-        // world frame, then re-swizzle (.xzy is its own inverse) for UpdateFromStateVectors (which expects
-        // swizzled inputs). A dropped/doubled swizzle silently corrupts the orbit - verified in-game by the
-        // canary. Returns null when the resulting conic is degenerate (NaN elements / non-finite sma).
+        // a body, and the SOI-crossing UT, build a body-relative Orbit from the transfer's OWN state at the
+        // crossing. Mirrors ReaimTransferSynthesizer.TrySynthesizeTransfer's transfer build EXACTLY:
+        // difference the parent-relative positions and velocities in the UN-swizzled (.xzy) world frame, then
+        // re-swizzle (.xzy is its own inverse) for UpdateFromStateVectors (which expects swizzled inputs). A
+        // dropped/doubled swizzle silently corrupts the orbit - verified in-game by the canary.
+        //
+        // VELOCITY SOURCE (reaim-fix-plan rework, finding root-cause): the body-relative velocity uses the
+        // transfer's OWN orbital velocity AT crossingUT (transfer.getOrbitalVelocityAtUT(crossingUT)), NOT
+        // the Lambert ENDPOINT velocity v1/v2. v1/v2 are the transfer's velocity at the planet CENTERS
+        // (departureUT / arrivalUT); pairing them with the POSITION sampled at the SOI crossing made the
+        // state vector inconsistent (position from one point on the conic, velocity from another), which
+        // UpdateFromStateVectors reconciled into a garbage hyperbola with periapsis tens of Mm up and ecc
+        // 8-13. Using the transfer's velocity at the SAME UT as the position yields a self-consistent point
+        // on the heliocentric conic, so the body-relative reduction is a real escape/capture state.
+        //
+        // FAIL-CLOSED GATE (reaim-fix-plan.md STEP 2/3, the never-implemented "MEASURE and fail-closed"
+        // step): even with a self-consistent state, the center-to-center transfer's position at the crossing
+        // is not guaranteed to land at a sane parking-orbit periapsis. Reject the leg (return null -> the
+        // assembler keeps the recorded leg verbatim / the chain falls back to today's baseline) unless it is
+        // a real hyperbola anchored at a sane periapsis altitude (ReaimChainGeometry.IsSaneLegConic). This
+        // guarantees flag-ON is NEVER worse than the baseline: a still-wrong leg fails closed, never renders.
         private static Orbit BuildBodyRelativeLeg(
-            Orbit transfer, CelestialBody body, Vector3d vHelio, double crossingUT)
+            Orbit transfer, CelestialBody body, double crossingUT)
         {
-            if (double.IsNaN(crossingUT) || double.IsInfinity(crossingUT) || body.orbit == null)
+            if (transfer == null || body == null
+                || double.IsNaN(crossingUT) || double.IsInfinity(crossingUT) || body.orbit == null)
                 return null;
 
-            // Un-swizzled, consistent-frame body-relative state at the crossing.
+            // Un-swizzled, consistent-frame body-relative state at the crossing. Position AND velocity are
+            // both sampled from the transfer at the SAME crossingUT, so the state is self-consistent.
             Vector3d rRel = ReaimChainGeometry.RelativePosition(
                 transfer.getRelativePositionAtUT(crossingUT).xzy,
                 body.orbit.getRelativePositionAtUT(crossingUT).xzy);
             Vector3d vRel = ReaimChainGeometry.RelativeVelocity(
-                vHelio,
+                transfer.getOrbitalVelocityAtUT(crossingUT).xzy,
                 body.orbit.getOrbitalVelocityAtUT(crossingUT).xzy);
 
             var leg = new Orbit();
             // Re-swizzle (.xzy) for UpdateFromStateVectors, exactly as the transfer build does.
             leg.UpdateFromStateVectors(rRel.xzy, vRel.xzy, body, crossingUT);
-            if (double.IsNaN(leg.semiMajorAxis) || double.IsInfinity(leg.semiMajorAxis)
-                || double.IsNaN(leg.eccentricity) || double.IsInfinity(leg.eccentricity))
+
+            // Periapsis lower bound: the body's surface, or the atmosphere top when it has one (a leg whose
+            // periapsis sits below the atmosphere top clips into the body and is not a real ejection/capture).
+            double minPeriapsisRadius = body.Radius
+                + (body.atmosphere && body.atmosphereDepth > 0.0 ? body.atmosphereDepth : 0.0);
+            if (!ReaimChainGeometry.IsSaneLegConic(
+                    leg.eccentricity, leg.semiMajorAxis, minPeriapsisRadius, body.sphereOfInfluence))
                 return null;
             return leg;
         }


### PR DESCRIPTION
Geometry phases (P2-P4) of the looped re-aim cross-SOI transfer fix, stacked on the merged P0/P1 foundation (#1169). **Default-OFF flag (`reaimChainSynthesis`); flag-OFF is byte-identical to today.**

## Status: regressed in playtest, then fixed + hardened (NOT yet validated in-game)
A flag-ON playtest (Kerbal X #2) rendered **worse** than baseline — the synth escape/capture legs were garbage hyperbolae (ecc 8-13: position sampled at the SOI boundary paired with the Lambert *endpoint* velocity at the planet center). A deep review found that plus 3 more issues. All fixed in the latest commit:

- **Fail-closed leg-sanity gate (the safety net):** new pure `ReaimChainGeometry.IsSaneLegConic` (ecc in [1,3]; periapsis `a(1-e)` in [body surface/atmo, 0.5·SOI]). A leg that fails it → `null` → the assembler keeps the recorded leg verbatim / the chain falls back to `ReplaceHeliocentricLeg`. **The captured ecc-12.9/7.77 garbage both fail the gate, so flag-ON can never render worse than baseline.**
- **Root cause:** `BuildBodyRelativeLeg` now samples velocity via `transfer.getOrbitalVelocityAtUT(crossingUT)` (self-consistent with the position at the same UT), not the endpoint `v1`/`v2`.
- **Capture bisection** walks backward from arrival to a valid inside/outside straddle (proximity path had `soiEntryUT==arrivalUT`).
- **Per-leg phase pin** lands each leg's SOI-crossing on the recorded-span boundary.
- **Flag-OFF is now a true no-op** (leg math + `chain legs:` log gated on the flag).

## What P2-P4 build
- **P2** — capture `v1`/`v2`, synthesize escape/capture legs (pure `ReaimChainGeometry` + SOI bisection), plan spans + `CaptureSynthesizable` (Ike-thread/atmospheric → false).
- **P3** — `ReplaceTransferChain` (contiguous tiling, capture pinned, capture fail-closed on Ike, all-or-nothing fallback), `useChain=true`; STEP 4 re-verified vs merged #1155.
- **P4** — `AssertSaneWindowSegments` drops `Count==3` and now asserts escape AND capture legs are sane hyperbolae; real Ike-threaded E2E fixture + in-game chain tests.

## Validation
Build clean; **15798 passed, 0 failed** (`InjectAllRecordings` excluded as the KSP-lock flake), incl. 9 new `IsSaneLegConic` tests.

**Not yet validated in-game.** The live escape/capture geometry can't be unit-tested headless; it needs a **clean direct (no parking-loiter, no moon-encounter) Kerbin→Duna** looped recording — neither Duna One (threads Ike) nor Kerbal X #2 (heliocentric-parking departure) is a clean case, so both fail closed on at least one side. Until that validation, the fail-closed gate guarantees worst-case == the current baseline. **Do not merge before the clean-mission playtest.**

## Deferred (out of scope, fail closed correctly)
Heliocentric-parking departures and the Ike-threaded (multi-moon) arrival; the center-to-center Lambert premise. Minor: the `UniformShift…` test comment is stale vs the per-leg pin (test still valid).