### PR TITLE
maprender Phase 1: pure L0/L2 type system (additive, unwired)

### DIFF
--- a/Source/Parsek.Tests/MapRender/AnchorFrameTests.cs
+++ b/Source/Parsek.Tests/MapRender/AnchorFrameTests.cs
@@ -152,6 +152,20 @@ namespace Parsek.Tests
         }
 
         [Fact]
+        public void ParentChild_PrimaryHasEnoughSamplesButUtOutOfRange_FallsToSecondaryWhenItCovers()
+        {
+            // The loop-anchored-chain case the contract calls out: the body-fixed PRIMARY has >=2
+            // samples BUT the playback UT is past its endpoint range, while the anchor-local SECONDARY
+            // still covers the UT -> AnchorLocalSecondary (an out-of-range primary must NOT block the
+            // covering secondary, nor clamp the stale primary sample).
+            var s = AnchorFrameResolver.ResolveParentAnchoredChild(
+                ut: 250,
+                bodyFixedSampleCount: 3, bodyFixedStartUt: 100, bodyFixedEndUt: 200,
+                hasAnchorLocalFrames: true, anchorLocalStartUt: 100, anchorLocalEndUt: 300);
+            Assert.Equal(AnchorFrameResolver.ParentChildSurface.AnchorLocalSecondary, s);
+        }
+
+        [Fact]
         public void ParentChild_OutOfRangeBothSurfaces_Retires()
         {
             var s = AnchorFrameResolver.ResolveParentAnchoredChild(

--- a/Source/Parsek.Tests/MapRender/AnchorFrameTests.cs
+++ b/Source/Parsek.Tests/MapRender/AnchorFrameTests.cs
@@ -1,0 +1,195 @@
+using System;
+using Parsek.MapRender;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    /// <summary>
+    /// Phase-1 guard for <see cref="AnchorFrame"/> + <see cref="AnchorFrameResolver"/> (design §5.2).
+    /// Covers the union's discriminator/token surface and the two RESOLVABLE v1 variants:
+    /// <see cref="AnchorFrame.BodyAnchor"/> (missing-body fail-closed, never NRE) and
+    /// <see cref="AnchorFrame.ParentAnchoredChild"/> (bodyFixedFrames-primary ≥2-sample,
+    /// out-of-range → RETIRE, never clamp).
+    ///
+    /// Each assertion states the bug it catches: a wrong fail-closed outcome would NRE on a renamed
+    /// modded body (or render a phantom); a wrong parent-anchored surface would clamp a stale child
+    /// offset (the documented "stale ghost" bug) instead of retiring, or pick the secondary surface
+    /// while the body-fixed primary still covers the UT.
+    /// </summary>
+    public class AnchorFrameTests
+    {
+        // ---- Union shape / tokens ----
+
+        [Fact]
+        public void Variants_CarryKindAndToken()
+        {
+            Assert.Equal(AnchorFrameKind.Body, new AnchorFrame.BodyAnchor("Kerbin").Kind);
+            Assert.Equal("body", new AnchorFrame.BodyAnchor("Kerbin").ToToken());
+
+            Assert.Equal(AnchorFrameKind.ParentAnchoredChild, new AnchorFrame.ParentAnchoredChild("rec-P").Kind);
+            Assert.Equal("parent-anchored-child", new AnchorFrame.ParentAnchoredChild("rec-P").ToToken());
+
+            Assert.Equal(AnchorFrameKind.ParentGeneratedConic,
+                new AnchorFrame.ParentGeneratedConicAnchor(new PhaseId("rec", 0, 1)).Kind);
+            Assert.Equal("parent-generated-conic",
+                new AnchorFrame.ParentGeneratedConicAnchor(new PhaseId("rec", 0, 1)).ToToken());
+
+            Assert.Equal(AnchorFrameKind.LiveVessel, new AnchorFrame.LiveVesselAnchor(Guid.NewGuid()).Kind);
+            Assert.Equal("live-vessel", new AnchorFrame.LiveVesselAnchor(Guid.NewGuid()).ToToken());
+
+            Assert.Equal(AnchorFrameKind.RecordedAnchor, new AnchorFrame.RecordedAnchorTrajectory("rec-A").Kind);
+            Assert.Equal("recorded-anchor", new AnchorFrame.RecordedAnchorTrajectory("rec-A").ToToken());
+        }
+
+        [Fact]
+        public void BodyAnchor_PreservesName()
+        {
+            Assert.Equal("Duna", new AnchorFrame.BodyAnchor("Duna").BodyName);
+        }
+
+        // ---- BodyAnchor resolution (fail-closed, never NRE) ----
+
+        [Fact]
+        public void ResolveBody_KnownStockBody_Resolves()
+        {
+            Func<string, bool> exists = name => name == "Kerbin" || name == "Mun" || name == "Duna";
+            Assert.Equal(AnchorFrameResolver.BodyResolveOutcome.Resolved,
+                AnchorFrameResolver.ResolveBody("Kerbin", exists));
+            Assert.True(AnchorFrameResolver.TryResolveBody("Mun", exists));
+        }
+
+        [Fact]
+        public void ResolveBody_NeverVisitedStockBody_StillResolves()
+        {
+            // Discovery level is irrelevant: the probe answers on EXISTENCE, so a never-visited stock
+            // body must resolve normally (design §11.4).
+            Func<string, bool> existsRegardlessOfDiscovery = _ => true;
+            Assert.Equal(AnchorFrameResolver.BodyResolveOutcome.Resolved,
+                AnchorFrameResolver.ResolveBody("Eeloo", existsRegardlessOfDiscovery));
+        }
+
+        [Fact]
+        public void ResolveBody_MissingName_FailsClosed_NotNre()
+        {
+            Func<string, bool> exists = _ => true;
+            Assert.Equal(AnchorFrameResolver.BodyResolveOutcome.FailClosedMissingName,
+                AnchorFrameResolver.ResolveBody(null, exists));
+            Assert.Equal(AnchorFrameResolver.BodyResolveOutcome.FailClosedMissingName,
+                AnchorFrameResolver.ResolveBody("   ", exists));
+            Assert.False(AnchorFrameResolver.TryResolveBody(null, exists));
+        }
+
+        [Fact]
+        public void ResolveBody_UnknownBody_FailsClosed()
+        {
+            // A renamed/removed modded body absent from the live set fails closed (never NRE).
+            Func<string, bool> exists = name => name == "Kerbin";
+            Assert.Equal(AnchorFrameResolver.BodyResolveOutcome.FailClosedUnknownBody,
+                AnchorFrameResolver.ResolveBody("OPM_Sarnus", exists));
+            Assert.False(AnchorFrameResolver.TryResolveBody("OPM_Sarnus", exists));
+        }
+
+        [Fact]
+        public void ResolveBody_NullProbe_FailsClosed_NotNre()
+        {
+            Assert.Equal(AnchorFrameResolver.BodyResolveOutcome.FailClosedUnknownBody,
+                AnchorFrameResolver.ResolveBody("Kerbin", null));
+        }
+
+        [Fact]
+        public void ResolveBody_ThrowingProbe_FailsClosed_NotPropagated()
+        {
+            Func<string, bool> throwing = _ => throw new InvalidOperationException("boom");
+            Assert.Equal(AnchorFrameResolver.BodyResolveOutcome.FailClosedUnknownBody,
+                AnchorFrameResolver.ResolveBody("Kerbin", throwing));
+        }
+
+        // ---- ParentAnchoredChild dual-surface routing ----
+
+        [Fact]
+        public void ParentChild_TwoBodyFixedSamples_InRange_UsesPrimary()
+        {
+            // >=2 body-fixed samples + UT in [100,200] -> body-fixed PRIMARY.
+            var s = AnchorFrameResolver.ResolveParentAnchoredChild(
+                ut: 150,
+                bodyFixedSampleCount: 5, bodyFixedStartUt: 100, bodyFixedEndUt: 200,
+                hasAnchorLocalFrames: true, anchorLocalStartUt: 100, anchorLocalEndUt: 200);
+            Assert.Equal(AnchorFrameResolver.ParentChildSurface.BodyFixedPrimary, s);
+        }
+
+        [Theory]
+        [InlineData(100.0)] // inclusive start
+        [InlineData(200.0)] // inclusive end
+        public void ParentChild_BodyFixedRange_IsInclusive(double ut)
+        {
+            var s = AnchorFrameResolver.ResolveParentAnchoredChild(
+                ut,
+                bodyFixedSampleCount: 2, bodyFixedStartUt: 100, bodyFixedEndUt: 200,
+                hasAnchorLocalFrames: false, anchorLocalStartUt: 0, anchorLocalEndUt: 0);
+            Assert.Equal(AnchorFrameResolver.ParentChildSurface.BodyFixedPrimary, s);
+        }
+
+        [Fact]
+        public void ParentChild_OneBodyFixedSample_FallsToSecondaryWhenItCovers()
+        {
+            // A single body-fixed sample fails the >=2 minimum; the anchor-local frames cover the UT.
+            var s = AnchorFrameResolver.ResolveParentAnchoredChild(
+                ut: 150,
+                bodyFixedSampleCount: 1, bodyFixedStartUt: 150, bodyFixedEndUt: 150,
+                hasAnchorLocalFrames: true, anchorLocalStartUt: 100, anchorLocalEndUt: 200);
+            Assert.Equal(AnchorFrameResolver.ParentChildSurface.AnchorLocalSecondary, s);
+        }
+
+        [Fact]
+        public void ParentChild_OutOfRangeBodyFixed_NoSecondary_Retires_NotClamped()
+        {
+            // UT past the body-fixed range, no covering secondary -> RETIRE (never clamp to stale).
+            var s = AnchorFrameResolver.ResolveParentAnchoredChild(
+                ut: 250,
+                bodyFixedSampleCount: 5, bodyFixedStartUt: 100, bodyFixedEndUt: 200,
+                hasAnchorLocalFrames: false, anchorLocalStartUt: 0, anchorLocalEndUt: 0);
+            Assert.Equal(AnchorFrameResolver.ParentChildSurface.Retire, s);
+        }
+
+        [Fact]
+        public void ParentChild_OutOfRangeBothSurfaces_Retires()
+        {
+            var s = AnchorFrameResolver.ResolveParentAnchoredChild(
+                ut: 250,
+                bodyFixedSampleCount: 5, bodyFixedStartUt: 100, bodyFixedEndUt: 200,
+                hasAnchorLocalFrames: true, anchorLocalStartUt: 100, anchorLocalEndUt: 200);
+            Assert.Equal(AnchorFrameResolver.ParentChildSurface.Retire, s);
+        }
+
+        [Fact]
+        public void ParentChild_PrimaryWinsOverSecondary_WhenBothCover()
+        {
+            // Both surfaces cover the UT; the body-fixed PRIMARY must win.
+            var s = AnchorFrameResolver.ResolveParentAnchoredChild(
+                ut: 150,
+                bodyFixedSampleCount: 3, bodyFixedStartUt: 100, bodyFixedEndUt: 200,
+                hasAnchorLocalFrames: true, anchorLocalStartUt: 100, anchorLocalEndUt: 200);
+            Assert.Equal(AnchorFrameResolver.ParentChildSurface.BodyFixedPrimary, s);
+        }
+
+        [Fact]
+        public void ParentChild_NonFiniteUt_Retires()
+        {
+            var s = AnchorFrameResolver.ResolveParentAnchoredChild(
+                ut: double.NaN,
+                bodyFixedSampleCount: 5, bodyFixedStartUt: 100, bodyFixedEndUt: 200,
+                hasAnchorLocalFrames: true, anchorLocalStartUt: 100, anchorLocalEndUt: 200);
+            Assert.Equal(AnchorFrameResolver.ParentChildSurface.Retire, s);
+        }
+
+        [Fact]
+        public void ParentChild_DegenerateRange_StartAfterEnd_Retires()
+        {
+            var s = AnchorFrameResolver.ResolveParentAnchoredChild(
+                ut: 150,
+                bodyFixedSampleCount: 5, bodyFixedStartUt: 200, bodyFixedEndUt: 100,
+                hasAnchorLocalFrames: false, anchorLocalStartUt: 0, anchorLocalEndUt: 0);
+            Assert.Equal(AnchorFrameResolver.ParentChildSurface.Retire, s);
+        }
+    }
+}

--- a/Source/Parsek.Tests/MapRender/PhaseChainTests.cs
+++ b/Source/Parsek.Tests/MapRender/PhaseChainTests.cs
@@ -1,0 +1,141 @@
+using System.Collections.Generic;
+using Parsek.MapRender;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    /// <summary>
+    /// Phase-1 guard for <see cref="PhaseChain"/> (design §6), the <see cref="GhostRenderChain"/>
+    /// successor. Mirrors <c>GhostRenderChainTests</c>: builds a chain with rigid-adjacent phases, an
+    /// interior gap (a FlexibleSoi seam UT), and a final phase, then sweeps UTs through locate +
+    /// the three-valued coverage. Also covers the HoldPhase whole-span coverage inside a chain.
+    ///
+    /// Each assertion states the bug it catches: a wrong locate mis-routes a frame to the wrong phase
+    /// (wrong treatment/position); a wrong coverage tri-state would double-draw, blink a ghost off in a
+    /// gap (should hold), or fail to retire past the window end.
+    /// </summary>
+    public class PhaseChainTests
+    {
+        private static readonly AnchorFrame Kerbin = new AnchorFrame.BodyAnchor("Kerbin");
+
+        private static OrbitSegment Conic(double s, double e)
+            => new OrbitSegment { startUT = s, endUT = e, bodyName = "Kerbin" };
+
+        private static PhaseId Id(int ordinal) => new PhaseId("rec-A", 0, ordinal);
+
+        // phase0 [0,10) ascent, phase1 [10,20) loiter (rigid-adjacent), gap [20,30), phase2 [30,40] arrival.
+        // Window [0,40].
+        private static PhaseChain BuildChain()
+        {
+            var phases = new List<TrajectoryPhase>
+            {
+                new AscentPhase(Id(0), SegmentProvenance.Recorded, Kerbin, 0, 10),
+                new DepartureLoiterPhase(Id(1), SegmentProvenance.Recorded, Kerbin, 10, 20, Conic(10, 20)),
+                new ArrivalLoiterPhase(Id(2), SegmentProvenance.Recorded, Kerbin, 30, 40, Conic(30, 40)),
+            };
+            return new PhaseChain("rec-A", committedIndex: 3, instanceKey: 0,
+                phases: phases, windowStartUt: 0, windowEndUt: 40);
+        }
+
+        [Theory]
+        // ut, expected coverage, expected phase index (-1 when not InSegment)
+        [InlineData(-1.0, (int)Coverage.OutsideWindow, -1)]
+        [InlineData(0.0, (int)Coverage.InSegment, 0)]          // window/phase start inclusive
+        [InlineData(5.0, (int)Coverage.InSegment, 0)]
+        [InlineData(10.0, (int)Coverage.InSegment, 1)]         // shared rigid boundary -> later phase
+        [InlineData(19.9, (int)Coverage.InSegment, 1)]
+        [InlineData(20.0, (int)Coverage.InInteriorGap, -1)]    // exclusive end of a non-last phase + gap
+        [InlineData(25.0, (int)Coverage.InInteriorGap, -1)]    // mid-gap -> hold, never retire/blink
+        [InlineData(30.0, (int)Coverage.InSegment, 2)]
+        [InlineData(40.0, (int)Coverage.InSegment, 2)]         // last phase end inclusive
+        [InlineData(40.001, (int)Coverage.OutsideWindow, -1)]  // past end -> retire
+        [InlineData(100.0, (int)Coverage.OutsideWindow, -1)]
+        public void ClassifyCoverage_ResolvesPhasesGapsAndWindow(double ut, int expectedCoverage, int expectedIndex)
+        {
+            Coverage expected = (Coverage)expectedCoverage;
+            var chain = BuildChain();
+            var cov = chain.ClassifyCoverage(ut, out TrajectoryPhase phase, out int index);
+            Assert.Equal(expected, cov);
+            Assert.Equal(expectedIndex, index);
+            if (expected == Coverage.InSegment)
+            {
+                Assert.NotNull(phase);
+                Assert.Equal(chain.Phases[expectedIndex].StartUt, phase.StartUt);
+            }
+        }
+
+        [Fact]
+        public void LocatePhaseIndex_MatchesClassify_ForInPhaseUTs()
+        {
+            var chain = BuildChain();
+            Assert.Equal(0, chain.LocatePhaseIndex(5.0));
+            Assert.Equal(1, chain.LocatePhaseIndex(10.0));
+            Assert.Equal(2, chain.LocatePhaseIndex(40.0)); // last phase inclusive end
+            Assert.Equal(-1, chain.LocatePhaseIndex(25.0)); // gap
+            Assert.Equal(-1, chain.LocatePhaseIndex(-5.0)); // before first
+        }
+
+        [Fact]
+        public void EmptyChain_IsAlwaysGapOrOutside_NeverThrows()
+        {
+            var chain = new PhaseChain("rec-empty", 0, 0,
+                phases: new List<TrajectoryPhase>(), windowStartUt: 0, windowEndUt: 10);
+            Assert.Equal(-1, chain.LocatePhaseIndex(5.0));
+            Assert.Equal(Coverage.InInteriorGap, chain.ClassifyCoverage(5.0, out _, out _));
+            Assert.Equal(Coverage.OutsideWindow, chain.ClassifyCoverage(50.0, out _, out _));
+        }
+
+        [Fact]
+        public void NonFiniteUt_IsOutsideWindow()
+        {
+            var chain = BuildChain();
+            Assert.Equal(Coverage.OutsideWindow, chain.ClassifyCoverage(double.NaN, out _, out _));
+            Assert.Equal(-1, chain.LocatePhaseIndex(double.PositiveInfinity));
+        }
+
+        [Fact]
+        public void HoldPhaseInChain_CoversItsWholeSpan_NotAGap()
+        {
+            // A HoldPhase sitting between two phases must NOT classify as an interior gap mid-hold - it
+            // covers its whole span (warp-step safety, §11.3).
+            var phases = new List<TrajectoryPhase>
+            {
+                new DepartureLoiterPhase(Id(0), SegmentProvenance.Recorded, Kerbin, 0, 10, Conic(0, 10)),
+                new HoldPhase(Id(1), Kerbin, 10, 1000),
+                new ArrivalLoiterPhase(Id(2), SegmentProvenance.Recorded, Kerbin, 1000, 1010, Conic(1000, 1010)),
+            };
+            var chain = new PhaseChain("rec-A", 0, 0, phases, windowStartUt: 0, windowEndUt: 1010);
+
+            Assert.Equal(1, chain.LocatePhaseIndex(10.0));   // hold start
+            Assert.Equal(1, chain.LocatePhaseIndex(500.0));  // deep inside the hold (a high-warp landing)
+            Assert.Equal(1, chain.LocatePhaseIndex(999.0));
+            Assert.Equal(2, chain.LocatePhaseIndex(1000.0)); // shared boundary -> the later phase
+
+            Assert.Equal(Coverage.InSegment, chain.ClassifyCoverage(500.0, out TrajectoryPhase p, out _));
+            Assert.IsType<HoldPhase>(p);
+        }
+
+        [Fact]
+        public void TryGetPhase_ReturnsPhaseOrFalse()
+        {
+            var chain = BuildChain();
+            Assert.True(chain.TryGetPhase(5.0, out TrajectoryPhase p, out int idx));
+            Assert.Equal(0, idx);
+            Assert.IsType<AscentPhase>(p);
+            Assert.False(chain.TryGetPhase(25.0, out _, out _)); // gap
+        }
+
+        [Fact]
+        public void ChainCarriesKeyingAndWindowFields()
+        {
+            var chain = BuildChain();
+            Assert.Equal("rec-A", chain.RecordingId);
+            Assert.Equal(3, chain.CommittedIndex);
+            Assert.Equal(0, chain.InstanceKey);
+            Assert.Equal(0, chain.WindowStartUt);
+            Assert.Equal(40, chain.WindowEndUt);
+            Assert.Equal(3, chain.PhaseCount);
+            Assert.False(chain.IsFaithfulFallback);
+        }
+    }
+}

--- a/Source/Parsek.Tests/MapRender/PhaseIdTests.cs
+++ b/Source/Parsek.Tests/MapRender/PhaseIdTests.cs
@@ -1,0 +1,77 @@
+using System.Collections.Generic;
+using Parsek.MapRender;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    /// <summary>
+    /// Phase-1 guard for <see cref="PhaseId"/> (design §6): the RUNTIME render-layer identity that is
+    /// value-equatable so it can key a dictionary / be asserted. The load-bearing property is that two
+    /// phases of the SAME recording but DIFFERENT instance-key (overlapping self-loop instances) or
+    /// different ordinal are DISTINCT ids.
+    ///
+    /// Each assertion states the bug it catches: a collision between two overlapping-instance phases
+    /// would make a per-phase dictionary (seam wiring / trace registry) overwrite one with the other.
+    /// </summary>
+    public class PhaseIdTests
+    {
+        [Fact]
+        public void Equality_SameComponents_AreEqual()
+        {
+            var a = new PhaseId("rec-A", instanceKey: 2, ordinal: 5);
+            var b = new PhaseId("rec-A", instanceKey: 2, ordinal: 5);
+            Assert.Equal(a, b);
+            Assert.Equal(a.GetHashCode(), b.GetHashCode());
+        }
+
+        [Fact]
+        public void Equality_DifferentInstanceKey_AreDistinct()
+        {
+            var a = new PhaseId("rec-A", instanceKey: 0, ordinal: 5);
+            var b = new PhaseId("rec-A", instanceKey: 1, ordinal: 5);
+            Assert.NotEqual(a, b);
+        }
+
+        [Fact]
+        public void Equality_DifferentOrdinal_AreDistinct()
+        {
+            var a = new PhaseId("rec-A", instanceKey: 0, ordinal: 1);
+            var b = new PhaseId("rec-A", instanceKey: 0, ordinal: 2);
+            Assert.NotEqual(a, b);
+        }
+
+        [Fact]
+        public void Equality_DifferentRecording_AreDistinct()
+        {
+            var a = new PhaseId("rec-A", 0, 0);
+            var b = new PhaseId("rec-B", 0, 0);
+            Assert.NotEqual(a, b);
+        }
+
+        [Fact]
+        public void CanKeyADictionary_OverlappingInstancesDoNotCollide()
+        {
+            var dict = new Dictionary<PhaseId, string>
+            {
+                [new PhaseId("rec-A", 0, 3)] = "instance0",
+                [new PhaseId("rec-A", 1, 3)] = "instance1",
+            };
+            Assert.Equal(2, dict.Count);
+            Assert.Equal("instance0", dict[new PhaseId("rec-A", 0, 3)]);
+            Assert.Equal("instance1", dict[new PhaseId("rec-A", 1, 3)]);
+        }
+
+        [Fact]
+        public void IsEmpty_DefaultStruct()
+        {
+            Assert.True(default(PhaseId).IsEmpty);
+            Assert.False(new PhaseId("rec-A", 0, 0).IsEmpty);
+        }
+
+        [Fact]
+        public void ToString_IsGrepStable()
+        {
+            Assert.Equal("rec-A#i2#p5", new PhaseId("rec-A", 2, 5).ToString());
+        }
+    }
+}

--- a/Source/Parsek.Tests/MapRender/PhaseSeamTests.cs
+++ b/Source/Parsek.Tests/MapRender/PhaseSeamTests.cs
@@ -1,0 +1,170 @@
+using Parsek.MapRender;
+using UnityEngine;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    /// <summary>
+    /// Phase-1 guard for <see cref="PhaseSeam"/> + <see cref="PhaseSeamClassifier"/> (design §6.1).
+    /// Covers the seam factories' kind/continuity, the body-change-vs-rigid-vs-switch classification,
+    /// and the G1 <c>rigid-seam-tangent-discontinuity</c> predicate the descent re-stitch (Phase 6)
+    /// enforces.
+    ///
+    /// Each assertion states the bug it catches: a wrong classification would assert G1 continuity on
+    /// an SOI boundary (false anomalies) or accept a real orbit↔landing discontinuity; a wrong tangent
+    /// predicate would either flag a continuous landing seam or miss a real kink.
+    /// </summary>
+    public class PhaseSeamTests
+    {
+        // ---- Factories ----
+
+        [Fact]
+        public void RigidFactory_IsRigidG1_RequiresTangentMatch()
+        {
+            var seam = PhaseSeam.Rigid();
+            Assert.Equal(PhaseSeamKind.Rigid, seam.Kind);
+            Assert.Equal(ContinuityOrder.G1, seam.Continuity);
+            Assert.True(seam.RequiresTangentMatch);
+            Assert.True(seam.OnCamera);
+            Assert.Null(seam.Crossing);
+        }
+
+        [Fact]
+        public void FlexibleSoiFactory_IsFlexibleG0_CarriesCrossing()
+        {
+            var crossing = new SoiCrossing("Kerbin", "Sun", crossingUt: 1000, soiRadius: 8.4e7);
+            var seam = PhaseSeam.FlexibleSoi(crossing);
+            Assert.Equal(PhaseSeamKind.FlexibleSoi, seam.Kind);
+            Assert.Equal(ContinuityOrder.G0, seam.Continuity);
+            Assert.False(seam.RequiresTangentMatch);
+            Assert.Same(crossing, seam.Crossing);
+        }
+
+        [Fact]
+        public void SwitchContinuationFactory_IsSwitchG0()
+        {
+            var seam = PhaseSeam.SwitchContinuation();
+            Assert.Equal(PhaseSeamKind.SwitchContinuation, seam.Kind);
+            Assert.Equal(ContinuityOrder.G0, seam.Continuity);
+            Assert.False(seam.RequiresTangentMatch);
+        }
+
+        // ---- Kind classification ----
+
+        [Fact]
+        public void Classify_BodyChange_IsFlexibleSoi_EvenForRigidKinds()
+        {
+            // A body change wins over the rigid join: an SOI crossing is never a G1 rigid seam.
+            var kind = PhaseSeamClassifier.Classify(
+                PhaseKind.Ascent, PhaseKind.DepartureLoiter,
+                leadingBody: "Kerbin", trailingBody: "Sun",
+                isMemberSwitchBoundary: false);
+            Assert.Equal(PhaseSeamKind.FlexibleSoi, kind);
+        }
+
+        [Fact]
+        public void Classify_AscentToOrbit_SameBody_IsRigid()
+        {
+            var kind = PhaseSeamClassifier.Classify(
+                PhaseKind.Ascent, PhaseKind.DepartureLoiter,
+                leadingBody: "Kerbin", trailingBody: "Kerbin",
+                isMemberSwitchBoundary: false);
+            Assert.Equal(PhaseSeamKind.Rigid, kind);
+        }
+
+        [Fact]
+        public void Classify_OrbitToLanding_SameBody_IsRigid_BothDirections()
+        {
+            Assert.Equal(PhaseSeamKind.Rigid, PhaseSeamClassifier.Classify(
+                PhaseKind.ArrivalLoiter, PhaseKind.Descent, "Duna", "Duna", false));
+            // Symmetric: the classifier treats the join as undirected.
+            Assert.Equal(PhaseSeamKind.Rigid, PhaseSeamClassifier.Classify(
+                PhaseKind.Descent, PhaseKind.ArrivalLoiter, "Duna", "Duna", false));
+        }
+
+        [Fact]
+        public void Classify_MemberSwitch_IsSwitchContinuation_OverridesEverything()
+        {
+            var kind = PhaseSeamClassifier.Classify(
+                PhaseKind.Ascent, PhaseKind.DepartureLoiter,
+                leadingBody: "Kerbin", trailingBody: "Sun",
+                isMemberSwitchBoundary: true);
+            Assert.Equal(PhaseSeamKind.SwitchContinuation, kind);
+        }
+
+        [Fact]
+        public void Classify_NonRigidSameBodyJoin_IsNone()
+        {
+            // Loiter -> Transfer same body is not a distinguished rigid seam.
+            var kind = PhaseSeamClassifier.Classify(
+                PhaseKind.DepartureLoiter, PhaseKind.HeliocentricTransfer,
+                leadingBody: "Sun", trailingBody: "Sun",
+                isMemberSwitchBoundary: false);
+            Assert.Equal(PhaseSeamKind.None, kind);
+        }
+
+        // ---- G1 tangent discontinuity predicate ----
+
+        [Fact]
+        public void TangentDiscontinuity_AlignedTangents_NoAnomaly()
+        {
+            Assert.False(PhaseSeamClassifier.IsRigidSeamTangentDiscontinuity(
+                new Vector3(1, 0, 0), new Vector3(2, 0, 0)));
+        }
+
+        [Fact]
+        public void TangentDiscontinuity_SmallAngleWithinTolerance_NoAnomaly()
+        {
+            // ~2.9 degrees < the 0.1 rad (~5.7 deg) default tolerance.
+            var a = new Vector3(1, 0, 0);
+            var b = new Vector3(Mathf.Cos(0.05f), Mathf.Sin(0.05f), 0);
+            Assert.False(PhaseSeamClassifier.IsRigidSeamTangentDiscontinuity(a, b));
+        }
+
+        [Fact]
+        public void TangentDiscontinuity_LargeAngle_FlagsAnomaly()
+        {
+            // 90 degrees >> tolerance.
+            Assert.True(PhaseSeamClassifier.IsRigidSeamTangentDiscontinuity(
+                new Vector3(1, 0, 0), new Vector3(0, 1, 0)));
+        }
+
+        [Fact]
+        public void TangentDiscontinuity_CustomTolerance_Respected()
+        {
+            // 0.05 rad angle, tolerance 0.01 -> over.
+            var a = new Vector3(1, 0, 0);
+            var b = new Vector3(Mathf.Cos(0.05f), Mathf.Sin(0.05f), 0);
+            Assert.True(PhaseSeamClassifier.IsRigidSeamTangentDiscontinuity(a, b, toleranceRadians: 0.01));
+        }
+
+        [Fact]
+        public void TangentDiscontinuity_ZeroOrNonFiniteTangent_NoFalseAnomaly()
+        {
+            // Unmeasurable tangent -> no anomaly (mirrors the oracle's no-false-positive contract).
+            Assert.False(PhaseSeamClassifier.IsRigidSeamTangentDiscontinuity(
+                Vector3.zero, new Vector3(1, 0, 0)));
+            Assert.False(PhaseSeamClassifier.IsRigidSeamTangentDiscontinuity(
+                new Vector3(1, 0, 0), Vector3.zero));
+            Assert.False(PhaseSeamClassifier.IsRigidSeamTangentDiscontinuity(
+                new Vector3(float.NaN, 0, 0), new Vector3(1, 0, 0)));
+        }
+
+        [Fact]
+        public void TangentDiscontinuity_NonFiniteTolerance_FallsBackToDefault()
+        {
+            // 90 deg is over the default; a NaN tolerance must fall back to the default, not pass-through.
+            Assert.True(PhaseSeamClassifier.IsRigidSeamTangentDiscontinuity(
+                new Vector3(1, 0, 0), new Vector3(0, 1, 0), toleranceRadians: double.NaN));
+        }
+
+        [Fact]
+        public void KindToken_IsGrepStable()
+        {
+            Assert.Equal("rigid", PhaseSeamClassifier.KindToken(PhaseSeamKind.Rigid));
+            Assert.Equal("flexible-soi", PhaseSeamClassifier.KindToken(PhaseSeamKind.FlexibleSoi));
+            Assert.Equal("switch-continuation", PhaseSeamClassifier.KindToken(PhaseSeamKind.SwitchContinuation));
+            Assert.Equal("none", PhaseSeamClassifier.KindToken(PhaseSeamKind.None));
+        }
+    }
+}

--- a/Source/Parsek.Tests/MapRender/SegmentProvenanceTests.cs
+++ b/Source/Parsek.Tests/MapRender/SegmentProvenanceTests.cs
@@ -1,0 +1,61 @@
+using Parsek.MapRender;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    /// <summary>
+    /// Phase-1 guard for <see cref="SegmentProvenance"/> + <see cref="SegmentProvenanceTokens"/>
+    /// (design §5.1). The provenance enum collapses the overloaded <c>OrbitSegment.isPredicted</c>;
+    /// the load-bearing decisions are the grep-stable token (trace lines) and the two predicates the
+    /// rest of the model leans on: <c>IsInMemoryOnly</c> (the §13 "never reach disk" gate) and
+    /// <c>IsFaithfulReplay</c> (the §14 faithful-vs-synthesized oracle-mode split).
+    ///
+    /// Each assertion states the bug it catches: a wrong token would mis-grep a trace line; a wrong
+    /// <c>IsInMemoryOnly</c> would let a synthesized arc be persisted (the immutability HARD RULE
+    /// violation); a wrong <c>IsFaithfulReplay</c> would diff a faithful member against the intended
+    /// arc instead of the recorded source.
+    /// </summary>
+    public class SegmentProvenanceTests
+    {
+        // SegmentProvenance is internal, so a public [Theory] cannot take it as a parameter (CS0051).
+        // Pass the underlying int (a compile-time constant; the enum is visible to the test assembly via
+        // InternalsVisibleTo) and cast back inside - the same idiom GhostRenderChainTests uses for the
+        // internal Coverage enum.
+        [Theory]
+        [InlineData((int)SegmentProvenance.Recorded, "recorded")]
+        [InlineData((int)SegmentProvenance.FinalizedPredicted, "finalized-predicted")]
+        [InlineData((int)SegmentProvenance.Synthesized, "synthesized")]
+        [InlineData((int)SegmentProvenance.FaithfulFallback, "faithful-fallback")]
+        [InlineData((int)SegmentProvenance.Unknown, "unknown")]
+        public void ToToken_IsGrepStable(int provenance, string expected)
+        {
+            Assert.Equal(expected, SegmentProvenanceTokens.ToToken((SegmentProvenance)provenance));
+        }
+
+        [Theory]
+        // Only Synthesized is in-memory-only (the §13 never-persist gate). FinalizedPredicted IS
+        // persisted (written once then immutable) so it must NOT be flagged in-memory-only.
+        [InlineData((int)SegmentProvenance.Synthesized, true)]
+        [InlineData((int)SegmentProvenance.Recorded, false)]
+        [InlineData((int)SegmentProvenance.FinalizedPredicted, false)]
+        [InlineData((int)SegmentProvenance.FaithfulFallback, false)]
+        [InlineData((int)SegmentProvenance.Unknown, false)]
+        public void IsInMemoryOnly_FlagsExactlySynthesized(int provenance, bool expected)
+        {
+            Assert.Equal(expected, SegmentProvenanceTokens.IsInMemoryOnly((SegmentProvenance)provenance));
+        }
+
+        [Theory]
+        // Faithful replay = Recorded OR FaithfulFallback (oracle FAITHFUL mode). Synthesized and
+        // FinalizedPredicted are NOT recorded-verbatim replays.
+        [InlineData((int)SegmentProvenance.Recorded, true)]
+        [InlineData((int)SegmentProvenance.FaithfulFallback, true)]
+        [InlineData((int)SegmentProvenance.Synthesized, false)]
+        [InlineData((int)SegmentProvenance.FinalizedPredicted, false)]
+        [InlineData((int)SegmentProvenance.Unknown, false)]
+        public void IsFaithfulReplay_SplitsForOracleMode(int provenance, bool expected)
+        {
+            Assert.Equal(expected, SegmentProvenanceTokens.IsFaithfulReplay((SegmentProvenance)provenance));
+        }
+    }
+}

--- a/Source/Parsek.Tests/MapRender/TrajectoryPhaseTests.cs
+++ b/Source/Parsek.Tests/MapRender/TrajectoryPhaseTests.cs
@@ -1,0 +1,199 @@
+using System.Linq;
+using Parsek.MapRender;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    /// <summary>
+    /// Phase-1 guard for the concrete <see cref="TrajectoryPhase"/> subclasses (design §6): each
+    /// subclass's <see cref="TrajectoryPhase.ResolveTreatment"/>, <see cref="TrajectoryPhase.CoversUt"/>,
+    /// and <see cref="TrajectoryPhase.Emit"/> (the typed-but-unwired geometry contract that Phase 2
+    /// byte-parities against the legacy assembler).
+    ///
+    /// Each assertion states the bug it catches: a wrong treatment would draw a conic as a polyline
+    /// (or vice-versa); a wrong CoversUt would mis-route a frame to the wrong phase or freeze a ghost
+    /// across a warp-skipped hold; a wrong Emit body/seam/payload would break the Phase-2 geometry
+    /// parity gate.
+    /// </summary>
+    public class TrajectoryPhaseTests
+    {
+        private static readonly AnchorFrame Kerbin = new AnchorFrame.BodyAnchor("Kerbin");
+        private static readonly AnchorFrame Sun = new AnchorFrame.BodyAnchor("Sun");
+
+        private static OrbitSegment Conic(string body, double start, double end)
+            => new OrbitSegment { startUT = start, endUT = end, bodyName = body, semiMajorAxis = 7e5 };
+
+        private static PhaseId Id(int ordinal) => new PhaseId("rec-A", 0, ordinal);
+        private static SampleContext Ctx(double ut, string body = "Kerbin") => new SampleContext(ut, body);
+
+        // ---- ResolveTreatment per subclass ----
+
+        [Fact]
+        public void Treatments_MatchTheSection6Table()
+        {
+            Assert.Equal(Treatment.TracedPath,
+                new AscentPhase(Id(0), SegmentProvenance.Recorded, Kerbin, 0, 10).ResolveTreatment());
+            Assert.Equal(Treatment.StockConic,
+                new DepartureLoiterPhase(Id(1), SegmentProvenance.Recorded, Kerbin, 10, 20, Conic("Kerbin", 10, 20)).ResolveTreatment());
+            Assert.Equal(Treatment.StockConic,
+                new HeliocentricTransferPhase(Id(2), SegmentProvenance.Synthesized, Sun, 20, 30, Conic("Sun", 20, 30)).ResolveTreatment());
+            Assert.Equal(Treatment.StockConic,
+                new ArrivalLoiterPhase(Id(3), SegmentProvenance.Recorded, Kerbin, 30, 40, Conic("Duna", 30, 40)).ResolveTreatment());
+            Assert.Equal(Treatment.TracedPath,
+                new DescentPhase(Id(4), SegmentProvenance.Recorded, Kerbin, 40, 50).ResolveTreatment());
+            Assert.Equal(Treatment.TracedPath,
+                new SurfacePhase(Id(5), SegmentProvenance.Recorded, Kerbin, 50, 60).ResolveTreatment());
+            Assert.Equal(Treatment.None,
+                new HoldPhase(Id(6), Kerbin, 60, 70).ResolveTreatment());
+        }
+
+        // Treatment is internal -> pass the underlying int into the [Theory] (CS0051 idiom).
+        [Theory]
+        [InlineData((int)Treatment.StockConic)]
+        [InlineData((int)Treatment.TracedPath)]
+        public void DualTreatmentSoiDeparture_HonoursExplicitTreatment(int treatmentInt)
+        {
+            var treatment = (Treatment)treatmentInt;
+            var p = new SoiDeparturePhase(
+                Id(0), treatment, SegmentProvenance.Recorded, Kerbin, 0, 10, Conic("Kerbin", 0, 10));
+            Assert.Equal(treatment, p.ResolveTreatment());
+        }
+
+        [Theory]
+        [InlineData((int)Treatment.StockConic)]
+        [InlineData((int)Treatment.TracedPath)]
+        public void DualTreatmentSoiArrival_HonoursExplicitTreatment(int treatmentInt)
+        {
+            var treatment = (Treatment)treatmentInt;
+            var p = new SoiArrivalPhase(
+                Id(0), treatment, SegmentProvenance.Recorded, Sun, 0, 10, Conic("Duna", 0, 10));
+            Assert.Equal(treatment, p.ResolveTreatment());
+        }
+
+        // ---- CoversUt ----
+
+        [Theory]
+        [InlineData(10.0, true)]   // inclusive start
+        [InlineData(15.0, true)]
+        [InlineData(19.9, true)]
+        [InlineData(20.0, false)]  // exclusive end (belongs to the next phase)
+        [InlineData(9.9, false)]
+        [InlineData(25.0, false)]
+        public void CoversUt_IsHalfOpenInterval(double ut, bool expected)
+        {
+            var p = new DepartureLoiterPhase(Id(0), SegmentProvenance.Recorded, Kerbin, 10, 20, Conic("Kerbin", 10, 20));
+            Assert.Equal(expected, p.CoversUt(ut));
+        }
+
+        [Fact]
+        public void CoversUt_NonFinite_IsFalse()
+        {
+            var p = new DepartureLoiterPhase(Id(0), SegmentProvenance.Recorded, Kerbin, 10, 20, Conic("Kerbin", 10, 20));
+            Assert.False(p.CoversUt(double.NaN));
+            Assert.False(p.CoversUt(double.PositiveInfinity));
+        }
+
+        [Theory]
+        // A HoldPhase must cover its WHOLE span so a high-warp frame landing anywhere inside the hold
+        // resolves to the hold (never a spurious gap that freezes the ghost for multiple frames, §11.3).
+        [InlineData(100.0, true)]
+        [InlineData(5000.0, true)]
+        [InlineData(99999.0, true)]
+        [InlineData(100000.0, false)] // exclusive end
+        [InlineData(99.0, false)]
+        public void HoldPhase_CoversWholeSpan_WarpStepSafe(double ut, bool expected)
+        {
+            var hold = new HoldPhase(Id(0), Kerbin, 100, 100000);
+            Assert.Equal(expected, hold.CoversUt(ut));
+        }
+
+        // ---- Emit geometry contract ----
+
+        [Fact]
+        public void ConicPhase_Emits_OneStockConicSegment_WithConicPayloadAndBody()
+        {
+            var conic = Conic("Duna", 30, 40);
+            var p = new ArrivalLoiterPhase(Id(0), SegmentProvenance.Recorded, new AnchorFrame.BodyAnchor("Duna"), 30, 40, conic);
+            var segs = p.Emit(Ctx(35, "Duna")).ToList();
+
+            Assert.Single(segs);
+            var s = segs[0];
+            Assert.Equal(Treatment.StockConic, s.Treatment);
+            Assert.Equal(30, s.StartUT);
+            Assert.Equal(40, s.EndUT);
+            Assert.Equal("Duna", s.FrameBodyName);   // resolved from the BodyAnchor
+            Assert.True(s.Payload.HasConic);
+            Assert.Equal("Duna", s.Payload.Conic.bodyName);
+            Assert.False(s.IsGenerated);             // Recorded provenance -> not generated
+        }
+
+        [Fact]
+        public void TracedPhase_Emits_OneTracedPathSegment_NoConic()
+        {
+            var p = new DescentPhase(Id(0), SegmentProvenance.Recorded, new AnchorFrame.BodyAnchor("Duna"), 40, 50);
+            var segs = p.Emit(Ctx(45, "Duna")).ToList();
+
+            Assert.Single(segs);
+            var s = segs[0];
+            Assert.Equal(Treatment.TracedPath, s.Treatment);
+            Assert.False(s.Payload.HasConic);
+            Assert.Equal(SegmentKind.Landing, s.Kind); // §6 map: Landing -> Descent
+            Assert.Equal("Duna", s.FrameBodyName);
+        }
+
+        [Fact]
+        public void SynthesizedConicPhase_Emits_IsGenerated()
+        {
+            var p = new HeliocentricTransferPhase(
+                Id(0), SegmentProvenance.Synthesized, Sun, 20, 30, Conic("Sun", 20, 30));
+            var s = p.Emit(Ctx(25, "Sun")).Single();
+            Assert.True(s.IsGenerated); // re-aim synthesized -> the legacy "generated" geometry flag
+            Assert.Equal(SegmentKind.Transfer, s.Kind);
+        }
+
+        [Fact]
+        public void HoldPhase_Emits_Nothing()
+        {
+            var hold = new HoldPhase(Id(0), Kerbin, 60, 70);
+            Assert.Empty(hold.Emit(Ctx(65)));
+        }
+
+        [Fact]
+        public void Emit_MapsPhaseSeam_DownToLegacySeamKind()
+        {
+            // A FlexibleSoi leading seam + Rigid trailing seam must surface on the emitted RenderSegment
+            // as the legacy SeamKind the live draw path reads.
+            var crossing = new SoiCrossing("Sun", "Duna", 30, 1e8);
+            var p = new SoiArrivalPhase(
+                Id(0), Treatment.StockConic, SegmentProvenance.Recorded, new AnchorFrame.BodyAnchor("Duna"),
+                30, 40, Conic("Duna", 30, 40),
+                leadingSeam: PhaseSeam.FlexibleSoi(crossing),
+                trailingSeam: PhaseSeam.Rigid());
+            var s = p.Emit(Ctx(35, "Duna")).Single();
+            Assert.Equal(SeamKind.FlexibleSoi, s.LeadingSeam);
+            Assert.Equal(SeamKind.Rigid, s.TrailingSeam);
+        }
+
+        [Fact]
+        public void Emit_SwitchContinuationSeam_MapsToLegacyNone()
+        {
+            // SwitchContinuation is a member boundary, not an intra-chain seam -> legacy None.
+            var p = new AscentPhase(
+                Id(0), SegmentProvenance.Recorded, Kerbin, 0, 10,
+                leadingSeam: PhaseSeam.SwitchContinuation());
+            var s = p.Emit(Ctx(5)).Single();
+            Assert.Equal(SeamKind.None, s.LeadingSeam);
+        }
+
+        [Fact]
+        public void DualTreatment_TracedPath_EmitsNoConicPayload()
+        {
+            var p = new SoiDeparturePhase(
+                Id(0), Treatment.TracedPath, SegmentProvenance.Recorded, Kerbin, 0, 10, Conic("Kerbin", 0, 10));
+            var s = p.Emit(Ctx(5)).Single();
+            Assert.Equal(Treatment.TracedPath, s.Treatment);
+            Assert.False(s.Payload.HasConic);
+            Assert.Equal(SegmentKind.Eject, s.Kind);
+        }
+    }
+}

--- a/Source/Parsek.Tests/MapRender/TrajectoryPhaseTests.cs
+++ b/Source/Parsek.Tests/MapRender/TrajectoryPhaseTests.cs
@@ -128,6 +128,31 @@ namespace Parsek.Tests
         }
 
         [Fact]
+        public void ConicPhase_FrameBodyName_PrefersAnchorOverConicAndCtx()
+        {
+            // Precedence pin: anchor body > conic body > ctx body. All three DISAGREE, so a wrong
+            // ResolveFrameBodyName would leak the conic's "Sun" or the ctx's "Kerbin" into the segment.
+            var conic = Conic("Sun", 30, 40);
+            var p = new ArrivalLoiterPhase(
+                Id(0), SegmentProvenance.Recorded, new AnchorFrame.BodyAnchor("Duna"), 30, 40, conic);
+            var s = p.Emit(Ctx(35, "Kerbin")).Single();
+            Assert.Equal("Duna", s.FrameBodyName); // BodyAnchor wins over conic "Sun" and ctx "Kerbin"
+        }
+
+        [Fact]
+        public void ConicPhase_FrameBodyName_FallsToConicBody_WhenAnchorProvidesNoBodyName()
+        {
+            // A non-BodyAnchor anchor provides no body name, so the conic body wins over the ctx body
+            // (anchor > conic > ctx -> conic). A wrong fall-through would leak the ctx's "Kerbin".
+            var conic = Conic("Sun", 30, 40);
+            var p = new ArrivalLoiterPhase(
+                Id(0), SegmentProvenance.Recorded,
+                new AnchorFrame.RecordedAnchorTrajectory("rec-A"), 30, 40, conic);
+            var s = p.Emit(Ctx(35, "Kerbin")).Single();
+            Assert.Equal("Sun", s.FrameBodyName); // conic "Sun" wins over ctx "Kerbin"
+        }
+
+        [Fact]
         public void TracedPhase_Emits_OneTracedPathSegment_NoConic()
         {
             var p = new DescentPhase(Id(0), SegmentProvenance.Recorded, new AnchorFrame.BodyAnchor("Duna"), 40, 50);

--- a/Source/Parsek.Tests/MapRender/TrajectorySampleTests.cs
+++ b/Source/Parsek.Tests/MapRender/TrajectorySampleTests.cs
@@ -1,0 +1,96 @@
+using Parsek;
+using Parsek.MapRender;
+using UnityEngine;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    /// <summary>
+    /// Phase-1 guard for the typed <see cref="ITrajectorySample"/> view (design §5.3) that splits the
+    /// frame-overloaded <c>TrajectoryPoint</c>. The load-bearing property is FRAME DISCRIMINATION: an
+    /// <see cref="AbsoluteSample"/> must report degrees-in-Absolute and a <see cref="RelativeSample"/>
+    /// must report metres-in-Relative, with distinct <see cref="TrajectorySampleKind"/>s, so no
+    /// downstream reader can mis-read a Relative sample's metres as lat/lon (the documented "ghost
+    /// inside the planet" trap).
+    ///
+    /// Each assertion states the bug it catches: a wrong <c>Frame</c>/<c>Kind</c> would route a
+    /// metre-scale Relative offset through <c>body.GetWorldSurfacePosition(lat,lon,alt)</c> and place
+    /// the ghost deep inside the planet.
+    /// </summary>
+    public class TrajectorySampleTests
+    {
+        [Fact]
+        public void AbsoluteSample_ReportsDegreesInAbsoluteFrame()
+        {
+            var s = new AbsoluteSample(
+                ut: 123.0, latitude: 10.5, longitude: -45.0, altitude: 1200.0,
+                bodyName: "Kerbin", srfRelRotation: Quaternion.identity);
+            ITrajectorySample view = s;
+
+            Assert.Equal(TrajectorySampleKind.Absolute, view.Kind);
+            Assert.Equal(ReferenceFrame.Absolute, view.Frame);
+            Assert.Equal(123.0, view.Ut);
+            Assert.Equal(10.5, s.Latitude);
+            Assert.Equal(-45.0, s.Longitude);
+            Assert.Equal(1200.0, s.Altitude);
+            Assert.Equal("Kerbin", s.BodyName);
+        }
+
+        [Fact]
+        public void RelativeSample_ReportsMetresInRelativeFrame()
+        {
+            var s = new RelativeSample(
+                ut: 200.0, localX: 5000.0, localY: -250.0, localZ: 17.0,
+                localRotation: Quaternion.identity);
+            ITrajectorySample view = s;
+
+            Assert.Equal(TrajectorySampleKind.Relative, view.Kind);
+            Assert.Equal(ReferenceFrame.Relative, view.Frame);
+            Assert.Equal(200.0, view.Ut);
+            // Metre-scale offsets that would be NONSENSE if read as degrees - the discriminator is the
+            // whole point.
+            Assert.Equal(5000.0, s.LocalX);
+            Assert.Equal(-250.0, s.LocalY);
+            Assert.Equal(17.0, s.LocalZ);
+        }
+
+        [Fact]
+        public void OrbitalState_WrapsOrbitSegment_AtItsEpoch()
+        {
+            var seg = new OrbitSegment
+            {
+                startUT = 500.0,
+                endUT = 900.0,
+                bodyName = "Sun",
+                semiMajorAxis = 1.3e10,
+                eccentricity = 0.2,
+            };
+            var s = OrbitalState.FromSegment(seg);
+            ITrajectorySample view = s;
+
+            Assert.Equal(TrajectorySampleKind.Orbital, view.Kind);
+            Assert.Equal(ReferenceFrame.OrbitalCheckpoint, view.Frame);
+            Assert.Equal(500.0, view.Ut); // FromSegment uses the segment's startUT as the epoch
+            Assert.Equal("Sun", s.Segment.bodyName);
+            Assert.Equal(1.3e10, s.Segment.semiMajorAxis);
+        }
+
+        [Fact]
+        public void OrbitalState_ExplicitUt_OverridesEpoch()
+        {
+            var seg = new OrbitSegment { startUT = 500.0, bodyName = "Sun" };
+            var s = new OrbitalState(ut: 777.0, segment: seg);
+            Assert.Equal(777.0, s.Ut);
+        }
+
+        [Fact]
+        public void SampleKinds_AreDistinct()
+        {
+            // The three views must not collide on Kind/Frame - that distinction is what prevents the
+            // mis-read.
+            Assert.NotEqual(TrajectorySampleKind.Absolute, TrajectorySampleKind.Relative);
+            Assert.NotEqual(TrajectorySampleKind.Relative, TrajectorySampleKind.Orbital);
+            Assert.NotEqual(ReferenceFrame.Absolute, ReferenceFrame.Relative);
+        }
+    }
+}

--- a/Source/Parsek/MapRender/AnchorFrame.cs
+++ b/Source/Parsek/MapRender/AnchorFrame.cs
@@ -1,0 +1,144 @@
+using System;
+
+namespace Parsek.MapRender
+{
+    /// <summary>
+    /// Phase 1 / design §5.2: the render-layer notion of "which frame a phase lives in", replacing the
+    /// bare <c>RenderSegment.FrameBodyName</c> string. A string cannot say "anchored to a <i>live
+    /// vessel</i> that is the same craft as a recorded anchor", which is why the depot-double /
+    /// dock-renders-absolute bug class existed. A discriminated union does.
+    ///
+    /// <para><b>NEW, additive, NOT wired in Phase 1.</b> v1 only needs the TYPES plus
+    /// <see cref="BodyAnchor"/> and <see cref="ParentAnchoredChild"/> resolvable (the pure decision
+    /// parts below); <see cref="LiveVesselAnchor"/>, <see cref="ParentGeneratedConicAnchor"/>, and
+    /// <see cref="RecordedAnchorTrajectory"/> are typed placeholders for the fail-closed
+    /// station / Jool / non-loop-relative cases (the producers are deferred — see the migration plan
+    /// Phase 7).</para>
+    ///
+    /// <para><b>Loud-assertion carry-forward (design §6, <c>RenderSegment.cs:94-98</c>):</b> a
+    /// <see cref="ParentAnchoredChild"/> is NEVER handed a re-aimed / generated segment list. The
+    /// factory/assembler must keep that failure loud (assert) rather than silently body-framing it, so
+    /// the transfer-leg-debris fail-closed (Phase 7) degrades loudly, not silently.</para>
+    /// </summary>
+    internal abstract class AnchorFrame
+    {
+        /// <summary>The discriminator for the union (grep-stable, switch-friendly, test-assertable).</summary>
+        internal abstract AnchorFrameKind Kind { get; }
+
+        /// <summary>Grep-stable lowercase token for trace lines (design §14 anchor-resolve).</summary>
+        internal string ToToken() => AnchorFrameTokens.ToToken(Kind);
+
+        // ---- Concrete variants ----
+
+        /// <summary>
+        /// design §5.2: the v1 common case — anchored to a celestial body by name.
+        ///
+        /// <para><b>Resolution contract:</b> a missing / renamed modded body name fails CLOSED
+        /// (<c>SuppressedMarker</c> or hide), never NRE. Discovery level does NOT block resolution —
+        /// all stock bodies exist regardless of whether the player has visited them, so a never-visited
+        /// stock body resolves normally; only a missing body name fails (design §11.4). The pure
+        /// decision part is <see cref="AnchorFrameResolver.TryResolveBody"/>.</para>
+        /// </summary>
+        internal sealed class BodyAnchor : AnchorFrame
+        {
+            internal string BodyName { get; }
+            internal BodyAnchor(string bodyName) { BodyName = bodyName; }
+            internal override AnchorFrameKind Kind => AnchorFrameKind.Body;
+            public override string ToString() => "Body(" + (BodyName ?? "?") + ")";
+        }
+
+        /// <summary>
+        /// design §5.2: a controlled-decoupled lander / probe off a decoupler
+        /// (<c>IsDebris = false</c>, <c>ParentAnchorRecordingId != null</c>) — it passes the
+        /// <c>IsDebris</c> gate and DOES render.
+        ///
+        /// <para><b>Resolution contract (CLAUDE.md parent-anchored invariant):</b> the faithful phase
+        /// reads <c>TrackSection.bodyFixedFrames</c> as the PRIMARY surface (body-fixed degrees
+        /// lat/lon/alt + srfRelRotation) and <c>frames</c> (anchor-local metres) as the
+        /// SECONDARY/fallback for loop-anchored chains. Body-fixed primary requires <b>≥2 samples</b>
+        /// AND a playback UT INSIDE the <c>bodyFixedFrames</c> endpoint range; an out-of-range UT must
+        /// <b>RETIRE</b> the ghost — never clamp to a stale child offset. The pure decision part is
+        /// <see cref="AnchorFrameResolver.ResolveParentAnchoredChild"/>.</para>
+        /// </summary>
+        internal sealed class ParentAnchoredChild : AnchorFrame
+        {
+            /// <summary>The parent recording id (the substrate's <c>Recording.ParentAnchorRecordingId</c>).</summary>
+            internal string ParentRecordingId { get; }
+            internal ParentAnchoredChild(string parentRecordingId) { ParentRecordingId = parentRecordingId; }
+            internal override AnchorFrameKind Kind => AnchorFrameKind.ParentAnchoredChild;
+            public override string ToString() => "ParentAnchoredChild(" + (ParentRecordingId ?? "?") + ")";
+        }
+
+        /// <summary>
+        /// design §5.2: a moon riding a parent's GENERATED Jool-centric conic arc. Typed placeholder —
+        /// the producer (nested-SOI synthetic re-aim) is deferred (fail-closed-to-faithful in v1).
+        /// </summary>
+        internal sealed class ParentGeneratedConicAnchor : AnchorFrame
+        {
+            /// <summary>The runtime render-layer id of the parent conic phase.</summary>
+            internal PhaseId ParentConicPhaseId { get; }
+            internal ParentGeneratedConicAnchor(PhaseId parentConicPhaseId) { ParentConicPhaseId = parentConicPhaseId; }
+            internal override AnchorFrameKind Kind => AnchorFrameKind.ParentGeneratedConic;
+            public override string ToString() => "ParentGeneratedConic(" + ParentConicPhaseId + ")";
+        }
+
+        /// <summary>
+        /// design §5.2: rendezvous / docking to a LIVE same-craft vessel (a moving anchor, not a body
+        /// center). Resolution reuses the existing guid-gated docking patch (the dock-anchor /
+        /// depot-double fix). Typed placeholder in v1 — the moving-target producer is deferred.
+        /// </summary>
+        internal sealed class LiveVesselAnchor : AnchorFrame
+        {
+            /// <summary>The launch-unique discriminator (KSP <c>Vessel.id</c>), NOT the craft-baked persistentId.</summary>
+            internal Guid LaunchGuid { get; }
+            internal LiveVesselAnchor(Guid launchGuid) { LaunchGuid = launchGuid; }
+            internal override AnchorFrameKind Kind => AnchorFrameKind.LiveVessel;
+            public override string ToString() => "LiveVessel(" + LaunchGuid + ")";
+        }
+
+        /// <summary>
+        /// design §5.2: a NON-LOOP Relative section anchored to a recorded anchor trajectory
+        /// (<c>TrackSection.anchorRecordingId</c>). The contract SPLITS: a non-loop Relative section
+        /// resolves through the recorded anchor trajectory, while a LOOP Relative section stays on the
+        /// live-PID contract (<c>Recording.LoopAnchorVesselId</c>, → <see cref="LiveVesselAnchor"/>).
+        /// When a re-aimed/looped mission shifts the anchor recording's UT out from under a dependent
+        /// member, the member fails closed to faithful. Typed placeholder in v1.
+        /// </summary>
+        internal sealed class RecordedAnchorTrajectory : AnchorFrame
+        {
+            /// <summary>The anchor recording's id.</summary>
+            internal string AnchorRecordingId { get; }
+            internal RecordedAnchorTrajectory(string anchorRecordingId) { AnchorRecordingId = anchorRecordingId; }
+            internal override AnchorFrameKind Kind => AnchorFrameKind.RecordedAnchor;
+            public override string ToString() => "RecordedAnchor(" + (AnchorRecordingId ?? "?") + ")";
+        }
+    }
+
+    /// <summary>The discriminator for <see cref="AnchorFrame"/> (design §5.2).</summary>
+    internal enum AnchorFrameKind
+    {
+        Unknown = 0,
+        Body = 1,
+        ParentAnchoredChild = 2,
+        ParentGeneratedConic = 3,
+        LiveVessel = 4,
+        RecordedAnchor = 5,
+    }
+
+    /// <summary>Grep-stable lowercase tokens for <see cref="AnchorFrameKind"/>.</summary>
+    internal static class AnchorFrameTokens
+    {
+        internal static string ToToken(AnchorFrameKind kind)
+        {
+            switch (kind)
+            {
+                case AnchorFrameKind.Body: return "body";
+                case AnchorFrameKind.ParentAnchoredChild: return "parent-anchored-child";
+                case AnchorFrameKind.ParentGeneratedConic: return "parent-generated-conic";
+                case AnchorFrameKind.LiveVessel: return "live-vessel";
+                case AnchorFrameKind.RecordedAnchor: return "recorded-anchor";
+                default: return "unknown";
+            }
+        }
+    }
+}

--- a/Source/Parsek/MapRender/AnchorFrameResolver.cs
+++ b/Source/Parsek/MapRender/AnchorFrameResolver.cs
@@ -1,0 +1,133 @@
+using System;
+
+namespace Parsek.MapRender
+{
+    /// <summary>
+    /// Phase 1 / design §5.2: the PURE decision parts of <see cref="AnchorFrame"/> resolution that v1
+    /// implements (<see cref="AnchorFrame.BodyAnchor"/> + <see cref="AnchorFrame.ParentAnchoredChild"/>).
+    /// Unity-ECall-FREE and KSP-API-free: body existence is supplied as a delegate so the fail-closed
+    /// decision is directly unit-testable, and the parent-anchored dual-surface routing is pure
+    /// arithmetic over sample count + UT endpoints.
+    ///
+    /// <para>NOT wired into the live pipeline in Phase 1. The live resolver (a later phase) supplies a
+    /// real body-existence probe (<c>FlightGlobals.Bodies</c> name lookup) and the real
+    /// <c>TrackSection.bodyFixedFrames</c> / <c>frames</c> endpoints; the DECISION stays here.</para>
+    /// </summary>
+    internal static class AnchorFrameResolver
+    {
+        /// <summary>
+        /// The outcome of a <see cref="AnchorFrame.BodyAnchor"/> resolution.
+        /// </summary>
+        internal enum BodyResolveOutcome
+        {
+            /// <summary>The body name resolved — render normally.</summary>
+            Resolved = 0,
+            /// <summary>A null / empty body name — fail closed (SuppressedMarker or hide), never NRE.</summary>
+            FailClosedMissingName = 1,
+            /// <summary>A non-empty body name that does not exist (renamed / removed modded body) — fail closed.</summary>
+            FailClosedUnknownBody = 2,
+        }
+
+        /// <summary>
+        /// design §5.2 / §11.4: resolve a <see cref="AnchorFrame.BodyAnchor"/> against a body-existence
+        /// probe. A null / whitespace name is <see cref="BodyResolveOutcome.FailClosedMissingName"/>; a
+        /// non-empty name the probe rejects is <see cref="BodyResolveOutcome.FailClosedUnknownBody"/>;
+        /// otherwise <see cref="BodyResolveOutcome.Resolved"/>. NEVER throws — a null
+        /// <paramref name="bodyExists"/> probe is treated as "cannot confirm" → fail closed (the
+        /// caller's safe default, not an NRE). Discovery level is irrelevant: the probe is expected to
+        /// answer purely on body existence, so a never-visited stock body resolves.
+        /// </summary>
+        internal static BodyResolveOutcome ResolveBody(string bodyName, Func<string, bool> bodyExists)
+        {
+            if (string.IsNullOrWhiteSpace(bodyName))
+                return BodyResolveOutcome.FailClosedMissingName;
+            if (bodyExists == null)
+                return BodyResolveOutcome.FailClosedUnknownBody;
+
+            bool exists;
+            try { exists = bodyExists(bodyName); }
+            catch { exists = false; }
+            return exists ? BodyResolveOutcome.Resolved : BodyResolveOutcome.FailClosedUnknownBody;
+        }
+
+        /// <summary>True iff <see cref="ResolveBody"/> says the body anchor renders.</summary>
+        internal static bool TryResolveBody(string bodyName, Func<string, bool> bodyExists)
+            => ResolveBody(bodyName, bodyExists) == BodyResolveOutcome.Resolved;
+
+        /// <summary>
+        /// The outcome of a <see cref="AnchorFrame.ParentAnchoredChild"/> dual-surface resolution at a
+        /// playback UT (design §5.2 / CLAUDE.md parent-anchored invariant).
+        /// </summary>
+        internal enum ParentChildSurface
+        {
+            /// <summary>
+            /// Resolve via <c>bodyFixedFrames</c> (PRIMARY): ≥2 body-fixed samples and the playback UT
+            /// inside their endpoint range.
+            /// </summary>
+            BodyFixedPrimary = 0,
+            /// <summary>
+            /// Resolve via <c>frames</c> (SECONDARY/fallback for loop-anchored chains): the body-fixed
+            /// primary is unusable but an anchor-local <c>frames</c> surface covers the UT.
+            /// </summary>
+            AnchorLocalSecondary = 1,
+            /// <summary>
+            /// Neither surface covers the UT (out-of-range / too few samples) — RETIRE the ghost. Never
+            /// clamp to a stale child offset.
+            /// </summary>
+            Retire = 2,
+        }
+
+        /// <summary>
+        /// Minimum body-fixed samples for the PRIMARY surface (design §5.2: "requires ≥2 samples").
+        /// </summary>
+        internal const int MinBodyFixedSamples = 2;
+
+        /// <summary>
+        /// design §5.2: choose the dual surface for a parent-anchored child at <paramref name="ut"/>.
+        /// PRIMARY (<see cref="ParentChildSurface.BodyFixedPrimary"/>) requires
+        /// <paramref name="bodyFixedSampleCount"/> ≥ <see cref="MinBodyFixedSamples"/> AND
+        /// <c><paramref name="bodyFixedStartUt"/> ≤ ut ≤ <paramref name="bodyFixedEndUt"/></c>. When the
+        /// primary is unusable, fall back to the anchor-local <c>frames</c> SECONDARY only if it covers
+        /// the UT (<paramref name="hasAnchorLocalFrames"/> and the local-frames range covers it).
+        /// Otherwise RETIRE — an out-of-range body-fixed UT must never clamp to a stale child offset.
+        ///
+        /// <para>Non-finite endpoints are treated as "no usable range" for that surface (fail toward
+        /// retire, never NaN-compare into a spurious in-range). A start &gt; end body-fixed range is
+        /// degenerate and rejected.</para>
+        /// </summary>
+        internal static ParentChildSurface ResolveParentAnchoredChild(
+            double ut,
+            int bodyFixedSampleCount,
+            double bodyFixedStartUt,
+            double bodyFixedEndUt,
+            bool hasAnchorLocalFrames,
+            double anchorLocalStartUt,
+            double anchorLocalEndUt)
+        {
+            if (bodyFixedSampleCount >= MinBodyFixedSamples
+                && RangeCoversUt(bodyFixedStartUt, bodyFixedEndUt, ut))
+            {
+                return ParentChildSurface.BodyFixedPrimary;
+            }
+
+            if (hasAnchorLocalFrames && RangeCoversUt(anchorLocalStartUt, anchorLocalEndUt, ut))
+                return ParentChildSurface.AnchorLocalSecondary;
+
+            return ParentChildSurface.Retire;
+        }
+
+        /// <summary>
+        /// Inclusive in-range test, NaN/Inf-safe and degenerate-range-safe (start &gt; end → false).
+        /// </summary>
+        private static bool RangeCoversUt(double startUt, double endUt, double ut)
+        {
+            if (!IsFinite(startUt) || !IsFinite(endUt) || !IsFinite(ut))
+                return false;
+            if (startUt > endUt)
+                return false;
+            return ut >= startUt && ut <= endUt;
+        }
+
+        private static bool IsFinite(double v) => !double.IsNaN(v) && !double.IsInfinity(v);
+    }
+}

--- a/Source/Parsek/MapRender/ITrajectorySample.cs
+++ b/Source/Parsek/MapRender/ITrajectorySample.cs
@@ -1,0 +1,148 @@
+using System.Globalization;
+
+namespace Parsek.MapRender
+{
+    /// <summary>
+    /// Phase 1 / design §5.3: a typed read-VIEW that splits the frame-overloaded
+    /// <c>TrajectoryPoint</c>. The persisted struct's <c>latitude/longitude/altitude</c> mean DEGREES
+    /// in Absolute frames but METRES along the anchor's local axes in Relative frames, with no
+    /// discriminator on the struct — the documented "ghost inside the planet" trap (CLAUDE.md). The
+    /// persisted struct stays as-is (design §13); the typed view the phase layer reads is discriminated
+    /// so no downstream reader can mis-read a Relative sample as lat/lon.
+    ///
+    /// <para><b>NEW, additive, NOT wired in Phase 1.</b> The view is produced once, at chain-assembly
+    /// time, by resolving <c>TrackSection.referenceFrame</c> for each sample (a later phase); the
+    /// resolution helper is parameterized so the discrimination is itself unit-testable here.</para>
+    /// </summary>
+    internal interface ITrajectorySample
+    {
+        /// <summary>The sample's universal-time stamp (assembled-chain clock).</summary>
+        double Ut { get; }
+
+        /// <summary>Which frame the sample's spatial fields live in (the discriminator the struct lacks).</summary>
+        ReferenceFrame Frame { get; }
+
+        /// <summary>The discriminator kind — drives the resolve dispatch (design §5.3).</summary>
+        TrajectorySampleKind Kind { get; }
+    }
+
+    /// <summary>The kind discriminator for an <see cref="ITrajectorySample"/>.</summary>
+    internal enum TrajectorySampleKind
+    {
+        /// <summary>Body-fixed degrees lat/lon/alt — resolves via <c>body.GetWorldSurfacePosition</c>.</summary>
+        Absolute = 0,
+        /// <summary>Anchor-local metres x/y/z — resolves via <c>ApplyRelativeLocalOffset</c>.</summary>
+        Relative = 1,
+        /// <summary>Keplerian elements (a thin wrapper over <c>OrbitSegment</c>).</summary>
+        Orbital = 2,
+    }
+
+    /// <summary>
+    /// design §5.3: an ABSOLUTE sample — body-fixed DEGREES. <see cref="Latitude"/>/<see cref="Longitude"/>
+    /// are degrees and <see cref="Altitude"/> is metres above the datum; the live resolver feeds these to
+    /// <c>body.GetWorldSurfacePosition(lat, lon, alt)</c>. <see cref="SrfRelRotation"/> is the recorded
+    /// surface-relative rotation (resolved as <c>body.bodyTransform.rotation * srfRelRotation</c> at
+    /// playback). This is the surface the <see cref="AnchorFrame.ParentAnchoredChild"/> dual-routing
+    /// treats as PRIMARY (bodyFixedFrames → AbsoluteSample, design §5.2).
+    /// </summary>
+    internal readonly struct AbsoluteSample : ITrajectorySample
+    {
+        public double Ut { get; }
+        public ReferenceFrame Frame => ReferenceFrame.Absolute;
+        public TrajectorySampleKind Kind => TrajectorySampleKind.Absolute;
+
+        internal double Latitude { get; }
+        internal double Longitude { get; }
+        internal double Altitude { get; }
+        internal string BodyName { get; }
+        internal UnityEngine.Quaternion SrfRelRotation { get; }
+
+        internal AbsoluteSample(
+            double ut, double latitude, double longitude, double altitude,
+            string bodyName, UnityEngine.Quaternion srfRelRotation)
+        {
+            Ut = ut;
+            Latitude = latitude;
+            Longitude = longitude;
+            Altitude = altitude;
+            BodyName = bodyName;
+            SrfRelRotation = srfRelRotation;
+        }
+
+        public override string ToString()
+            => string.Format(
+                CultureInfo.InvariantCulture,
+                "Abs UT={0:F1} lat={1:F4} lon={2:F4} alt={3:F1} body={4}",
+                Ut, Latitude, Longitude, Altitude, BodyName ?? "?");
+    }
+
+    /// <summary>
+    /// design §5.3: a RELATIVE sample — METRES along the anchor's local x/y/z axes (NOT lat/lon, the
+    /// documented trap). The live resolver feeds these to <c>ApplyRelativeLocalOffset</c> against the
+    /// anchor's world rotation/position. This is the surface the
+    /// <see cref="AnchorFrame.ParentAnchoredChild"/> dual-routing treats as SECONDARY (frames →
+    /// RelativeSample, design §5.2).
+    /// </summary>
+    internal readonly struct RelativeSample : ITrajectorySample
+    {
+        public double Ut { get; }
+        public ReferenceFrame Frame => ReferenceFrame.Relative;
+        public TrajectorySampleKind Kind => TrajectorySampleKind.Relative;
+
+        /// <summary>Anchor-local offset (metres along the anchor's local x axis).</summary>
+        internal double LocalX { get; }
+        /// <summary>Anchor-local offset (metres along the anchor's local y axis).</summary>
+        internal double LocalY { get; }
+        /// <summary>Anchor-local offset (metres along the anchor's local z axis).</summary>
+        internal double LocalZ { get; }
+        /// <summary>Anchor-local world rotation: <c>Inverse(anchor.rotation) * focusWorldRotation</c>.</summary>
+        internal UnityEngine.Quaternion LocalRotation { get; }
+
+        internal RelativeSample(
+            double ut, double localX, double localY, double localZ,
+            UnityEngine.Quaternion localRotation)
+        {
+            Ut = ut;
+            LocalX = localX;
+            LocalY = localY;
+            LocalZ = localZ;
+            LocalRotation = localRotation;
+        }
+
+        public override string ToString()
+            => string.Format(
+                CultureInfo.InvariantCulture,
+                "Rel UT={0:F1} dx={1:F1} dy={2:F1} dz={3:F1}",
+                Ut, LocalX, LocalY, LocalZ);
+    }
+
+    /// <summary>
+    /// design §5.3: an ORBITAL sample — a thin, immutable WRAPPER over the existing
+    /// <see cref="OrbitSegment"/> Keplerian currency (kept as the universal orbital representation,
+    /// design §13). It exposes the segment as an <see cref="ITrajectorySample"/> so a phase's
+    /// geometry can be sampled uniformly; the wrapped <see cref="Segment"/> is the source of truth and
+    /// is value-copied (a struct), never mutated.
+    /// </summary>
+    internal readonly struct OrbitalState : ITrajectorySample
+    {
+        public double Ut { get; }
+        public ReferenceFrame Frame => ReferenceFrame.OrbitalCheckpoint;
+        public TrajectorySampleKind Kind => TrajectorySampleKind.Orbital;
+
+        /// <summary>The wrapped recorded / generated orbit (Kepler elements, value-copied).</summary>
+        internal OrbitSegment Segment { get; }
+
+        internal OrbitalState(double ut, OrbitSegment segment)
+        {
+            Ut = ut;
+            Segment = segment;
+        }
+
+        /// <summary>Wrap a segment at its own <c>startUT</c> (the natural epoch for a segment-as-sample).</summary>
+        internal static OrbitalState FromSegment(OrbitSegment segment)
+            => new OrbitalState(segment.startUT, segment);
+
+        public override string ToString()
+            => string.Format(CultureInfo.InvariantCulture, "Orb UT={0:F1} [{1}]", Ut, Segment);
+    }
+}

--- a/Source/Parsek/MapRender/PhaseChain.cs
+++ b/Source/Parsek/MapRender/PhaseChain.cs
@@ -1,0 +1,123 @@
+using System.Collections.Generic;
+
+namespace Parsek.MapRender
+{
+    /// <summary>
+    /// Phase 1 / design §6: the <see cref="GhostRenderChain"/> SUCCESSOR — the per-(member,
+    /// cycle-instance) ordered list of <see cref="TrajectoryPhase"/>s for one ghost.
+    ///
+    /// <para><b>NEW, additive, NOT a replacement of <see cref="GhostRenderChain"/> yet.</b> It mirrors
+    /// the chain's shape (keying by recording id + committed index + instance key, O(log n) locate,
+    /// three-valued coverage) so Phase 3 can swap the spine to consume phases; the actual swap is a
+    /// later phase, so this coexists with <see cref="GhostRenderChain"/> in Phase 1.</para>
+    ///
+    /// <para>It is PER MEMBER (one <see cref="CommittedIndex"/>), not per whole mission: a looped
+    /// mission's launch→transfer→landing spans several committed members sequenced by the span clock
+    /// (design §6 / §11.3). Phases are ordered by <see cref="TrajectoryPhase.StartUt"/>; interior gaps
+    /// are allowed (a FlexibleSoi seam UT, or a <see cref="HoldPhase"/> which itself covers the span).</para>
+    /// </summary>
+    internal sealed class PhaseChain
+    {
+        internal string RecordingId { get; }
+        /// <summary>Positional index into the committed-recordings list (the LoopUnitSet contract).</summary>
+        internal int CommittedIndex { get; }
+        /// <summary>Cycle/instance discriminator — distinguishes overlapping self-loop instances (design §10.8).</summary>
+        internal int InstanceKey { get; }
+        /// <summary>Phases ordered by <see cref="TrajectoryPhase.StartUt"/>.</summary>
+        internal IReadOnlyList<TrajectoryPhase> Phases { get; }
+        internal double WindowStartUt { get; }
+        internal double WindowEndUt { get; }
+        /// <summary>A producer declined re-aim for this window → assembled from the recorded trajectory as-is (design §6.9 / §7).</summary>
+        internal bool IsFaithfulFallback { get; }
+
+        internal PhaseChain(
+            string recordingId,
+            int committedIndex,
+            int instanceKey,
+            IReadOnlyList<TrajectoryPhase> phases,
+            double windowStartUt,
+            double windowEndUt,
+            bool isFaithfulFallback = false)
+        {
+            RecordingId = recordingId;
+            CommittedIndex = committedIndex;
+            InstanceKey = instanceKey;
+            Phases = phases ?? System.Array.Empty<TrajectoryPhase>();
+            WindowStartUt = windowStartUt;
+            WindowEndUt = windowEndUt;
+            IsFaithfulFallback = isFaithfulFallback;
+        }
+
+        internal int PhaseCount => Phases.Count;
+
+        /// <summary>
+        /// O(log n) locate: the index of the phase containing <paramref name="ut"/> (assembled-chain
+        /// clock), or -1 if <paramref name="ut"/> falls in a gap / outside all phases. A non-last phase
+        /// owns <c>[StartUt, EndUt)</c>; the LAST phase owns <c>[StartUt, EndUt]</c> (inclusive end), so
+        /// a boundary UT shared by two adjacent phases belongs to the LATER one — mirroring
+        /// <see cref="GhostRenderChain.LocateSegmentIndex"/> exactly.
+        /// </summary>
+        internal int LocatePhaseIndex(double ut)
+        {
+            var phases = Phases;
+            int n = phases.Count;
+            if (n == 0) return -1;
+            if (double.IsNaN(ut) || double.IsInfinity(ut)) return -1;
+
+            // rightmost phase with StartUt <= ut
+            int lo = 0, hi = n - 1, found = -1;
+            while (lo <= hi)
+            {
+                int mid = lo + ((hi - lo) >> 1);
+                if (phases[mid].StartUt <= ut) { found = mid; lo = mid + 1; }
+                else hi = mid - 1;
+            }
+            if (found < 0) return -1; // ut is before the first phase
+
+            var p = phases[found];
+            bool isLast = found == n - 1;
+            // The last phase gets the inclusive end; non-last phases use the phase's own (half-open)
+            // CoversUt so a subclass with special coverage (HoldPhase) is honoured.
+            bool contains = isLast ? (ut >= p.StartUt && ut <= p.EndUt) : p.CoversUt(ut);
+            return contains ? found : -1; // -1 = a gap after phases[found]
+        }
+
+        internal bool TryGetPhase(double ut, out TrajectoryPhase phase, out int index)
+        {
+            index = LocatePhaseIndex(ut);
+            if (index >= 0) { phase = Phases[index]; return true; }
+            phase = null;
+            return false;
+        }
+
+        /// <summary>
+        /// Classify a UT (already mapped into the assembled-chain clock by the sampler) into the
+        /// three-valued <see cref="Coverage"/> — reusing the existing live enum. Outside the window →
+        /// <see cref="Coverage.OutsideWindow"/>; inside the window but in no phase →
+        /// <see cref="Coverage.InInteriorGap"/> (hold prior intent); otherwise
+        /// <see cref="Coverage.InSegment"/>.
+        ///
+        /// <para>design §11.1: a mid-window TERMINAL retire (crash/impact mid-window) is NOT modelled
+        /// here as an interior gap — the producer is expected to end the phase list at the recorded
+        /// end-of-data so the post-terminal UT falls OUTSIDE the window → Hidden, not held. This method
+        /// only classifies coverage against the supplied window + phases; the terminal trigger is the
+        /// factory's concern.</para>
+        /// </summary>
+        internal Coverage ClassifyCoverage(double ut, out TrajectoryPhase phase, out int index)
+        {
+            phase = null;
+            index = -1;
+            if (double.IsNaN(ut) || double.IsInfinity(ut))
+                return Coverage.OutsideWindow;
+            if (ut < WindowStartUt || ut > WindowEndUt)
+                return Coverage.OutsideWindow;
+            index = LocatePhaseIndex(ut);
+            if (index >= 0)
+            {
+                phase = Phases[index];
+                return Coverage.InSegment;
+            }
+            return Coverage.InInteriorGap;
+        }
+    }
+}

--- a/Source/Parsek/MapRender/PhaseId.cs
+++ b/Source/Parsek/MapRender/PhaseId.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Globalization;
+
+namespace Parsek.MapRender
+{
+    /// <summary>
+    /// Phase 1 / design §6: a stable RUNTIME render-layer identity for a <see cref="TrajectoryPhase"/>.
+    ///
+    /// <para><b>This is render-layer identity ONLY.</b> It is explicitly NOT the persisted
+    /// <c>Mission.ExcludedIntervalKeys</c> / <c>&lt;head&gt;</c>/<c>segN</c> selection keys — those
+    /// remain a composition-layer persistence concern (design §4 / §6 / §12). A <see cref="PhaseId"/>
+    /// is never serialized; it identifies a phase within an in-memory <see cref="PhaseChain"/> for
+    /// debugging, seam wiring (a seam can name its neighbour phase), and trace lines.</para>
+    ///
+    /// <para>Built from the owning recording id + an ordinal within the chain + an instance-key
+    /// discriminator so overlapping self-loop instances (design §10.8 / the
+    /// <see cref="PhaseChain.InstanceKey"/>) of one recording stay distinct. Value-equatable so it can
+    /// key a dictionary / be asserted in tests.</para>
+    /// </summary>
+    internal readonly struct PhaseId : IEquatable<PhaseId>
+    {
+        /// <summary>The owning recording's id (matches <see cref="PhaseChain.RecordingId"/>).</summary>
+        internal string RecordingId { get; }
+
+        /// <summary>The instance-key discriminator (matches <see cref="PhaseChain.InstanceKey"/>).</summary>
+        internal int InstanceKey { get; }
+
+        /// <summary>The phase's ordinal within its chain (0-based, ascending by StartUt).</summary>
+        internal int Ordinal { get; }
+
+        internal PhaseId(string recordingId, int instanceKey, int ordinal)
+        {
+            RecordingId = recordingId;
+            InstanceKey = instanceKey;
+            Ordinal = ordinal;
+        }
+
+        /// <summary>True for the default / unset id.</summary>
+        internal bool IsEmpty => RecordingId == null && InstanceKey == 0 && Ordinal == 0;
+
+        public bool Equals(PhaseId other)
+            => string.Equals(RecordingId, other.RecordingId, StringComparison.Ordinal)
+               && InstanceKey == other.InstanceKey
+               && Ordinal == other.Ordinal;
+
+        public override bool Equals(object obj) => obj is PhaseId other && Equals(other);
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                int h = RecordingId == null ? 0 : RecordingId.GetHashCode();
+                h = (h * 397) ^ InstanceKey;
+                h = (h * 397) ^ Ordinal;
+                return h;
+            }
+        }
+
+        public override string ToString()
+            => string.Format(
+                CultureInfo.InvariantCulture,
+                "{0}#i{1}#p{2}",
+                RecordingId ?? "?", InstanceKey, Ordinal);
+    }
+}

--- a/Source/Parsek/MapRender/PhaseSeam.cs
+++ b/Source/Parsek/MapRender/PhaseSeam.cs
@@ -1,0 +1,105 @@
+using System.Globalization;
+
+namespace Parsek.MapRender
+{
+    /// <summary>
+    /// Phase 1 / design §6.1: the join between two adjacent <see cref="TrajectoryPhase"/>s, carrying a
+    /// continuity contract. The successor of the cosmetic 2-value <c>RenderSegment.SeamKind</c>.
+    ///
+    /// <para><b>NEW enum, NOT a mutation of the live <see cref="SeamKind"/>.</b> The live draw path
+    /// switches on <c>RenderSegment.SeamKind</c> (a 2-value <c>None/Rigid/FlexibleSoi</c>); this Phase-1
+    /// type needs a third value (<see cref="PhaseSeamKind.SwitchContinuation"/>) plus a continuity
+    /// order, and is additive / unwired, so it is a SEPARATE enum
+    /// (<see cref="PhaseSeamKind"/> / <see cref="ContinuityOrder"/>) — the live enum is untouched so no
+    /// existing switch breaks. Old → new mapping: <c>SeamKind.None</c> has no <see cref="PhaseSeam"/>
+    /// (null), <c>SeamKind.Rigid</c> → <see cref="PhaseSeamKind.Rigid"/>, <c>SeamKind.FlexibleSoi</c> →
+    /// <see cref="PhaseSeamKind.FlexibleSoi"/>.</para>
+    /// </summary>
+    internal sealed class PhaseSeam
+    {
+        /// <summary>The seam's kind (design §6.1).</summary>
+        internal PhaseSeamKind Kind { get; }
+        /// <summary>The continuity order the seam asserts (G0 position, G1 position + tangent).</summary>
+        internal ContinuityOrder Continuity { get; }
+        /// <summary>Non-null at a body change (design §10); null otherwise.</summary>
+        internal SoiCrossing Crossing { get; }
+        /// <summary>Does the seam ever render in view? (off-camera seams tolerate discontinuity).</summary>
+        internal bool OnCamera { get; }
+
+        internal PhaseSeam(
+            PhaseSeamKind kind,
+            ContinuityOrder continuity,
+            SoiCrossing crossing = null,
+            bool onCamera = false)
+        {
+            Kind = kind;
+            Continuity = continuity;
+            Crossing = crossing;
+            OnCamera = onCamera;
+        }
+
+        /// <summary>True iff this seam asserts G1 (position + tangent) continuity (design §6.1).</summary>
+        internal bool RequiresTangentMatch => Continuity == ContinuityOrder.G1;
+
+        /// <summary>
+        /// design §6.1: the canonical <b>Rigid + G1</b> seam — ascent↔orbit and orbit↔landing (descent
+        /// re-stitch). A tangent mismatch beyond tolerance raises <c>rigid-seam-tangent-discontinuity</c>
+        /// (the predicate is <see cref="PhaseSeamClassifier.IsRigidSeamTangentDiscontinuity"/>).
+        /// </summary>
+        internal static PhaseSeam Rigid(bool onCamera = true)
+            => new PhaseSeam(PhaseSeamKind.Rigid, ContinuityOrder.G1, crossing: null, onCamera: onCamera);
+
+        /// <summary>
+        /// design §6.1: the <b>FlexibleSoi + G0</b> seam — the two recorded↔synthetic SOI boundaries
+        /// (the ~62° kink lives here; tolerated in v1). Carries the <see cref="SoiCrossing"/>.
+        /// </summary>
+        internal static PhaseSeam FlexibleSoi(SoiCrossing crossing, bool onCamera = false)
+            => new PhaseSeam(PhaseSeamKind.FlexibleSoi, ContinuityOrder.G0, crossing: crossing, onCamera: onCamera);
+
+        /// <summary>
+        /// design §6.1: the <b>SwitchContinuation + G0</b> seam — the vessel-switch continuation member
+        /// boundary (mothership→lander, Fly/Switch-To). An ACCEPTED coverage-handoff, NOT a
+        /// position-match: vessel B's first sample need not meet vessel A's terminal. Not a built
+        /// geometric seam in v1 (deferred to MissionComposite, design §17).
+        /// </summary>
+        internal static PhaseSeam SwitchContinuation(bool onCamera = false)
+            => new PhaseSeam(PhaseSeamKind.SwitchContinuation, ContinuityOrder.G0, crossing: null, onCamera: onCamera);
+
+        public override string ToString()
+            => string.Format(
+                CultureInfo.InvariantCulture,
+                "{0}+{1}{2}{3}",
+                PhaseSeamClassifier.KindToken(Kind),
+                Continuity,
+                Crossing != null ? " " + Crossing : string.Empty,
+                OnCamera ? " onCam" : string.Empty);
+    }
+
+    /// <summary>
+    /// design §6.1: the seam's kind. NEW enum (extends the live 2-value <c>SeamKind</c> with the
+    /// <see cref="SwitchContinuation"/> member-boundary value) — kept separate so the live draw-path
+    /// switches on <c>SeamKind</c> are untouched.
+    /// </summary>
+    internal enum PhaseSeamKind
+    {
+        /// <summary>No seam (chain start/end, or no neighbour).</summary>
+        None = 0,
+        /// <summary>Must connect cleanly (ascent↔orbit, orbit↔landing) — numerically enforced (G1).</summary>
+        Rigid = 1,
+        /// <summary>Tolerated, off-camera discontinuity at an SOI boundary (G0).</summary>
+        FlexibleSoi = 2,
+        /// <summary>Accepted coverage-handoff at a vessel-switch member boundary (G0, design §6.1).</summary>
+        SwitchContinuation = 3,
+    }
+
+    /// <summary>
+    /// design §6.1: the continuity order a seam asserts. NEW enum (no live equivalent).
+    /// </summary>
+    internal enum ContinuityOrder
+    {
+        /// <summary>Position continuity only (the two phases meet in position).</summary>
+        G0 = 0,
+        /// <summary>Position + tangent continuity (the two phases meet smoothly — velocity direction matches).</summary>
+        G1 = 1,
+    }
+}

--- a/Source/Parsek/MapRender/PhaseSeamClassifier.cs
+++ b/Source/Parsek/MapRender/PhaseSeamClassifier.cs
@@ -1,0 +1,146 @@
+using System;
+using UnityEngine;
+
+namespace Parsek.MapRender
+{
+    /// <summary>
+    /// Phase 1 / design §6.1: the PURE classification + continuity decisions for <see cref="PhaseSeam"/>.
+    /// Maps a pair of adjacent phase kinds to the seam kind the model demands, and provides the G1
+    /// tangent-match math the descent re-stitch (Phase 6) enforces. Unity-vector math only (no ECalls /
+    /// no KSP API), so it is directly unit-testable.
+    ///
+    /// <para>NOT wired in Phase 1 — the cross-member descent seam builder (Phase 6) is the first
+    /// consumer of <see cref="IsRigidSeamTangentDiscontinuity"/>.</para>
+    /// </summary>
+    internal static class PhaseSeamClassifier
+    {
+        /// <summary>Grep-stable lowercase token for a <see cref="PhaseSeamKind"/>.</summary>
+        internal static string KindToken(PhaseSeamKind kind)
+        {
+            switch (kind)
+            {
+                case PhaseSeamKind.Rigid: return "rigid";
+                case PhaseSeamKind.FlexibleSoi: return "flexible-soi";
+                case PhaseSeamKind.SwitchContinuation: return "switch-continuation";
+                default: return "none";
+            }
+        }
+
+        /// <summary>
+        /// design §6.1: classify the seam KIND between two adjacent phases by their kinds and bodies.
+        ///
+        /// <list type="bullet">
+        ///   <item>A body change (<paramref name="leadingBody"/> != <paramref name="trailingBody"/>) is
+        ///     a <see cref="PhaseSeamKind.FlexibleSoi"/> SOI boundary (G0) — design §10.</item>
+        ///   <item>An ascent↔orbit or orbit↔landing join WITHIN one body is
+        ///     <see cref="PhaseSeamKind.Rigid"/> (G1) — design §6.1.</item>
+        ///   <item>A <paramref name="isMemberSwitchBoundary"/> handoff is
+        ///     <see cref="PhaseSeamKind.SwitchContinuation"/> (G0) — design §6.1.</item>
+        ///   <item>Everything else is <see cref="PhaseSeamKind.None"/> (intra-phase contiguity / no
+        ///     distinguished seam).</item>
+        /// </list>
+        /// A body change wins over the rigid classification: an SOI crossing is never a G1 rigid seam.
+        /// </summary>
+        internal static PhaseSeamKind Classify(
+            PhaseKind leadingKind,
+            PhaseKind trailingKind,
+            string leadingBody,
+            string trailingBody,
+            bool isMemberSwitchBoundary)
+        {
+            if (isMemberSwitchBoundary)
+                return PhaseSeamKind.SwitchContinuation;
+
+            if (!string.Equals(leadingBody, trailingBody, StringComparison.Ordinal))
+                return PhaseSeamKind.FlexibleSoi;
+
+            if (IsRigidJoin(leadingKind, trailingKind))
+                return PhaseSeamKind.Rigid;
+
+            return PhaseSeamKind.None;
+        }
+
+        /// <summary>
+        /// The within-body G1 joins (design §6.1): ascent↔orbit and orbit↔landing (the descent
+        /// re-stitch). Symmetric.
+        /// </summary>
+        internal static bool IsRigidJoin(PhaseKind a, PhaseKind b)
+        {
+            return IsAscentOrbitJoin(a, b) || IsAscentOrbitJoin(b, a)
+                   || IsOrbitLandingJoin(a, b) || IsOrbitLandingJoin(b, a);
+        }
+
+        private static bool IsAscentOrbitJoin(PhaseKind leading, PhaseKind trailing)
+            => leading == PhaseKind.Ascent && IsOrbitalPhase(trailing);
+
+        private static bool IsOrbitLandingJoin(PhaseKind leading, PhaseKind trailing)
+            => IsOrbitalPhase(leading) && trailing == PhaseKind.Descent;
+
+        /// <summary>An "orbital" phase a rigid seam can join to (loiter / transfer / arrival around a body).</summary>
+        private static bool IsOrbitalPhase(PhaseKind kind)
+        {
+            switch (kind)
+            {
+                case PhaseKind.DepartureLoiter:
+                case PhaseKind.SoiDeparture:
+                case PhaseKind.HeliocentricTransfer:
+                case PhaseKind.SoiArrival:
+                case PhaseKind.ArrivalLoiter:
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        /// <summary>
+        /// design §6.1 / §9.1: default tolerance (radians) for the G1 tangent match. ~5.7° — a generous
+        /// bound separating a continuous orbit↔landing handoff from a real discontinuity (the dossier's
+        /// reconciler uses ~1° for icon-off-orbit; a stitched capture-orbit tangent vs a recorded-descent
+        /// first-sample tangent is noisier).
+        /// </summary>
+        internal const double DefaultTangentToleranceRadians = 0.1;
+
+        /// <summary>
+        /// design §6.1 / §9.1: the <c>rigid-seam-tangent-discontinuity</c> predicate. Given the leaving
+        /// phase's terminal velocity direction and the entering phase's first-sample velocity direction,
+        /// return true iff the angle between them exceeds <paramref name="toleranceRadians"/>.
+        ///
+        /// <para>NaN/Inf-safe and degenerate-safe: a zero-length or non-finite tangent on either side
+        /// yields NO anomaly (false) — an unmeasurable tangent is not a discontinuity (mirrors the
+        /// oracle's "no false anomaly" contract). A non-finite / negative tolerance is treated as
+        /// <see cref="DefaultTangentToleranceRadians"/>.</para>
+        /// </summary>
+        internal static bool IsRigidSeamTangentDiscontinuity(
+            Vector3 leavingTangent,
+            Vector3 enteringTangent,
+            double toleranceRadians = DefaultTangentToleranceRadians)
+        {
+            double tol = (double.IsNaN(toleranceRadians) || double.IsInfinity(toleranceRadians) || toleranceRadians < 0.0)
+                ? DefaultTangentToleranceRadians
+                : toleranceRadians;
+
+            if (!TryNormalize(leavingTangent, out Vector3 a) || !TryNormalize(enteringTangent, out Vector3 b))
+                return false; // unmeasurable -> no anomaly
+
+            float dot = Mathf.Clamp(Vector3.Dot(a, b), -1f, 1f);
+            double angle = Math.Acos(dot);
+            if (double.IsNaN(angle) || double.IsInfinity(angle))
+                return false;
+            return angle > tol;
+        }
+
+        private static bool TryNormalize(Vector3 v, out Vector3 normalized)
+        {
+            normalized = Vector3.zero;
+            if (!IsFinite(v.x) || !IsFinite(v.y) || !IsFinite(v.z))
+                return false;
+            float mag = v.magnitude;
+            if (mag <= 1e-9f || float.IsNaN(mag) || float.IsInfinity(mag))
+                return false;
+            normalized = v / mag;
+            return true;
+        }
+
+        private static bool IsFinite(float v) => !float.IsNaN(v) && !float.IsInfinity(v);
+    }
+}

--- a/Source/Parsek/MapRender/SegmentProvenance.cs
+++ b/Source/Parsek/MapRender/SegmentProvenance.cs
@@ -1,0 +1,75 @@
+namespace Parsek.MapRender
+{
+    /// <summary>
+    /// Phase 1 / design §5.1: the render-view PROVENANCE of a phase's geometry — where the geometry
+    /// came from. Collapses the overloaded <c>OrbitSegment.isPredicted</c> (re-aim synthetic = false,
+    /// recorded-extrapolated tail = true) into one explicit token.
+    ///
+    /// <para>This is a NEW, additive enum. It is NOT wired into the live pipeline in Phase 1 and the
+    /// persisted <c>OrbitSegment</c> struct is unchanged (design §13). Provenance is stamped
+    /// <b>by the producer</b> that emits the phase at emit time, never re-derived downstream by
+    /// reference equality (the brittle <c>ReferenceEquals(effective, recorded)</c> the model replaces).</para>
+    ///
+    /// <para><b>Immutability contract (design §7 / §13):</b> <see cref="Synthesized"/> is a derived,
+    /// IN-MEMORY-ONLY flag and must never reach disk. The two write epochs stay distinct:
+    /// finalize-time-predicted (<see cref="FinalizedPredicted"/>, written once then immutable) vs
+    /// playback-time-synthesized (<see cref="Synthesized"/>, never written).</para>
+    /// </summary>
+    internal enum SegmentProvenance
+    {
+        /// <summary>Default / unset.</summary>
+        Unknown = 0,
+
+        /// <summary>Exact recorded geometry, immutable.</summary>
+        Recorded = 1,
+
+        /// <summary>Predicted-tail written ONCE at scene exit, then immutable.</summary>
+        FinalizedPredicted = 2,
+
+        /// <summary>Re-aim / re-time / re-rotate output. IN-MEMORY ONLY, never persisted.</summary>
+        Synthesized = 3,
+
+        /// <summary>A producer was unsupported, so exact recorded replay was chosen instead.</summary>
+        FaithfulFallback = 4,
+    }
+
+    /// <summary>
+    /// Pure token helpers for <see cref="SegmentProvenance"/> — grep-stable lowercase tokens for the
+    /// (Phase 8) tracer lines and a single decision the rest of the model leans on: only
+    /// <see cref="SegmentProvenance.Synthesized"/> geometry is in-memory-only and must never be
+    /// persisted (design §13).
+    /// </summary>
+    internal static class SegmentProvenanceTokens
+    {
+        /// <summary>Grep-stable lowercase token for trace lines.</summary>
+        internal static string ToToken(SegmentProvenance provenance)
+        {
+            switch (provenance)
+            {
+                case SegmentProvenance.Recorded: return "recorded";
+                case SegmentProvenance.FinalizedPredicted: return "finalized-predicted";
+                case SegmentProvenance.Synthesized: return "synthesized";
+                case SegmentProvenance.FaithfulFallback: return "faithful-fallback";
+                default: return "unknown";
+            }
+        }
+
+        /// <summary>
+        /// True iff the geometry is in-memory-only and must NEVER be serialized (design §13). Exactly
+        /// <see cref="SegmentProvenance.Synthesized"/> today; a single chokepoint so a future
+        /// "no synthesized phase reaches disk" assertion can route through one predicate.
+        /// </summary>
+        internal static bool IsInMemoryOnly(SegmentProvenance provenance)
+            => provenance == SegmentProvenance.Synthesized;
+
+        /// <summary>
+        /// True iff the geometry replays a recorded source verbatim (no re-aim transform):
+        /// <see cref="SegmentProvenance.Recorded"/> or <see cref="SegmentProvenance.FaithfulFallback"/>.
+        /// The parity oracle diffs these in FAITHFUL mode (rendered == recorded); the others diff in
+        /// SYNTHESIZED mode (rendered == intended arc). See design §14.
+        /// </summary>
+        internal static bool IsFaithfulReplay(SegmentProvenance provenance)
+            => provenance == SegmentProvenance.Recorded
+               || provenance == SegmentProvenance.FaithfulFallback;
+    }
+}

--- a/Source/Parsek/MapRender/SoiCrossing.cs
+++ b/Source/Parsek/MapRender/SoiCrossing.cs
@@ -1,0 +1,49 @@
+using System.Globalization;
+using UnityEngine;
+
+namespace Parsek.MapRender
+{
+    /// <summary>
+    /// Phase 1 / design §10: a typed sphere-of-influence boundary crossing, unifying the ≥4 places a
+    /// body change is re-derived today (<c>GhostOrbitBodyChanged</c>, <c>MapRenderProbe.bodyChanged</c>,
+    /// the <c>lastLineToggleBody</c> blink guard, <c>SeamBetween</c>'s string compare).
+    ///
+    /// <para><b>NEW, additive, NOT wired in Phase 1. v1 RECORDS, does not ENFORCE</b> — the
+    /// <see cref="ExitState"/>/<see cref="EntryState"/> are carried for future continuity work; the
+    /// cross-SOI ~62° kink fix (the whole-patched-conic-chain synthesis) is deferred (design §9.2 /
+    /// §17). A <see cref="PhaseSeam"/> references this only at a body change.</para>
+    /// </summary>
+    internal sealed class SoiCrossing
+    {
+        /// <summary>The body left at the crossing.</summary>
+        internal string FromBody { get; }
+        /// <summary>The body entered at the crossing.</summary>
+        internal string ToBody { get; }
+        /// <summary>The assembled-chain UT of the crossing.</summary>
+        internal double CrossingUt { get; }
+        /// <summary>The SOI radius (metres) at the crossing.</summary>
+        internal double SoiRadius { get; }
+        /// <summary>State vector leaving <see cref="FromBody"/>'s SOI (for future continuity; v1 unused).</summary>
+        internal Vector3d ExitState { get; }
+        /// <summary>State vector entering <see cref="ToBody"/>'s SOI (for future continuity; v1 unused).</summary>
+        internal Vector3d EntryState { get; }
+
+        internal SoiCrossing(
+            string fromBody, string toBody, double crossingUt, double soiRadius,
+            Vector3d exitState = default(Vector3d), Vector3d entryState = default(Vector3d))
+        {
+            FromBody = fromBody;
+            ToBody = toBody;
+            CrossingUt = crossingUt;
+            SoiRadius = soiRadius;
+            ExitState = exitState;
+            EntryState = entryState;
+        }
+
+        public override string ToString()
+            => string.Format(
+                CultureInfo.InvariantCulture,
+                "SOI {0}->{1} UT={2:F1} r={3:F0}",
+                FromBody ?? "?", ToBody ?? "?", CrossingUt, SoiRadius);
+    }
+}

--- a/Source/Parsek/MapRender/TrajectoryPhase.cs
+++ b/Source/Parsek/MapRender/TrajectoryPhase.cs
@@ -1,0 +1,188 @@
+using System.Collections.Generic;
+using System.Globalization;
+
+namespace Parsek.MapRender
+{
+    /// <summary>
+    /// Phase 1 / design §6: the NEW first-class composable trajectory unit — a polymorphic object owning
+    /// a contiguous run of trajectory with ONE provenance, ONE anchor frame, ONE treatment choice, and
+    /// its seam contracts. This is the "heart of the design": the GMAT command-owns-behaviour pattern
+    /// replacing the <c>RenderSegment</c> struct + <c>SegmentKind</c> enum + assembler <c>if/else</c> +
+    /// director <c>switch</c> + 5-boolean predicates. Adding a phase becomes one new subclass, not a
+    /// five-site edit.
+    ///
+    /// <para><b>NEW, additive, NOT wired in Phase 1.</b> The factory that builds these from env-class
+    /// (faithful) or the <c>ReaimMissionPlan</c> (re-aimed) is Phase 2; the spine consuming them is
+    /// Phase 3. The concrete subclasses delegate geometry to the existing kernels (<c>OrbitSegment</c>,
+    /// <c>OrbitArcSampler</c>, the span clock) — this is a re-typing, not a re-implementation.</para>
+    /// </summary>
+    internal abstract class TrajectoryPhase
+    {
+        /// <summary>
+        /// Stable RUNTIME render-layer identity (design §6). NOT the persisted
+        /// <c>Mission.ExcludedIntervalKeys</c> / <c>&lt;head&gt;</c>/<c>segN</c> selection keys — those
+        /// stay a composition-layer persistence concern (design §4).
+        /// </summary>
+        internal PhaseId Id { get; }
+
+        /// <summary>The phase's gameplay kind (design §6) — the authoritative phase vocabulary that
+        /// replaces the cosmetic <c>SegmentKind</c>.</summary>
+        internal PhaseKind Kind { get; }
+
+        /// <summary>Where the geometry came from (design §5.1) — stamped by the producer, never re-derived.</summary>
+        internal SegmentProvenance Provenance { get; }
+
+        /// <summary>Which frame the phase lives in (design §5.2).</summary>
+        internal AnchorFrame Anchor { get; }
+
+        /// <summary>Phase start in the ASSEMBLED-chain clock.</summary>
+        internal double StartUt { get; }
+
+        /// <summary>Phase end in the ASSEMBLED-chain clock.</summary>
+        internal double EndUt { get; }
+
+        /// <summary>The seam joining the PRECEDING phase to this one (null = chain start / no neighbour).</summary>
+        internal PhaseSeam LeadingSeam { get; }
+
+        /// <summary>The seam joining this phase to the FOLLOWING one (null = chain end / no neighbour).</summary>
+        internal PhaseSeam TrailingSeam { get; }
+
+        private protected TrajectoryPhase(
+            PhaseId id,
+            PhaseKind kind,
+            SegmentProvenance provenance,
+            AnchorFrame anchor,
+            double startUt,
+            double endUt,
+            PhaseSeam leadingSeam,
+            PhaseSeam trailingSeam)
+        {
+            Id = id;
+            Kind = kind;
+            Provenance = provenance;
+            Anchor = anchor;
+            StartUt = startUt;
+            EndUt = endUt;
+            LeadingSeam = leadingSeam;
+            TrailingSeam = trailingSeam;
+        }
+
+        /// <summary>The phase's duration in the assembled-chain clock.</summary>
+        internal double DurationSeconds => EndUt - StartUt;
+
+        /// <summary>
+        /// design §6: how the phase is drawn — was <c>ChainAssembler</c>'s orbit-vs-polyline if/else,
+        /// now polymorphic per phase. Returns the existing live <see cref="Treatment"/>
+        /// (<c>StockConic</c> / <c>TracedPath</c>); the future <c>SuppressedMarker</c> tier is a director
+        /// fallback applied to a no-bounds/no-conic frame, not a phase-declared treatment (design §8 /
+        /// §11.4), so it is NOT a new <see cref="Treatment"/> value here in Phase 1.
+        /// </summary>
+        internal abstract Treatment ResolveTreatment();
+
+        /// <summary>
+        /// design §6: does this phase own <paramref name="ut"/> (assembled-chain clock)? Default is the
+        /// half-open interval <c>[StartUt, EndUt)</c> so a UT shared with the next phase's start belongs
+        /// to the LATER phase (mirroring <see cref="GhostRenderChain.LocateSegmentIndex"/>). The CHAIN
+        /// is responsible for the inclusive end of the LAST phase. Subclasses override only when their
+        /// coverage is special (e.g. <see cref="HoldPhase"/> must cover an entire warp-skipped span).
+        /// </summary>
+        internal virtual bool CoversUt(double ut)
+        {
+            if (double.IsNaN(ut) || double.IsInfinity(ut))
+                return false;
+            return ut >= StartUt && ut < EndUt;
+        }
+
+        /// <summary>
+        /// design §6: the geometry the phase contributes for the current frame. In Phase 1 this is the
+        /// typed-but-unwired contract; the concrete subclasses return the same <see cref="RenderSegment"/>
+        /// the legacy assembler would (so Phase 2 can byte-parity it), delegating to the existing
+        /// kernels. A phase with no geometry this frame (e.g. <see cref="HoldPhase"/>) yields nothing.
+        /// </summary>
+        internal abstract IEnumerable<RenderSegment> Emit(SampleContext ctx);
+
+        public override string ToString()
+            => string.Format(
+                CultureInfo.InvariantCulture,
+                "{0} {1} prov={2} anchor={3} UT={4:F1}-{5:F1} treat={6}",
+                PhaseKindTokens.ToToken(Kind), Id, SegmentProvenanceTokens.ToToken(Provenance),
+                Anchor == null ? "?" : Anchor.ToToken(), StartUt, EndUt, ResolveTreatment());
+    }
+
+    /// <summary>
+    /// design §6: the NEW authoritative phase vocabulary, replacing the cosmetic 10-value
+    /// <c>SegmentKind</c> (of which only <c>Transfer</c>/<c>Loiter</c>/<c>Surface</c> were ever
+    /// assigned).
+    ///
+    /// <para><b>Old <c>SegmentKind</c> → new <see cref="PhaseKind"/> mapping</b> (design §6):
+    /// <list type="bullet">
+    ///   <item><c>Ascent</c> → <see cref="Ascent"/></item>
+    ///   <item><c>Loiter</c> → <see cref="DepartureLoiter"/> or <see cref="ArrivalLoiter"/> (the
+    ///     departure-vs-arrival split is NEW, from <c>EnvironmentToPhase</c> + role)</item>
+    ///   <item><c>Eject</c> → <see cref="SoiDeparture"/></item>
+    ///   <item><c>Transfer</c> → <see cref="HeliocentricTransfer"/></item>
+    ///   <item><c>Approach</c> / <c>ArrivalOrbit</c> → <see cref="SoiArrival"/></item>
+    ///   <item><c>ArrivalLoiter</c> → <see cref="ArrivalLoiter"/></item>
+    ///   <item><c>Landing</c> → <see cref="Descent"/></item>
+    ///   <item><c>Surface</c> → <see cref="Surface"/></item>
+    ///   <item><c>Other</c> → context-dependent (an interior gap becomes <see cref="Hold"/>, promoted
+    ///     from the invisible <c>InInteriorGap</c> clock insertion)</item>
+    /// </list></para>
+    /// </summary>
+    internal enum PhaseKind
+    {
+        Unknown = 0,
+        Ascent = 1,
+        DepartureLoiter = 2,
+        SoiDeparture = 3,
+        HeliocentricTransfer = 4,
+        SoiArrival = 5,
+        ArrivalLoiter = 6,
+        Descent = 7,
+        Surface = 8,
+        /// <summary>Promoted from the invisible <c>InInteriorGap</c> clock insertion (design §6).</summary>
+        Hold = 9,
+    }
+
+    /// <summary>Grep-stable lowercase tokens for <see cref="PhaseKind"/>.</summary>
+    internal static class PhaseKindTokens
+    {
+        internal static string ToToken(PhaseKind kind)
+        {
+            switch (kind)
+            {
+                case PhaseKind.Ascent: return "ascent";
+                case PhaseKind.DepartureLoiter: return "departure-loiter";
+                case PhaseKind.SoiDeparture: return "soi-departure";
+                case PhaseKind.HeliocentricTransfer: return "heliocentric-transfer";
+                case PhaseKind.SoiArrival: return "soi-arrival";
+                case PhaseKind.ArrivalLoiter: return "arrival-loiter";
+                case PhaseKind.Descent: return "descent";
+                case PhaseKind.Surface: return "surface";
+                case PhaseKind.Hold: return "hold";
+                default: return "unknown";
+            }
+        }
+    }
+
+    /// <summary>
+    /// design §6: the per-frame context handed to <see cref="TrajectoryPhase.Emit"/>. Phase 1 holds the
+    /// minimal slice the typed subclasses need to mirror the legacy assembler's geometry: the assembled
+    /// UT being sampled and the resolved frame body name (the v1 <see cref="AnchorFrame.BodyAnchor"/>
+    /// payload). It is intentionally small and Unity-free; later phases widen it (the live trajectory
+    /// view, the orbit sampler) as the wiring lands.
+    /// </summary>
+    internal readonly struct SampleContext
+    {
+        /// <summary>The assembled-chain UT being sampled this frame.</summary>
+        internal double SampleUt { get; }
+        /// <summary>The resolved body-frame name for the phase (the v1 BodyAnchor payload).</summary>
+        internal string FrameBodyName { get; }
+
+        internal SampleContext(double sampleUt, string frameBodyName)
+        {
+            SampleUt = sampleUt;
+            FrameBodyName = frameBodyName;
+        }
+    }
+}

--- a/Source/Parsek/MapRender/TrajectoryPhases.cs
+++ b/Source/Parsek/MapRender/TrajectoryPhases.cs
@@ -1,0 +1,332 @@
+using System;
+using System.Collections.Generic;
+
+namespace Parsek.MapRender
+{
+    // Phase 1 / design §6: the concrete TrajectoryPhase subclasses. Each maps to existing code that
+    // becomes its implementation (see the §6 phase table). NONE is wired into the live pipeline; the
+    // Emit overrides return the same RenderSegment the legacy assembler would so Phase 2 can prove
+    // geometry byte-parity, and ResolveTreatment / CoversUt are the per-phase decision logic the §15
+    // test plan covers.
+    //
+    // A StockConic phase carries an OrbitSegment conic (Kepler currency, value-copied); a TracedPath
+    // phase carries no conic (the treatment reads recorded Points by the [StartUt, EndUt) window).
+
+    /// <summary>
+    /// design §6: a CONIC phase drawn as a stock orbit line + icon (MANAGED vs KSP). The base for
+    /// departure/arrival loiter, SOI departure/arrival, and the heliocentric transfer. Carries the
+    /// <see cref="OrbitSegment"/> and emits one conic <see cref="RenderSegment"/>.
+    /// </summary>
+    internal abstract class ConicPhase : TrajectoryPhase
+    {
+        /// <summary>The orbit this phase draws (recorded loiter / arrival, or the generated transfer).</summary>
+        internal OrbitSegment Conic { get; }
+
+        private protected ConicPhase(
+            PhaseId id, PhaseKind kind, SegmentProvenance provenance, AnchorFrame anchor,
+            double startUt, double endUt, PhaseSeam leadingSeam, PhaseSeam trailingSeam,
+            OrbitSegment conic)
+            : base(id, kind, provenance, anchor, startUt, endUt, leadingSeam, trailingSeam)
+        {
+            Conic = conic;
+        }
+
+        internal override Treatment ResolveTreatment() => Treatment.StockConic;
+
+        internal override IEnumerable<RenderSegment> Emit(SampleContext ctx)
+        {
+            yield return new RenderSegment(
+                LegacyKind,
+                Treatment.StockConic,
+                StartUt,
+                EndUt,
+                ResolveFrameBodyName(ctx),
+                SegmentPayload.ForConic(Conic),
+                isGenerated: Provenance == SegmentProvenance.Synthesized,
+                leadingSeam: ToLegacySeam(LeadingSeam),
+                trailingSeam: ToLegacySeam(TrailingSeam));
+        }
+
+        /// <summary>The legacy <see cref="SegmentKind"/> this phase emits (geometry-irrelevant; see §6 map).</summary>
+        private protected abstract SegmentKind LegacyKind { get; }
+
+        /// <summary>
+        /// Resolve the frame body name: prefer the <see cref="AnchorFrame.BodyAnchor"/> payload, else the
+        /// conic's own body, else the sample context's resolved body.
+        /// </summary>
+        private protected string ResolveFrameBodyName(SampleContext ctx)
+        {
+            if (Anchor is AnchorFrame.BodyAnchor body && !string.IsNullOrEmpty(body.BodyName))
+                return body.BodyName;
+            if (!string.IsNullOrEmpty(Conic.bodyName))
+                return Conic.bodyName;
+            return ctx.FrameBodyName;
+        }
+
+        private protected static SeamKind ToLegacySeam(PhaseSeam seam)
+            => PhaseGeometry.ToLegacySeam(seam);
+    }
+
+    /// <summary>
+    /// design §6: a TRACED phase drawn as our owned polyline (atmospheric / surface / descent). Carries
+    /// no conic; the treatment reads recorded Points by the <c>[StartUt, EndUt)</c> window.
+    /// </summary>
+    internal abstract class TracedPhase : TrajectoryPhase
+    {
+        private protected TracedPhase(
+            PhaseId id, PhaseKind kind, SegmentProvenance provenance, AnchorFrame anchor,
+            double startUt, double endUt, PhaseSeam leadingSeam, PhaseSeam trailingSeam)
+            : base(id, kind, provenance, anchor, startUt, endUt, leadingSeam, trailingSeam) { }
+
+        internal override Treatment ResolveTreatment() => Treatment.TracedPath;
+
+        internal override IEnumerable<RenderSegment> Emit(SampleContext ctx)
+        {
+            yield return new RenderSegment(
+                LegacyKind,
+                Treatment.TracedPath,
+                StartUt,
+                EndUt,
+                ResolveFrameBodyName(ctx),
+                SegmentPayload.Traced,
+                isGenerated: Provenance == SegmentProvenance.Synthesized,
+                leadingSeam: PhaseGeometry.ToLegacySeam(LeadingSeam),
+                trailingSeam: PhaseGeometry.ToLegacySeam(TrailingSeam));
+        }
+
+        private protected abstract SegmentKind LegacyKind { get; }
+
+        private protected string ResolveFrameBodyName(SampleContext ctx)
+        {
+            if (Anchor is AnchorFrame.BodyAnchor body && !string.IsNullOrEmpty(body.BodyName))
+                return body.BodyName;
+            return ctx.FrameBodyName;
+        }
+    }
+
+    // ---- Concrete phases (one per §6 row) ----
+
+    /// <summary>
+    /// design §6: powered ascent. TracedPath, Recorded. Implemented by
+    /// <c>ChainAssembler.AppendTracedRuns/FlushRun</c>. The single-recording re-aim ascent re-time is a
+    /// DEFERRED known gap (this class hosts the eventual fix; its producer fail-opens, design §4/§11).
+    /// </summary>
+    internal sealed class AscentPhase : TracedPhase
+    {
+        internal AscentPhase(
+            PhaseId id, SegmentProvenance provenance, AnchorFrame anchor, double startUt, double endUt,
+            PhaseSeam leadingSeam = null, PhaseSeam trailingSeam = null)
+            : base(id, PhaseKind.Ascent, provenance, anchor, startUt, endUt, leadingSeam, trailingSeam) { }
+
+        private protected override SegmentKind LegacyKind => SegmentKind.Ascent;
+    }
+
+    /// <summary>
+    /// design §6: the parking-orbit loiter BEFORE the transfer. StockConic; Recorded, or SYNTHESIZED for
+    /// the heliocentric-park→planet variant (s15: a recorded park copy LAN-re-phased via
+    /// <c>RotateLanForParkRephase</c>, stamped by <c>DecideDepartureAnchor</c>) — built in v1.
+    /// </summary>
+    internal sealed class DepartureLoiterPhase : ConicPhase
+    {
+        internal DepartureLoiterPhase(
+            PhaseId id, SegmentProvenance provenance, AnchorFrame anchor, double startUt, double endUt,
+            OrbitSegment conic, PhaseSeam leadingSeam = null, PhaseSeam trailingSeam = null)
+            : base(id, PhaseKind.DepartureLoiter, provenance, anchor, startUt, endUt,
+                   leadingSeam, trailingSeam, conic) { }
+
+        private protected override SegmentKind LegacyKind => SegmentKind.Loiter;
+    }
+
+    /// <summary>
+    /// design §6: the SOI departure leg (the ejection out of the origin body's SOI). StockConic or
+    /// TracedPath; Recorded or Synthesized. Implemented by <c>ReaimClassifier.RecordedSoiExitUT</c>.
+    /// Carries an explicit treatment because the §6 table marks it dual.
+    /// </summary>
+    internal sealed class SoiDeparturePhase : DualTreatmentConicPhase
+    {
+        internal SoiDeparturePhase(
+            PhaseId id, Treatment treatment, SegmentProvenance provenance, AnchorFrame anchor,
+            double startUt, double endUt, OrbitSegment conic,
+            PhaseSeam leadingSeam = null, PhaseSeam trailingSeam = null)
+            : base(id, PhaseKind.SoiDeparture, SegmentKind.Eject, treatment, provenance, anchor,
+                   startUt, endUt, conic, leadingSeam, trailingSeam) { }
+    }
+
+    /// <summary>
+    /// design §6: the heliocentric (planet→planet / park→planet / →station) transfer. StockConic;
+    /// SYNTHESIZED (re-aim) or Recorded (faithful). Implemented by
+    /// <c>ReaimSegmentAssembler.ReplaceHeliocentricLeg</c> + <c>UvLambert</c>. This is the ONLY leg the
+    /// recorded-vs-synthetic rule (design §7) re-solves when a re-aim window succeeds.
+    /// </summary>
+    internal sealed class HeliocentricTransferPhase : ConicPhase
+    {
+        internal HeliocentricTransferPhase(
+            PhaseId id, SegmentProvenance provenance, AnchorFrame anchor, double startUt, double endUt,
+            OrbitSegment conic, PhaseSeam leadingSeam = null, PhaseSeam trailingSeam = null)
+            : base(id, PhaseKind.HeliocentricTransfer, provenance, anchor, startUt, endUt,
+                   leadingSeam, trailingSeam, conic) { }
+
+        private protected override SegmentKind LegacyKind => SegmentKind.Transfer;
+    }
+
+    /// <summary>
+    /// design §6: the SOI arrival leg (capture into the destination body's SOI). StockConic or
+    /// TracedPath; Recorded or Synthesized. Implemented by <c>ReaimClassifier.ArrivalLeg</c> + intra-arc
+    /// moon split. Dual-treatment like <see cref="SoiDeparturePhase"/>.
+    /// </summary>
+    internal sealed class SoiArrivalPhase : DualTreatmentConicPhase
+    {
+        internal SoiArrivalPhase(
+            PhaseId id, Treatment treatment, SegmentProvenance provenance, AnchorFrame anchor,
+            double startUt, double endUt, OrbitSegment conic,
+            PhaseSeam leadingSeam = null, PhaseSeam trailingSeam = null)
+            : base(id, PhaseKind.SoiArrival, SegmentKind.Approach, treatment, provenance, anchor,
+                   startUt, endUt, conic, leadingSeam, trailingSeam) { }
+    }
+
+    /// <summary>
+    /// design §6: the loiter AFTER arrival (parking around the destination). StockConic; Recorded.
+    /// Same role-blind conic emit as <see cref="DepartureLoiterPhase"/> with the NEW arrival role;
+    /// <c>DestinationLoiterTrim</c>.
+    /// </summary>
+    internal sealed class ArrivalLoiterPhase : ConicPhase
+    {
+        internal ArrivalLoiterPhase(
+            PhaseId id, SegmentProvenance provenance, AnchorFrame anchor, double startUt, double endUt,
+            OrbitSegment conic, PhaseSeam leadingSeam = null, PhaseSeam trailingSeam = null)
+            : base(id, PhaseKind.ArrivalLoiter, provenance, anchor, startUt, endUt,
+                   leadingSeam, trailingSeam, conic) { }
+
+        private protected override SegmentKind LegacyKind => SegmentKind.ArrivalLoiter;
+    }
+
+    /// <summary>
+    /// design §6 / §9.1: atmospheric / powered descent to landing. TracedPath; Recorded. Implemented by
+    /// <c>DescentTrigger.*</c>; in v1 it gains a cross-member stitcher (Phase 6) owning the orbit↔landing
+    /// G1 seam. Promoted to a visible first-class phase (no longer hidden in the transfer member).
+    /// </summary>
+    internal sealed class DescentPhase : TracedPhase
+    {
+        internal DescentPhase(
+            PhaseId id, SegmentProvenance provenance, AnchorFrame anchor, double startUt, double endUt,
+            PhaseSeam leadingSeam = null, PhaseSeam trailingSeam = null)
+            : base(id, PhaseKind.Descent, provenance, anchor, startUt, endUt, leadingSeam, trailingSeam) { }
+
+        private protected override SegmentKind LegacyKind => SegmentKind.Landing;
+    }
+
+    /// <summary>
+    /// design §6: a landed / splashed / prelaunch / rover surface stretch. TracedPath; Recorded. Traced
+    /// runs below surface. (A no-bounds surface ghost falls to a SuppressedMarker via the director, §11.4
+    /// — that is a director decision, not this phase's treatment.)
+    /// </summary>
+    internal sealed class SurfacePhase : TracedPhase
+    {
+        internal SurfacePhase(
+            PhaseId id, SegmentProvenance provenance, AnchorFrame anchor, double startUt, double endUt,
+            PhaseSeam leadingSeam = null, PhaseSeam trailingSeam = null)
+            : base(id, PhaseKind.Surface, provenance, anchor, startUt, endUt, leadingSeam, trailingSeam) { }
+
+        private protected override SegmentKind LegacyKind => SegmentKind.Surface;
+    }
+
+    /// <summary>
+    /// design §6: a first-class "parked" identity, promoted from the invisible <c>InInteriorGap</c>
+    /// clock insertion (<c>ArrivalHoldPlanner</c> / launch-hold). It renders quietly (no own geometry —
+    /// the prior intent is held) but EXISTS in the chain for debugging / composition.
+    ///
+    /// <para><b>Warp-step safety (design §11.3):</b> a single high-warp frame can advance the live UT
+    /// across an entire hold. <see cref="CoversUt"/> covers the WHOLE <c>[StartUt, EndUt)</c> span so the
+    /// hold never resolves to "no phase" mid-warp and freeze the ghost for multiple frames; the span
+    /// clock then resolves the correct post-hold assembled-UT.</para>
+    /// </summary>
+    internal sealed class HoldPhase : TrajectoryPhase
+    {
+        internal HoldPhase(
+            PhaseId id, AnchorFrame anchor, double startUt, double endUt,
+            PhaseSeam leadingSeam = null, PhaseSeam trailingSeam = null)
+            : base(id, PhaseKind.Hold, SegmentProvenance.Recorded, anchor, startUt, endUt,
+                   leadingSeam, trailingSeam) { }
+
+        /// <summary>A hold draws nothing of its own; the prior intent is held (design §6).</summary>
+        internal override Treatment ResolveTreatment() => Treatment.None;
+
+        /// <summary>No geometry — yields nothing.</summary>
+        internal override IEnumerable<RenderSegment> Emit(SampleContext ctx)
+            => Array.Empty<RenderSegment>();
+
+        // CoversUt uses the base half-open [StartUt, EndUt) — already covers the whole hold span, so a
+        // warp step that lands anywhere inside the hold resolves to THIS phase (never a spurious gap).
+        // The inclusive end of the chain's LAST phase is handled by the chain (see PhaseChain).
+    }
+
+    /// <summary>
+    /// design §6: shared base for the two DUAL-treatment conic phases (<see cref="SoiDeparturePhase"/> /
+    /// <see cref="SoiArrivalPhase"/>) that the §6 table marks as StockConic OR TracedPath. Carries an
+    /// explicit treatment; the conic is still carried (a TracedPath SOI leg may still have a conic
+    /// reference for its endpoints, but the treatment governs the draw).
+    /// </summary>
+    internal abstract class DualTreatmentConicPhase : TrajectoryPhase
+    {
+        internal OrbitSegment Conic { get; }
+        private readonly Treatment treatment;
+        private readonly SegmentKind legacyKind;
+
+        private protected DualTreatmentConicPhase(
+            PhaseId id, PhaseKind kind, SegmentKind legacyKind, Treatment treatment,
+            SegmentProvenance provenance, AnchorFrame anchor, double startUt, double endUt,
+            OrbitSegment conic, PhaseSeam leadingSeam, PhaseSeam trailingSeam)
+            : base(id, kind, provenance, anchor, startUt, endUt, leadingSeam, trailingSeam)
+        {
+            this.treatment = treatment;
+            this.legacyKind = legacyKind;
+            Conic = conic;
+        }
+
+        internal override Treatment ResolveTreatment() => treatment;
+
+        internal override IEnumerable<RenderSegment> Emit(SampleContext ctx)
+        {
+            bool conicTreatment = treatment == Treatment.StockConic;
+            string body = (Anchor is AnchorFrame.BodyAnchor b && !string.IsNullOrEmpty(b.BodyName))
+                ? b.BodyName
+                : (!string.IsNullOrEmpty(Conic.bodyName) ? Conic.bodyName : ctx.FrameBodyName);
+
+            yield return new RenderSegment(
+                legacyKind,
+                treatment,
+                StartUt,
+                EndUt,
+                body,
+                conicTreatment ? SegmentPayload.ForConic(Conic) : SegmentPayload.Traced,
+                isGenerated: Provenance == SegmentProvenance.Synthesized,
+                leadingSeam: PhaseGeometry.ToLegacySeam(LeadingSeam),
+                trailingSeam: PhaseGeometry.ToLegacySeam(TrailingSeam));
+        }
+    }
+
+    /// <summary>
+    /// Pure geometry/seam helpers shared by the phase <c>Emit</c> overrides. Kept Unity-free.
+    /// </summary>
+    internal static class PhaseGeometry
+    {
+        /// <summary>
+        /// Map a Phase-1 <see cref="PhaseSeam"/> down to the legacy <see cref="SeamKind"/> the emitted
+        /// <see cref="RenderSegment"/> carries (the live draw path still reads <c>SeamKind</c>). The new
+        /// <see cref="PhaseSeamKind.SwitchContinuation"/> has no legacy equivalent (it is a member
+        /// boundary, not an intra-chain seam) and maps to <see cref="SeamKind.None"/>; a null seam is
+        /// <see cref="SeamKind.None"/>.
+        /// </summary>
+        internal static SeamKind ToLegacySeam(PhaseSeam seam)
+        {
+            if (seam == null)
+                return SeamKind.None;
+            switch (seam.Kind)
+            {
+                case PhaseSeamKind.Rigid: return SeamKind.Rigid;
+                case PhaseSeamKind.FlexibleSoi: return SeamKind.FlexibleSoi;
+                default: return SeamKind.None;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Phase 1 of the map/TS render overhaul (migration plan `docs/dev/plans/map-ts-render-overhaul-migration.md`). **Stacked on #1208 (Phase 0)** — base branch is `maprender-phase0-parity-oracle`.

Introduces the new composable type system (design §3/§5/§6) that later phases re-type the render atom into. **Purely additive and unwired** — new `internal` types under `MapRender/`, nothing calls them yet, zero change to the live draw path or any behavior.

- **L0 primitives:** `SegmentProvenance` (collapses the overloaded `isPredicted`), `AnchorFrame` discriminated union + pure `AnchorFrameResolver` (BodyAnchor fail-closed-never-NRE; ParentAnchoredChild bodyFixedFrames-primary, >=2-sample, out-of-range -> retire-not-clamp), `ITrajectorySample` (Absolute/Relative/OrbitalState split of the frame-overloaded sample).
- **L2 phases:** `TrajectoryPhase` abstract + 9 concrete subclasses, `PhaseKind` (replaces the cosmetic `SegmentKind`; old->new map in XML-doc), `PhaseSeam` (new `PhaseSeamKind` incl. `SwitchContinuation` + `ContinuityOrder` G0/G1 + `PhaseSeamClassifier` incl. the rigid-seam G1 tangent-discontinuity predicate), `PhaseId` (runtime render-layer identity, NOT the persisted Mission /segN keys), `SoiCrossing`.
- **L3:** `PhaseChain` (the `GhostRenderChain` successor; additive, not a swap).

**Safety:** the live `SeamKind`/`Treatment` enums are untouched (a separate `PhaseSeamKind` + a `ToLegacySeam` down-map). +100 unit tests; `dotnet test` 16417 green; no KSP deploy from this branch.

Self-reviewed (low-risk additive/unwired/fully-tested phase, per the project's review norms); the heavy clean-context reviews are reserved for the high-risk behavioral phases (3/4/5/6).