### PR TITLE
docs(changelog): refactor-5 internals entries under 0.10.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to Parsek are documented here.
 
 ## 0.10.2
 
+### Internals & Tests
+
+- Code-health refactor pass over the systems added since the last structural cleanup, with no behavior change: several large methods were split into well-named same-file helpers (the supply-route builder, the mission loop-unit builder, the map render-session rebuild, mission scheduling and structure building, route source revalidation and harvest analysis, the relative-anchor resolver, terminal-orbit spawn safety, and the pannotations / FX sidecar codecs). Pure restructuring, verified byte-for-byte behavior-neutral by the existing test suites; no gameplay, save-format, or log change.
+- De-duplicated repeated blocks across the route and settings code (settings persistence, switch-segment refusal logging, route-codec field loaders, and recovered-credit sums) into single shared helpers. No behavior change.
+- Introduced two shared owners to remove copy-pasted code: a route-id log-shortening helper used across the logistics route files, and a shared ConfigNode codec for route endpoints and connection kinds used by both the route and route-proof serializers (the on-disk byte and field order is unchanged). No behavior or save-format change.
+
 ## 0.10.1
 
 ### Features


### PR DESCRIPTION
Stacked on #1193 (the 0.10.2 version bump). Populates the new `## 0.10.2` section with the refactor-5 work under `### Internals & Tests`, matching the existing CHANGELOG convention for internal/refactor changes (each entry noting it is behavior-neutral).

Three entries cover all five refactor-5 slices:
- the pure same-file method extractions (Slices 1 + 5),
- the repeated-block de-duplications (Slice 2),
- the two new shared owners `RouteIds.Short` (Slice 3) and `RouteNodeCodec` (Slice 4.1).

CHANGELOG-only; no code change. Merge after #1193.