### PR TITLE
maprender Phase 0: recorded-vs-rendered parity oracle + regression safety net

### DIFF
--- a/Source/Parsek.Tests/RenderGeometrySamplerTests.cs
+++ b/Source/Parsek.Tests/RenderGeometrySamplerTests.cs
@@ -1,0 +1,241 @@
+using Parsek.MapRender;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    /// <summary>
+    /// Phase-0 unit coverage for the PURE part of the recorded-vs-rendered parity SAMPLER
+    /// (<see cref="RenderGeometrySampler"/>): the body-relative reframing, the Vector3d -&gt; flat
+    /// double[] flattening the oracle consumes, the even sample-UT spread across the orbit's visible
+    /// span, and the loop-shift (renderedUT - shift) recorded-clock UT mapping. These are the only
+    /// genuinely-new pure primitives between a raw Unity sample and
+    /// <see cref="RenderParityOracle.ComputeDrift"/>; the Unity reads (Orbit.getPositionAtUT,
+    /// GetWorldPos3D) stay in MapRenderProbe and are guarded by the separate in-game capture-harness
+    /// fixture. No Unity ECalls here (Vector3d is a plain primitive struct), no shared static state.
+    /// </summary>
+    public class RenderGeometrySamplerTests
+    {
+        private const double Eps = 1e-9;
+
+        // ---- ToBodyRelative ----
+
+        [Fact]
+        public void ToBodyRelative_SubtractsBodyPosition()
+        {
+            var world = new Vector3d(1000.0, 2000.0, 3000.0);
+            var body = new Vector3d(100.0, 200.0, 300.0);
+
+            Vector3d rel = RenderGeometrySampler.ToBodyRelative(world, body);
+
+            Assert.Equal(900.0, rel.x, 6);
+            Assert.Equal(1800.0, rel.y, 6);
+            Assert.Equal(2700.0, rel.z, 6);
+        }
+
+        [Fact]
+        public void ToBodyRelative_NonFiniteWorld_ReturnsNaN()
+        {
+            var world = new Vector3d(double.NaN, 0.0, 0.0);
+            var body = new Vector3d(1.0, 2.0, 3.0);
+
+            Vector3d rel = RenderGeometrySampler.ToBodyRelative(world, body);
+
+            Assert.True(double.IsNaN(rel.x));
+            Assert.True(double.IsNaN(rel.y));
+            Assert.True(double.IsNaN(rel.z));
+        }
+
+        [Fact]
+        public void ToBodyRelative_NonFiniteBody_ReturnsNaN()
+        {
+            var world = new Vector3d(1.0, 2.0, 3.0);
+            var body = new Vector3d(0.0, double.PositiveInfinity, 0.0);
+
+            Vector3d rel = RenderGeometrySampler.ToBodyRelative(world, body);
+
+            Assert.True(double.IsNaN(rel.x));
+            Assert.True(double.IsNaN(rel.y));
+            Assert.True(double.IsNaN(rel.z));
+        }
+
+        // ---- Flatten ----
+
+        [Fact]
+        public void Flatten_ProducesXYZTriples()
+        {
+            var pts = new[]
+            {
+                new Vector3d(1.0, 2.0, 3.0),
+                new Vector3d(4.0, 5.0, 6.0),
+            };
+
+            double[] flat = RenderGeometrySampler.Flatten(pts, pts.Length);
+
+            Assert.Equal(6, flat.Length);
+            Assert.Equal(new[] { 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 }, flat);
+        }
+
+        [Fact]
+        public void Flatten_RespectsCountCap_ReusesOversizedBuffer()
+        {
+            // A 4-element scratch buffer but only the first 2 are live.
+            var pts = new[]
+            {
+                new Vector3d(1.0, 1.0, 1.0),
+                new Vector3d(2.0, 2.0, 2.0),
+                new Vector3d(9.0, 9.0, 9.0),
+                new Vector3d(9.0, 9.0, 9.0),
+            };
+
+            double[] flat = RenderGeometrySampler.Flatten(pts, 2);
+
+            Assert.Equal(6, flat.Length);
+            Assert.Equal(new[] { 1.0, 1.0, 1.0, 2.0, 2.0, 2.0 }, flat);
+        }
+
+        [Fact]
+        public void Flatten_NullOrZeroCount_ReturnsEmpty()
+        {
+            Assert.Empty(RenderGeometrySampler.Flatten(null, 5));
+            Assert.Empty(RenderGeometrySampler.Flatten(new Vector3d[0], 5));
+            Assert.Empty(RenderGeometrySampler.Flatten(new[] { new Vector3d(1, 1, 1) }, 0));
+        }
+
+        [Fact]
+        public void Flatten_PreservesNonFinite_NotZeroed()
+        {
+            var pts = new[] { new Vector3d(double.NaN, double.PositiveInfinity, 5.0) };
+
+            double[] flat = RenderGeometrySampler.Flatten(pts, 1);
+
+            Assert.True(double.IsNaN(flat[0]));
+            Assert.True(double.IsInfinity(flat[1]));
+            Assert.Equal(5.0, flat[2], 6);
+        }
+
+        [Fact]
+        public void FlattenSingle_OnePoint()
+        {
+            double[] flat = RenderGeometrySampler.FlattenSingle(new Vector3d(7.0, 8.0, 9.0));
+            Assert.Equal(new[] { 7.0, 8.0, 9.0 }, flat);
+        }
+
+        // ---- BuildSampleUTs ----
+
+        [Fact]
+        public void BuildSampleUTs_EvenSpread_EndpointsAndCentre()
+        {
+            double[] uts = RenderGeometrySampler.BuildSampleUTs(1000.0, 100.0, 5);
+
+            Assert.Equal(5, uts.Length);
+            Assert.Equal(900.0, uts[0], 6);   // centre - half
+            Assert.Equal(950.0, uts[1], 6);
+            Assert.Equal(1000.0, uts[2], 6);  // centre
+            Assert.Equal(1050.0, uts[3], 6);
+            Assert.Equal(1100.0, uts[4], 6);  // centre + half
+        }
+
+        [Fact]
+        public void BuildSampleUTs_CountOne_IsCentreOnly()
+        {
+            double[] uts = RenderGeometrySampler.BuildSampleUTs(1234.0, 500.0, 1);
+            Assert.Single(uts);
+            Assert.Equal(1234.0, uts[0], 6);
+        }
+
+        [Fact]
+        public void BuildSampleUTs_NonPositiveCountOrNonFinite_ReturnsEmpty()
+        {
+            Assert.Empty(RenderGeometrySampler.BuildSampleUTs(1000.0, 100.0, 0));
+            Assert.Empty(RenderGeometrySampler.BuildSampleUTs(double.NaN, 100.0, 5));
+            Assert.Empty(RenderGeometrySampler.BuildSampleUTs(1000.0, double.PositiveInfinity, 5));
+        }
+
+        [Fact]
+        public void BuildSampleUTs_NegativeHalfSpan_TreatedAsMagnitude()
+        {
+            double[] a = RenderGeometrySampler.BuildSampleUTs(0.0, -50.0, 3);
+            double[] b = RenderGeometrySampler.BuildSampleUTs(0.0, 50.0, 3);
+            Assert.Equal(b, a);
+        }
+
+        // ---- ShiftSampleUTs ----
+
+        [Fact]
+        public void ShiftSampleUTs_SubtractsShift()
+        {
+            var rendered = new[] { 1000.0, 1100.0, 1200.0 };
+
+            double[] recorded = RenderGeometrySampler.ShiftSampleUTs(rendered, 240000.0);
+
+            Assert.Equal(new[] { 1000.0 - 240000.0, 1100.0 - 240000.0, 1200.0 - 240000.0 }, recorded);
+        }
+
+        [Fact]
+        public void ShiftSampleUTs_ZeroShift_Unchanged()
+        {
+            var rendered = new[] { 1.0, 2.0, 3.0 };
+            double[] recorded = RenderGeometrySampler.ShiftSampleUTs(rendered, 0.0);
+            Assert.Equal(rendered, recorded);
+        }
+
+        [Fact]
+        public void ShiftSampleUTs_NonFiniteShift_ReturnsCopyUnchanged()
+        {
+            var rendered = new[] { 1.0, 2.0 };
+            double[] recorded = RenderGeometrySampler.ShiftSampleUTs(rendered, double.NaN);
+            Assert.Equal(rendered, recorded);
+            Assert.NotSame(rendered, recorded); // a NEW array, never the recorded source aliased
+        }
+
+        [Fact]
+        public void ShiftSampleUTs_Null_ReturnsEmpty()
+        {
+            Assert.Empty(RenderGeometrySampler.ShiftSampleUTs(null, 10.0));
+        }
+
+        // ---- End-to-end with the oracle: a loop-shifted faithful pair reads ~0 drift ----
+
+        [Fact]
+        public void FaithfulLoopShiftedPair_FlattensToZeroDrift()
+        {
+            // Two identical "orbits" sampled at matching clocks (rendered live UTs, recorded = live - shift)
+            // produce the SAME body-relative geometry, so the oracle measures ~0 drift. This is the loop-
+            // shift invariant the probe relies on: a faithful loop ghost is NOT flagged.
+            const double shift = 240000.0;
+            double[] renderedUTs = RenderGeometrySampler.BuildSampleUTs(1000.0, 100.0, 5);
+            double[] recordedUTs = RenderGeometrySampler.ShiftSampleUTs(renderedUTs, shift);
+
+            // Model "the same orbit" as a deterministic function of the orbit PHASE (clock minus its own
+            // epoch). Rendered phase uses the live epoch; recorded phase uses the shifted epoch; both land on
+            // the identical phase set, hence identical positions.
+            var renderedPts = new Vector3d[renderedUTs.Length];
+            var recordedPts = new Vector3d[recordedUTs.Length];
+            for (int i = 0; i < renderedUTs.Length; i++)
+            {
+                renderedPts[i] = PhasePoint(renderedUTs[i] - 1000.0);
+                recordedPts[i] = PhasePoint(recordedUTs[i] - (1000.0 - shift));
+            }
+
+            double[] referenceFlat = RenderGeometrySampler.Flatten(recordedPts, recordedPts.Length);
+            double[] renderedFlat = RenderGeometrySampler.Flatten(renderedPts, renderedPts.Length);
+
+            var r = RenderParityOracle.ComputeDrift(
+                RenderParityOracle.ParityMode.Faithful, referenceFlat, renderedFlat, toleranceMeters: 1.0);
+
+            Assert.True(r.HasMeasurement);
+            Assert.False(r.OverTolerance);
+            Assert.True(r.MaxDeviationMeters <= 1e-6);
+        }
+
+        // A simple deterministic position-from-phase model (a circle of radius 700 km in the XY plane), so
+        // two clocks at the same phase land on the same point.
+        private static Vector3d PhasePoint(double phaseSeconds)
+        {
+            const double radius = 700000.0;
+            const double period = 3600.0;
+            double theta = (phaseSeconds / period) * 2.0 * System.Math.PI;
+            return new Vector3d(radius * System.Math.Cos(theta), radius * System.Math.Sin(theta), 0.0);
+        }
+    }
+}

--- a/Source/Parsek.Tests/RenderParityOracleTests.cs
+++ b/Source/Parsek.Tests/RenderParityOracleTests.cs
@@ -1,0 +1,426 @@
+using System.Collections.Generic;
+using System.Linq;
+using Parsek;
+using Parsek.MapRender;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    /// <summary>
+    /// Phase-0 unit coverage for the recorded-vs-rendered parity oracle's PURE geometry-diff math
+    /// (<see cref="RenderParityOracle"/>), the new DISTINCT axis added beside
+    /// <see cref="GhostRenderReconciler"/>. Covers both modes (faithful = rendered vs recorded,
+    /// synthesized = rendered vs intended arc), within-/over-tolerance drift, mismatched + empty
+    /// counts, NaN/Inf inputs (no false positive, mirroring the reconciler), the scale-from-geometry
+    /// tolerance helper, and that the now-LIVE `parity-drift` token can flow through the gated
+    /// <see cref="MapRenderTrace.EmitAnomaly"/> sink (the token is fired in game by
+    /// <c>MapRenderProbe.TrySampleAndEmitFaithfulOrbitParity</c>).
+    ///
+    /// <para>The diff math is pure (no Unity, no shared static state). The single anomaly-emit test
+    /// touches the gated <see cref="MapRenderTrace"/> + <see cref="ParsekLog"/> static state, so the
+    /// whole class joins the Sequential collection for safety.</para>
+    /// </summary>
+    [Collection("Sequential")]
+    public class RenderParityOracleTests : System.IDisposable
+    {
+        private readonly List<string> logLines = new List<string>();
+
+        public RenderParityOracleTests()
+        {
+            MapRenderTrace.Reset();
+            MapRenderTrace.ForceEnabledForTesting = true;
+            MapRenderTrace.FrameCounterOverrideForTesting = () => 7;
+            ParsekSettings.CurrentOverrideForTesting = null;
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = false;
+            ParsekLog.VerboseOverrideForTesting = true;
+            ParsekLog.TestSinkForTesting = line => logLines.Add(line);
+        }
+
+        public void Dispose()
+        {
+            MapRenderTrace.Reset();
+            MapRenderTrace.ForceEnabledForTesting = false;
+            MapRenderTrace.FrameCounterOverrideForTesting = null;
+            ParsekSettings.CurrentOverrideForTesting = null;
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = true;
+        }
+
+        // ---- Helpers ----
+
+        // A simple ascending straight "arc" of n points along +X at a fixed step, optionally offset
+        // along +Y so the rendered set is uniformly displaced from the reference by a known distance.
+        private static double[] Line(int n, double step, double yOffset = 0.0)
+        {
+            var a = new double[n * 3];
+            for (int i = 0; i < n; i++)
+            {
+                a[i * 3] = i * step;     // x
+                a[i * 3 + 1] = yOffset;  // y
+                a[i * 3 + 2] = 0.0;      // z
+            }
+            return a;
+        }
+
+        // ---- ComputeDrift: within tolerance (no drift) ----
+
+        [Fact]
+        public void ComputeDrift_IdenticalGeometry_NoDrift()
+        {
+            double[] recorded = Line(5, 1000.0);
+            double[] rendered = Line(5, 1000.0);
+
+            var r = RenderParityOracle.ComputeDrift(
+                RenderParityOracle.ParityMode.Faithful, recorded, rendered, toleranceMeters: 10.0);
+
+            Assert.True(r.HasMeasurement);
+            Assert.False(r.OverTolerance);
+            Assert.Equal(0.0, r.MaxDeviationMeters, 6);
+            Assert.False(r.CountMismatch);
+            Assert.Equal(RenderParityOracle.ParityMode.Faithful, r.Mode);
+        }
+
+        [Fact]
+        public void ComputeDrift_SmallOffsetWithinTolerance_NoDrift()
+        {
+            // Rendered uniformly 5 m off the reference; tolerance 10 m -> no drift.
+            double[] recorded = Line(5, 1000.0, yOffset: 0.0);
+            double[] rendered = Line(5, 1000.0, yOffset: 5.0);
+
+            var r = RenderParityOracle.ComputeDrift(
+                RenderParityOracle.ParityMode.Faithful, recorded, rendered, toleranceMeters: 10.0);
+
+            Assert.True(r.HasMeasurement);
+            Assert.False(r.OverTolerance);
+            Assert.True(r.MaxDeviationMeters <= 5.0 + 1e-6);
+        }
+
+        // ---- ComputeDrift: over tolerance (drift) ----
+
+        [Fact]
+        public void ComputeDrift_LargeOffsetOverTolerance_FlagsDrift()
+        {
+            // Rendered 500 m off; tolerance 10 m -> drift.
+            double[] recorded = Line(5, 1000.0, yOffset: 0.0);
+            double[] rendered = Line(5, 1000.0, yOffset: 500.0);
+
+            var r = RenderParityOracle.ComputeDrift(
+                RenderParityOracle.ParityMode.Faithful, recorded, rendered, toleranceMeters: 10.0);
+
+            Assert.True(r.HasMeasurement);
+            Assert.True(r.OverTolerance);
+            Assert.True(r.MaxDeviationMeters >= 500.0 - 1e-6);
+        }
+
+        // ---- Faithful vs Synthesized: same math, different reference, carried on the result ----
+
+        [Fact]
+        public void ComputeDrift_SynthesizedMode_CarriesModeOnResult()
+        {
+            // In Synthesized mode the reference is the producer's INTENDED arc (here a re-aimed line).
+            double[] intended = Line(4, 2000.0);
+            double[] rendered = Line(4, 2000.0);
+
+            var r = RenderParityOracle.ComputeDrift(
+                RenderParityOracle.ParityMode.Synthesized, intended, rendered, toleranceMeters: 50.0);
+
+            Assert.Equal(RenderParityOracle.ParityMode.Synthesized, r.Mode);
+            Assert.Equal("synthesized", RenderParityOracle.ParityModeToken(r.Mode));
+            Assert.False(r.OverTolerance);
+        }
+
+        [Fact]
+        public void ComputeDrift_SameGeometry_BothModesAgreeOnDeviation()
+        {
+            // The diff MATH is identical across modes; only the reference's MEANING differs. Same point
+            // sets in both modes must produce the same deviation + over-tolerance decision.
+            double[] a = Line(6, 1500.0, yOffset: 0.0);
+            double[] b = Line(6, 1500.0, yOffset: 120.0);
+
+            var faithful = RenderParityOracle.ComputeDrift(
+                RenderParityOracle.ParityMode.Faithful, a, b, toleranceMeters: 100.0);
+            var synth = RenderParityOracle.ComputeDrift(
+                RenderParityOracle.ParityMode.Synthesized, a, b, toleranceMeters: 100.0);
+
+            Assert.Equal(faithful.MaxDeviationMeters, synth.MaxDeviationMeters, 6);
+            Assert.Equal(faithful.OverTolerance, synth.OverTolerance);
+            Assert.True(faithful.OverTolerance); // 120 m off vs 100 m tol
+        }
+
+        // ---- Count-independence: different sampling density, same curve -> no drift ----
+
+        [Fact]
+        public void ComputeDrift_DifferentDensitySameCurve_NoDrift_ButCountMismatchRecorded()
+        {
+            // Reference sampled densely, rendered sparsely, both along the SAME straight curve. The
+            // nearest-point projection makes this count-independent: no drift, but the count delta is
+            // recorded for logging.
+            double[] reference = Line(11, 100.0); // 0..1000 in 100 m steps
+            double[] rendered = Line(3, 500.0);   // 0,500,1000 - same line, coarser
+
+            var r = RenderParityOracle.ComputeDrift(
+                RenderParityOracle.ParityMode.Faithful, reference, rendered, toleranceMeters: 1.0);
+
+            Assert.True(r.HasMeasurement);
+            Assert.False(r.OverTolerance);
+            Assert.True(r.CountMismatch);
+            Assert.Equal(11, r.ReferenceCount);
+            Assert.Equal(3, r.RenderedCount);
+            Assert.True(r.MaxDeviationMeters <= RenderParityOracle.MinToleranceMeters);
+        }
+
+        // ---- Empty / null inputs: no measurement, no false anomaly ----
+
+        [Fact]
+        public void ComputeDrift_EmptyReference_NoMeasurement()
+        {
+            var r = RenderParityOracle.ComputeDrift(
+                RenderParityOracle.ParityMode.Faithful, new double[0], Line(3, 100.0), 10.0);
+
+            Assert.False(r.HasMeasurement);
+            Assert.False(r.OverTolerance);
+            Assert.Equal(0, r.ReferenceCount);
+            Assert.Equal(3, r.RenderedCount);
+        }
+
+        [Fact]
+        public void ComputeDrift_EmptyRendered_NoMeasurement()
+        {
+            var r = RenderParityOracle.ComputeDrift(
+                RenderParityOracle.ParityMode.Faithful, Line(3, 100.0), new double[0], 10.0);
+
+            Assert.False(r.HasMeasurement);
+            Assert.False(r.OverTolerance);
+        }
+
+        [Fact]
+        public void ComputeDrift_NullInputs_NoMeasurement_NoThrow()
+        {
+            var r = RenderParityOracle.ComputeDrift(
+                RenderParityOracle.ParityMode.Faithful, null, null, 10.0);
+
+            Assert.False(r.HasMeasurement);
+            Assert.False(r.OverTolerance);
+            Assert.Equal(0, r.ReferenceCount);
+            Assert.Equal(0, r.RenderedCount);
+        }
+
+        [Fact]
+        public void ComputeDrift_SynthesizedMode_EmptyRendered_NoMeasurement_CarriesMode()
+        {
+            // The no-measurement path must behave identically in BOTH modes (it is mode-agnostic), and the
+            // mode must still be carried on the no-measurement result so a log line records which reference
+            // could not be diffed. Covers the both-modes x no-measurement cell that was Faithful-only.
+            var r = RenderParityOracle.ComputeDrift(
+                RenderParityOracle.ParityMode.Synthesized, Line(3, 100.0), new double[0], 10.0);
+
+            Assert.Equal(RenderParityOracle.ParityMode.Synthesized, r.Mode);
+            Assert.False(r.HasMeasurement);
+            Assert.False(r.OverTolerance);
+            Assert.Equal(3, r.ReferenceCount);
+            Assert.Equal(0, r.RenderedCount);
+        }
+
+        // ---- NaN / Inf inputs: no false positive (mirror GhostRenderReconciler / RewindReadbackGuard) ----
+
+        [Fact]
+        public void ComputeDrift_AllRenderedNonFinite_NoMeasurement_NoFalseAnomaly()
+        {
+            double[] reference = Line(4, 1000.0);
+            double[] rendered = new double[]
+            {
+                double.NaN, 0.0, 0.0,
+                double.PositiveInfinity, 0.0, 0.0,
+                0.0, double.NegativeInfinity, 0.0,
+            };
+
+            var r = RenderParityOracle.ComputeDrift(
+                RenderParityOracle.ParityMode.Faithful, reference, rendered, toleranceMeters: 1.0);
+
+            Assert.False(r.HasMeasurement);
+            Assert.False(r.OverTolerance);
+        }
+
+        [Fact]
+        public void ComputeDrift_AllReferenceNonFinite_NoMeasurement_NoFalseAnomaly()
+        {
+            double[] reference = new double[]
+            {
+                double.NaN, double.NaN, double.NaN,
+                double.PositiveInfinity, 0.0, 0.0,
+            };
+            double[] rendered = Line(4, 1000.0);
+
+            var r = RenderParityOracle.ComputeDrift(
+                RenderParityOracle.ParityMode.Faithful, reference, rendered, toleranceMeters: 1.0);
+
+            Assert.False(r.HasMeasurement);
+            Assert.False(r.OverTolerance);
+        }
+
+        [Fact]
+        public void ComputeDrift_PartialNonFinitePoints_SkippedNotFlagged()
+        {
+            // A scattered NaN point on each side must be SKIPPED, not read as a giant deviation. The
+            // remaining finite points are identical -> no drift.
+            double[] reference = new double[]
+            {
+                0.0, 0.0, 0.0,
+                double.NaN, double.NaN, double.NaN, // skipped
+                2000.0, 0.0, 0.0,
+            };
+            double[] rendered = new double[]
+            {
+                0.0, 0.0, 0.0,
+                double.PositiveInfinity, 0.0, 0.0,  // skipped
+                2000.0, 0.0, 0.0,
+            };
+
+            var r = RenderParityOracle.ComputeDrift(
+                RenderParityOracle.ParityMode.Faithful, reference, rendered, toleranceMeters: 10.0);
+
+            Assert.True(r.HasMeasurement);
+            Assert.False(r.OverTolerance);
+            Assert.Equal(0.0, r.MaxDeviationMeters, 6);
+        }
+
+        [Fact]
+        public void ComputeDrift_NonFiniteTolerance_FallsBackToFloor()
+        {
+            double[] reference = Line(3, 100.0, yOffset: 0.0);
+            double[] rendered = Line(3, 100.0, yOffset: 0.5); // 0.5 m off, below the 1 m floor
+
+            var r = RenderParityOracle.ComputeDrift(
+                RenderParityOracle.ParityMode.Faithful, reference, rendered, toleranceMeters: double.NaN);
+
+            Assert.Equal(RenderParityOracle.MinToleranceMeters, r.ToleranceMeters, 6);
+            Assert.False(r.OverTolerance); // 0.5 m < 1 m floor
+        }
+
+        // ---- Tolerance-from-scale helper ----
+
+        [Fact]
+        public void ToleranceForScale_ScalesWithGeometry_NotABlanketConstant()
+        {
+            // A heliocentric-scale arc (1e10 m) gets a far larger tolerance than an LKO arc (7e5 m).
+            double small = RenderParityOracle.ToleranceForScale(700_000.0);
+            double large = RenderParityOracle.ToleranceForScale(1.0e10);
+
+            Assert.True(large > small);
+            Assert.Equal(700_000.0 * RenderParityOracle.DefaultScaleToleranceFraction, small, 3);
+            Assert.Equal(1.0e10 * RenderParityOracle.DefaultScaleToleranceFraction, large, 0);
+        }
+
+        [Fact]
+        public void ToleranceForScale_DegenerateScale_FallsBackToFloor()
+        {
+            Assert.Equal(RenderParityOracle.MinToleranceMeters, RenderParityOracle.ToleranceForScale(0.0), 6);
+            Assert.Equal(RenderParityOracle.MinToleranceMeters, RenderParityOracle.ToleranceForScale(-5.0), 6);
+            Assert.Equal(RenderParityOracle.MinToleranceMeters, RenderParityOracle.ToleranceForScale(double.NaN), 6);
+            Assert.Equal(
+                RenderParityOracle.MinToleranceMeters,
+                RenderParityOracle.ToleranceForScale(double.PositiveInfinity), 6);
+        }
+
+        [Fact]
+        public void ToleranceForScale_NonFiniteFraction_UsesDefault()
+        {
+            double withDefault = RenderParityOracle.ToleranceForScale(1.0e8);
+            double withNaNFraction = RenderParityOracle.ToleranceForScale(1.0e8, fraction: double.NaN);
+            double withNegFraction = RenderParityOracle.ToleranceForScale(1.0e8, fraction: -0.5);
+
+            Assert.Equal(withDefault, withNaNFraction, 3);
+            Assert.Equal(withDefault, withNegFraction, 3);
+        }
+
+        [Fact]
+        public void EstimateScaleFromPoints_BoundingBoxDiagonal()
+        {
+            // A 3-4-0 box -> diagonal 5.
+            double[] pts = new double[]
+            {
+                0.0, 0.0, 0.0,
+                3.0, 4.0, 0.0,
+            };
+            Assert.Equal(5.0, RenderParityOracle.EstimateScaleFromPoints(pts), 6);
+        }
+
+        [Fact]
+        public void EstimateScaleFromPoints_SkipsNonFinite_AndHandlesEmpty()
+        {
+            Assert.Equal(0.0, RenderParityOracle.EstimateScaleFromPoints(null), 6);
+            Assert.Equal(0.0, RenderParityOracle.EstimateScaleFromPoints(new double[0]), 6);
+
+            double[] withNan = new double[]
+            {
+                0.0, 0.0, 0.0,
+                double.NaN, 1e9, 0.0, // skipped, must not inflate the box
+                6.0, 8.0, 0.0,
+            };
+            Assert.Equal(10.0, RenderParityOracle.EstimateScaleFromPoints(withNan), 6); // 6-8-0 box -> 10
+        }
+
+        // ---- Scale-derived convenience overload ----
+
+        [Fact]
+        public void ComputeDriftScaleDerived_LkoDriftFlagged_AtSameAbsoluteOffsetHeliocentricNot()
+        {
+            // The same ABSOLUTE 2 km rendered offset is a drift on an LKO-scale reference but within
+            // tolerance on a heliocentric-scale reference -> exactly the per-scenario behavior a blanket
+            // metre tolerance cannot give.
+            double[] lkoRef = Line(5, 350_000.0, yOffset: 0.0);     // extent ~1.4e6 m
+            double[] lkoRend = Line(5, 350_000.0, yOffset: 2000.0); // 2 km off
+
+            double[] helioRef = Line(5, 5.0e9, yOffset: 0.0);       // extent ~2e10 m
+            double[] helioRend = Line(5, 5.0e9, yOffset: 2000.0);   // 2 km off
+
+            var lko = RenderParityOracle.ComputeDriftScaleDerived(
+                RenderParityOracle.ParityMode.Faithful, lkoRef, lkoRend);
+            var helio = RenderParityOracle.ComputeDriftScaleDerived(
+                RenderParityOracle.ParityMode.Faithful, helioRef, helioRend);
+
+            Assert.True(lko.OverTolerance);    // 2 km > ~0.1% of 1.4e6 (~1.4 km)
+            Assert.False(helio.OverTolerance); // 2 km < ~0.1% of 2e10 (~2e7 m)
+        }
+
+        // ---- Wired-but-inert: the parity-drift token flows through the gated EmitAnomaly sink ----
+
+        [Fact]
+        public void ParityDriftToken_EmitsThroughGatedAnomalySink()
+        {
+            // parity-drift is now WIRED + LIVE: the gated probe sampler
+            // (MapRenderProbe.TrySampleAndEmitFaithfulOrbitParity) fires it in game when a faithful ghost's
+            // rendered orbit diverges from its recorded reference. This unit test pins the emit SHAPE (the
+            // oracle computes the drift, the caller emits the token through the gated sink) headlessly; the
+            // end-to-end wiring is proven by the in-game RenderParityBaselineTest.
+            double[] reference = Line(4, 1000.0, yOffset: 0.0);
+            double[] rendered = Line(4, 1000.0, yOffset: 5000.0);
+            var r = RenderParityOracle.ComputeDrift(
+                RenderParityOracle.ParityMode.Faithful, reference, rendered, toleranceMeters: 10.0);
+            Assert.True(r.OverTolerance);
+
+            MapRenderTrace.EmitAnomaly(
+                MapRenderTrace.RenderSurface.ProtoOrbitLine, "7", currentUT: 100.0, effUT: 100.0,
+                reason: MapRenderTrace.AnomalyParityDrift,
+                details: "mode=" + RenderParityOracle.ParityModeToken(r.Mode)
+                    + " maxDev=" + MapRenderTrace.FormatDouble(r.MaxDeviationMeters, "F1")
+                    + " tol=" + MapRenderTrace.FormatDouble(r.ToleranceMeters, "F1"));
+
+            Assert.Contains(logLines, l =>
+                l.Contains("[MapRenderTrace]") && l.Contains("phase=Anomaly")
+                && l.Contains("reason=parity-drift") && l.Contains("mode=faithful"));
+        }
+
+        [Fact]
+        public void NewAnomalyTokens_AreStableStrings()
+        {
+            // Lock the five new reason tokens so a later rename can't silently break a grep / LogContract.
+            Assert.Equal("parity-drift", MapRenderTrace.AnomalyParityDrift);
+            Assert.Equal("rigid-seam-tangent-discontinuity", MapRenderTrace.AnomalyRigidSeamTangentDiscontinuity);
+            Assert.Equal("retire-not-held", MapRenderTrace.AnomalyRetireNotHeld);
+            Assert.Equal("anchor-resolve-fail", MapRenderTrace.AnomalyAnchorResolveFail);
+            Assert.Equal("clock-not-ready", MapRenderTrace.AnomalyClockNotReady);
+        }
+    }
+}

--- a/Source/Parsek.Tests/RenderParityRegressionScenarioTests.cs
+++ b/Source/Parsek.Tests/RenderParityRegressionScenarioTests.cs
@@ -1,0 +1,542 @@
+using System;
+using Parsek.MapRender;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    /// <summary>
+    /// Phase 0 / migration §2 - the HEADLESS REGRESSION SCENARIO SET for the recorded-vs-rendered
+    /// parity oracle (<see cref="RenderParityOracle"/>). Each test builds a representative synthetic
+    /// geometry pair (a "recorded"/"intended" reference curve + the geometry the pipeline "rendered")
+    /// and asserts the oracle's verdict, so every later phase has an objective "did I break rendering?"
+    /// gate over a fixed set of situations from the design §11.5 coverage matrix.
+    ///
+    /// <para><b>What this suite is and is NOT.</b> The oracle's headless contract takes ALREADY-FRAMED
+    /// flat <c>double[]</c> XYZ triples in one consistent metres frame (the Unity sampler in
+    /// <see cref="MapRenderProbe"/> supplies them in game). So this suite models each matrix row's
+    /// geometry directly: an orbit via a tiny PURE Kepler-circle/ellipse sampler, an ascent/descent via a
+    /// vertical metre profile, a heliocentric arc via a wide circle, etc. The LIVE Unity capture path
+    /// (reading <c>OrbitDriver.orbit</c> / <c>GetWorldPos3D</c>) is validated separately by the in-game
+    /// <c>RenderParitySamplerFixtureTest</c> (capture-harness) + the <c>parity-baseline</c> in-game test;
+    /// those are the "green but blind" guard the migration plan calls out. This suite is the diff-verdict
+    /// gate per matrix row, NOT a second capture-path test.</para>
+    ///
+    /// <para><b>Two halves per situation.</b> A KNOWN-GOOD pair (recorded == "rendered", sampled the same
+    /// way, incl. a loop-shifted faithful ghost) must read <c>OverTolerance == false</c> (zero drift); a
+    /// deliberately-DRIFTED pair (rendered perturbed beyond tolerance: a rotated/offset arc, a mis-applied
+    /// loop shift, a wrong-body orbit) must read <c>OverTolerance == true</c>. Both
+    /// <see cref="RenderParityOracle.ParityMode"/> values are exercised (faithful = rendered-vs-recorded;
+    /// synthesized = rendered-vs-INTENDED arc, the re-aim cases) so neither mode is left uncovered.</para>
+    ///
+    /// <para>Pure math, no Unity ECalls, no shared static state - so NOT in the Sequential collection.
+    /// See <c>docs/dev/plans/map-ts-render-phase0-regression-traceability.md</c> for the scenario ->
+    /// §11.5-matrix-row mapping (the DoD traceability artifact this suite anchors).</para>
+    /// </summary>
+    public class RenderParityRegressionScenarioTests
+    {
+        // ===================================================================================
+        //  Pure synthetic-geometry builders (a recording's geometry as flat XYZ triples)
+        // ===================================================================================
+
+        // A circular orbit of the given radius in the body-relative XZ plane (Y = out-of-plane), sampled
+        // at `count` evenly-spaced true anomalies starting at `phase0` radians. This is the headless
+        // analogue of the in-game OrbitRelativePositionYup sample of a circular equatorial orbit: every
+        // point has magnitude == radius and (for inc=0) zero Y. The recorded and rendered sides build the
+        // SAME curve at the SAME phases for a faithful pair.
+        private static double[] CircleXZ(double radius, int count, double phase0 = 0.0)
+        {
+            var flat = new double[count * 3];
+            for (int i = 0; i < count; i++)
+            {
+                double theta = phase0 + (2.0 * Math.PI * i) / count;
+                flat[i * 3] = radius * Math.Cos(theta);   // x
+                flat[i * 3 + 1] = 0.0;                     // y (equatorial)
+                flat[i * 3 + 2] = radius * Math.Sin(theta); // z
+            }
+            return flat;
+        }
+
+        // A circular equatorial orbit position function in body-relative Y-up metres at a set of UTs - the
+        // headless analogue of OrbitRelativePositionYup on a circular orbit. The mean anomaly at UT `t` is
+        // omega * (t - epoch), so a loop-shifted ghost whose epoch is baked with +shift evaluated at the
+        // live clock lands on the SAME angle as the raw-epoch recorded orbit evaluated at (t - shift). This
+        // lets the loop-shift row ACTUALLY apply a shift (via RenderGeometrySampler.ShiftSampleUTs) and
+        // prove the "shift the clock, not the shape" invariant headlessly, rather than diffing a circle
+        // against an identical copy of itself.
+        private static double[] CircleAtUTs(double radius, double omega, double epoch, double[] uts)
+        {
+            var flat = new double[uts.Length * 3];
+            for (int i = 0; i < uts.Length; i++)
+            {
+                double theta = omega * (uts[i] - epoch);
+                flat[i * 3] = radius * Math.Cos(theta);
+                flat[i * 3 + 1] = 0.0;
+                flat[i * 3 + 2] = radius * Math.Sin(theta);
+            }
+            return flat;
+        }
+
+        // An eccentric orbit in the XZ plane: r(theta) = a(1-e^2)/(1+e cos theta), sampled at `count`
+        // evenly-spaced true anomalies. Used for the aerobraking / eccentric-orbit rows where the arc
+        // shape (not just radius) must match.
+        private static double[] EllipseXZ(double sma, double ecc, int count, double phase0 = 0.0)
+        {
+            var flat = new double[count * 3];
+            double p = sma * (1.0 - ecc * ecc);
+            for (int i = 0; i < count; i++)
+            {
+                double theta = phase0 + (2.0 * Math.PI * i) / count;
+                double r = p / (1.0 + ecc * Math.Cos(theta));
+                flat[i * 3] = r * Math.Cos(theta);
+                flat[i * 3 + 1] = 0.0;
+                flat[i * 3 + 2] = r * Math.Sin(theta);
+            }
+            return flat;
+        }
+
+        // A near-vertical ascent/descent profile: a column of points climbing/falling in +Y over a small
+        // downrange +X drift. The atmospheric portions (ascent, descent-to-landing) draw as a traced
+        // polyline, not a conic, so the geometry is a line of metres, not a circle.
+        private static double[] VerticalProfile(
+            double startAltitude, double endAltitude, double downrange, int count)
+        {
+            var flat = new double[count * 3];
+            for (int i = 0; i < count; i++)
+            {
+                double t = count == 1 ? 0.0 : (double)i / (count - 1);
+                flat[i * 3] = downrange * t;                                  // x downrange
+                flat[i * 3 + 1] = startAltitude + (endAltitude - startAltitude) * t; // y altitude
+                flat[i * 3 + 2] = 0.0;
+            }
+            return flat;
+        }
+
+        // Rotate every point of a flat XYZ set about the Y axis by `deg` degrees. Models the documented
+        // "looped re-aim / icon-off-orbit rotation" draw bug: the rendered arc is the recorded arc spun
+        // about the body axis, so it has the same shape but is angularly offset - the exact failure the
+        // oracle must flag (a continuous nearest-point projection still sees the perpendicular gap).
+        private static double[] RotateAboutY(double[] xyz, double deg)
+        {
+            double rad = deg * Math.PI / 180.0;
+            double c = Math.Cos(rad), s = Math.Sin(rad);
+            var outp = new double[xyz.Length];
+            int n = xyz.Length / 3;
+            for (int i = 0; i < n; i++)
+            {
+                double x = xyz[i * 3], y = xyz[i * 3 + 1], z = xyz[i * 3 + 2];
+                outp[i * 3] = c * x + s * z;
+                outp[i * 3 + 1] = y;
+                outp[i * 3 + 2] = -s * x + c * z;
+            }
+            return outp;
+        }
+
+        // Uniformly translate a flat XYZ set by (dx,dy,dz) metres.
+        private static double[] Translate(double[] xyz, double dx, double dy, double dz)
+        {
+            var outp = new double[xyz.Length];
+            int n = xyz.Length / 3;
+            for (int i = 0; i < n; i++)
+            {
+                outp[i * 3] = xyz[i * 3] + dx;
+                outp[i * 3 + 1] = xyz[i * 3 + 1] + dy;
+                outp[i * 3 + 2] = xyz[i * 3 + 2] + dz;
+            }
+            return outp;
+        }
+
+        // Scenario constants (body-relative metres, KSP-scale).
+        private const double LkoRadius = 700_000.0;       // ~low Kerbin orbit
+        private const double MunOrbitRadius = 12_000_000.0; // Munar-distance arc
+        private const double HelioRadius = 1.3e10;         // heliocentric transfer scale
+        private const int SampleCount = 24;
+
+        // ===================================================================================
+        //  FAITHFUL known-good rows -> zero drift
+        // ===================================================================================
+
+        [Fact]
+        public void Faithful_AscentToOrbit_KnownGood_ZeroDrift()
+        {
+            // Row: faithful ascent -> orbit. Recorded == rendered (a circular LKO arc).
+            double[] recorded = CircleXZ(LkoRadius, SampleCount);
+            double[] rendered = CircleXZ(LkoRadius, SampleCount);
+
+            var r = RenderParityOracle.ComputeDriftScaleDerived(
+                RenderParityOracle.ParityMode.Faithful, recorded, rendered);
+
+            Assert.True(r.HasMeasurement);
+            Assert.False(r.OverTolerance);
+            Assert.True(r.MaxDeviationMeters <= 1e-3);
+        }
+
+        [Fact]
+        public void Faithful_AtmosphericAscent_KnownGood_ZeroDrift()
+        {
+            // Row: atmospheric ascent (a traced polyline, not a conic). Recorded == rendered profile.
+            double[] recorded = VerticalProfile(0.0, 70_000.0, 30_000.0, SampleCount);
+            double[] rendered = VerticalProfile(0.0, 70_000.0, 30_000.0, SampleCount);
+
+            var r = RenderParityOracle.ComputeDriftScaleDerived(
+                RenderParityOracle.ParityMode.Faithful, recorded, rendered);
+
+            Assert.True(r.HasMeasurement);
+            Assert.False(r.OverTolerance);
+        }
+
+        [Fact]
+        public void Faithful_DescentToLanding_KnownGood_ZeroDrift()
+        {
+            // Row: atmospheric descent to landing/splashdown. Recorded == rendered descent profile.
+            double[] recorded = VerticalProfile(60_000.0, 0.0, 20_000.0, SampleCount);
+            double[] rendered = VerticalProfile(60_000.0, 0.0, 20_000.0, SampleCount);
+
+            var r = RenderParityOracle.ComputeDriftScaleDerived(
+                RenderParityOracle.ParityMode.Faithful, recorded, rendered);
+
+            Assert.True(r.HasMeasurement);
+            Assert.False(r.OverTolerance);
+        }
+
+        [Fact]
+        public void Faithful_SoiCrossing_KnownGood_ZeroDrift()
+        {
+            // Row: single-level SOI transition (Kerbin -> Sun). Faithful rendering draws the recorded
+            // post-crossing heliocentric arc verbatim - the diff is taken AFTER the crossing in the new
+            // reference body's own frame (the probe suppresses the cross-body delta via bodyChanged), so a
+            // faithful SOI leg reads zero drift on the heliocentric segment.
+            double[] recorded = CircleXZ(HelioRadius, SampleCount, phase0: 0.3);
+            double[] rendered = CircleXZ(HelioRadius, SampleCount, phase0: 0.3);
+
+            var r = RenderParityOracle.ComputeDriftScaleDerived(
+                RenderParityOracle.ParityMode.Faithful, recorded, rendered);
+
+            Assert.True(r.HasMeasurement);
+            Assert.False(r.OverTolerance);
+        }
+
+        [Fact]
+        public void Faithful_BgOnRailsAllOrbital_KnownGood_ZeroDrift()
+        {
+            // Row: BG-on-rails recorded vessel (all-orbital chain, no Descent/Surface phase). The faithful
+            // render is the recorded orbit arc; recorded == rendered.
+            double[] recorded = CircleXZ(MunOrbitRadius, SampleCount);
+            double[] rendered = CircleXZ(MunOrbitRadius, SampleCount);
+
+            var r = RenderParityOracle.ComputeDriftScaleDerived(
+                RenderParityOracle.ParityMode.Faithful, recorded, rendered);
+
+            Assert.True(r.HasMeasurement);
+            Assert.False(r.OverTolerance);
+        }
+
+        [Fact]
+        public void Faithful_AerobrakingEccentric_KnownGood_ZeroDrift()
+        {
+            // Row: aerobraking (many periapsis grazes) - alternating conic/traced. The eccentric conic
+            // portion's arc SHAPE (not just radius) must match; recorded == rendered ellipse.
+            double[] recorded = EllipseXZ(MunOrbitRadius, 0.6, SampleCount);
+            double[] rendered = EllipseXZ(MunOrbitRadius, 0.6, SampleCount);
+
+            var r = RenderParityOracle.ComputeDriftScaleDerived(
+                RenderParityOracle.ParityMode.Faithful, recorded, rendered);
+
+            Assert.True(r.HasMeasurement);
+            Assert.False(r.OverTolerance);
+        }
+
+        [Fact]
+        public void Faithful_LoopShiftedGhost_SameOrbit_ZeroDrift()
+        {
+            // Row: loop a single recording. A loop-shifted FAITHFUL ghost renders the SAME orbit shape; the
+            // loop shift only sets WHERE on the orbit the icon sits, not the orbit's geometry, so the diff
+            // is ~0. This ACTUALLY applies the shift (it does not diff a circle against an identical copy):
+            // the RENDERED orbit's epoch is baked with +shift and sampled at the LIVE-clock UTs (mirroring
+            // StockConicTreatment.SeedAndDriveLive: epoch = seg.epoch + loopShift), and the RECORDED
+            // reference is the raw-epoch orbit sampled at the recorded-clock UTs (liveUT - shift, via
+            // RenderGeometrySampler.ShiftSampleUTs). Both therefore land on the SAME mean-anomaly angle, so
+            // a correct "shift the clock, not the shape" pipeline reads zero drift. (This is the headless
+            // analogue of the production probe's BuildPhaseMatchedReferenceOrbit + same-UT sampling; the
+            // in-game RenderParityBaselineTest loop-shifted variant proves the live path.)
+            const double omega = 2.0 * Math.PI / 5400.0; // ~1.5 h circular period
+            const double epoch = 100_000.0;
+            const double shift = 1300.0;                  // a sizeable fraction of the period
+            const double liveCenterUT = epoch + 4.0 * 5400.0; // four loops later
+
+            double[] renderedUTs = RenderGeometrySampler.BuildSampleUTs(
+                liveCenterUT, 5400.0 * 0.25, SampleCount);
+            // Recorded reference sampled at the recorded-clock UTs (liveUT - shift), raw epoch.
+            double[] recordedUTs = RenderGeometrySampler.ShiftSampleUTs(renderedUTs, shift);
+            // Rendered orbit epoch baked with +shift, sampled at the live-clock UTs.
+            double[] rendered = CircleAtUTs(LkoRadius, omega, epoch + shift, renderedUTs);
+            double[] recorded = CircleAtUTs(LkoRadius, omega, epoch, recordedUTs);
+
+            var r = RenderParityOracle.ComputeDriftScaleDerived(
+                RenderParityOracle.ParityMode.Faithful, recorded, rendered);
+
+            Assert.True(r.HasMeasurement);
+            Assert.False(r.OverTolerance);
+
+            // Negative control: drop the shift cancellation (sample the raw-epoch recorded orbit at the
+            // LIVE clock instead of the recorded clock) and the loop phase no longer cancels - the two
+            // orbits trace different arcs and the oracle MUST flag drift. This is exactly the BLOCKER the
+            // production probe's phase-matched epoch fixes; here it proves the row is a real shift, not a
+            // tautological circle-vs-itself.
+            double[] recordedUnshifted = CircleAtUTs(LkoRadius, omega, epoch, renderedUTs);
+            var rBug = RenderParityOracle.ComputeDriftScaleDerived(
+                RenderParityOracle.ParityMode.Faithful, recordedUnshifted, rendered);
+            Assert.True(rBug.HasMeasurement);
+            Assert.True(rBug.OverTolerance);
+        }
+
+        [Fact]
+        public void Faithful_DifferentSampleDensity_SameCurve_ZeroDrift()
+        {
+            // Row: faithful orbit at DIFFERENT sample densities (the common recorded-points-list vs dense
+            // Vectrosity-line case). The oracle's nearest-point projection is count-independent: a recorded
+            // reference point projects onto the rendered POLYLINE, so as long as the rendered line is
+            // sampled finely enough to approximate the curve (a dense Vectrosity line, like the stock orbit
+            // renderer draws), a coarser recorded reference reads ~0 drift. (A pathologically coarse
+            // rendered N-gon is NOT a faithful draw of a circle - its chords cut megametres inside the arc
+            // - and the oracle correctly flags that; that is a drift case, not a known-good one.)
+            double[] recorded = CircleXZ(LkoRadius, 9);   // coarse recorded points
+            double[] rendered = CircleXZ(LkoRadius, 256);  // dense rendered polyline (Vectrosity-like)
+
+            var r = RenderParityOracle.ComputeDriftScaleDerived(
+                RenderParityOracle.ParityMode.Faithful, recorded, rendered);
+
+            Assert.True(r.HasMeasurement);
+            Assert.False(r.OverTolerance);
+            Assert.True(r.CountMismatch); // recorded (9) vs rendered (256)
+        }
+
+        // ===================================================================================
+        //  FAITHFUL drifted rows -> drift flagged
+        // ===================================================================================
+
+        [Fact]
+        public void Faithful_LoopRotationBug_OffOrbitArc_FlagsDrift()
+        {
+            // Row (drift): the documented looped-re-aim / icon-off-orbit ROTATION bug. The rendered arc is
+            // the recorded arc spun 20 deg about the body axis - same shape, angularly offset. The oracle
+            // must flag it (a faithful member is drawing the wrong geometry).
+            double[] recorded = CircleXZ(LkoRadius, SampleCount);
+            double[] rendered = RotateAboutY(recorded, 20.0);
+
+            var r = RenderParityOracle.ComputeDriftScaleDerived(
+                RenderParityOracle.ParityMode.Faithful, recorded, rendered);
+
+            Assert.True(r.HasMeasurement);
+            Assert.True(r.OverTolerance);
+        }
+
+        [Fact]
+        public void Faithful_WrongBodyOrbit_DifferentScale_FlagsDrift()
+        {
+            // Row (drift): the rendered orbit is reseeded onto the WRONG body / wrong elements - here a
+            // Mun-scale orbit drawn where an LKO orbit was recorded. The radii differ by ~17x, far beyond
+            // any scale-derived tolerance.
+            double[] recorded = CircleXZ(LkoRadius, SampleCount);
+            double[] rendered = CircleXZ(MunOrbitRadius, SampleCount);
+
+            var r = RenderParityOracle.ComputeDriftScaleDerived(
+                RenderParityOracle.ParityMode.Faithful, recorded, rendered);
+
+            Assert.True(r.HasMeasurement);
+            Assert.True(r.OverTolerance);
+        }
+
+        [Fact]
+        public void Faithful_MisAppliedLoopShift_PhaseOffset_FlagsDrift()
+        {
+            // Row (drift): a MIS-applied loop shift. Unlike the correct loop case (same shape, same phase
+            // set), a wrong shift samples the rendered orbit at a different ROTATED phase set whose curve
+            // no longer overlays the recorded one - modelled here as a large rotation (a half-turn) so the
+            // rendered arc spans the opposite side of the body. (A pure phase slide along the SAME closed
+            // circle is invisible to a nearest-point diff; the visible loop-shift bug is a wrong-orbit /
+            // wrong-rotation reseed, which this rotation models.)
+            double[] recorded = EllipseXZ(LkoRadius, 0.5, SampleCount);
+            double[] rendered = RotateAboutY(EllipseXZ(LkoRadius, 0.5, SampleCount), 90.0);
+
+            var r = RenderParityOracle.ComputeDriftScaleDerived(
+                RenderParityOracle.ParityMode.Faithful, recorded, rendered);
+
+            Assert.True(r.HasMeasurement);
+            Assert.True(r.OverTolerance);
+        }
+
+        [Fact]
+        public void Faithful_DescentArcOffset_FlagsDrift()
+        {
+            // Row (drift): a descent rendered with a large lateral offset (a mis-stitched deorbit arc
+            // landing off the recorded ground track). 5 km off a ~60 km-scale descent is well over
+            // tolerance.
+            double[] recorded = VerticalProfile(60_000.0, 0.0, 20_000.0, SampleCount);
+            double[] rendered = Translate(recorded, 0.0, 0.0, 5_000.0);
+
+            var r = RenderParityOracle.ComputeDriftScaleDerived(
+                RenderParityOracle.ParityMode.Faithful, recorded, rendered);
+
+            Assert.True(r.HasMeasurement);
+            Assert.True(r.OverTolerance);
+        }
+
+        [Fact]
+        public void Faithful_AerobrakingWrongEccentricity_FlagsDrift()
+        {
+            // Row (drift): the eccentric aerobraking conic rendered with the WRONG eccentricity - same sma
+            // but ecc 0.6 recorded vs 0.2 rendered, so periapsis/apoapsis differ by megametres.
+            double[] recorded = EllipseXZ(MunOrbitRadius, 0.6, SampleCount);
+            double[] rendered = EllipseXZ(MunOrbitRadius, 0.2, SampleCount);
+
+            var r = RenderParityOracle.ComputeDriftScaleDerived(
+                RenderParityOracle.ParityMode.Faithful, recorded, rendered);
+
+            Assert.True(r.HasMeasurement);
+            Assert.True(r.OverTolerance);
+        }
+
+        // ===================================================================================
+        //  SYNTHESIZED known-good rows -> zero drift (rendered == the producer's INTENDED arc)
+        // ===================================================================================
+
+        [Fact]
+        public void Synthesized_ReaimedLoopIntendedArc_KnownGood_ZeroDrift()
+        {
+            // Row: re-aim with a synodic target move. In SYNTHESIZED mode the reference is the producer's
+            // INTENDED re-aimed arc (NOT the recorded transfer), and the oracle validates DRAW-FIDELITY
+            // (rendered == intended), not solve-correctness. A correct draw of the intended heliocentric
+            // transfer reads zero drift.
+            double[] intended = EllipseXZ(HelioRadius, 0.25, SampleCount);
+            double[] rendered = EllipseXZ(HelioRadius, 0.25, SampleCount);
+
+            var r = RenderParityOracle.ComputeDriftScaleDerived(
+                RenderParityOracle.ParityMode.Synthesized, intended, rendered);
+
+            Assert.Equal(RenderParityOracle.ParityMode.Synthesized, r.Mode);
+            Assert.True(r.HasMeasurement);
+            Assert.False(r.OverTolerance);
+        }
+
+        [Fact]
+        public void Synthesized_MixedFaithfulReaimedMembers_IntendedArc_ZeroDrift()
+        {
+            // Row: mixed faithful + re-aimed members. The re-aimed member's intended arc (a Mun-scale
+            // departure conic) drawn faithfully reads zero drift in synthesized mode.
+            double[] intended = CircleXZ(MunOrbitRadius, SampleCount, phase0: 0.7);
+            double[] rendered = CircleXZ(MunOrbitRadius, SampleCount, phase0: 0.7);
+
+            var r = RenderParityOracle.ComputeDriftScaleDerived(
+                RenderParityOracle.ParityMode.Synthesized, intended, rendered);
+
+            Assert.True(r.HasMeasurement);
+            Assert.False(r.OverTolerance);
+        }
+
+        [Fact]
+        public void Synthesized_DescentReStitchIntendedG1Arc_KnownGood_ZeroDrift()
+        {
+            // Row: Phase 6 descent re-stitch gates in SYNTHESIZED mode (the stitcher intentionally CHANGES
+            // the deorbit geometry vs the recorded arc, so faithful-vs-recorded is the wrong axis). A
+            // correct draw of the stitcher's intended G1 deorbit arc reads zero drift against the intended
+            // reference.
+            double[] intendedDeorbit = VerticalProfile(70_000.0, 0.0, 40_000.0, SampleCount);
+            double[] rendered = VerticalProfile(70_000.0, 0.0, 40_000.0, SampleCount);
+
+            var r = RenderParityOracle.ComputeDriftScaleDerived(
+                RenderParityOracle.ParityMode.Synthesized, intendedDeorbit, rendered);
+
+            Assert.True(r.HasMeasurement);
+            Assert.False(r.OverTolerance);
+        }
+
+        // ===================================================================================
+        //  SYNTHESIZED drifted rows -> drift flagged (rendered != the producer's intended arc)
+        // ===================================================================================
+
+        [Fact]
+        public void Synthesized_ReaimedArc_DrawnRotated_FlagsDrift()
+        {
+            // Row (drift): the re-aimed member's intended arc drawn with a draw-fidelity bug - the
+            // rendered transfer is rotated 15 deg off the intended arc (a draw regression, NOT a solve
+            // error). Synthesized mode catches it.
+            double[] intended = EllipseXZ(HelioRadius, 0.25, SampleCount);
+            double[] rendered = RotateAboutY(intended, 15.0);
+
+            var r = RenderParityOracle.ComputeDriftScaleDerived(
+                RenderParityOracle.ParityMode.Synthesized, intended, rendered);
+
+            Assert.True(r.HasMeasurement);
+            Assert.True(r.OverTolerance);
+        }
+
+        [Fact]
+        public void Synthesized_DescentReStitch_SeamDiscontinuity_FlagsDrift()
+        {
+            // Row (drift): the descent re-stitch draws a deorbit arc that diverges from the stitcher's
+            // intended G1 arc (the rendered arc lands 8 km off the intended ground track) - the draw-
+            // fidelity failure the Phase 6 synthesized gate exists to catch, distinct from the
+            // rigid-seam-tangent-discontinuity anomaly the stitcher itself raises.
+            double[] intendedDeorbit = VerticalProfile(70_000.0, 0.0, 40_000.0, SampleCount);
+            double[] rendered = Translate(intendedDeorbit, 0.0, 0.0, 8_000.0);
+
+            var r = RenderParityOracle.ComputeDriftScaleDerived(
+                RenderParityOracle.ParityMode.Synthesized, intendedDeorbit, rendered);
+
+            Assert.True(r.HasMeasurement);
+            Assert.True(r.OverTolerance);
+        }
+
+        // ===================================================================================
+        //  Cross-cutting: tolerance is per-scenario (scale-derived), and the no-measurement
+        //  paths never raise a false drift (the documented-buggy rows are tracked as
+        //  expected-to-change and excluded from the zero-drift baseline; see the traceability doc).
+        // ===================================================================================
+
+        [Fact]
+        public void SameAbsoluteOffset_DriftOnLko_NotOnHeliocentric_PerScenarioTolerance()
+        {
+            // Row: the SAME absolute rendered offset is a drift on an LKO-scale arc but within tolerance
+            // on a heliocentric-scale arc - the per-scenario, scale-derived tolerance the migration plan
+            // requires (a blanket metre tolerance would either mask the LKO drift or false-fire helio).
+            const double offset = 5_000.0; // 5 km
+
+            double[] lkoRef = CircleXZ(LkoRadius, SampleCount);
+            double[] lkoRend = Translate(lkoRef, 0.0, 0.0, offset);
+            double[] helioRef = CircleXZ(HelioRadius, SampleCount);
+            double[] helioRend = Translate(helioRef, 0.0, 0.0, offset);
+
+            var lko = RenderParityOracle.ComputeDriftScaleDerived(
+                RenderParityOracle.ParityMode.Faithful, lkoRef, lkoRend);
+            var helio = RenderParityOracle.ComputeDriftScaleDerived(
+                RenderParityOracle.ParityMode.Faithful, helioRef, helioRend);
+
+            Assert.True(lko.OverTolerance);     // 5 km > ~0.1% of the LKO arc extent (~1.4 km)
+            Assert.False(helio.OverTolerance);  // 5 km < ~0.1% of the heliocentric extent (~2.6e7 m)
+        }
+
+        [Fact]
+        public void NoMeasurement_NeverFalseDrift_RegressionSafety()
+        {
+            // Row: a degenerate scenario (an empty / not-yet-resolved rendered set, e.g. a ghost mid-
+            // reseed) must report NO measurement and NO drift, never a false regression. This is the
+            // safety property the whole regression set leans on: a hole reads as "could not measure",
+            // not "passed" and not "broke".
+            double[] recorded = CircleXZ(LkoRadius, SampleCount);
+
+            var empty = RenderParityOracle.ComputeDriftScaleDerived(
+                RenderParityOracle.ParityMode.Faithful, recorded, Array.Empty<double>());
+            Assert.False(empty.HasMeasurement);
+            Assert.False(empty.OverTolerance);
+
+            // All-non-finite rendered (a NaN-flung reseed) is also no-measurement, no false drift.
+            double[] allNaN = new double[recorded.Length];
+            for (int i = 0; i < allNaN.Length; i++)
+                allNaN[i] = double.NaN;
+            var nan = RenderParityOracle.ComputeDriftScaleDerived(
+                RenderParityOracle.ParityMode.Faithful, recorded, allNaN);
+            Assert.False(nan.HasMeasurement);
+            Assert.False(nan.OverTolerance);
+        }
+    }
+}

--- a/Source/Parsek/InGameTests/RenderParityBaselineTest.cs
+++ b/Source/Parsek/InGameTests/RenderParityBaselineTest.cs
@@ -1,0 +1,297 @@
+using System.Collections.Generic;
+using System.Globalization;
+using UnityEngine;
+
+namespace Parsek.InGameTests
+{
+    // Phase 0 / migration §2 - the parity-BASELINE in-game test: the POSITIVE gate complementing the
+    // sampler's drift-DETECTION (slice 2's TrySampleAndEmitFaithfulOrbitParity + the headless drifted
+    // scenarios). It runs a KNOWN-GOOD scenario end-to-end through the REAL wired probe orchestration
+    // (MapRenderProbe.ComputeFaithfulOrbitParity: the live OrbitDriver.orbit, the recorded reference rebuilt
+    // PHASE-MATCHED via BuildPhaseMatchedReferenceOrbit, both sampled through OrbitRelativePositionYup,
+    // diffed by RenderParityOracle) and asserts ZERO parity-drift - both directly on the ParityResult AND on
+    // the gated MapRenderTrace anomaly sink (no reason=parity-drift line emitted for the known-good ghost).
+    //
+    // CRITICAL (the "green but blind" guard): this test calls the SAME internal seam the production probe
+    // calls (MapRenderProbe.ComputeFaithfulOrbitParity), NOT an inlined copy of the diff. An earlier version
+    // re-implemented the diff inline with shift=0, so it never exercised the loop-shift epoch-bake
+    // orchestration where the BLOCKER lived (the reference was built from the raw segment epoch while the
+    // live orbit was baked to seg.epoch + loopShift, tracing opposite arcs and reporting a FALSE drift on
+    // every faithful loop ghost). The LOOP-SHIFTED variant below drives a ghost whose live orbit epoch IS
+    // baked with a non-zero loop shift and asserts ZERO drift end-to-end - the in-game proof the blocker
+    // fix (phase-matched reference epoch) works.
+    //
+    // Why it complements the others: the diff MATH is unit-tested headless (RenderParityOracleTests), the
+    // pure reframing/flattening is unit-tested headless (RenderGeometrySamplerTests), the Unity CAPTURE
+    // path is validated against a hand-computed orbit (RenderParitySamplerFixtureTest), and the headless
+    // regression set asserts the oracle's VERDICT per §11.5 row (RenderParityRegressionScenarioTests).
+    // This test is the end-to-end "a real faithful ghost, rendered live, reports zero drift" baseline the
+    // migration plan gates every later phase on - captured on KNOWN-GOOD scenarios ONLY (the documented-
+    // buggy scenarios are tracked as expected-to-change, NOT baselined; see the traceability doc).
+    //
+    // NOTE: in-game test (Ctrl+Shift+T / Settings > Diagnostics); cannot run headless (it builds a live
+    // ghost ProtoVessel and reads its OrbitDriver). Career-independent; FLIGHT + TRACKSTATION variants.
+    public class RenderParityBaselineTest
+    {
+        private const string KerbinBodyName = "Kerbin";
+
+        // A clean, unambiguously-orbital, fully-above-atmosphere CIRCULAR equatorial Kerbin orbit - the
+        // same known-good shape the capture-harness fixture uses, so the baseline shares its
+        // hand-verifiable geometry. A faithful ghost on this orbit MUST report zero drift.
+        private const double Sma = 850000.0;
+        private const double Ecc = 0.0;
+        private const double Inc = 0.0;
+
+        // A deliberately non-zero loop epoch shift (seconds) for the loop-shifted variant: about 18 minutes,
+        // a sizeable fraction of the ~1.4 h orbit period at Sma, so the icon sits well around the orbit from
+        // the raw recorded phase. With the BLOCKER bug present (raw-epoch reference + offShift~0 remap) the
+        // rendered and reference orbits would trace opposite arcs at this shift and report a ~orbit-diameter
+        // false drift; with the fix (phase-matched reference epoch) the diff is ~0.
+        private const double LoopEpochShiftSeconds = 1100.0;
+
+        [InGameTest(Category = "GhostMap", Scene = GameScenes.FLIGHT,
+            Description = "Phase 0 parity-baseline (FLIGHT): a known-good faithful ghost rendered live "
+                + "reports ZERO parity-drift through the REAL wired probe seam (positive gate "
+                + "complementing the drift-detection sampler)")]
+        public void ParityBaseline_KnownGoodFaithfulGhost_ZeroDrift_Flight()
+        {
+            AssertKnownGoodGhostReportsZeroDrift("FLIGHT", LoopEpochShiftSeconds: 0.0);
+        }
+
+        [InGameTest(Category = "GhostMap", Scene = GameScenes.TRACKSTATION,
+            Description = "Phase 0 parity-baseline (TRACKSTATION): a known-good faithful ghost rendered "
+                + "live reports ZERO parity-drift through the REAL wired probe seam (flight-map<->TS "
+                + "render parity is a v1 requirement)")]
+        public void ParityBaseline_KnownGoodFaithfulGhost_ZeroDrift_TrackingStation()
+        {
+            AssertKnownGoodGhostReportsZeroDrift("TRACKSTATION", LoopEpochShiftSeconds: 0.0);
+        }
+
+        [InGameTest(Category = "GhostMap", Scene = GameScenes.FLIGHT,
+            Description = "Phase 0 parity-baseline (FLIGHT, LOOP-SHIFTED): a faithful ghost whose live "
+                + "orbit epoch is baked with a NON-ZERO loop shift reports ZERO parity-drift through the "
+                + "REAL wired probe seam - the in-game proof the false-drift blocker fix (phase-matched "
+                + "reference epoch) works on the buggy loop-shift orchestration path")]
+        public void ParityBaseline_LoopShiftedFaithfulGhost_ZeroDrift_Flight()
+        {
+            AssertKnownGoodGhostReportsZeroDrift("FLIGHT-loop", LoopEpochShiftSeconds);
+        }
+
+        private static void AssertKnownGoodGhostReportsZeroDrift(string scene, double LoopEpochShiftSeconds)
+        {
+            CelestialBody kerbin = FlightGlobals.Bodies?.Find(b => b.bodyName == KerbinBodyName);
+            if (kerbin == null)
+            {
+                InGameAssert.Skip("Kerbin not found in FlightGlobals.Bodies (non-stock pack)");
+                return;
+            }
+
+            double liveUT = Planetarium.GetUniversalTime();
+            // The recording is authored in the RAW recorded clock: a loop-shifted ghost replays a PAST
+            // recorded segment whose effUT = liveUT - shift. Author the segment around that effUT so the
+            // covering-segment lookup at offEffUT resolves, mirroring a real loop replay.
+            double effUT = liveUT - LoopEpochShiftSeconds;
+            double startUT = effUT - 1800.0;
+            OrbitSegment seg = BuildSegment(startUT);
+
+            // Force the tracer ON for this test so the anomaly sink is live (the gate routes everything
+            // through MapRenderTrace.IsEnabled). Capture the emitted lines via the ParsekLog test sink so
+            // we can assert NO reason=parity-drift line fires for the known-good ghost.
+            bool prevForceEnabled = MapRenderTrace.ForceEnabledForTesting;
+            var capturedLines = new List<string>();
+            System.Action<string> prevSink = ParsekLog.TestSinkForTesting;
+            bool prevSuppress = ParsekLog.SuppressLogging;
+
+            System.Func<double> prevUTNow = GhostMapPresence.CurrentUTNow;
+            List<Recording> prevRecordings = RecordingStore.CommittedRecordings != null
+                ? new List<Recording>(RecordingStore.CommittedRecordings)
+                : new List<Recording>();
+            List<RecordingTree> prevTrees = RecordingStore.CommittedTrees != null
+                ? new List<RecordingTree>(RecordingStore.CommittedTrees)
+                : new List<RecordingTree>();
+
+            Recording rec = BuildRecording(startUT, seg);
+            RecordingStore.ClearCommittedInternal();
+            RecordingStore.ClearCommittedTreesInternal();
+            RecordingStore.AddCommittedInternal(rec);
+            int recordingIndex = RecordingStore.CommittedRecordings.Count - 1;
+            GhostMapPresence.CurrentUTNow = () => liveUT;
+            GhostMapPresence.RemoveAllGhostVessels("parity-baseline-start");
+
+            uint pid = 0u;
+            try
+            {
+                MapRenderTrace.ForceEnabledForTesting = true;
+                ParsekLog.SuppressLogging = false;
+                ParsekLog.TestSinkForTesting = line => capturedLines.Add(line);
+
+                // Create the live ghost with the loop epoch shift baked in (shift 0 for the non-loop
+                // variants). For a non-zero shift this seeds the rendered OrbitDriver.orbit epoch to
+                // seg.epoch + shift (BuildAndLoadGhostProtoVessel + StockConicTreatment.SeedAndDriveLive)
+                // and records the shift via GhostMapPresence.GetGhostOrbitEpochShift(pid) - the EXACT
+                // orchestration the production probe reads. The probe's ComputeFaithfulOrbitParity then
+                // rebuilds the reference PHASE-MATCHED to that baked epoch, so a correct fix reads ~0.
+                Vessel ghost = GhostMapPresence.CreateGhostVesselFromSource(
+                    recordingIndex,
+                    rec,
+                    GhostMapPresence.TrackingStationGhostSource.Segment,
+                    seg,
+                    default(TrajectoryPoint),
+                    startUT,
+                    loopEpochShiftSeconds: LoopEpochShiftSeconds);
+
+                if (ghost == null || ghost.orbitDriver == null || ghost.orbitDriver.orbit == null)
+                {
+                    InGameAssert.Skip("Faithful ghost did not create in this context (no proto)");
+                    return;
+                }
+                pid = ghost.persistentId;
+
+                Orbit renderedOrbit = ghost.orbitDriver.orbit;
+
+                // Read the loop shift the live orbit was ACTUALLY baked with from the production map (NOT a
+                // local constant): proves the create path stored it and the probe reads the same value.
+                double loopShift = GhostMapPresence.GetGhostOrbitEpochShift(pid);
+                InGameAssert.ApproxEqual(LoopEpochShiftSeconds, loopShift, 1.0,
+                    "Live ghost must record the loop epoch shift the production probe reads back");
+
+                // The icon point exactly as the production sampler anchors the rendered set.
+                Vector3d iconBodyRel = ghost.GetWorldPos3D() - kerbin.position;
+
+                // *** Drive the REAL production seam (not an inlined diff) ***. This exercises the recorded-
+                // segment lookup, the loop-shift epoch bake (BuildPhaseMatchedReferenceOrbit), the
+                // OrbitRelativePositionYup sampling of BOTH orbits at the SAME UTs, the scale-derived
+                // tolerance, and the oracle diff - the same call the probe makes each frame.
+                MapRenderProbe.FaithfulParitySample sample = MapRenderProbe.ComputeFaithfulOrbitParity(
+                    renderedOrbit, kerbin, iconBodyRel, effUT, loopShift, liveUT, rec.RecordingId);
+
+                Parsek.MapRender.RenderParityOracle.ParityResult result = sample.Result;
+
+                ParsekLog.Info("TestRunner",
+                    string.Format(CultureInfo.InvariantCulture,
+                        "ParityBaseline_KnownGood ({0}): pid={1} sma={2:F0} ecc={3:F2} loopShift={4:F1} "
+                        + "sampled={5} skip={6} hasMeas={7} maxDev={8:F1}m tol={9:F1}m scale={10:F0}m over={11}",
+                        scene, pid, Sma, Ecc, loopShift, sample.Sampled, sample.SkipReason ?? "(none)",
+                        result.HasMeasurement, result.MaxDeviationMeters, result.ToleranceMeters,
+                        sample.Scale, result.OverTolerance));
+
+                // The KNOWN-GOOD baseline: a faithful ghost drawing its own recorded orbit MUST sample (a
+                // skip here means the covering segment / body guard mis-fired) and MUST measure within
+                // tolerance (zero drift). A no-sample / no-measurement here is a sampler-blindness bug (the
+                // positive gate that would otherwise pass silently), so assert both.
+                InGameAssert.IsTrue(sample.Sampled,
+                    "Known-good faithful ghost must SAMPLE (not skip) the parity diff; skipReason="
+                    + (sample.SkipReason ?? "(none)"));
+                InGameAssert.IsTrue(result.HasMeasurement,
+                    "Known-good faithful ghost must yield a parity MEASUREMENT (else the positive gate is "
+                    + "blind); HasMeasurement was false.");
+                InGameAssert.IsFalse(result.OverTolerance,
+                    string.Format(CultureInfo.InvariantCulture,
+                        "Known-good faithful ghost (loopShift={0:F1}) must report ZERO drift; maxDev={1:F1}m "
+                        + "exceeded tol={2:F1}m (scale={3:F0}m). The wired parity path is flagging a faithful "
+                        + "baseline as drifted - a positive-gate regression (the loop-shift false-drift "
+                        + "blocker if loopShift != 0).",
+                        loopShift, result.MaxDeviationMeters, result.ToleranceMeters, sample.Scale));
+
+                // Mirror the production emit decision: a known-good ghost would NOT emit a parity-drift
+                // anomaly. Run the same EmitAnomaly-on-over-tolerance gate and assert nothing fired.
+                if (result.HasMeasurement && result.OverTolerance)
+                    MapRenderTrace.EmitAnomaly(
+                        MapRenderTrace.RenderSurface.ProtoOrbitLine, pid.ToString(CultureInfo.InvariantCulture),
+                        liveUT, effUT, MapRenderTrace.AnomalyParityDrift,
+                        "mode=faithful (baseline test emit)");
+
+                foreach (string line in capturedLines)
+                    InGameAssert.IsFalse(
+                        line.Contains("reason=" + MapRenderTrace.AnomalyParityDrift),
+                        "Known-good baseline must emit NO parity-drift anomaly; saw: " + line);
+            }
+            finally
+            {
+                if (pid != 0u)
+                    GhostMapPresence.RemoveAllGhostVessels("parity-baseline-cleanup");
+                RecordingStore.ClearCommittedInternal();
+                RecordingStore.ClearCommittedTreesInternal();
+                for (int i = 0; i < prevRecordings.Count; i++)
+                    RecordingStore.AddCommittedInternal(prevRecordings[i]);
+                for (int i = 0; i < prevTrees.Count; i++)
+                    RecordingStore.AddCommittedTreeInternal(prevTrees[i]);
+                GhostMapPresence.CurrentUTNow = prevUTNow;
+                MapRenderTrace.ForceEnabledForTesting = prevForceEnabled;
+                ParsekLog.TestSinkForTesting = prevSink;
+                ParsekLog.SuppressLogging = prevSuppress;
+            }
+        }
+
+        private static OrbitSegment BuildSegment(double startUT)
+        {
+            return new OrbitSegment
+            {
+                startUT = startUT,
+                endUT = startUT + 3600.0,
+                inclination = Inc,
+                eccentricity = Ecc,
+                semiMajorAxis = Sma,
+                longitudeOfAscendingNode = 0.0,
+                argumentOfPeriapsis = 0.0,
+                meanAnomalyAtEpoch = 0.0,
+                epoch = startUT,
+                bodyName = KerbinBodyName,
+                isPredicted = false,
+                orbitalFrameRotation = Quaternion.identity,
+                angularVelocity = Vector3.zero,
+            };
+        }
+
+        private static Recording BuildRecording(double startUT, OrbitSegment seg)
+        {
+            double endUT = startUT + 3600.0;
+            var rec = new Recording
+            {
+                RecordingId = "parity-baseline-" + System.Guid.NewGuid().ToString("N"),
+                VesselName = "Parsek Parity Baseline",
+                TerminalStateValue = null,
+                EndpointPhase = RecordingEndpointPhase.OrbitSegment,
+                EndpointBodyName = KerbinBodyName,
+                TerminalOrbitBody = KerbinBodyName,
+                TerminalOrbitSemiMajorAxis = Sma,
+                TerminalOrbitEccentricity = Ecc,
+                TerminalOrbitInclination = Inc,
+                TerminalOrbitLAN = 0.0,
+                TerminalOrbitArgumentOfPeriapsis = 0.0,
+                TerminalOrbitMeanAnomalyAtEpoch = 0.0,
+                TerminalOrbitEpoch = startUT,
+                ExplicitStartUT = startUT,
+                ExplicitEndUT = endUT,
+                PlaybackEnabled = true,
+            };
+            rec.Points.Add(new TrajectoryPoint
+            {
+                ut = startUT,
+                latitude = 0.0,
+                longitude = 0.0,
+                altitude = Sma - KerbinRadiusFallback,
+                rotation = Quaternion.identity,
+                velocity = new Vector3(0f, 2200f, 0f),
+                bodyName = KerbinBodyName,
+            });
+            rec.Points.Add(new TrajectoryPoint
+            {
+                ut = endUT,
+                latitude = 0.0,
+                longitude = 5.0,
+                altitude = Sma - KerbinRadiusFallback,
+                rotation = Quaternion.identity,
+                velocity = new Vector3(0f, 2200f, 0f),
+                bodyName = KerbinBodyName,
+            });
+            rec.OrbitSegments.Add(seg);
+            rec.MarkFilesDirty();
+            return rec;
+        }
+
+        // Only used to author plausible TrajectoryPoint altitudes; the geometry under test is driven by
+        // the OrbitSegment elements, so the exact value is not load-bearing.
+        private const double KerbinRadiusFallback = 600000.0;
+    }
+}

--- a/Source/Parsek/InGameTests/RenderParitySamplerFixtureTest.cs
+++ b/Source/Parsek/InGameTests/RenderParitySamplerFixtureTest.cs
@@ -1,0 +1,248 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Parsek.InGameTests
+{
+    // Phase 0 / design §14: the recorded-vs-rendered PARITY SAMPLER capture-harness (the review's
+    // "green but blind" guard). The RenderParityOracle's diff MATH and the RenderGeometrySampler's pure
+    // reframing/flattening are unit-tested headless; this in-game fixture is the SEPARATE guard that the
+    // Unity CAPTURE PATH itself is correct - i.e. that the geometry MapRenderProbe reads off a live ghost
+    // (the rendered OrbitDriver.orbit via OrbitRelativePositionYup, the icon point via GetWorldPos3D -
+    // body.position, and the recorded reference via BuildOrbitFromSegment) lands where a HAND-COMPUTED
+    // orbit at known elements says it should. Without this, a sampler that read the wrong frame / wrong
+    // clock would still pass every diff-math unit test (both sides wrong the same way) yet be blind in
+    // game.
+    //
+    // It deliberately does NOT touch the oracle: it asserts the captured Vector3d positions directly
+    // against an independent KSP Orbit built from the SAME known elements. Career-independent; runs in
+    // FLIGHT on a stock Kerbin pack. NOTE: in-game test (Ctrl+Shift+T / Settings > Diagnostics); cannot
+    // run headless.
+    public class RenderParitySamplerFixtureTest
+    {
+        private const string KerbinBodyName = "Kerbin";
+
+        // A clean, unambiguously-orbital, fully-above-atmosphere CIRCULAR equatorial Kerbin orbit: ecc=0
+        // and inc=0 make the hand-computed reference trivial - every body-relative position has magnitude
+        // == sma and lies in the equatorial (XZ, Y-up world) plane.
+        private const double Sma = 800000.0;
+        private const double Ecc = 0.0;
+        private const double Inc = 0.0;
+
+        // Capture-vs-hand-computed tolerances. The capture must land essentially exactly on the
+        // independent Orbit (same elements, same body, same UT): a few metres of float slack on an
+        // 800 km-radius orbit. The "icon lies on its own captured orbit line" check is the cross-surface
+        // agreement: the icon point and the captured orbit curve are both rendered from the live
+        // OrbitDriver, so they must coincide closely.
+        private const double CapturePositionToleranceMeters = 50.0;
+        private const double IconOnLineToleranceMeters = 2000.0;
+
+        [InGameTest(Category = "GhostMap", Scene = GameScenes.FLIGHT,
+            Description = "Phase 0 parity capture-harness: the MapRenderProbe Unity sampler captures a live "
+                + "ghost's rendered orbit / icon geometry and the recorded reference at the SAME hand-"
+                + "computed positions (guards the capture path, separate from the oracle diff-math tests)")]
+        public void ParitySampler_CapturesHandComputedOrbitGeometry()
+        {
+            CelestialBody kerbin = FlightGlobals.Bodies?.Find(b => b.bodyName == KerbinBodyName);
+            if (kerbin == null)
+            {
+                InGameAssert.Skip("Kerbin not found in FlightGlobals.Bodies (non-stock pack)");
+                return;
+            }
+
+            double liveUT = Planetarium.GetUniversalTime();
+            double startUT = liveUT;
+            OrbitSegment seg = BuildSegment(startUT);
+
+            System.Func<double> prevUTNow = GhostMapPresence.CurrentUTNow;
+            List<Recording> prevRecordings = RecordingStore.CommittedRecordings != null
+                ? new List<Recording>(RecordingStore.CommittedRecordings)
+                : new List<Recording>();
+            List<RecordingTree> prevTrees = RecordingStore.CommittedTrees != null
+                ? new List<RecordingTree>(RecordingStore.CommittedTrees)
+                : new List<RecordingTree>();
+
+            Recording rec = BuildRecording(startUT, seg);
+            RecordingStore.ClearCommittedInternal();
+            RecordingStore.ClearCommittedTreesInternal();
+            RecordingStore.AddCommittedInternal(rec);
+            int recordingIndex = RecordingStore.CommittedRecordings.Count - 1;
+            GhostMapPresence.CurrentUTNow = () => liveUT;
+            GhostMapPresence.RemoveAllGhostVessels("parity-sampler-fixture-start");
+
+            uint pid = 0u;
+            try
+            {
+                Vessel ghost = GhostMapPresence.CreateGhostVesselFromSource(
+                    recordingIndex,
+                    rec,
+                    GhostMapPresence.TrackingStationGhostSource.Segment,
+                    seg,
+                    default(TrajectoryPoint),
+                    startUT,
+                    loopEpochShiftSeconds: 0.0);
+
+                if (ghost == null || ghost.orbitDriver == null || ghost.orbitDriver.orbit == null)
+                {
+                    InGameAssert.Skip("Faithful ghost did not create in this context (no proto)");
+                    return;
+                }
+                pid = ghost.persistentId;
+                InGameAssert.IsTrue(GhostMapPresence.IsGhostMapVessel(pid),
+                    "Freshly created faithful ghost must be registered as a ghost map vessel");
+
+                Orbit renderedOrbit = ghost.orbitDriver.orbit;
+
+                // --- Capture surface 1: the rendered orbit-line geometry (OrbitRelativePositionYup, the
+                // EXACT production capture). A circular equatorial orbit's body-relative samples must each
+                // have magnitude == sma and (near-)zero out-of-plane (Y, Y-up world) component. ---
+                int n = 5;
+                for (int i = 0; i < n; i++)
+                {
+                    double ut = startUT + i * 600.0; // five samples across ~50 min of the orbit
+                    Vector3d capturedRel = MapRenderProbe.OrbitRelativePositionYup(renderedOrbit, ut);
+                    double r = capturedRel.magnitude;
+                    InGameAssert.ApproxEqual(Sma, r, CapturePositionToleranceMeters,
+                        string.Format(System.Globalization.CultureInfo.InvariantCulture,
+                            "Captured rendered orbit sample {0} radius must equal the known sma {1:F0} m "
+                            + "(circular), was {2:F0} m. The capture is reading the wrong frame/clock.",
+                            i, Sma, r));
+                    InGameAssert.IsLessThan(System.Math.Abs(capturedRel.y), CapturePositionToleranceMeters,
+                        string.Format(System.Globalization.CultureInfo.InvariantCulture,
+                            "Captured rendered equatorial (inc=0) orbit sample {0} must lie in the Y-up "
+                            + "equatorial plane (|y| ~ 0), was y={1:F1} m.",
+                            i, capturedRel.y));
+                }
+
+                // --- Capture surface 2: the recorded reference reconstruction (BuildOrbitFromSegment, the
+                // EXACT production construction) sampled through the SAME OrbitRelativePositionYup must match
+                // the rendered orbit at the same UT (faithful: recorded == rendered). ---
+                CelestialBody recordedBody = MapRenderProbe.ResolveBodyByName(seg.bodyName);
+                InGameAssert.IsNotNull(recordedBody, "Recorded segment body must resolve");
+                Orbit recordedOrbit = MapRenderProbe.BuildOrbitFromSegment(seg, recordedBody);
+                InGameAssert.IsNotNull(recordedOrbit,
+                    "BuildOrbitFromSegment must reconstruct a usable Orbit from the recorded segment");
+
+                double refCheckUT = startUT + 1200.0;
+                Vector3d renderedAt = MapRenderProbe.OrbitRelativePositionYup(renderedOrbit, refCheckUT);
+                Vector3d recordedAt = MapRenderProbe.OrbitRelativePositionYup(recordedOrbit, refCheckUT);
+                double refDelta = (renderedAt - recordedAt).magnitude;
+                InGameAssert.IsLessThan(refDelta, CapturePositionToleranceMeters,
+                    string.Format(System.Globalization.CultureInfo.InvariantCulture,
+                        "For a FAITHFUL ghost the recorded reference orbit (BuildOrbitFromSegment) and the "
+                        + "rendered OrbitDriver.orbit must coincide at the same UT; captured |delta|={0:F1} m "
+                        + "exceeds {1:F0} m. rendered={2} recorded={3}",
+                        refDelta, CapturePositionToleranceMeters, renderedAt, recordedAt));
+
+                // --- Cross-surface agreement: the rendered ICON point (GetWorldPos3D - body.position, the
+                // probe's bodyRelPos capture) must lie ON the captured rendered orbit curve at the icon's
+                // resolved clock (here the live clock, shift 0). This proves the icon-point capture and the
+                // orbit-curve capture are in the SAME frame - the precondition for the parity diff. ---
+                Vector3d iconBodyRel = ghost.GetWorldPos3D() - kerbin.position;
+                if (iconBodyRel.magnitude < 1.0)
+                {
+                    InGameAssert.Skip("Ghost world position not resolved on the creation frame");
+                    return;
+                }
+                Vector3d orbitAtLive = MapRenderProbe.OrbitRelativePositionYup(renderedOrbit, liveUT);
+                double iconOnLine = (iconBodyRel - orbitAtLive).magnitude;
+
+                ParsekLog.Info("TestRunner",
+                    string.Format(System.Globalization.CultureInfo.InvariantCulture,
+                        "ParitySampler_CapturesHandComputedOrbitGeometry: pid={0} sma={1:F0} ecc={2:F2} "
+                        + "iconR={3:F0} orbitAtLiveR={4:F0} iconOnLineDelta={5:F0}m refDelta={6:F1}m",
+                        pid, Sma, Ecc, iconBodyRel.magnitude, orbitAtLive.magnitude, iconOnLine, refDelta));
+
+                InGameAssert.IsLessThan(iconOnLine, IconOnLineToleranceMeters,
+                    string.Format(System.Globalization.CultureInfo.InvariantCulture,
+                        "The rendered icon point (GetWorldPos3D - body.position) must lie on the captured "
+                        + "rendered orbit curve at the icon's clock; captured |delta|={0:F0} m exceeds "
+                        + "{1:F0} m. The icon-point capture and the orbit-curve capture are in different "
+                        + "frames, so the parity diff would be meaningless.",
+                        iconOnLine, IconOnLineToleranceMeters));
+            }
+            finally
+            {
+                if (pid != 0u)
+                    GhostMapPresence.RemoveAllGhostVessels("parity-sampler-fixture-cleanup");
+                RecordingStore.ClearCommittedInternal();
+                RecordingStore.ClearCommittedTreesInternal();
+                for (int i = 0; i < prevRecordings.Count; i++)
+                    RecordingStore.AddCommittedInternal(prevRecordings[i]);
+                for (int i = 0; i < prevTrees.Count; i++)
+                    RecordingStore.AddCommittedTreeInternal(prevTrees[i]);
+                GhostMapPresence.CurrentUTNow = prevUTNow;
+            }
+        }
+
+        private static OrbitSegment BuildSegment(double startUT)
+        {
+            return new OrbitSegment
+            {
+                startUT = startUT,
+                endUT = startUT + 3600.0,
+                inclination = Inc,
+                eccentricity = Ecc,
+                semiMajorAxis = Sma,
+                longitudeOfAscendingNode = 0.0,
+                argumentOfPeriapsis = 0.0,
+                meanAnomalyAtEpoch = 0.0,
+                epoch = startUT,
+                bodyName = KerbinBodyName,
+                isPredicted = false,
+                orbitalFrameRotation = Quaternion.identity,
+                angularVelocity = Vector3.zero,
+            };
+        }
+
+        private static Recording BuildRecording(double startUT, OrbitSegment seg)
+        {
+            double endUT = startUT + 3600.0;
+            var rec = new Recording
+            {
+                RecordingId = "parity-sampler-fixture-" + System.Guid.NewGuid().ToString("N"),
+                VesselName = "Parsek Parity Sampler Fixture",
+                TerminalStateValue = null,
+                EndpointPhase = RecordingEndpointPhase.OrbitSegment,
+                EndpointBodyName = KerbinBodyName,
+                TerminalOrbitBody = KerbinBodyName,
+                TerminalOrbitSemiMajorAxis = Sma,
+                TerminalOrbitEccentricity = Ecc,
+                TerminalOrbitInclination = Inc,
+                TerminalOrbitLAN = 0.0,
+                TerminalOrbitArgumentOfPeriapsis = 0.0,
+                TerminalOrbitMeanAnomalyAtEpoch = 0.0,
+                TerminalOrbitEpoch = startUT,
+                ExplicitStartUT = startUT,
+                ExplicitEndUT = endUT,
+                PlaybackEnabled = true,
+            };
+            rec.Points.Add(new TrajectoryPoint
+            {
+                ut = startUT,
+                latitude = 0.0,
+                longitude = 0.0,
+                altitude = Sma - kerbinRadiusFallback,
+                rotation = Quaternion.identity,
+                velocity = new Vector3(0f, 2200f, 0f),
+                bodyName = KerbinBodyName,
+            });
+            rec.Points.Add(new TrajectoryPoint
+            {
+                ut = endUT,
+                latitude = 0.0,
+                longitude = 5.0,
+                altitude = Sma - kerbinRadiusFallback,
+                rotation = Quaternion.identity,
+                velocity = new Vector3(0f, 2200f, 0f),
+                bodyName = KerbinBodyName,
+            });
+            rec.OrbitSegments.Add(seg);
+            rec.MarkFilesDirty();
+            return rec;
+        }
+
+        // Only used to author plausible TrajectoryPoint altitudes; the orbit geometry under test is driven
+        // entirely by the OrbitSegment elements, so the exact value is not load-bearing.
+        private const double kerbinRadiusFallback = 600000.0;
+    }
+}

--- a/Source/Parsek/MapRender/RenderGeometrySampler.cs
+++ b/Source/Parsek/MapRender/RenderGeometrySampler.cs
@@ -1,0 +1,148 @@
+using System;
+
+namespace Parsek.MapRender
+{
+    /// <summary>
+    /// Phase 0 / design §14: the PURE, Unity-ECall-free part of the recorded-vs-rendered parity
+    /// SAMPLER that feeds <see cref="RenderParityOracle"/>. The oracle takes ALREADY-FRAMED flat
+    /// <c>double[]</c> XYZ triples in ONE consistent metres frame; this helper does the small amount of
+    /// genuinely-new pure logic between a raw <c>Vector3d</c> sample and that flat array:
+    ///
+    /// <list type="bullet">
+    ///   <item>BODY-RELATIVE REFRAMING: turning an ABSOLUTE world position into the orbit's own
+    ///     reference-body frame (<c>worldPos - bodyWorldPos</c>) - the SAME frame
+    ///     <see cref="MapRenderProbe"/> already uses for the icon-jump / icon-off-orbit checks
+    ///     (<c>GetWorldPos3D - referenceBody.position</c>). Both the rendered and the recorded sample
+    ///     MUST be reframed against the SAME body world position so the diff is body-motion-free
+    ///     (KSP builds an on-rails vessel's world position as <c>referenceBody.position + orbitRelative</c>,
+    ///     so the body-relative delta IS the orbital arc, with the floating-origin / body-world-motion
+    ///     contamination cancelled).</item>
+    ///   <item>FLATTENING a sequence of <c>Vector3d</c> samples into the flat <c>[x0,y0,z0, x1,...]</c>
+    ///     layout the oracle expects.</item>
+    ///   <item>BUILDING THE PARITY SAMPLE UTs: a small, even spread of UTs across the orbit's visible
+    ///     span at which BOTH sides are sampled (the rendered orbit at a live-clock UT, the recorded
+    ///     reference at the matching recorded-clock UT = renderedUT - loopShift), so a loop-shifted
+    ///     FAITHFUL ghost reads ~0 drift (the shift only sets WHERE on the orbit, not the orbit's shape)
+    ///     while a real draw regression (wrong elements / wrong body / icon off its own recorded orbit)
+    ///     shows drift.</item>
+    /// </list>
+    ///
+    /// <para>Unity reads (the actual <c>Orbit.getPositionAtUT</c> / <c>OrbitDriver.orbit</c> /
+    /// <c>Vessel.GetWorldPos3D</c> sampling) stay in the probe; this helper only manipulates primitives
+    /// and <c>Vector3d</c>, so it is unit-testable headless. NaN/Inf-safe: a non-finite sample is written
+    /// through unchanged (the oracle skips non-finite points and never raises a false anomaly), never
+    /// silently zeroed.</para>
+    /// </summary>
+    internal static class RenderGeometrySampler
+    {
+        /// <summary>
+        /// Default number of parity sample points spread across the orbit's visible span. Enough to
+        /// distinguish two same-shaped orbits at different phases / elements from one continuous
+        /// nearest-point projection (the oracle's diff) while keeping the per-frame
+        /// <c>Orbit.getPositionAtUT</c> cost trivial (a handful of evaluations per tracked ghost, gated by
+        /// <see cref="MapRenderTrace.IsEnabled"/>). Odd so one sample lands on the centre clock.
+        /// </summary>
+        internal const int DefaultOrbitSampleCount = 9;
+
+        /// <summary>
+        /// Pure: reframe an ABSOLUTE world position into the orbit's reference-body frame
+        /// (<c>worldPos - bodyWorldPos</c>). A non-finite component on EITHER operand yields a NaN-filled
+        /// result so the oracle skips the point (no false anomaly) rather than projecting onto a
+        /// body-motion-contaminated delta.
+        /// </summary>
+        internal static Vector3d ToBodyRelative(Vector3d worldPos, Vector3d bodyWorldPos)
+        {
+            if (!IsFinite(worldPos) || !IsFinite(bodyWorldPos))
+                return new Vector3d(double.NaN, double.NaN, double.NaN);
+            return worldPos - bodyWorldPos;
+        }
+
+        /// <summary>
+        /// Pure: flatten a sequence of <c>Vector3d</c> samples into the flat <c>[x0,y0,z0, x1,...]</c>
+        /// layout <see cref="RenderParityOracle.ComputeDrift"/> expects. <paramref name="count"/> caps how
+        /// many entries of <paramref name="points"/> are read (so a caller can reuse an oversized scratch
+        /// buffer). Non-finite components are written through unchanged - the oracle filters them. A null /
+        /// empty source (or count &lt;= 0) returns an empty array (the oracle's "no measurement" path).
+        /// </summary>
+        internal static double[] Flatten(Vector3d[] points, int count)
+        {
+            if (points == null || count <= 0)
+                return Array.Empty<double>();
+            int n = Math.Min(count, points.Length);
+            if (n <= 0)
+                return Array.Empty<double>();
+            var flat = new double[n * 3];
+            for (int i = 0; i < n; i++)
+            {
+                flat[i * 3] = points[i].x;
+                flat[i * 3 + 1] = points[i].y;
+                flat[i * 3 + 2] = points[i].z;
+            }
+            return flat;
+        }
+
+        /// <summary>
+        /// Pure convenience: flatten a single sample into a one-point flat array (the icon point case,
+        /// where the oracle's count==1 reference / rendered path applies).
+        /// </summary>
+        internal static double[] FlattenSingle(Vector3d point)
+        {
+            return new[] { point.x, point.y, point.z };
+        }
+
+        /// <summary>
+        /// Pure: build the EVEN spread of <paramref name="count"/> sample UTs across
+        /// <c>[centerUT - halfSpanSeconds, centerUT + halfSpanSeconds]</c> the rendered orbit is sampled
+        /// at. With <c>count == 1</c> the single sample is the centre clock. The recorded reference is
+        /// sampled at <c>renderedUT - loopShiftSeconds</c> for each of these (see
+        /// <see cref="ShiftSampleUTs"/>); the rendered orbit at these UTs directly. A non-finite
+        /// <paramref name="centerUT"/> / <paramref name="halfSpanSeconds"/>, or a non-positive
+        /// <paramref name="count"/>, returns an empty array (caller treats it as "cannot sample").
+        /// </summary>
+        internal static double[] BuildSampleUTs(double centerUT, double halfSpanSeconds, int count)
+        {
+            if (count <= 0 || !IsFiniteScalar(centerUT) || !IsFiniteScalar(halfSpanSeconds))
+                return Array.Empty<double>();
+            double half = Math.Abs(halfSpanSeconds);
+            var uts = new double[count];
+            if (count == 1)
+            {
+                uts[0] = centerUT;
+                return uts;
+            }
+            double step = (2.0 * half) / (count - 1);
+            for (int i = 0; i < count; i++)
+                uts[i] = centerUT - half + i * step;
+            return uts;
+        }
+
+        /// <summary>
+        /// Pure: produce a NEW array of <c>ut - shiftSeconds</c> (the recorded-clock UTs matching a set of
+        /// rendered live-clock sample UTs). The loop-epoch shift is <c>liveUT - effUT</c>, so the recorded
+        /// reference is sampled at <c>renderedUT - shift</c>. A null source returns an empty array; a
+        /// non-finite shift returns the source UTs unchanged (the caller's downstream finite-guard handles
+        /// the resulting samples).
+        /// </summary>
+        internal static double[] ShiftSampleUTs(double[] renderedUTs, double shiftSeconds)
+        {
+            if (renderedUTs == null)
+                return Array.Empty<double>();
+            if (!IsFiniteScalar(shiftSeconds))
+                return (double[])renderedUTs.Clone();
+            var shifted = new double[renderedUTs.Length];
+            for (int i = 0; i < renderedUTs.Length; i++)
+                shifted[i] = renderedUTs[i] - shiftSeconds;
+            return shifted;
+        }
+
+        private static bool IsFinite(Vector3d v)
+        {
+            return IsFiniteScalar(v.x) && IsFiniteScalar(v.y) && IsFiniteScalar(v.z);
+        }
+
+        private static bool IsFiniteScalar(double v)
+        {
+            return !double.IsNaN(v) && !double.IsInfinity(v);
+        }
+    }
+}

--- a/Source/Parsek/MapRender/RenderParityOracle.cs
+++ b/Source/Parsek/MapRender/RenderParityOracle.cs
@@ -1,0 +1,394 @@
+using System;
+
+namespace Parsek.MapRender
+{
+    /// <summary>
+    /// Phase 0 / design §14: the recorded-vs-rendered geometry-diff PARITY ORACLE.
+    ///
+    /// <para>This is a NEW, DISTINCT acceptance axis added BESIDE the existing
+    /// <see cref="GhostRenderReconciler"/> (intent-vs-old-truth). The two comparators COEXIST through
+    /// Phases 0-8 (Phase 8 unwires the old one); this oracle is NOT a rename or promotion of the
+    /// reconciler. Where the reconciler asks "did the new pipeline's INTENT match what the OLD path
+    /// actually drew?", this oracle asks "did the geometry the pipeline actually RENDERED match the
+    /// REFERENCE geometry it was supposed to render?" - a recorded-vs-rendered (or
+    /// intended-vs-rendered) drift, the objective "did I break rendering?" gate every later phase runs
+    /// over the regression set.</para>
+    ///
+    /// <para><b>Two modes (design §14 faithful-vs-synthesized):</b>
+    /// <list type="bullet">
+    ///   <item><see cref="ParityMode.Faithful"/>: rendered geometry vs the RECORDED source geometry.
+    ///     A faithful (non-re-aimed) member must draw exactly what it recorded - any drift is a draw
+    ///     regression. Phases 5a/5b/7 gate in this mode.</item>
+    ///   <item><see cref="ParityMode.Synthesized"/>: rendered geometry vs the PRODUCER'S INTENDED arc
+    ///     (the re-aim / re-time / re-rotate output). Here the oracle validates DRAW-FIDELITY (rendered
+    ///     == intended arc), NOT SOLVE-CORRECTNESS (intended arc == physically-correct transfer). The
+    ///     latter (plane-tilt / near-180 handedness, etc.) stays the re-aim solver's own test surface.
+    ///     Phase 6 (descent re-stitch, which intentionally CHANGES the deorbit geometry) gates in this
+    ///     mode.</list>
+    /// The diff MATH is identical in both modes; only the REFERENCE point set differs. The mode is
+    /// carried on the result purely so a caller / log line records which reference was diffed.</para>
+    ///
+    /// <para><b>Headless contract:</b> this type is Unity-ECall-FREE and primitive-only. It takes
+    /// ALREADY-FRAMED geometry (flat <c>double[]</c> XYZ triples). The Unity sampling + the
+    /// body-relative / scaled-to-world framing (reading <c>OrbitDriver</c> world pos, <c>ScaledSpace</c>,
+    /// Vectrosity <c>VectorLine.points3</c>) is the NEXT slice in <c>MapRenderProbe</c>; that probe must
+    /// hand this oracle points already in a single consistent metres frame (the design's
+    /// <c>bodyRelPos</c> for icon/orbit, scaled-&gt;world for the polyline). NaN/Inf handling mirrors
+    /// <see cref="GhostRenderReconciler"/> / <c>RewindReadbackGuard</c>: a non-finite input yields NO
+    /// false anomaly.</para>
+    /// </summary>
+    internal static class RenderParityOracle
+    {
+        /// <summary>Which reference geometry the rendered geometry was diffed against (design §14).</summary>
+        internal enum ParityMode : byte
+        {
+            /// <summary>Default / unset.</summary>
+            Unknown = 0,
+
+            /// <summary>Rendered vs the RECORDED source geometry (a faithful member must draw what it recorded).</summary>
+            Faithful = 1,
+
+            /// <summary>
+            /// Rendered vs the producer's INTENDED arc (re-aim / re-stitch). Validates draw-fidelity, NOT
+            /// solve-correctness.
+            /// </summary>
+            Synthesized = 2,
+        }
+
+        internal static string ParityModeToken(ParityMode mode)
+        {
+            switch (mode)
+            {
+                case ParityMode.Faithful: return "faithful";
+                case ParityMode.Synthesized: return "synthesized";
+                default: return "unknown";
+            }
+        }
+
+        /// <summary>
+        /// The outcome of one recorded-vs-rendered (or intended-vs-rendered) geometry diff.
+        /// </summary>
+        internal readonly struct ParityResult
+        {
+            /// <summary>The reference the diff was taken against (faithful = recorded, synthesized = intended).</summary>
+            internal ParityMode Mode { get; }
+
+            /// <summary>
+            /// True when the diff produced a usable measurement: both point sets had at least one finite
+            /// point and the rendered polyline had at least one finite segment endpoint to project onto.
+            /// When false (<see cref="OverTolerance"/> is forced false) the inputs were empty / all
+            /// non-finite and the oracle DELIBERATELY reports no drift (no false anomaly) - the caller
+            /// should treat this as "could not measure", not "passed".
+            /// </summary>
+            internal bool HasMeasurement { get; }
+
+            /// <summary>
+            /// The maximum deviation (metres) of any finite REFERENCE point from the rendered polyline
+            /// (the nearest-distance from each reference point to the rendered point sequence). 0 when
+            /// there is no measurement.
+            /// </summary>
+            internal double MaxDeviationMeters { get; }
+
+            /// <summary>The tolerance (metres) the deviation was compared against.</summary>
+            internal double ToleranceMeters { get; }
+
+            /// <summary>
+            /// True when the reference and rendered point COUNTS differed. Not itself an anomaly - the
+            /// diff is count-independent (nearest-point projection) - but recorded so a caller can log
+            /// it (a large count delta is a useful secondary signal).
+            /// </summary>
+            internal bool CountMismatch { get; }
+
+            /// <summary>Number of reference points supplied (finite + non-finite).</summary>
+            internal int ReferenceCount { get; }
+
+            /// <summary>Number of rendered points supplied (finite + non-finite).</summary>
+            internal int RenderedCount { get; }
+
+            /// <summary>
+            /// True iff there is a measurement AND the max deviation exceeds the tolerance. This is the
+            /// <c>parity-drift</c> decision. Always false when there is no measurement (NaN/Inf/empty
+            /// inputs never raise a false anomaly).
+            /// </summary>
+            internal bool OverTolerance { get; }
+
+            internal ParityResult(
+                ParityMode mode, bool hasMeasurement, double maxDeviationMeters, double toleranceMeters,
+                bool countMismatch, int referenceCount, int renderedCount, bool overTolerance)
+            {
+                Mode = mode;
+                HasMeasurement = hasMeasurement;
+                MaxDeviationMeters = maxDeviationMeters;
+                ToleranceMeters = toleranceMeters;
+                CountMismatch = countMismatch;
+                ReferenceCount = referenceCount;
+                RenderedCount = renderedCount;
+                OverTolerance = overTolerance;
+            }
+
+            internal static ParityResult NoMeasurement(
+                ParityMode mode, double toleranceMeters, int referenceCount, int renderedCount)
+            {
+                return new ParityResult(
+                    mode, hasMeasurement: false, maxDeviationMeters: 0.0, toleranceMeters: toleranceMeters,
+                    countMismatch: referenceCount != renderedCount,
+                    referenceCount: referenceCount, renderedCount: renderedCount, overTolerance: false);
+            }
+        }
+
+        // ---- Tolerance from geometry scale (design §14: per-scenario, derived from scale, NOT a blanket constant) ----
+
+        /// <summary>
+        /// Floor under the scale-derived tolerance (metres). Even a tiny-scale near-surface scene
+        /// carries float / interpolation / sampling jitter; below this floor a "drift" is noise.
+        /// </summary>
+        internal const double MinToleranceMeters = 1.0;
+
+        /// <summary>
+        /// Default fraction of the geometry scale used as the parity tolerance. A rendered arc that is
+        /// faithful to within this fraction of the arc's own extent is drawing the same geometry; a
+        /// looped-rotation / off-orbit / mis-stitched arc deviates by a far larger fraction. 0.1% of the
+        /// scale separates the two with margin (cf. the reconciler's 1-deg icon-off-orbit threshold,
+        /// which is ~1.7% of a full circle).
+        /// </summary>
+        internal const double DefaultScaleToleranceFraction = 0.001;
+
+        /// <summary>
+        /// Pure per-scenario tolerance helper: derive the parity tolerance (metres) from the geometry's
+        /// own SCALE (its characteristic extent in metres at the relevant map zoom), NOT a blanket
+        /// constant. A low-Kerbin-orbit arc (~700 km radius) and a heliocentric transfer (~1e10 m) want
+        /// wildly different absolute tolerances; a fixed metre tolerance would either mask real drift on
+        /// the big arc or false-fire on float jitter on the small one.
+        ///
+        /// <para>Returns <c>max(MinToleranceMeters, fraction * |scaleMeters|)</c>. A non-finite or
+        /// non-positive scale (degenerate / unknown) falls back to the floor so the caller still gets a
+        /// usable, conservative tolerance rather than 0 or NaN. <paramref name="fraction"/> defaults to
+        /// <see cref="DefaultScaleToleranceFraction"/>; a non-finite / negative fraction is treated as
+        /// the default.</para>
+        /// </summary>
+        internal static double ToleranceForScale(
+            double scaleMeters, double fraction = DefaultScaleToleranceFraction)
+        {
+            double f = (double.IsNaN(fraction) || double.IsInfinity(fraction) || fraction < 0.0)
+                ? DefaultScaleToleranceFraction
+                : fraction;
+            double scale = (double.IsNaN(scaleMeters) || double.IsInfinity(scaleMeters))
+                ? 0.0
+                : Math.Abs(scaleMeters);
+            double derived = scale * f;
+            if (double.IsNaN(derived) || double.IsInfinity(derived))
+                return MinToleranceMeters;
+            return Math.Max(MinToleranceMeters, derived);
+        }
+
+        /// <summary>
+        /// Pure: estimate a geometry's characteristic SCALE (metres) from a flat XYZ-triple point set, as
+        /// the diagonal of the set's finite-point bounding box. This is the natural "extent of the arc at
+        /// the relevant zoom" the tolerance scales off (the same arc the oracle diffs). Non-finite points
+        /// are skipped; an empty / all-non-finite / single-point set has zero extent and returns 0 (the
+        /// caller's <see cref="ToleranceForScale"/> then floors it).
+        /// </summary>
+        internal static double EstimateScaleFromPoints(double[] xyzFlat)
+        {
+            if (xyzFlat == null)
+                return 0.0;
+
+            bool any = false;
+            double minX = 0, minY = 0, minZ = 0, maxX = 0, maxY = 0, maxZ = 0;
+            int n = xyzFlat.Length / 3;
+            for (int i = 0; i < n; i++)
+            {
+                double x = xyzFlat[i * 3];
+                double y = xyzFlat[i * 3 + 1];
+                double z = xyzFlat[i * 3 + 2];
+                if (!IsFinite(x) || !IsFinite(y) || !IsFinite(z))
+                    continue;
+                if (!any)
+                {
+                    minX = maxX = x; minY = maxY = y; minZ = maxZ = z;
+                    any = true;
+                }
+                else
+                {
+                    if (x < minX) minX = x; else if (x > maxX) maxX = x;
+                    if (y < minY) minY = y; else if (y > maxY) maxY = y;
+                    if (z < minZ) minZ = z; else if (z > maxZ) maxZ = z;
+                }
+            }
+            if (!any)
+                return 0.0;
+            double dx = maxX - minX, dy = maxY - minY, dz = maxZ - minZ;
+            double diag = Math.Sqrt(dx * dx + dy * dy + dz * dz);
+            return (double.IsNaN(diag) || double.IsInfinity(diag)) ? 0.0 : diag;
+        }
+
+        // ---- The geometry diff ----
+
+        /// <summary>
+        /// PURE recorded-vs-rendered (or intended-vs-rendered) geometry diff. Both point sets are flat
+        /// XYZ triples (<c>[x0,y0,z0, x1,y1,z1, ...]</c>) ALREADY in one consistent metres frame (the
+        /// Unity sampler in the next slice supplies body-relative for icon/orbit and scaled-&gt;world for
+        /// the polyline). <paramref name="referenceXyz"/> is the geometry the pipeline was SUPPOSED to
+        /// draw (the RECORDED source in <see cref="ParityMode.Faithful"/>, the INTENDED arc in
+        /// <see cref="ParityMode.Synthesized"/>); <paramref name="renderedXyz"/> is what it ACTUALLY
+        /// drew this frame.
+        ///
+        /// <para>The deviation is count-independent: for each finite REFERENCE point, the nearest
+        /// distance to the rendered POLYLINE (every consecutive finite rendered segment, plus the
+        /// rendered vertices themselves) is taken, and the max over all reference points is the drift.
+        /// This is the right diff for "is the rendered arc the same curve as the reference arc?" even
+        /// when the two are sampled at different densities (the common case: a recorded points list vs a
+        /// Vectrosity line). Mismatched counts are recorded on the result but are NOT themselves an
+        /// anomaly.</para>
+        ///
+        /// <para>NaN/Inf-safe (mirrors <see cref="GhostRenderReconciler"/>): non-finite points are
+        /// skipped on BOTH sides; if no finite reference point or no finite rendered point survives,
+        /// the result is <see cref="ParityResult.HasMeasurement"/> = false with
+        /// <see cref="ParityResult.OverTolerance"/> = false (no false anomaly). A non-finite / negative
+        /// <paramref name="toleranceMeters"/> is treated as <see cref="MinToleranceMeters"/>.</para>
+        /// </summary>
+        internal static ParityResult ComputeDrift(
+            ParityMode mode, double[] referenceXyz, double[] renderedXyz, double toleranceMeters)
+        {
+            double tol = (double.IsNaN(toleranceMeters) || double.IsInfinity(toleranceMeters)
+                          || toleranceMeters < MinToleranceMeters)
+                ? MinToleranceMeters
+                : toleranceMeters;
+
+            int refCount = referenceXyz == null ? 0 : referenceXyz.Length / 3;
+            int rendCount = renderedXyz == null ? 0 : renderedXyz.Length / 3;
+
+            if (refCount == 0 || rendCount == 0)
+                return ParityResult.NoMeasurement(mode, tol, refCount, rendCount);
+
+            // Collect the finite rendered points (the polyline vertices we project onto).
+            // Done once so the inner per-reference-point loop is a flat scan.
+            int finiteRendered = 0;
+            double[] rxs = new double[rendCount];
+            double[] rys = new double[rendCount];
+            double[] rzs = new double[rendCount];
+            for (int j = 0; j < rendCount; j++)
+            {
+                double x = renderedXyz[j * 3];
+                double y = renderedXyz[j * 3 + 1];
+                double z = renderedXyz[j * 3 + 2];
+                if (!IsFinite(x) || !IsFinite(y) || !IsFinite(z))
+                    continue;
+                rxs[finiteRendered] = x;
+                rys[finiteRendered] = y;
+                rzs[finiteRendered] = z;
+                finiteRendered++;
+            }
+            if (finiteRendered == 0)
+                return ParityResult.NoMeasurement(mode, tol, refCount, rendCount);
+
+            double maxDev = 0.0;
+            int finiteReference = 0;
+            for (int i = 0; i < refCount; i++)
+            {
+                double px = referenceXyz[i * 3];
+                double py = referenceXyz[i * 3 + 1];
+                double pz = referenceXyz[i * 3 + 2];
+                if (!IsFinite(px) || !IsFinite(py) || !IsFinite(pz))
+                    continue;
+                finiteReference++;
+
+                double nearest = NearestDistanceToPolyline(
+                    px, py, pz, rxs, rys, rzs, finiteRendered);
+                if (nearest > maxDev)
+                    maxDev = nearest;
+            }
+            if (finiteReference == 0)
+                return ParityResult.NoMeasurement(mode, tol, refCount, rendCount);
+
+            bool over = maxDev > tol;
+            return new ParityResult(
+                mode, hasMeasurement: true, maxDeviationMeters: maxDev, toleranceMeters: tol,
+                countMismatch: refCount != rendCount, referenceCount: refCount, renderedCount: rendCount,
+                overTolerance: over);
+        }
+
+        /// <summary>
+        /// Convenience overload: derive the tolerance from the REFERENCE geometry's own scale (its
+        /// bounding-box diagonal via <see cref="EstimateScaleFromPoints"/>) so the caller does not have
+        /// to pass an explicit metre tolerance. Equivalent to
+        /// <c>ComputeDrift(mode, reference, rendered, ToleranceForScale(EstimateScaleFromPoints(reference), fraction))</c>.
+        /// The reference (not the rendered) drives the scale: it is the geometry of record, and a drifted
+        /// rendered arc could have a misleadingly large or small extent.
+        /// </summary>
+        internal static ParityResult ComputeDriftScaleDerived(
+            ParityMode mode, double[] referenceXyz, double[] renderedXyz,
+            double fraction = DefaultScaleToleranceFraction)
+        {
+            double scale = EstimateScaleFromPoints(referenceXyz);
+            double tol = ToleranceForScale(scale, fraction);
+            return ComputeDrift(mode, referenceXyz, renderedXyz, tol);
+        }
+
+        // ---- Internals (pure, primitive-only) ----
+
+        /// <summary>
+        /// Nearest distance from point (px,py,pz) to the polyline through the first <paramref name="count"/>
+        /// rendered vertices. With one vertex it is the point-to-point distance; with two or more it is
+        /// the min over each segment of the point-to-segment distance. All finite by construction (the
+        /// caller pre-filtered non-finite vertices).
+        /// </summary>
+        private static double NearestDistanceToPolyline(
+            double px, double py, double pz,
+            double[] xs, double[] ys, double[] zs, int count)
+        {
+            if (count == 1)
+                return Distance(px, py, pz, xs[0], ys[0], zs[0]);
+
+            double best = double.PositiveInfinity;
+            for (int s = 0; s < count - 1; s++)
+            {
+                double d = PointToSegmentDistance(
+                    px, py, pz,
+                    xs[s], ys[s], zs[s],
+                    xs[s + 1], ys[s + 1], zs[s + 1]);
+                if (d < best)
+                    best = d;
+            }
+            return best;
+        }
+
+        /// <summary>
+        /// Pure point-to-segment distance in 3D (metres). The segment is [A,B]; returns the distance from
+        /// P to the closest point on the segment (the projection clamped to [A,B]). A degenerate segment
+        /// (A==B) falls back to the point-to-A distance.
+        /// </summary>
+        private static double PointToSegmentDistance(
+            double px, double py, double pz,
+            double ax, double ay, double az,
+            double bx, double by, double bz)
+        {
+            double abx = bx - ax, aby = by - ay, abz = bz - az;
+            double apx = px - ax, apy = py - ay, apz = pz - az;
+            double abLenSq = abx * abx + aby * aby + abz * abz;
+            if (abLenSq <= 0.0)
+                return Distance(px, py, pz, ax, ay, az);
+
+            double t = (apx * abx + apy * aby + apz * abz) / abLenSq;
+            if (t < 0.0) t = 0.0;
+            else if (t > 1.0) t = 1.0;
+
+            double cx = ax + t * abx;
+            double cy = ay + t * aby;
+            double cz = az + t * abz;
+            return Distance(px, py, pz, cx, cy, cz);
+        }
+
+        private static double Distance(
+            double ax, double ay, double az, double bx, double by, double bz)
+        {
+            double dx = ax - bx, dy = ay - by, dz = az - bz;
+            return Math.Sqrt(dx * dx + dy * dy + dz * dz);
+        }
+
+        private static bool IsFinite(double v)
+        {
+            return !double.IsNaN(v) && !double.IsInfinity(v);
+        }
+    }
+}

--- a/Source/Parsek/MapRenderProbe.cs
+++ b/Source/Parsek/MapRenderProbe.cs
@@ -60,6 +60,18 @@ namespace Parsek
         // sits off its line, enough to read the angle without flooding.
         private const double OffOrbitAnomalyMinIntervalSeconds = 1.0;
 
+        // Soft rate-limit on the Phase-0 recorded-vs-rendered parity-drift anomaly. Like the off-orbit
+        // anomaly it is a PERSISTENT condition (a faithful member drawing the wrong geometry diverges every
+        // frame), so throttle to one line per pid per second; the detailed window EmitAnomaly opens still
+        // refreshes every divergent frame.
+        private const double ParityDriftAnomalyMinIntervalSeconds = 1.0;
+
+        // Number of UTs the rendered orbit (and the matching recorded reference orbit) is sampled at across
+        // its visible span for the FAITHFUL parity diff. Mirrored from
+        // RenderGeometrySampler.DefaultOrbitSampleCount so the probe + the pure helper agree.
+        private const int ParityOrbitSampleCount =
+            Parsek.MapRender.RenderGeometrySampler.DefaultOrbitSampleCount;
+
         // Soft rate-limit on the in-window per-frame full snapshot (phase=Snapshot). A persistent
         // anomaly keeps the detailed window open continuously, so an un-throttled snapshot floods
         // the log per-frame for the whole stretch. Sample at ~2 Hz per pid - enough to capture the
@@ -116,6 +128,9 @@ namespace Parsek
         private readonly Dictionary<uint, double> lastSnapshotEmitRealtime = new Dictionary<uint, double>();
         // Soft rate-limit timestamps for the per-pid icon-off-orbit anomaly.
         private readonly Dictionary<uint, double> lastOffOrbitEmitRealtime = new Dictionary<uint, double>();
+        // Soft rate-limit timestamps for the per-pid Phase-0 recorded-vs-rendered parity-drift anomaly (a
+        // PERSISTENT condition, like icon-off-orbit, so it must not fire every frame).
+        private readonly Dictionary<uint, double> lastParityDriftEmitRealtime = new Dictionary<uint, double>();
         // Soft rate-limit timestamps for the per-pid polyline-orbit-overlap anomaly (a PERSISTENT
         // condition through a whole burn, so it must not fire every frame).
         private readonly Dictionary<uint, double> lastPolylineOverlapEmitRealtime = new Dictionary<uint, double>();
@@ -190,6 +205,7 @@ namespace Parsek
             lastJumpEmitRealtime.Clear();
             lastSnapshotEmitRealtime.Clear();
             lastOffOrbitEmitRealtime.Clear();
+            lastParityDriftEmitRealtime.Clear();
             lastPolylineOverlapEmitRealtime.Clear();
             firstPositionEmittedPids.Clear();
             lastUnaccountedEmitRealtime.Clear();
@@ -761,6 +777,32 @@ namespace Parsek
                                 bodyName),
                             recId);
                     }
+
+                    // --- Phase 0 / design §14: recorded-vs-rendered FAITHFUL parity-drift ---
+                    // The DISTINCT new acceptance axis (RenderParityOracle), beside the icon-off-orbit
+                    // angle above. Where icon-off-orbit asks "is the ICON on its own DRIVEN orbit?", this
+                    // asks "did the orbit geometry the pipeline actually RENDERED (the live OrbitDriver.orbit
+                    // that drives both the icon AND the orbit line) match the RECORDED source geometry it was
+                    // supposed to draw?" - a faithful (non-re-aimed) member must draw what it recorded.
+                    //
+                    // FAITHFUL ONLY this slice: the reference is the RECORDED OrbitSegment covering the
+                    // ghost's drive clock (offEffUT). Re-aimed / synthesized members (whose intended arc is
+                    // NOT the recorded segment) are skipped cleanly inside the sampler when the recorded
+                    // reference cannot be sampled at offEffUT (no covering recorded segment), so no false
+                    // anomaly fires for them. The diff is sampled at a spread of UTs across the visible orbit;
+                    // the reference orbit is built PHASE-MATCHED to the live rendered orbit (its epoch baked
+                    // with the SAME loop shift StockConicTreatment.SeedAndDriveLive used: epoch = seg.epoch +
+                    // loopShift) and BOTH orbits are sampled at the SAME UTs, so a loop-shifted FAITHFUL ghost
+                    // lands on the SAME recorded phase as the rendered orbit and reads ~0 drift (the shift only
+                    // sets WHERE on the orbit, not its shape) while a wrong-elements / wrong-body / off-orbit
+                    // draw shows drift. Body-relative frame (the same bodyRelPos frame the off-orbit check
+                    // uses) so the diff is body-world-motion-free. loopShift is the SAME value the live orbit
+                    // was baked with (GetGhostOrbitEpochShift(pid)), NOT offShift (which is ~0 in the director
+                    // path and does NOT carry the loop phase - that was the false-drift blocker).
+                    double parityLoopShift = GhostMapPresence.GetGhostOrbitEpochShift(pid);
+                    TrySampleAndEmitFaithfulOrbitParity(
+                        offOrbit, body, bodyRelPos, offEffUT, offShift, parityLoopShift, currentUT,
+                        pid, pidKey, recId, lineActive, bodyName, realtime);
                 }
 
                 // Record this frame's body-relative position + body so the next
@@ -913,11 +955,310 @@ namespace Parsek
             return true;
         }
 
+        private bool PassesParityDriftRateLimit(uint pid, double realtime)
+        {
+            double last;
+            if (lastParityDriftEmitRealtime.TryGetValue(pid, out last)
+                && realtime - last < ParityDriftAnomalyMinIntervalSeconds)
+                return false;
+            lastParityDriftEmitRealtime[pid] = realtime;
+            return true;
+        }
+
+        /// <summary>
+        /// Outcome of one FAITHFUL recorded-vs-rendered orbit parity sample: the oracle's
+        /// <see cref="Parsek.MapRender.RenderParityOracle.ParityResult"/> plus the contextual values the
+        /// emit line carries. <see cref="Sampled"/> is false (and <see cref="SkipReason"/> set) when the
+        /// sampler cleanly bailed before a diff (wrong body / no covering recorded segment / degenerate
+        /// elements / re-aimed member): the caller MUST treat a non-sampled outcome as "no anomaly", never
+        /// as a pass or a drift. internal so the in-game baseline test exercises the REAL orchestration
+        /// (the buggy loop-shift bake path included) instead of an inlined copy.
+        /// </summary>
+        internal readonly struct FaithfulParitySample
+        {
+            internal bool Sampled { get; }
+            internal string SkipReason { get; }
+            internal Parsek.MapRender.RenderParityOracle.ParityResult Result { get; }
+            internal double Scale { get; }
+            internal double RecordedSegmentSma { get; }
+            internal double RecordedSegmentEcc { get; }
+            internal string RecordedSegmentBody { get; }
+
+            internal FaithfulParitySample(
+                bool sampled, string skipReason,
+                Parsek.MapRender.RenderParityOracle.ParityResult result, double scale,
+                double recordedSegmentSma, double recordedSegmentEcc, string recordedSegmentBody)
+            {
+                Sampled = sampled;
+                SkipReason = skipReason;
+                Result = result;
+                Scale = scale;
+                RecordedSegmentSma = recordedSegmentSma;
+                RecordedSegmentEcc = recordedSegmentEcc;
+                RecordedSegmentBody = recordedSegmentBody;
+            }
+
+            internal static FaithfulParitySample Skip(string reason)
+            {
+                return new FaithfulParitySample(
+                    false, reason,
+                    default(Parsek.MapRender.RenderParityOracle.ParityResult),
+                    0.0, 0.0, 0.0, null);
+            }
+        }
+
+        // --- Phase 0 / design §14: recorded-vs-rendered FAITHFUL parity sampler (Unity capture) ---
+        //
+        // Samples the RENDERED orbit geometry (the live OrbitDriver.orbit that drives both the icon and the
+        // orbit line) and the FAITHFUL RECORDED reference (the recorded OrbitSegment covering the ghost's
+        // drive clock), both in the SAME Y-up body-relative metres frame (OrbitRelativePositionYup, the same
+        // frame the icon's bodyRelPos = GetWorldPos3D - body.position lives in), hands them to the pure
+        // RenderParityOracle, and emits a parity-drift anomaly on OverTolerance. FAITHFUL ONLY: a re-aimed /
+        // synthesized member (no covering recorded segment at offEffUT, or a recorded segment on a different
+        // body than the rendered orbit) is skipped cleanly with no anomaly. Additive observability: no draw
+        // change. Gated by the caller's IsEnabled check (the whole probe LateUpdate is IsEnabled-gated).
+        //
+        // Returns the FaithfulParitySample (the oracle result + context) so the in-game baseline test can
+        // assert on the REAL orchestration (not an inlined copy). The probe ignores the return value; only
+        // the rate-limited emit-on-OverTolerance below has a production side effect.
+        private Parsek.MapRender.RenderParityOracle.ParityResult TrySampleAndEmitFaithfulOrbitParity(
+            Orbit renderedOrbit, CelestialBody renderedBody, Vector3d iconBodyRel,
+            double offEffUT, double offShift, double loopShift, double currentUT,
+            uint pid, string pidKey, string recId, string lineActive, string bodyName, double realtime)
+        {
+            FaithfulParitySample sample = ComputeFaithfulOrbitParity(
+                renderedOrbit, renderedBody, iconBodyRel, offEffUT, loopShift, currentUT, recId);
+
+            if (!sample.Sampled)
+                return sample.Result;
+            Parsek.MapRender.RenderParityOracle.ParityResult result = sample.Result;
+            if (!result.HasMeasurement || !result.OverTolerance)
+                return result;
+            if (!PassesParityDriftRateLimit(pid, realtime))
+                return result;
+
+            MapRenderTrace.EmitAnomaly(
+                MapRenderTrace.RenderSurface.ProtoOrbitLine, pidKey, currentUT, offEffUT,
+                MapRenderTrace.AnomalyParityDrift,
+                string.Format(ic,
+                    "mode=faithful maxDev={0}m tol={1}m scale={2}m refCount={3} rendCount={4} "
+                    + "countMismatch={5} offShift={6} loopShift={7} effUT={8} | recSeg=[sma={9} ecc={10} body={11}] "
+                    + "rendOrbit=[sma={12} ecc={13} body={14}] iconR={15} lineActive={16}",
+                    MapRenderTrace.FormatDouble(result.MaxDeviationMeters, "F0"),
+                    MapRenderTrace.FormatDouble(result.ToleranceMeters, "F0"),
+                    MapRenderTrace.FormatDouble(sample.Scale, "F0"),
+                    result.ReferenceCount, result.RenderedCount, result.CountMismatch,
+                    MapRenderTrace.FormatDouble(offShift, "F1"),
+                    MapRenderTrace.FormatDouble(loopShift, "F1"),
+                    MapRenderTrace.FormatDouble(offEffUT, "F1"),
+                    MapRenderTrace.FormatDouble(sample.RecordedSegmentSma, "F0"),
+                    MapRenderTrace.FormatDouble(sample.RecordedSegmentEcc, "F4"),
+                    sample.RecordedSegmentBody ?? "(null)",
+                    MapRenderTrace.FormatDouble(renderedOrbit.semiMajorAxis, "F0"),
+                    MapRenderTrace.FormatDouble(renderedOrbit.eccentricity, "F4"),
+                    bodyName,
+                    MapRenderTrace.FormatDouble(iconBodyRel.magnitude, "F0"),
+                    lineActive),
+                recId);
+            return result;
+        }
+
+        // The pure-orchestration CORE of the faithful parity sample: resolve the recorded reference, build
+        // the PHASE-MATCHED reference orbit, sample both, and run the oracle diff. No emit, no rate-limit,
+        // no per-pid state - so the in-game baseline test drives the EXACT production geometry path (the
+        // recorded-segment lookup, the loop-shift epoch bake, the OrbitRelativePositionYup sampling, the
+        // scale-derived tolerance, the oracle diff) end-to-end, including the loop-shifted bake that the
+        // BLOCKER fix corrects. internal for that test.
+        internal static FaithfulParitySample ComputeFaithfulOrbitParity(
+            Orbit renderedOrbit, CelestialBody renderedBody, Vector3d iconBodyRel,
+            double offEffUT, double loopShift, double currentUT, string recId)
+        {
+            if (renderedOrbit == null || renderedBody == null)
+                return FaithfulParitySample.Skip("no-rendered-orbit");
+            if (string.IsNullOrEmpty(recId))
+                return FaithfulParitySample.Skip("no-recId");
+
+            // Resolve the FAITHFUL recorded reference: the recorded OrbitSegment covering the ghost's drive
+            // clock (offEffUT), on the SAME body as the rendered orbit. A re-aim / synthesized member, a
+            // window the recording has no covering segment for, or a different-body segment -> no reference,
+            // skip (no false anomaly). Reuses the existing recorded-segment lookup (TrajectoryMath
+            // .FindOrbitSegment + HasUsableOrbitSegmentElements) and the EXACT Kepler-to-Orbit construction
+            // TrajectoryMath.EvaluateOrbitSegmentAtUT / GhostMapPresence.TryResolveOrbitWorldPosition use
+            // (BuildPhaseMatchedReferenceOrbit below, which is BuildOrbitFromSegment with the live orbit's
+            // loop-shift epoch bake); no new recording-to-world projector. The reconstructed Orbit is then
+            // sampled through the SAME OrbitRelativePositionYup the rendered side uses, so both sides land in
+            // one identical Y-up body-relative metres frame by construction.
+            if (!Parsek.GhostMapPresence.TryGetCommittedRecordingById(
+                    recId, out int _, out Recording rec)
+                || rec == null || rec.OrbitSegments == null || rec.OrbitSegments.Count == 0)
+                return FaithfulParitySample.Skip("no-recording-or-segments");
+
+            OrbitSegment? coveringMaybe = TrajectoryMath.FindOrbitSegment(rec.OrbitSegments, offEffUT);
+            if (!coveringMaybe.HasValue)
+                return FaithfulParitySample.Skip("no-covering-segment"); // re-aim / trim gap -> skip
+            OrbitSegment covering = coveringMaybe.Value;
+            if (!TrajectoryMath.HasUsableOrbitSegmentElements(covering))
+                return FaithfulParitySample.Skip("degenerate-elements");
+            // Faithful-only frame guard: the rendered and recorded body-relative inertial positions are
+            // comparable ONLY about the SAME body. A different recorded body is a re-aim / SOI-leg case -> skip.
+            if (!string.Equals(covering.bodyName, renderedBody.bodyName, System.StringComparison.Ordinal))
+                return FaithfulParitySample.Skip("body-mismatch");
+            CelestialBody recordedBody = ResolveBodyByName(covering.bodyName);
+            if (recordedBody == null)
+                return FaithfulParitySample.Skip("recorded-body-unresolved");
+
+            // Build the rendered Orbit's own visible-span half-window from its period (a full conic) or a
+            // fixed window (degenerate / hyperbolic), centred on the live drive clock so the samples lie on
+            // the part of the orbit the line draws. BOTH the rendered orbit AND the PHASE-MATCHED reference
+            // orbit are sampled at these SAME UTs (the BLOCKER fix: phase is cancelled by baking the loop
+            // shift into the reference EPOCH, NOT by remapping the reference UTs by offShift - which is ~0 in
+            // the director path and would leave the loop phase uncancelled, tracing opposite arcs).
+            double halfSpan = ResolveOrbitSampleHalfSpanSeconds(renderedOrbit);
+            double[] sampleUTs = Parsek.MapRender.RenderGeometrySampler.BuildSampleUTs(
+                currentUT, halfSpan, ParityOrbitSampleCount);
+            if (sampleUTs.Length == 0)
+                return FaithfulParitySample.Skip("no-sample-uts");
+
+            // Sample both orbits in the SAME Y-up body-relative frame at the SAME UTs.
+            var renderedPts = new Vector3d[sampleUTs.Length];
+            for (int i = 0; i < sampleUTs.Length; i++)
+                renderedPts[i] = OrbitRelativePositionYup(renderedOrbit, sampleUTs[i]);
+
+            // The recorded reference orbit, built ONCE from the covering segment's Kepler elements with its
+            // epoch PHASE-MATCHED to the live rendered orbit. StockConicTreatment.SeedAndDriveLive baked the
+            // rendered orbit's epoch to seg.epoch + loopShift and propagates it at the LIVE clock, so the
+            // reference MUST use the SAME epoch for evaluation at the same UT to land on the same recorded
+            // phase. (When loopShift == 0, this is BuildOrbitFromSegment verbatim.)
+            Orbit recordedOrbit = BuildPhaseMatchedReferenceOrbit(covering, recordedBody, loopShift);
+            if (recordedOrbit == null)
+                return FaithfulParitySample.Skip("reference-orbit-build-failed");
+            // Reference set = the recorded curve samples PLUS the recorded position at the exact drive clock
+            // (the point the icon SHOULD sit on). The rendered icon point (iconBodyRel) anchors the rendered
+            // set so the diff also catches an icon parked off its own rendered line. Wrapped in a try/catch:
+            // an unexpected getRelativePositionAtUT throw on degenerate reconstructed elements skips this
+            // parity sample (no measurement) rather than aborting the rest of the tracing-on probe pass.
+            var referencePts = new Vector3d[sampleUTs.Length + 1];
+            try
+            {
+                for (int i = 0; i < sampleUTs.Length; i++)
+                    referencePts[i] = OrbitRelativePositionYup(recordedOrbit, sampleUTs[i]);
+                referencePts[sampleUTs.Length] = OrbitRelativePositionYup(recordedOrbit, offEffUT);
+            }
+            catch (System.Exception)
+            {
+                return FaithfulParitySample.Skip("reference-sample-threw");
+            }
+
+            var renderedAll = new Vector3d[renderedPts.Length + 1];
+            System.Array.Copy(renderedPts, renderedAll, renderedPts.Length);
+            renderedAll[renderedPts.Length] = iconBodyRel;
+
+            double[] referenceFlat = Parsek.MapRender.RenderGeometrySampler.Flatten(
+                referencePts, referencePts.Length);
+            double[] renderedFlat = Parsek.MapRender.RenderGeometrySampler.Flatten(
+                renderedAll, renderedAll.Length);
+
+            // Per-scenario tolerance derived from the recorded reference's OWN scale (its bounding-box
+            // diagonal) - NOT a blanket metre constant (a LKO arc and a heliocentric transfer want wildly
+            // different absolute tolerances). 0.1% of the arc extent separates a faithful draw from a
+            // looped-rotation / off-orbit / wrong-element draw with margin.
+            double scale = Parsek.MapRender.RenderParityOracle.EstimateScaleFromPoints(referenceFlat);
+            double tol = Parsek.MapRender.RenderParityOracle.ToleranceForScale(scale);
+            Parsek.MapRender.RenderParityOracle.ParityResult result =
+                Parsek.MapRender.RenderParityOracle.ComputeDrift(
+                    Parsek.MapRender.RenderParityOracle.ParityMode.Faithful,
+                    referenceFlat, renderedFlat, tol);
+
+            return new FaithfulParitySample(
+                true, null, result, scale,
+                covering.semiMajorAxis, covering.eccentricity, covering.bodyName);
+        }
+
+        // Half-window (seconds) the parity samples span on either side of the drive clock. A full closed
+        // conic samples a quarter-period each side (half the orbit total - enough of the arc to distinguish
+        // two same-shaped orbits at different elements / phase while keeping the few getPositionAtUT calls
+        // cheap); a degenerate / non-finite period (hyperbolic / open) falls back to a fixed 1-hour window.
+        private static double ResolveOrbitSampleHalfSpanSeconds(Orbit orbit)
+        {
+            const double FallbackHalfSpanSeconds = 3600.0;
+            if (orbit == null)
+                return FallbackHalfSpanSeconds;
+            double period = orbit.period;
+            if (double.IsNaN(period) || double.IsInfinity(period) || period <= 0.0)
+                return FallbackHalfSpanSeconds;
+            return period * 0.25;
+        }
+
+        // Build a KSP Orbit from a recorded OrbitSegment's Kepler elements (the SAME construction
+        // TrajectoryMath.EvaluateOrbitSegmentAtUT / GhostMapPresence.TryResolveOrbitWorldPosition use). Unity
+        // construction isolated here so the pure RenderGeometrySampler stays Unity-ECall-free. Returns null
+        // on any throw (degenerate elements). internal so the in-game capture-harness fixture builds the
+        // reference orbit through the EXACT production construction.
+        internal static Orbit BuildOrbitFromSegment(OrbitSegment seg, CelestialBody body)
+        {
+            try
+            {
+                return new Orbit(
+                    seg.inclination, seg.eccentricity, seg.semiMajorAxis,
+                    seg.longitudeOfAscendingNode, seg.argumentOfPeriapsis,
+                    seg.meanAnomalyAtEpoch, seg.epoch, body);
+            }
+            catch (System.Exception)
+            {
+                return null;
+            }
+        }
+
+        // Build the FAITHFUL reference orbit PHASE-MATCHED to the live rendered orbit: identical elements to
+        // BuildOrbitFromSegment but with the epoch baked by the SAME loop shift the live orbit was seeded
+        // with (StockConicTreatment.SeedAndDriveLive: epoch = seg.epoch + loopShift). This cancels the loop
+        // phase by construction - evaluating BOTH orbits at the SAME UT lands on the SAME recorded mean
+        // anomaly (M(t) = MAE + n*(t - seg.epoch - loopShift) on both sides), so a faithful loop ghost reads
+        // ~0 drift. The shift moves PHASE only (LAN/inc/argPe/sma/ecc untouched), so the orbit SHAPE is
+        // unchanged. When loopShift == 0 (a non-loop faithful ghost) this is BuildOrbitFromSegment verbatim.
+        // A non-finite loopShift falls back to 0 (raw epoch) rather than poisoning the epoch with NaN.
+        // internal so the in-game baseline test builds the reference through the EXACT production path.
+        internal static Orbit BuildPhaseMatchedReferenceOrbit(
+            OrbitSegment seg, CelestialBody body, double loopShift)
+        {
+            double shift = (double.IsNaN(loopShift) || double.IsInfinity(loopShift)) ? 0.0 : loopShift;
+            try
+            {
+                return new Orbit(
+                    seg.inclination, seg.eccentricity, seg.semiMajorAxis,
+                    seg.longitudeOfAscendingNode, seg.argumentOfPeriapsis,
+                    seg.meanAnomalyAtEpoch, seg.epoch + shift, body);
+            }
+            catch (System.Exception)
+            {
+                return null;
+            }
+        }
+
+        internal static CelestialBody ResolveBodyByName(string bodyName)
+        {
+            if (string.IsNullOrEmpty(bodyName))
+                return null;
+            var bodies = FlightGlobals.Bodies;
+            if (bodies == null)
+                return null;
+            for (int i = 0; i < bodies.Count; i++)
+            {
+                CelestialBody b = bodies[i];
+                if (b != null && string.Equals(b.bodyName, bodyName, System.StringComparison.Ordinal))
+                    return b;
+            }
+            return null;
+        }
+
         // Body-relative orbit position in Y-up WORLD axes (the same frame the icon's
         // bodyRelPos = GetWorldPos3D - body.position lives in). orbit.getRelativePositionAtUT
         // returns Z-up KSP-internal axes; Swizzle() converts to Y-up world. Isolated here so
-        // the pure MapRenderTrace.IsIconOffOrbit predicate stays Unity-ECall-free.
-        private static Vector3d OrbitRelativePositionYup(Orbit orbit, double ut)
+        // the pure MapRenderTrace.IsIconOffOrbit predicate stays Unity-ECall-free. internal so
+        // the in-game parity capture-harness fixture exercises the REAL capture function (the
+        // "green but blind" guard: it proves the Unity sampler itself is correct, separate from
+        // the oracle's pure diff-math unit tests).
+        internal static Vector3d OrbitRelativePositionYup(Orbit orbit, double ut)
         {
             Vector3d p = orbit.getRelativePositionAtUT(ut);
             p.Swizzle();

--- a/Source/Parsek/MapRenderTrace.cs
+++ b/Source/Parsek/MapRenderTrace.cs
@@ -35,6 +35,40 @@ namespace Parsek
         internal const double AnomalyWindowSeconds = 5.0;
         internal const double DestroyWindowSeconds = 1.0;
 
+        // ---- New Tier-C anomaly reason tokens (design §14) ----
+        //
+        // Canonical reason strings for the new render-overhaul anomaly classes, passed as the
+        // `reason` argument to EmitAnomaly so a grep finds them by a single stable token. `parity-drift`
+        // is now WIRED + LIVE: it is fired by the gated probe sampler
+        // MapRenderProbe.TrySampleAndEmitFaithfulOrbitParity (the Unity geometry sampler driving
+        // RenderParityOracle in Faithful mode) whenever a faithful ghost's rendered orbit diverges from
+        // its recorded reference beyond tolerance. The OTHER FOUR tokens below
+        // (rigid-seam-tangent-discontinuity / retire-not-held / anchor-resolve-fail / clock-not-ready)
+        // remain WIRED-BUT-INERT: the constants exist (and EmitAnomaly already routes any reason through
+        // the gated sink) so later phases emit them without re-touching this file; no caller fires those
+        // four yet.
+        //
+        //  - parity-drift: the geometry the pipeline actually RENDERED diverged from the reference it
+        //    was supposed to draw (recorded in Faithful mode / the producer's intended arc in
+        //    Synthesized mode) beyond tolerance - the recorded-vs-rendered oracle's anomaly. This is a
+        //    DISTINCT axis from GhostRenderReconciler's intent-vs-old-truth `decision-vs-old-truth` /
+        //    `gap-vs-retire`; the two coexist through Phases 0-8.
+        //  - rigid-seam-tangent-discontinuity: a Rigid seam's two sides (e.g. capture-orbit velocity
+        //    direction at SOI/atmosphere entry vs the recorded descent's first-sample tangent) diverged
+        //    beyond tolerance at the G1 descent re-stitch (Phase 6).
+        //  - retire-not-held: a terminal / out-of-range member HELD its last visible intent across an
+        //    interior gap where it should have RETIRED (rendered nothing) - the inverse of the
+        //    held-across-gap contract (design §6.4 / §10.7).
+        //  - anchor-resolve-fail: a BodyAnchor or parent-anchor resolution failed (missing body /
+        //    unresolvable parent trajectory) -> the phase fails closed to faithful rather than NRE.
+        //  - clock-not-ready: the render path was sampled at UT<=0 (cold-load Planetarium UT=0); the
+        //    sampler must defer rather than produce a degenerate ghost.
+        internal const string AnomalyParityDrift = "parity-drift";
+        internal const string AnomalyRigidSeamTangentDiscontinuity = "rigid-seam-tangent-discontinuity";
+        internal const string AnomalyRetireNotHeld = "retire-not-held";
+        internal const string AnomalyAnchorResolveFail = "anchor-resolve-fail";
+        internal const string AnomalyClockNotReady = "clock-not-ready";
+
         // ---- Tier-C anomaly tuning ----
 
         /// <summary>

--- a/docs/dev/plans/map-ts-render-phase0-regression-traceability.md
+++ b/docs/dev/plans/map-ts-render-phase0-regression-traceability.md
@@ -1,0 +1,158 @@
+# Phase 0 Regression Traceability: §11.5 matrix row -> scenario
+
+> **STATUS: CURRENT (Phase 0 DoD artifact).** This table is the migration plan's required
+> "scenario -> design-§11.5-matrix-row traceability" deliverable
+> ([`map-ts-render-overhaul-migration.md`](map-ts-render-overhaul-migration.md) §2). Every situation in
+> §11.5 of [`../design-map-ts-render-architecture.md`](../design-map-ts-render-architecture.md) maps to
+> EITHER a headless regression scenario (a named xUnit test), OR a dedicated in-game scenario/test, OR an
+> explicit out-of-scope entry with a one-line reason. No row is left unmapped, so coverage holes cannot
+> pass silently.
+
+---
+
+## The instruments this table maps onto
+
+The Phase 0 safety net is four cooperating pieces (the parity diff is the same oracle in every case; only
+the reference set + the capture surface differ):
+
+1. **`RenderParityOracle`** (`Source/Parsek/MapRender/RenderParityOracle.cs`) - the pure recorded-vs-
+   rendered (faithful) / intended-vs-rendered (synthesized) geometry-diff. Unit-tested by
+   `Source/Parsek.Tests/RenderParityOracleTests.cs`.
+2. **`RenderGeometrySampler`** (`Source/Parsek/MapRender/RenderGeometrySampler.cs`) - the pure reframing /
+   flattening / sample-UT helpers. Unit-tested by `Source/Parsek.Tests/RenderGeometrySamplerTests.cs`.
+3. **`MapRenderProbe.TrySampleAndEmitFaithfulOrbitParity`** - the WIRED Unity capture path that samples a
+   live ghost's rendered orbit + recorded reference and emits the `parity-drift` Tier-C anomaly. It builds
+   the recorded reference PHASE-MATCHED to the live rendered orbit (its epoch baked with the SAME loop
+   shift `StockConicTreatment.SeedAndDriveLive` used, via `BuildPhaseMatchedReferenceOrbit`) and samples
+   BOTH orbits at the SAME UTs, so a faithful LOOP ghost reads ~0 drift instead of a false
+   orbit-diameter drift. The pure-orchestration core (`MapRenderProbe.ComputeFaithfulOrbitParity`,
+   returning a `FaithfulParitySample`) is the seam the in-game baseline test calls directly. The Unity
+   capture is validated by the in-game `RenderParitySamplerFixtureTest` (capture-harness) and the in-game
+   `RenderParityBaselineTest` (positive zero-drift gate, with a LOOP-SHIFTED variant that drives a
+   non-zero baked loop shift end-to-end through the real seam and asserts zero drift).
+4. **The HEADLESS regression scenario set** (`Source/Parsek.Tests/RenderParityRegressionScenarioTests.cs`) - representative synthetic geometry per §11.5 row, asserting the oracle's VERDICT (known-good -> zero
+   drift; deliberately drifted -> drift flagged), in both faithful and synthesized modes.
+
+**How a "scenario" maps to a row.** The oracle's headless contract takes already-framed flat `double[]`
+XYZ triples, so a headless scenario models a row's GEOMETRY directly (an orbit via a pure Kepler
+circle/ellipse, an ascent/descent via a vertical metre profile, a heliocentric arc via a wide circle, a
+re-aim/draw bug via a rotation/offset). The live Unity capture path (reading `OrbitDriver.orbit` /
+`GetWorldPos3D`) is exercised by the two in-game tests, NOT re-modelled per row in the headless suite.
+
+**Tolerance-calibration caveat (carried from the migration plan).** The zero-drift baseline is captured
+on KNOWN-GOOD scenarios ONLY. Today's output carries open bugs (icon-off-orbit, warp-reseed-lag,
+depot-double, sub-surface-ghost-not-retiring); those are tracked as **expected-to-change**, NOT baselined,
+so a later incidental fix does not trip `parity-drift` and read as a regression. Where a §11.5 row is one
+of those documented-buggy classes, the table marks it expected-to-change and points at the headless
+DRIFTED scenario that pins the failure shape (so the eventual fix has a target), without adding it to the
+zero-drift baseline.
+
+---
+
+## Runtime-only rows (synthetic recordings cannot exercise these)
+
+The migration plan calls out six row classes that a synthetic recording / headless diff cannot exercise
+because they are about KSP runtime LIFECYCLE / CLOCK / SCENE state, not geometry. Each needs a DEDICATED
+in-game scenario. They are listed here once and cross-referenced from the table:
+
+| Runtime-only concern | Why headless cannot cover it | Phase-0 status |
+|---|---|---|
+| Cold-load, Planetarium UT=0 | `liveUT <= 0` defer-render guard fires only on a real cold `OnLoad` frame | **In-game scenario REQUIRED** (deferred to the producer's phase; see below) |
+| Quickload mid-record/loop/gap | Director cold-start with no stale prior intent needs a real quickload | **In-game scenario REQUIRED** |
+| Scene transition mid-segment / mid-seam (no one-frame blank; flight-map<->TS parity) | proto re-seed settle is a multi-frame runtime behavior | **Partially covered now** by the FLIGHT + TRACKSTATION `RenderParityBaselineTest` variants (render parity across the two scenes); the no-one-frame-blank settle is producer-phase in-game |
+| Warp through `HoldPhase` / compressed loiter / descent re-anchor | a single high-warp frame advancing `liveUt` across a hold is a real-clock event | **In-game scenario REQUIRED** (HoldPhase is a Phase-1+ type; no producer yet to test in Phase 0) |
+| Dock-merge retire at `dockUT` | the make-before-break member swap is a presence-lifecycle runtime event | **In-game scenario REQUIRED** |
+| Overlap gap-hold | the single-rendered-ghost-holds-prior-intent symptom is a per-frame runtime state | **In-game scenario REQUIRED** |
+
+**Phase-0 disposition of the runtime-only rows.** Phase 0 builds the OBSERVER (oracle + sampler +
+tracer skeleton), not the producers, so most runtime-only rows have no Phase-0 code to assert against yet.
+Their dedicated in-game scenarios are authored **in the phase that introduces the producing code** (the
+plan's "everything runtime-only gets an in-game test" DoD applies per phase): cold-load UT=0 / quickload /
+warp-through-HoldPhase land with the `PlaybackResolver` (Phase 3, §11.2/§11.3); dock-merge retire and
+overlap gap-hold land with the presence-lifecycle re-home (Phase 3/4, §11.1/§11.3). Phase 0 records the
+REQUIREMENT here so the hole is visible, and ships the one runtime row it CAN cover now: flight-map<->TS
+render parity, via the two-scene `RenderParityBaselineTest`.
+
+---
+
+## §11.5 coverage matrix -> Phase-0 scenario mapping
+
+Legend: **headless** = a named test in `RenderParityRegressionScenarioTests`. **in-game** = a named
+`[InGameTest]`. **oos** = out-of-scope-ok (with reason). **expected-to-change** = documented-buggy,
+pinned but not baselined. **runtime-only** = needs a dedicated in-game scenario in the producing phase.
+
+| § Situation | Mapping | Scenario / test (or reason) |
+|---|---|---|
+| Staging/decoupler debris (`IsDebris`) | oos | Excluded upstream by the `IsDebris` gate; the factory/resolver is never invoked, so there is no rendered geometry to diff. |
+| Controlled-decoupled child (lander off a stage) | headless (faithful) + in-game capture | Faithful body-relative orbit arc: `Faithful_BgOnRailsAllOrbital_KnownGood_ZeroDrift` covers the all-orbital member shape; the `ParentAnchoredChild` dual-surface (>=2-sample / out-of-range-retire) routing is a producer-phase in-game (Phase 1/3). |
+| Docking (two -> one at dockUT) | runtime-only | Dock-merge retire-at-`dockUT` (see runtime-only table); presence-lifecycle in-game in Phase 3/4. |
+| Undocking / EVA split (one -> N) | runtime-only | Member-chain begin/end at `splitUT` is a presence-lifecycle event; in-game in the producing phase. |
+| EVA kerbal | oos (Phase 0) | Renders as a faithful `TracedPath`/`SuppressedMarker` member; its geometry is the same faithful-arc / vertical-profile shape already covered by `Faithful_*`; no distinct Phase-0 geometry. |
+| Asteroid/comet claw grab+release | oos (Phase 0) | Generic couple/decouple seam - same member-swap lifecycle as dock/undock; no distinct Phase-0 geometry. |
+| Structural breakup (`onPartJointBreak`) | oos | Debris excluded; the controlled survivor is an ordinary member (covered by `Faithful_*`). |
+| Reentry burn-up / explosion / destruction mid-recording | expected-to-change | The "sub-surface-ghost-not-retiring" bug class - mid-window terminal retire is a Phase-6 fix. Pinned (geometry-side) by `Faithful_DescentArcOffset_FlagsDrift`; NOT baselined. The retire trigger itself is a presence-lifecycle in-game in Phase 6. |
+| Vessel recovery (KSC / flight Recover) | oos | Terminal-eligibility gate + live-vs-ghost dedup keep recovered recordings out of presence; no rendered geometry. |
+| Cross-tree dock (foreign-tree vessel) | oos (deferred §17) | `LiveVesselAnchor` cross-tree composition is deferred; fail-closed in v1. |
+| Fly from TS / KSC marker / Map Switch-To | runtime-only | `StockActionIntent` teardown-before-Fly is a navigation/scene lifecycle event; existing switch in-game tests + producer-phase coverage. |
+| In-bubble vessel switch (`[`/`]`) | runtime-only | guid-gated dedup + chain-cache invalidation is a runtime active-vessel-change event. |
+| Re-Fly / Rewind supersede mid-session | runtime-only | ERS-exempt render; effectiveness via the ProtoVessel lifecycle - a presence-lifecycle runtime event. |
+| Rewinding a looped mission | runtime-only | `LoopUnitSet` rebuild + cache invalidation on a post-split index change - runtime. |
+| Quicksave/quickload mid-record/loop/gap | runtime-only | Director cold-start, no prior intent (see runtime-only table). |
+| Cold load, Planetarium UT=0 | runtime-only | `liveUt <= 0` defer-render guard (see runtime-only table). |
+| Load a different save / new game | oos | ProtoVessel teardown + schema-compat reject; no rendered geometry to diff. |
+| Scene transition mid-segment / mid-seam | runtime-only (partial now) | No-one-frame-blank settle is producer-phase in-game; **flight-map<->TS render parity is covered now** by `RenderParityBaselineTest` (FLIGHT + TRACKSTATION variants). |
+| Camera focus / target a ghost across swap | oos (partial, §11.2) | `SuppressedMarker` not targetable / re-home focus anchor - a scene-adapter lifecycle concern, no geometry diff. |
+| Warp through HoldPhase / loiter / descent re-anchor | runtime-only | `HoldPhase.CoversUt` warp-step-safe (see runtime-only table); HoldPhase has no Phase-0 producer. |
+| Warp-reseed-lag at SOI / orbit-raise gaps | expected-to-change | The documented warp-reseed-lag bug class - `InInteriorGap` hold + SOI-block + CoMD re-snap. NOT baselined; the wrong-reseed shape is pinned by `Faithful_WrongBodyOrbit_DifferentScale_FlagsDrift`. |
+| Warp across a re-aim synodic window boundary | runtime-only | `\|w{window}` chain-signature token invalidation - a runtime cache event. |
+| Loop a single recording | headless (faithful) | `Faithful_LoopShiftedGhost_SameOrbit_ZeroDrift` (loop shift sets phase, not shape -> zero drift). |
+| Loop a whole multi-member mission | headless (faithful) | N independent `PhaseChain`s - each member's faithful arc is covered by `Faithful_*`; `Faithful_LoopShiftedGhost_SameOrbit_ZeroDrift` exercises the per-member loop invariant. |
+| Looping mission while player flies live nearby | oos (Phase 0) | Disjoint tree indices - a presence-selection concern; the rendered geometry of each loop member is the faithful-arc case already covered. |
+| Overlap (N instances) | runtime-only | One ghost at the selected cycle head; the gap-hold caveat is a per-frame runtime symptom (see runtime-only table). |
+| Loiter compression / arrival hold / loiter trim | headless (synthesized) | Span-clock transforms reshape WHERE/WHEN, not the arc; `Synthesized_ReaimedLoopIntendedArc_KnownGood_ZeroDrift` covers a trimmed/transformed intended arc drawn faithfully. |
+| Chain continuation across vessel switches | oos (deferred §6.1/§17) | `SwitchContinuation` seam is deferred to `MissionComposite`; fail-closed in v1. |
+| Mixed faithful + re-aimed members | headless (synthesized) | `Synthesized_MixedFaithfulReaimedMembers_IntendedArc_ZeroDrift` (the re-aimed member's intended arc) + `Faithful_*` (the faithful members). |
+| Re-aim with a large synodic target move | headless (synthesized) | `Synthesized_ReaimedLoopIntendedArc_KnownGood_ZeroDrift` (good draw) + `Synthesized_ReaimedArc_DrawnRotated_FlagsDrift` (draw-fidelity bug). |
+| Synthetic RouteBackingMission, trimmed window | headless (synthesized) | The mid-recording window clip reshapes the visible span; the clipped intended arc drawn faithfully is the `Synthesized_*` known-good case. |
+| Debris shed on a re-aimed/generated transfer leg | oos | `ParentGeneratedConicAnchor` fail-closed in v1; does not render on its parent's generated arc. |
+| BG-on-rails recorded vessel | headless (faithful) | `Faithful_BgOnRailsAllOrbital_KnownGood_ZeroDrift` (all-orbital chain, no Descent/Surface phase). |
+| Atmospheric descent to landing/splashdown | headless (faithful + synthesized) | `Faithful_DescentToLanding_KnownGood_ZeroDrift` (faithful descent), `Synthesized_DescentReStitchIntendedG1Arc_KnownGood_ZeroDrift` (the Phase-6 re-stitch intended arc), `Faithful_DescentArcOffset_FlagsDrift` + `Synthesized_DescentReStitch_SeamDiscontinuity_FlagsDrift` (drift). |
+| Prelaunch / landed / splashed / rover | oos (Phase 0) | `SurfacePhase` + `SuppressedMarker`; terrain-aware altitude is a flight-adapter concern out of v1, and the rendered indicator is a marker not a diffable arc. |
+| Suborbital hop | headless (faithful) | Ascent -> ballistic -> descent within one body: `Faithful_AtmosphericAscent_KnownGood_ZeroDrift` + `Faithful_DescentToLanding_KnownGood_ZeroDrift` cover the traced portions. |
+| Aerobraking (many periapsis grazes) | headless (faithful) | `Faithful_AerobrakingEccentric_KnownGood_ZeroDrift` (the eccentric conic arc shape) + `Faithful_AerobrakingWrongEccentricity_FlagsDrift` (wrong-ecc drift). |
+| Escape / hyperbolic / Sun-escape | headless (faithful) | `Faithful_SoiCrossing_KnownGood_ZeroDrift` (the heliocentric/open-arc faithful case; the oracle's hyperbolic half-span fallback is also unit-covered). |
+| Single-level SOI transition (Kerbin->Mun, ->Sun) | headless (faithful) + in-game | `Faithful_SoiCrossing_KnownGood_ZeroDrift` (post-crossing heliocentric arc in the new body's frame); the live cross-body-suppression frame is exercised by the in-game capture/baseline. |
+| Moon-rich / nested-SOI Jool tour | oos (faithful fail-closed) | Synthetic moon-to-moon re-aim is fail-closed in v1 (renders recorded faithfully); the faithful per-leg arc is the `Faithful_*` case. |
+| Multiple ghosts at different bodies | oos (Phase 0) | Independent per-body `PhaseChain`s - each ghost's arc is an independent faithful diff already covered; the multi-ghost selection is a presence concern. |
+| Ghost at a never-visited body | in-game | Renders normally (discovery level does not block `CelestialBody` resolution); the `BodyAnchor`-resolves-for-a-stock-body path is exercised by the in-game baseline (Kerbin resolves regardless of visit state). Only a MISSING body name fails (fail-closed, no NRE), a producer-phase in-game. |
+| Career-economy: ghost must not corrupt the ledger | oos | The `ghostMapVesselPids` guard-timing invariant is a presence/ledger concern, not a render-geometry diff (§12 must-not-regress). |
+| TS automatic ghost presence | in-game | `DiscoveryLevels.Owned` + forced `VesselType` - exercised by the TRACKSTATION `RenderParityBaselineTest` variant (a ghost renders and reports zero drift in the TS scene). |
+| Map filters / `MapView.fetch==null` cold-start | oos | KSP-API render gate (no-op when `MapView.fetch == null`); a §12 must-not-regress boundary condition, no geometry diff. |
+
+---
+
+## Coverage summary
+
+**45 §11.5 rows total** (every row mapped; the categories below sum to 45). The headless suite backing the
+mappings is **20 `[Fact]`s** in `RenderParityRegressionScenarioTests` (a row can map to more than one test - e.g. the descent row maps to four - so the test count exceeds the row count it serves).
+
+- **Headless-mapped rows: 13** - 6 faithful, 4 synthesized, and 3 combined headless+in-game. Covers
+  ascent / orbit / descent / suborbital / aerobraking / escape / SOI-crossing / BG-on-rails / loop /
+  re-aim / mixed-members / per-scenario-tolerance / no-measurement-safety, known-good AND drifted, both
+  oracle modes.
+- **In-game scenarios (Phase 0, shipped now):** flight-map<->TS render parity (the 2-scene
+  `RenderParityBaselineTest`), TS automatic ghost presence, ghost-at-a-stock-body resolution, and the
+  capture-harness (`RenderParitySamplerFixtureTest`). Two rows are in-game-primary; three more pair an
+  in-game leg with a headless leg.
+- **Runtime-only rows (dedicated in-game scenario REQUIRED, authored in the producing phase): 12** - cold-load UT=0, quickload mid-gap, dock + undock/EVA member swaps, Fly/Switch-To, in-bubble switch,
+  Re-Fly/Rewind supersede, rewind-a-loop, overlap gap-hold, warp-through-HoldPhase, warp across a synodic
+  boundary, and the scene-transition no-blank settle (whose flight-map<->TS-parity half ships now).
+- **Expected-to-change (documented-buggy, pinned but NOT baselined): 2** - reentry/destruction
+  mid-recording retire (Phase-6 fix) and warp-reseed-lag; the icon-off-orbit rotation class is
+  geometry-pinned by `Faithful_LoopRotationBug_OffOrbitArc_FlagsDrift`.
+- **Out-of-scope-ok (with reason): 18** - debris-excluded, deferred-to-§17 composition,
+  presence/selection/ledger concerns with no diffable geometry, EVA/claw member-swap lifecycle, and
+  marker-only (`SuppressedMarker`) surfaces.
+
+No row is unmapped. The runtime-only rows are explicitly flagged so a later phase cannot ship its
+producing code without the corresponding in-game scenario (the per-phase DoD enforces it).


### PR DESCRIPTION
Phase 0 of the map/TS render overhaul (`docs/dev/plans/map-ts-render-overhaul-migration.md`). The **safety net every later phase gates on**: a recorded-vs-rendered geometry parity oracle + a regression scenario set + the tracer skeleton. **Purely additive, gated-off-by-default observability — no change to drawn output.**

## What it adds
- **`RenderParityOracle`** (pure) — recorded-vs-rendered geometry diff: count-independent point-to-polyline projection, NaN/Inf-safe (no false anomaly), per-scenario **scale-derived** tolerance, and the two design-§14 modes (`Faithful` = rendered-vs-recorded; `Synthesized` = rendered-vs-intended draw-fidelity).
- **`RenderGeometrySampler` + `MapRenderProbe` wiring** — samples the live rendered orbit vs the **phase-matched recorded reference** in one body-relative frame and emits the `parity-drift` Tier-C anomaly on over-tolerance drift. The reference orbit is built with `epoch = seg.epoch + loopShift` to match `StockConicTreatment.SeedAndDriveLive`'s live epoch bake, so a faithful loop ghost reads ~0 drift. Fully gated behind the `mapRenderTracing` setting (a single bool check when off), rate-limited, fail-safe.
- **`MapRenderTrace`** — five new Tier-C anomaly tokens. `parity-drift` is wired+live; the other four (`rigid-seam-tangent-discontinuity` / `retire-not-held` / `anchor-resolve-fail` / `clock-not-ready`) remain inert for later phases.
- **Tests** — headless oracle/sampler/regression suites (faithful zero-drift, deliberately-drifted, both modes, NaN/empty, scale-derived tolerance, real loop-shift invariant + negative control); in-game capture-harness fixture (validates the sampler against a hand-computed orbit) + parity-baseline (incl. a loop-shifted zero-drift variant through the real production seam).
- **Docs** — the 45-row §11.5 gameplay-situations -> regression-scenario traceability table (13 headless, runtime-only rows flagged as per-phase in-game obligations, documented-buggy excluded from baseline).

## Safety
Additive only: no draw-path file touched, `GhostRenderReconciler` untouched, the parity oracle is a distinct coexisting axis. Zero cost when `mapRenderTracing` is off (the default). `dotnet test` 16317 green; no KSP deploy from this branch.

## Review
Built and reviewed clean-context. The review caught one real blocker — the reference orbit was originally built from the raw epoch, so a faithful **loop** ghost false-fired `parity-drift` (rendered/reference traced opposite arcs); fixed by phase-matching the reference epoch to the live bake, verified against `SeedAndDriveLive`, with a loop-shifted regression negative-control + an in-game loop-shifted zero-drift variant.

In-game runs of the capture-harness + parity-baseline tests (Ctrl+Shift+T) are the remaining confirmation, consistent with the project's other in-game parity tests.