### PR TITLE
chore: bump version to 0.10.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to Parsek are documented here.
 
 ---
 
+## 0.10.2
+
 ## 0.10.1
 
 ### Features

--- a/GameData/Parsek/Parsek.version
+++ b/GameData/Parsek/Parsek.version
@@ -1,7 +1,7 @@
 {
     "NAME": "Parsek",
     "URL": "https://raw.githubusercontent.com/vl3c/Parsek/main/GameData/Parsek/Parsek.version",
-    "VERSION": { "MAJOR": 0, "MINOR": 10, "PATCH": 1 },
+    "VERSION": { "MAJOR": 0, "MINOR": 10, "PATCH": 2 },
     "KSP_VERSION": { "MAJOR": 1, "MINOR": 12, "PATCH": 5 },
     "KSP_VERSION_MIN": { "MAJOR": 1, "MINOR": 12, "PATCH": 0 },
     "KSP_VERSION_MAX": { "MAJOR": 1, "MINOR": 12, "PATCH": 99 }

--- a/Source/Parsek/Properties/AssemblyInfo.cs
+++ b/Source/Parsek/Properties/AssemblyInfo.cs
@@ -17,7 +17,7 @@ using System.Runtime.InteropServices;
 
 [assembly: Guid("a1b2c3d4-e5f6-7890-abcd-ef1234567890")]
 
-[assembly: AssemblyVersion("0.10.1.0")]
-[assembly: AssemblyFileVersion("0.10.1.0")]
+[assembly: AssemblyVersion("0.10.2.0")]
+[assembly: AssemblyFileVersion("0.10.2.0")]
 
 [assembly: KSPAssembly("Parsek", 0, 10)]


### PR DESCRIPTION
Bumps the mod version from 0.10.1 to 0.10.2 in `AssemblyInfo.cs` (AssemblyVersion + AssemblyFileVersion) and `GameData/Parsek/Parsek.version` (kept in sync, as `release.py` validates), and opens an empty `## 0.10.2` section at the top of the CHANGELOG.

The 0.10.2 changelog entries land in a stacked follow-up PR on top of this one.