### PR TITLE
maprender Phase 2: PhaseFactory in shadow + geometry byte-parity

### DIFF
--- a/Source/Parsek.Tests/MapRender/GeometryParityComparatorTests.cs
+++ b/Source/Parsek.Tests/MapRender/GeometryParityComparatorTests.cs
@@ -1,0 +1,283 @@
+using System.Collections.Generic;
+using Parsek.MapRender;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    /// <summary>
+    /// Phase-2 guard for <see cref="GeometryParityComparator"/> (migration plan §4): the PURE byte-parity
+    /// comparator over the GEOMETRY fields of a <see cref="PhaseChain"/> vs a <see cref="GhostRenderChain"/>.
+    /// Covers (1) a matching chain returns <see cref="GeometryParityComparator.ParityResult.Match"/>, and
+    /// (2) a deliberately-mismatched chain on EACH geometry field (treatment / UTs / frame / conic
+    /// elements / chain window / faithful-fallback / count) returns the right diverging field.
+    /// Crucially: a chain that differs ONLY in <see cref="PhaseKind"/> / <see cref="SegmentProvenance"/>
+    /// (the NON-parity fields) must still MATCH.
+    ///
+    /// Each assertion states the bug it catches: a false MATCH would let the Phase-2 shadow gate pass a
+    /// wrong-geometry factory; a false DIVERGE (e.g. flagging a kind/provenance difference) would spam
+    /// the factory-parity anomaly on a correct factory and block Phase 3.
+    /// </summary>
+    public class GeometryParityComparatorTests
+    {
+        private static readonly AnchorFrame Kerbin = new AnchorFrame.BodyAnchor("Kerbin");
+        private static readonly AnchorFrame Mun = new AnchorFrame.BodyAnchor("Mun");
+
+        private static OrbitSegment Conic(string body, double s, double e, double sma = 7e5)
+            => new OrbitSegment { startUT = s, endUT = e, bodyName = body, semiMajorAxis = sma };
+
+        private static PhaseId Id(int ord) => new PhaseId("rec-A", 0, ord);
+
+        // A reference chain: ascent (Kerbin traced 0..10), loiter (Kerbin conic 10..20), arrival (Mun
+        // traced 20..30). Window [0,30].
+        private static (PhaseChain factory, GhostRenderChain assembler) BuildAligned()
+        {
+            var phases = new List<TrajectoryPhase>
+            {
+                new AscentPhase(Id(0), SegmentProvenance.Recorded, Kerbin, 0, 10,
+                    trailingSeam: PhaseSeam.Rigid()),
+                new DepartureLoiterPhase(Id(1), SegmentProvenance.Recorded, Kerbin, 10, 20, Conic("Kerbin", 10, 20),
+                    leadingSeam: PhaseSeam.Rigid(), trailingSeam: PhaseSeam.FlexibleSoi(null)),
+                new DescentPhase(Id(2), SegmentProvenance.Recorded, Mun, 20, 30,
+                    leadingSeam: PhaseSeam.FlexibleSoi(null)),
+            };
+            var factory = new PhaseChain("rec-A", 3, 0, phases, 0, 30, false);
+
+            var segs = new List<RenderSegment>
+            {
+                new RenderSegment(SegmentKind.Surface, Treatment.TracedPath, 0, 10, "Kerbin", SegmentPayload.Traced,
+                    leadingSeam: SeamKind.None, trailingSeam: SeamKind.Rigid),
+                new RenderSegment(SegmentKind.Loiter, Treatment.StockConic, 10, 20, "Kerbin",
+                    SegmentPayload.ForConic(Conic("Kerbin", 10, 20)),
+                    leadingSeam: SeamKind.Rigid, trailingSeam: SeamKind.FlexibleSoi),
+                new RenderSegment(SegmentKind.Surface, Treatment.TracedPath, 20, 30, "Mun", SegmentPayload.Traced,
+                    leadingSeam: SeamKind.FlexibleSoi),
+            };
+            var assembler = new GhostRenderChain("rec-A", 3, 0, segs, 0, 30, false);
+            return (factory, assembler);
+        }
+
+        // ---- Match cases ----
+
+        [Fact]
+        public void AlignedChains_Match()
+        {
+            var (factory, assembler) = BuildAligned();
+            var r = GeometryParityComparator.Compare(factory, assembler);
+            Assert.True(r.IsMatch, r.ToString());
+            Assert.Null(r.DivergingField);
+            Assert.False(r.CountMismatch);
+        }
+
+        [Fact]
+        public void BothNull_Match()
+        {
+            Assert.True(GeometryParityComparator.Compare(null, null).IsMatch);
+        }
+
+        [Fact]
+        public void DiffOnlyInKindOrProvenance_StillMatches()
+        {
+            // The factory phase uses a DIFFERENT legacy kind + provenance than the assembler's segment, but
+            // the GEOMETRY (treatment/UT/body/conic) is identical -> MATCH (kind/provenance are non-parity).
+            var phases = new List<TrajectoryPhase>
+            {
+                // ArrivalLoiterPhase emits SegmentKind.ArrivalLoiter; the assembler segment below is Loiter.
+                new ArrivalLoiterPhase(Id(0), SegmentProvenance.Synthesized, Kerbin, 10, 20, Conic("Kerbin", 10, 20)),
+            };
+            var factory = new PhaseChain("rec-A", 0, 0, phases, 0, 30, false);
+
+            var segs = new List<RenderSegment>
+            {
+                new RenderSegment(SegmentKind.Loiter, Treatment.StockConic, 10, 20, "Kerbin",
+                    SegmentPayload.ForConic(Conic("Kerbin", 10, 20)), isGenerated: false),
+            };
+            var assembler = new GhostRenderChain("rec-A", 0, 0, segs, 0, 30, false);
+
+            Assert.True(GeometryParityComparator.Compare(factory, assembler).IsMatch);
+        }
+
+        [Fact]
+        public void HoldPhase_EmitsNothing_DoesNotDisruptAlignment()
+        {
+            // A HoldPhase (no geometry) interleaved in the factory chain must not shift the projected
+            // segment alignment - the assembler never emits a hold.
+            var phases = new List<TrajectoryPhase>
+            {
+                new DepartureLoiterPhase(Id(0), SegmentProvenance.Recorded, Kerbin, 10, 20, Conic("Kerbin", 10, 20)),
+                new HoldPhase(Id(1), Kerbin, 20, 25),
+                new DescentPhase(Id(2), SegmentProvenance.Recorded, Mun, 25, 30),
+            };
+            var factory = new PhaseChain("rec-A", 0, 0, phases, 0, 30, false);
+            var segs = new List<RenderSegment>
+            {
+                new RenderSegment(SegmentKind.Loiter, Treatment.StockConic, 10, 20, "Kerbin",
+                    SegmentPayload.ForConic(Conic("Kerbin", 10, 20))),
+                new RenderSegment(SegmentKind.Surface, Treatment.TracedPath, 25, 30, "Mun", SegmentPayload.Traced),
+            };
+            var assembler = new GhostRenderChain("rec-A", 0, 0, segs, 0, 30, false);
+
+            Assert.True(GeometryParityComparator.Compare(factory, assembler).IsMatch);
+        }
+
+        // ---- Deliberate divergence per field ----
+
+        [Fact]
+        public void TreatmentMismatch_Diverges()
+        {
+            var (factory, assembler) = BuildAligned();
+            // Replace the assembler's loiter conic with a TracedPath (treatment mismatch).
+            var segs = new List<RenderSegment>(assembler.Segments);
+            segs[1] = new RenderSegment(SegmentKind.Loiter, Treatment.TracedPath, 10, 20, "Kerbin", SegmentPayload.Traced);
+            var mutated = new GhostRenderChain("rec-A", 3, 0, segs, 0, 30, false);
+
+            var r = GeometryParityComparator.Compare(factory, mutated);
+            Assert.False(r.IsMatch);
+            Assert.Equal("Treatment", r.DivergingField);
+            Assert.Equal(1, r.SegmentIndex);
+        }
+
+        [Fact]
+        public void StartUtMismatch_Diverges()
+        {
+            var (factory, assembler) = BuildAligned();
+            var segs = new List<RenderSegment>(assembler.Segments);
+            segs[0] = new RenderSegment(SegmentKind.Surface, Treatment.TracedPath, 0.5, 10, "Kerbin", SegmentPayload.Traced);
+            var mutated = new GhostRenderChain("rec-A", 3, 0, segs, 0, 30, false);
+            var r = GeometryParityComparator.Compare(factory, mutated);
+            Assert.Equal("StartUt", r.DivergingField);
+            Assert.Equal(0, r.SegmentIndex);
+        }
+
+        [Fact]
+        public void EndUtMismatch_Diverges()
+        {
+            var (factory, assembler) = BuildAligned();
+            var segs = new List<RenderSegment>(assembler.Segments);
+            segs[2] = new RenderSegment(SegmentKind.Surface, Treatment.TracedPath, 20, 29.5, "Mun", SegmentPayload.Traced);
+            var mutated = new GhostRenderChain("rec-A", 3, 0, segs, 0, 30, false);
+            var r = GeometryParityComparator.Compare(factory, mutated);
+            Assert.Equal("EndUt", r.DivergingField);
+        }
+
+        [Fact]
+        public void FrameBodyMismatch_Diverges()
+        {
+            var (factory, assembler) = BuildAligned();
+            var segs = new List<RenderSegment>(assembler.Segments);
+            segs[2] = new RenderSegment(SegmentKind.Surface, Treatment.TracedPath, 20, 30, "Minmus", SegmentPayload.Traced);
+            var mutated = new GhostRenderChain("rec-A", 3, 0, segs, 0, 30, false);
+            var r = GeometryParityComparator.Compare(factory, mutated);
+            Assert.Equal("FrameBodyName", r.DivergingField);
+        }
+
+        [Fact]
+        public void HasConicMismatch_Diverges()
+        {
+            var (factory, assembler) = BuildAligned();
+            var segs = new List<RenderSegment>(assembler.Segments);
+            // assembler loiter has a conic; drop it (Traced payload but still StockConic treatment).
+            segs[1] = new RenderSegment(SegmentKind.Loiter, Treatment.StockConic, 10, 20, "Kerbin", SegmentPayload.Traced);
+            var mutated = new GhostRenderChain("rec-A", 3, 0, segs, 0, 30, false);
+            var r = GeometryParityComparator.Compare(factory, mutated);
+            Assert.Equal("HasConic", r.DivergingField);
+        }
+
+        [Fact]
+        public void ConicElementMismatch_Diverges()
+        {
+            var (factory, assembler) = BuildAligned();
+            var segs = new List<RenderSegment>(assembler.Segments);
+            // different sma in the loiter conic
+            segs[1] = new RenderSegment(SegmentKind.Loiter, Treatment.StockConic, 10, 20, "Kerbin",
+                SegmentPayload.ForConic(Conic("Kerbin", 10, 20, sma: 8e5)));
+            var mutated = new GhostRenderChain("rec-A", 3, 0, segs, 0, 30, false);
+            var r = GeometryParityComparator.Compare(factory, mutated);
+            Assert.Equal("conic.semiMajorAxis", r.DivergingField);
+        }
+
+        [Fact]
+        public void ConicIsPredictedMismatch_Diverges()
+        {
+            var phases = new List<TrajectoryPhase>
+            {
+                new DepartureLoiterPhase(Id(0), SegmentProvenance.Recorded, Kerbin, 10, 20,
+                    new OrbitSegment { startUT = 10, endUT = 20, bodyName = "Kerbin", semiMajorAxis = 7e5, isPredicted = false }),
+            };
+            var factory = new PhaseChain("rec-A", 0, 0, phases, 0, 30, false);
+            var segs = new List<RenderSegment>
+            {
+                new RenderSegment(SegmentKind.Loiter, Treatment.StockConic, 10, 20, "Kerbin",
+                    SegmentPayload.ForConic(new OrbitSegment { startUT = 10, endUT = 20, bodyName = "Kerbin", semiMajorAxis = 7e5, isPredicted = true })),
+            };
+            var assembler = new GhostRenderChain("rec-A", 0, 0, segs, 0, 30, false);
+            var r = GeometryParityComparator.Compare(factory, assembler);
+            Assert.Equal("conic.isPredicted", r.DivergingField);
+        }
+
+        [Fact]
+        public void WindowStartMismatch_Diverges()
+        {
+            var (factory, assembler) = BuildAligned();
+            var mutated = new GhostRenderChain("rec-A", 3, 0, assembler.Segments, 1.0, 30, false);
+            var r = GeometryParityComparator.Compare(factory, mutated);
+            Assert.Equal("WindowStartUt", r.DivergingField);
+            Assert.Equal(-1, r.SegmentIndex);
+        }
+
+        [Fact]
+        public void WindowEndMismatch_Diverges()
+        {
+            var (factory, assembler) = BuildAligned();
+            var mutated = new GhostRenderChain("rec-A", 3, 0, assembler.Segments, 0, 31, false);
+            var r = GeometryParityComparator.Compare(factory, mutated);
+            Assert.Equal("WindowEndUt", r.DivergingField);
+        }
+
+        [Fact]
+        public void FaithfulFallbackMismatch_Diverges()
+        {
+            var (factory, assembler) = BuildAligned();
+            var mutated = new GhostRenderChain("rec-A", 3, 0, assembler.Segments, 0, 30, true);
+            var r = GeometryParityComparator.Compare(factory, mutated);
+            Assert.Equal("IsFaithfulFallback", r.DivergingField);
+        }
+
+        [Fact]
+        public void SegmentCountMismatch_Diverges_AndFlagsCountMismatch()
+        {
+            var (factory, assembler) = BuildAligned();
+            // assembler has one extra (aligned) segment; the first 3 match, the 4th makes counts differ.
+            var segs = new List<RenderSegment>(assembler.Segments)
+            {
+                new RenderSegment(SegmentKind.Surface, Treatment.TracedPath, 30, 40, "Mun", SegmentPayload.Traced),
+            };
+            var mutated = new GhostRenderChain("rec-A", 3, 0, segs, 0, 30, false);
+            var r = GeometryParityComparator.Compare(factory, mutated);
+            Assert.False(r.IsMatch);
+            Assert.True(r.CountMismatch);
+            Assert.Equal("segment-count", r.DivergingField);
+        }
+
+        [Fact]
+        public void OneNull_Diverges()
+        {
+            var (factory, _) = BuildAligned();
+            Assert.False(GeometryParityComparator.Compare(factory, null).IsMatch);
+            Assert.False(GeometryParityComparator.Compare(null, new GhostRenderChain("x", 0, 0, null, 0, 1, false)).IsMatch);
+        }
+
+        [Fact]
+        public void ProjectGeometry_SkipsHoldPhases()
+        {
+            var phases = new List<TrajectoryPhase>
+            {
+                new HoldPhase(Id(0), Kerbin, 0, 10),
+                new DepartureLoiterPhase(Id(1), SegmentProvenance.Recorded, Kerbin, 10, 20, Conic("Kerbin", 10, 20)),
+            };
+            var chain = new PhaseChain("rec-A", 0, 0, phases, 0, 30, false);
+            var projected = GeometryParityComparator.ProjectGeometry(chain);
+            Assert.Single(projected);
+            Assert.Equal(Treatment.StockConic, projected[0].Treatment);
+        }
+    }
+}

--- a/Source/Parsek.Tests/MapRender/PhaseFactoryTests.cs
+++ b/Source/Parsek.Tests/MapRender/PhaseFactoryTests.cs
@@ -1,0 +1,412 @@
+using System.Collections.Generic;
+using Parsek;
+using Parsek.Display;
+using Parsek.MapRender;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    /// <summary>
+    /// Phase-2 guard for <see cref="PhaseFactory"/> (migration plan §4): the factory builds a typed
+    /// <see cref="PhaseChain"/> from the SAME inputs as <see cref="ChainAssembler.Build"/>, and its
+    /// emitted GEOMETRY must byte-match the assembler's <see cref="GhostRenderChain"/>. These tests cover
+    /// (1) the per-phase-kind classification (faithful env-class vs re-aimed plan), (2) the park /
+    /// BG-on-rails / single-recording / null edge cases, and (3) the geometry byte-parity round-trip per
+    /// fixture. The byte-parity comparator itself is tested in <c>GeometryParityComparatorTests</c>.
+    ///
+    /// Each assertion states the bug it catches: a wrong subclass/kind would mis-label a phase (caught by
+    /// the explicit kind asserts, which are NOT the parity gate); a wrong geometry handling (window,
+    /// override, coalesce, body-split) would diverge from the assembler (caught by the byte-parity
+    /// asserts, which ARE the gate).
+    /// </summary>
+    public class PhaseFactoryTests
+    {
+        private static TrajectoryPoint Pt(double ut, string body)
+            => new TrajectoryPoint { ut = ut, bodyName = body };
+
+        private static TrackSection Sec(double s, double e, SegmentEnvironment env)
+            => new TrackSection { startUT = s, endUT = e, environment = env };
+
+        // ascent (Kerbin points 0..8) -> loiter (Kerbin orbit 10..30) -> arrival (Mun points 32..36)
+        private static MockTrajectory FullChain()
+            => new MockTrajectory
+            {
+                RecordingId = "rec-1",
+                Points = new List<TrajectoryPoint>
+                {
+                    Pt(0, "Kerbin"), Pt(2, "Kerbin"), Pt(4, "Kerbin"), Pt(6, "Kerbin"), Pt(8, "Kerbin"),
+                    Pt(32, "Mun"), Pt(34, "Mun"), Pt(36, "Mun"),
+                },
+                OrbitSegments = new List<OrbitSegment>
+                {
+                    new OrbitSegment { startUT = 10, endUT = 30, bodyName = "Kerbin", semiMajorAxis = 700000, eccentricity = 0 },
+                },
+            };
+
+        // Assert the factory's projected geometry byte-matches the assembler's chain for one fixture.
+        private static void AssertByteParity(
+            IPlaybackTrajectory traj, double wStart, double wEnd,
+            GhostTrajectoryPolylineRenderer.BodySurfaceProvider surface = null,
+            IReadOnlyList<OrbitSegment> overrideSegs = null, string ancestor = null,
+            bool faithfulFallback = false)
+        {
+            var assembler = ChainAssembler.Build(
+                traj, committedIndex: 3, instanceKey: 0, wStart, wEnd, faithfulFallback,
+                surface, overrideSegs, ancestor);
+            var factory = PhaseFactory.BuildPhaseChain(
+                traj, committedIndex: 3, instanceKey: 0, wStart, wEnd, faithfulFallback,
+                surface, overrideSegs, ancestor);
+
+            var result = GeometryParityComparator.Compare(factory, assembler);
+            Assert.True(result.IsMatch, "geometry parity divergence: " + result);
+        }
+
+        // ---- Geometry byte-parity per fixture (the GATE) ----
+
+        [Fact]
+        public void FullChain_FactoryGeometry_ByteMatchesAssembler()
+        {
+            AssertByteParity(FullChain(), 0, 40);
+        }
+
+        [Fact]
+        public void BelowSurfaceDescent_FactoryGeometry_ByteMatchesAssembler()
+        {
+            var traj = new MockTrajectory
+            {
+                RecordingId = "rec-desc",
+                Points = new List<TrajectoryPoint>
+                {
+                    Pt(12, "Kerbin"), Pt(16, "Kerbin"), Pt(20, "Kerbin"), Pt(24, "Kerbin"), Pt(28, "Kerbin"),
+                },
+                OrbitSegments = new List<OrbitSegment>
+                {
+                    new OrbitSegment { startUT = 10, endUT = 30, bodyName = "Kerbin", semiMajorAxis = 500000, eccentricity = 0 },
+                },
+            };
+            GhostTrajectoryPolylineRenderer.BodySurfaceProvider kerbin =
+                (string b, out GhostTrajectoryPolylineRenderer.BodySurfaceInfo info) =>
+                { info = new GhostTrajectoryPolylineRenderer.BodySurfaceInfo { radius = 600000 }; return b == "Kerbin"; };
+            AssertByteParity(traj, 0, 40, surface: kerbin);
+        }
+
+        [Fact]
+        public void Coalesce_FactoryGeometry_ByteMatchesAssembler()
+        {
+            var traj = new MockTrajectory
+            {
+                RecordingId = "rec-frag",
+                Points = new List<TrajectoryPoint>(),
+                OrbitSegments = new List<OrbitSegment>
+                {
+                    new OrbitSegment { startUT = 10, endUT = 100, bodyName = "Kerbin", semiMajorAxis = 700000, eccentricity = 0.001, epoch = 10 },
+                    new OrbitSegment { startUT = 150, endUT = 300, bodyName = "Kerbin", semiMajorAxis = 700000, eccentricity = 0.001, epoch = 150 },
+                    new OrbitSegment { startUT = 311, endUT = 351, bodyName = "Kerbin", semiMajorAxis = 700000, eccentricity = 0.001, epoch = 311 },
+                    new OrbitSegment { startUT = 400, endUT = 5000, bodyName = "Kerbin", semiMajorAxis = -380000, eccentricity = 1.2, epoch = 400 },
+                },
+            };
+            AssertByteParity(traj, 0, 6000);
+        }
+
+        [Fact]
+        public void FaithfulFallbackFlag_FactoryGeometry_ByteMatchesAssembler()
+        {
+            AssertByteParity(FullChain(), 0, 40, faithfulFallback: true);
+        }
+
+        // ---- Per-phase-kind classification (NOT the parity gate; documents the typed identity) ----
+
+        [Fact]
+        public void FullChain_ClassifiesAscentLoiterArrival()
+        {
+            // env-class: ascent (Kerbin atmo) -> departure loiter (Kerbin orbit) -> arrival (Mun).
+            var traj = FullChain();
+            traj.TrackSections = new List<TrackSection>
+            {
+                Sec(0, 8, SegmentEnvironment.Atmospheric),     // ascent run
+                Sec(10, 30, SegmentEnvironment.ExoBallistic),  // Kerbin parking
+                Sec(32, 36, SegmentEnvironment.Approach),      // Mun approach
+            };
+            var chain = PhaseFactory.BuildPhaseChain(traj, 0, 0, 0, 40);
+
+            Assert.Equal(3, chain.PhaseCount);
+            Assert.IsType<AscentPhase>(chain.Phases[0]);
+            Assert.Equal(PhaseKind.Ascent, chain.Phases[0].Kind);
+            Assert.IsType<DepartureLoiterPhase>(chain.Phases[1]);
+            Assert.Equal(PhaseKind.DepartureLoiter, chain.Phases[1].Kind);
+            // The Mun arrival traced run after the orbit + an approach env => SoiArrival is conic-only here;
+            // a traced Mun run after the first conic classifies as Descent unless surface/approach. With an
+            // Approach env on the Mun run, the traced kind is approach -> not surface, after first conic =>
+            // Descent. The leaf kind is non-parity; assert it is a traced phase on Mun.
+            Assert.Equal(Treatment.TracedPath, chain.Phases[2].ResolveTreatment());
+            Assert.Equal("Mun", ((AnchorFrame.BodyAnchor)chain.Phases[2].Anchor).BodyName);
+        }
+
+        [Fact]
+        public void SurfaceEnv_ClassifiesSurfacePhase()
+        {
+            var traj = new MockTrajectory
+            {
+                RecordingId = "rec-surf",
+                Points = new List<TrajectoryPoint> { Pt(0, "Kerbin"), Pt(2, "Kerbin"), Pt(4, "Kerbin") },
+                TrackSections = new List<TrackSection> { Sec(0, 4, SegmentEnvironment.SurfaceStationary) },
+            };
+            var chain = PhaseFactory.BuildPhaseChain(traj, 0, 0, 0, 10);
+            Assert.Single(chain.Phases);
+            Assert.IsType<SurfacePhase>(chain.Phases[0]);
+            Assert.Equal(PhaseKind.Surface, chain.Phases[0].Kind);
+        }
+
+        [Fact]
+        public void ReaimedMember_ClassifiesSynthesizedHeliocentricTransfer()
+        {
+            // A re-aimed override (reference-distinct from recorded) whose conic is the ancestor body and
+            // isPredicted=false => the synthesized heliocentric transfer (HeliocentricTransferPhase,
+            // Synthesized provenance). Geometry must still byte-match the assembler.
+            var traj = new MockTrajectory
+            {
+                RecordingId = "rec-reaim",
+                Points = new List<TrajectoryPoint>(),
+                OrbitSegments = new List<OrbitSegment>
+                {
+                    new OrbitSegment { startUT = 10, endUT = 30, bodyName = "Sun", semiMajorAxis = 9e9, eccentricity = 0.2 },
+                },
+            };
+            var reaimed = new List<OrbitSegment>
+            {
+                new OrbitSegment { startUT = 10, endUT = 30, bodyName = "Sun", semiMajorAxis = 7.777e9, eccentricity = 0.5, isPredicted = false },
+            };
+            var chain = PhaseFactory.BuildPhaseChain(
+                traj, 0, 0, 0, 40, orbitSegmentsOverride: reaimed, reaimAncestorBody: "Sun");
+
+            var transfer = Assert.Single(chain.Phases);
+            Assert.IsType<HeliocentricTransferPhase>(transfer);
+            Assert.Equal(PhaseKind.HeliocentricTransfer, transfer.Kind);
+            Assert.Equal(SegmentProvenance.Synthesized, transfer.Provenance);
+            // and byte-parity (the override conic flows through unchanged)
+            AssertByteParity(traj, 0, 40, overrideSegs: reaimed, ancestor: "Sun");
+        }
+
+        [Fact]
+        public void HeliocentricParkVariant_ClassifiesSynthesizedDepartureLoiter()
+        {
+            // A re-aimed member with a recorded park copy on the ancestor (star) body that is NOT the
+            // generated transfer (isPredicted=true so the isPredicted heuristic + non-ancestor-only-match
+            // would NOT mark it Transfer; but it IS on the ancestor body) => synthesized DepartureLoiter
+            // (the s15 heliocentric-park variant). We feed an override that does NOT mark this segment
+            // generated (the ancestor match marks generated only via the override's matching ancestor body
+            // path - so to isolate the park, the override's segment must be isPredicted=true).
+            var traj = new MockTrajectory
+            {
+                RecordingId = "rec-park",
+                Points = new List<TrajectoryPoint>(),
+                OrbitSegments = new List<OrbitSegment>
+                {
+                    new OrbitSegment { startUT = 10, endUT = 30, bodyName = "Sun", semiMajorAxis = 9e9, eccentricity = 0.01, isPredicted = true },
+                },
+            };
+            // Override reference-distinct but same shape, isPredicted=true so the assembler does NOT mark it
+            // generated even with a matching ancestor (the ancestor-match marks generated; so to get a park
+            // we must NOT match the ancestor). Use a NON-matching ancestor so the segment stays Loiter, and
+            // the factory's park rule (re-aimed + conic body == ancestor) needs the ancestor to match -
+            // so instead assert the byte-parity holds and the phase is a conic loiter.
+            var reaimed = new List<OrbitSegment>
+            {
+                new OrbitSegment { startUT = 10, endUT = 30, bodyName = "Sun", semiMajorAxis = 9e9, eccentricity = 0.01, isPredicted = true },
+            };
+            var chain = PhaseFactory.BuildPhaseChain(
+                traj, 0, 0, 0, 40, orbitSegmentsOverride: reaimed, reaimAncestorBody: "Sun");
+
+            // ancestor matches "Sun", segment not generated (isPredicted true, ancestor-match marks
+            // generated only in ChainAssembler when isPredicted=false? No - ChainAssembler marks generated
+            // when isPredicted OR ancestor-match) -> so this conic is generated -> HeliocentricTransfer.
+            // The park-only case (non-generated ancestor conic) cannot arise from the assembler's marking,
+            // so the realistic synthesized-departure-loiter is exercised by the dedicated ClassifySegment
+            // test below. Here we only assert byte-parity.
+            AssertByteParity(traj, 0, 40, overrideSegs: reaimed, ancestor: "Sun");
+            Assert.Single(chain.Phases);
+        }
+
+        [Fact]
+        public void ClassifySegment_ReaimedNonGeneratedAncestorConic_IsSynthesizedDepartureLoiter()
+        {
+            // Directly exercise the park rule in ClassifySegment: a re-aimed member, a non-generated conic
+            // whose frame body == the ancestor => synthesized DepartureLoiterPhase (s15).
+            var conic = new OrbitSegment { startUT = 10, endUT = 30, bodyName = "Sun", semiMajorAxis = 9e9 };
+            var seg = new RenderSegment(
+                SegmentKind.Loiter, Treatment.StockConic, 10, 30, "Sun",
+                SegmentPayload.ForConic(conic), isGenerated: false);
+            var traj = new MockTrajectory { RecordingId = "rec-park2" };
+            var phase = PhaseFactory.ClassifySegment(
+                seg, ordinal: 0, traj, instanceKey: 0, isReaimedMember: true, reaimAncestorBody: "Sun");
+
+            Assert.IsType<DepartureLoiterPhase>(phase);
+            Assert.Equal(SegmentProvenance.Synthesized, phase.Provenance);
+        }
+
+        // ---- BG-on-rails: no env-class sections -> all-orbital chain, tolerated (no assert) ----
+
+        [Fact]
+        public void BgOnRails_NoTrackSections_AllOrbitalChain_NoSurfaceOrDescent()
+        {
+            // A BG on-rails recording emits orbit-bridge OrbitSegments and NO env-classified TrackSections.
+            // The factory must build an all-orbital (conic) chain with NO Descent/Surface phase and must
+            // NOT assert on the absent SegmentPhase data (design §11.3).
+            var traj = new MockTrajectory
+            {
+                RecordingId = "rec-bg",
+                Points = new List<TrajectoryPoint>(),       // no per-frame points
+                TrackSections = new List<TrackSection>(),   // BG on-rails: no env-class sections
+                OrbitSegments = new List<OrbitSegment>
+                {
+                    new OrbitSegment { startUT = 10, endUT = 1000, bodyName = "Kerbin", semiMajorAxis = 800000, eccentricity = 0.6 },
+                    new OrbitSegment { startUT = 1000, endUT = 5000, bodyName = "Sun", semiMajorAxis = 1.3e10, eccentricity = 0.1 },
+                },
+            };
+            var chain = PhaseFactory.BuildPhaseChain(traj, 0, 0, 0, 6000);
+
+            Assert.Equal(2, chain.PhaseCount);
+            Assert.All(chain.Phases, p => Assert.Equal(Treatment.StockConic, p.ResolveTreatment()));
+            Assert.DoesNotContain(chain.Phases, p => p.Kind == PhaseKind.Descent || p.Kind == PhaseKind.Surface);
+            // body-change conic-to-conic byte-parity (Kerbin -> Sun FlexibleSoi seam)
+            AssertByteParity(traj, 0, 6000);
+        }
+
+        // ---- single-recording empty Points ----
+
+        [Fact]
+        public void SingleRecording_EmptyPoints_ConicOnlyChain()
+        {
+            var traj = new MockTrajectory
+            {
+                RecordingId = "rec-empty",
+                Points = new List<TrajectoryPoint>(),
+                OrbitSegments = new List<OrbitSegment>
+                {
+                    new OrbitSegment { startUT = 10, endUT = 30, bodyName = "Kerbin", semiMajorAxis = 700000 },
+                },
+            };
+            var chain = PhaseFactory.BuildPhaseChain(traj, 0, 0, 0, 40);
+            Assert.Single(chain.Phases);
+            Assert.Equal(Treatment.StockConic, chain.Phases[0].ResolveTreatment());
+            AssertByteParity(traj, 0, 40);
+        }
+
+        [Fact]
+        public void SingleRecording_FullyEmpty_EmptyChain()
+        {
+            var traj = new MockTrajectory
+            {
+                RecordingId = "rec-none",
+                Points = new List<TrajectoryPoint>(),
+                OrbitSegments = new List<OrbitSegment>(),
+            };
+            var chain = PhaseFactory.BuildPhaseChain(traj, 0, 0, 0, 40);
+            Assert.Equal(0, chain.PhaseCount);
+            AssertByteParity(traj, 0, 40);
+        }
+
+        // ---- null trajectory ----
+
+        [Fact]
+        public void NullTrajectory_EmptyChain_ByteMatchesAssembler()
+        {
+            var chain = PhaseFactory.BuildPhaseChain(null, 0, 0, 0, 40);
+            Assert.Equal(0, chain.PhaseCount);
+            Assert.Null(chain.RecordingId);
+            // assembler also returns an empty chain for null traj
+            var assembler = ChainAssembler.Build(null, 0, 0, 0, 40);
+            Assert.True(GeometryParityComparator.Compare(chain, assembler).IsMatch);
+        }
+
+        // ---- chain-level fields propagate (window + faithful-fallback) ----
+
+        [Fact]
+        public void ChainLevelFields_PropagateFromAssembler()
+        {
+            var chain = PhaseFactory.BuildPhaseChain(FullChain(), 0, 0, 5, 35, faithfulFallback: true);
+            Assert.Equal(5, chain.WindowStartUt);
+            Assert.Equal(35, chain.WindowEndUt);
+            Assert.True(chain.IsFaithfulFallback);
+            Assert.Equal("rec-1", chain.RecordingId);
+        }
+
+        // ---- loud-assertion: parent-anchored child never handed a re-aimed override ----
+
+        [Fact]
+        public void ParentAnchoredChild_WithReaimedOverride_FallsBackToFaithful_LoudWarn()
+        {
+            // A controlled-decoupled child (ParentAnchorRecordingId != null) handed a re-aimed override
+            // must NOT be silently body-framed onto a generated arc - the factory strips the override and
+            // builds the faithful chain (the RenderSegment.cs:94-98 loud-assertion carry-forward).
+            var traj = new MockTrajectory
+            {
+                RecordingId = "rec-child",
+                ParentAnchorRecordingId = "rec-parent",
+                Points = new List<TrajectoryPoint>(),
+                OrbitSegments = new List<OrbitSegment>
+                {
+                    new OrbitSegment { startUT = 10, endUT = 30, bodyName = "Sun", semiMajorAxis = 9e9 },
+                },
+            };
+            var reaimed = new List<OrbitSegment>
+            {
+                new OrbitSegment { startUT = 10, endUT = 30, bodyName = "Sun", semiMajorAxis = 7e9, isPredicted = false },
+            };
+            var chain = PhaseFactory.BuildPhaseChain(
+                traj, 0, 0, 0, 40, orbitSegmentsOverride: reaimed, reaimAncestorBody: "Sun");
+
+            // The faithful (recorded) conic (sma 9e9) is used, NOT the re-aimed override (7e9).
+            var phase = Assert.Single(chain.Phases);
+            Assert.True(phase is ConicPhase || phase is DepartureLoiterPhase || phase is ArrivalLoiterPhase);
+            // The anchor is the parent-anchored-child frame, never a body-framed generated arc.
+            Assert.IsType<AnchorFrame.ParentAnchoredChild>(phase.Anchor);
+            // geometry uses the recorded conic
+            var conicPhase = (ConicPhase)phase;
+            Assert.Equal(9e9, conicPhase.Conic.semiMajorAxis);
+        }
+
+        [Fact]
+        public void FaithfulParentAnchoredChild_WithTracedLeg_ByteMatchesAssembler()
+        {
+            // The direct proof of the FrameBodyName round-trip fix: a FAITHFUL (no override) parent-anchored
+            // controlled-decoupled child (IsDebris=false, ParentAnchorRecordingId != null) with a TracedPath
+            // leg gets a ParentAnchoredChild anchor (NOT a BodyAnchor), so the traced phase has no BodyAnchor
+            // payload to resolve its frame body from. Before the fix, ProjectGeometry handed null as the
+            // SampleContext frame body and TracedPhase.ResolveFrameBodyName returned null while the assembler
+            // stamped the real recorded body ("Mun") -> a FrameBodyName false-fire. The geometry is genuinely
+            // identical (the assembler stamps FrameBodyName from the recorded point's body regardless of
+            // anchor), so the projection must reproduce it losslessly: this asserts byte-parity.
+            var traj = new MockTrajectory
+            {
+                RecordingId = "rec-faithful-child",
+                ParentAnchorRecordingId = "rec-parent",
+                IsDebris = false,
+                // A traced leg on Mun (the parent-anchored child near its parent) + a Mun conic.
+                Points = new List<TrajectoryPoint>
+                {
+                    Pt(0, "Mun"), Pt(2, "Mun"), Pt(4, "Mun"), Pt(6, "Mun"),
+                },
+                OrbitSegments = new List<OrbitSegment>
+                {
+                    new OrbitSegment { startUT = 10, endUT = 30, bodyName = "Mun", semiMajorAxis = 200000, eccentricity = 0 },
+                },
+                TrackSections = new List<TrackSection>
+                {
+                    Sec(0, 6, SegmentEnvironment.Atmospheric),
+                    Sec(10, 30, SegmentEnvironment.ExoBallistic),
+                },
+            };
+
+            // The traced leg projects with the real body name even though the anchor is ParentAnchoredChild.
+            var chain = PhaseFactory.BuildPhaseChain(traj, 3, 0, 0, 40);
+            var traced = Assert.Single(chain.Phases, p => p.ResolveTreatment() == Treatment.TracedPath);
+            Assert.IsType<AnchorFrame.ParentAnchoredChild>(traced.Anchor);
+            var projected = GeometryParityComparator.ProjectGeometry(chain);
+            Assert.Contains(projected, s => s.Treatment == Treatment.TracedPath && s.FrameBodyName == "Mun");
+
+            // The gate: factory geometry byte-matches the assembler (no FrameBodyName divergence).
+            AssertByteParity(traj, 0, 40);
+        }
+    }
+}

--- a/Source/Parsek.Tests/MapRenderTraceTests.cs
+++ b/Source/Parsek.Tests/MapRenderTraceTests.cs
@@ -784,6 +784,47 @@ namespace Parsek.Tests
             Assert.Empty(logLines);
         }
 
+        // ---- Phase 2: factory-parity Tier-C anomaly emit ----
+
+        [Fact]
+        public void EmitFactoryParity_Enabled_EmitsAnomalyWithReasonAndDivergingField()
+        {
+            MapRenderTrace.ForceEnabledForTesting = true;
+
+            MapRenderTrace.EmitFactoryParity(
+                "rec-factory", 1234.0, "diverging=Treatment seg=1 countMismatch=False");
+
+            Assert.Contains(logLines, l =>
+                l.Contains("[MapRenderTrace]")
+                && l.Contains("phase=Anomaly")
+                && l.Contains("reason=factory-parity")
+                && l.Contains("pid=rec-factory")
+                && l.Contains("recId=rec-factory")
+                && l.Contains("diverging=Treatment"));
+        }
+
+        [Fact]
+        public void EmitFactoryParity_Disabled_NoOp()
+        {
+            MapRenderTrace.ForceEnabledForTesting = false;
+            MapRenderTrace.EmitFactoryParity("rec-factory-off", 100.0, "diverging=EndUt seg=0");
+            Assert.Empty(logLines);
+        }
+
+        [Fact]
+        public void EmitFactoryParity_RateLimitedPerRecording()
+        {
+            MapRenderTrace.ForceEnabledForTesting = true;
+
+            // Two back-to-back emits for the SAME recording at the same clock: the second is rate-limited
+            // (one line only), proving the per-recording rate limit bounds a per-frame shadow loop.
+            MapRenderTrace.EmitFactoryParity("rec-rl", 100.0, "diverging=StartUt seg=0");
+            MapRenderTrace.EmitFactoryParity("rec-rl", 100.0, "diverging=StartUt seg=0");
+
+            int count = logLines.Count(l => l.Contains("reason=factory-parity") && l.Contains("pid=rec-rl"));
+            Assert.Equal(1, count);
+        }
+
         // ---- GAP-2: first-class Polyline-surface trace at the shared Driver's per-leg draw site ----
 
         [Fact]

--- a/Source/Parsek/InGameTests/PhaseFactoryShadowParityTest.cs
+++ b/Source/Parsek/InGameTests/PhaseFactoryShadowParityTest.cs
@@ -1,0 +1,255 @@
+using System.Collections.Generic;
+using System.Globalization;
+using Parsek.Display;
+using Parsek.MapRender;
+using UnityEngine;
+
+namespace Parsek.InGameTests
+{
+    // Phase 2 / migration §4 - the SHADOW-PARITY in-game gate: over a set of regression-representative
+    // recordings, the new PhaseFactory's emitted GEOMETRY must byte-match the live ChainAssembler's
+    // GhostRenderChain, so ZERO factory-parity anomalies fire. This is the Phase-2 gate to Phase 3.
+    //
+    // It runs the SAME shadow path the production hook runs (ShadowRenderDriver.GetOrBuildChain calls
+    // ChainAssembler.Build then, under MapRenderTrace.IsEnabled, builds the PhaseFactory chain + compares),
+    // but exercised directly over real Recording objects (which ARE IPlaybackTrajectory) with the
+    // FlightGlobals-backed body-surface provider, so the below-surface descent split and the body radii
+    // are the REAL ones (not a synthetic null surface as in the headless unit tests). For each scenario it
+    // asserts GeometryParityComparator.Compare matches AND (with the tracer forced on, sink captured) that
+    // no reason=factory-parity line was emitted - the same emit decision the production hook makes.
+    //
+    // NOTE: in-game test (Ctrl+Shift+T / Settings > Diagnostics). Career-independent; FLIGHT scene (needs
+    // FlightGlobals.Bodies for the surface provider). Restores the committed store + tracer flag in finally.
+    public class PhaseFactoryShadowParityTest
+    {
+        private const string Kerbin = "Kerbin";
+        private const string Mun = "Mun";
+        private const string Sun = "Sun";
+
+        [InGameTest(Category = "GhostMap", Scene = GameScenes.FLIGHT,
+            Description = "Phase 2 shadow-parity: the PhaseFactory's emitted geometry byte-matches the "
+                + "ChainAssembler over the regression scenarios (zero factory-parity anomalies) - the gate "
+                + "to Phase 3")]
+        public void ShadowParity_RegressionScenarios_ZeroFactoryParityAnomalies()
+        {
+            CelestialBody kerbin = FlightGlobals.Bodies?.Find(b => b.bodyName == Kerbin);
+            if (kerbin == null)
+            {
+                InGameAssert.Skip("Kerbin not found in FlightGlobals.Bodies (non-stock pack)");
+                return;
+            }
+
+            // Real FlightGlobals-backed body radius provider (mirrors GhostMapSceneBase.ResolveBodySurface).
+            GhostTrajectoryPolylineRenderer.BodySurfaceProvider surface =
+                (string bodyName, out GhostTrajectoryPolylineRenderer.BodySurfaceInfo info) =>
+                {
+                    info = default(GhostTrajectoryPolylineRenderer.BodySurfaceInfo);
+                    if (string.IsNullOrEmpty(bodyName))
+                        return false;
+                    CelestialBody b = FlightGlobals.GetBodyByName(bodyName);
+                    if (b == null)
+                        return false;
+                    info = new GhostTrajectoryPolylineRenderer.BodySurfaceInfo { radius = b.Radius };
+                    return true;
+                };
+
+            double kerbinR = kerbin.Radius;
+            var scenarios = BuildScenarios(kerbinR);
+
+            bool prevForceEnabled = MapRenderTrace.ForceEnabledForTesting;
+            System.Action<string> prevSink = ParsekLog.TestSinkForTesting;
+            bool prevSuppress = ParsekLog.SuppressLogging;
+            var captured = new List<string>();
+
+            try
+            {
+                MapRenderTrace.ForceEnabledForTesting = true;
+                ParsekLog.SuppressLogging = false;
+                ParsekLog.TestSinkForTesting = line => captured.Add(line);
+
+                for (int i = 0; i < scenarios.Count; i++)
+                {
+                    Scenario sc = scenarios[i];
+
+                    GhostRenderChain assembler = ChainAssembler.Build(
+                        sc.Traj, committedIndex: i, instanceKey: 0, sc.WindowStart, sc.WindowEnd,
+                        faithfulFallback: false, surface: surface,
+                        orbitSegmentsOverride: sc.Override, reaimAncestorBody: sc.Ancestor);
+
+                    PhaseChain factory = PhaseFactory.BuildPhaseChain(
+                        sc.Traj, committedIndex: i, instanceKey: 0, sc.WindowStart, sc.WindowEnd,
+                        faithfulFallback: false, surface: surface,
+                        orbitSegmentsOverride: sc.Override, reaimAncestorBody: sc.Ancestor);
+
+                    GeometryParityComparator.ParityResult result =
+                        GeometryParityComparator.Compare(factory, assembler);
+
+                    ParsekLog.Info("TestRunner", string.Format(CultureInfo.InvariantCulture,
+                        "ShadowParity scenario={0} assemblerSegs={1} factoryPhases={2} match={3} {4}",
+                        sc.Name, assembler.SegmentCount, factory.PhaseCount, result.IsMatch,
+                        result.IsMatch ? string.Empty : result.ToString()));
+
+                    // Mirror the production hook's emit decision: a mismatch would fire factory-parity.
+                    if (!result.IsMatch)
+                        MapRenderTrace.EmitFactoryParity(
+                            sc.Traj.RecordingId, sc.WindowStart,
+                            string.Format(CultureInfo.InvariantCulture,
+                                "diverging={0} seg={1} countMismatch={2} {3}",
+                                result.DivergingField, result.SegmentIndex, result.CountMismatch,
+                                result.Detail ?? string.Empty));
+
+                    InGameAssert.IsTrue(result.IsMatch,
+                        "Scenario '" + sc.Name + "' geometry diverged: " + result);
+                }
+
+                // The end-to-end gate: NO factory-parity anomaly fired across the regression set.
+                foreach (string line in captured)
+                    InGameAssert.IsFalse(
+                        line.Contains("reason=" + MapRenderTrace.AnomalyFactoryParity),
+                        "Phase-2 shadow gate: a factory-parity anomaly fired; saw: " + line);
+            }
+            finally
+            {
+                MapRenderTrace.ForceEnabledForTesting = prevForceEnabled;
+                ParsekLog.TestSinkForTesting = prevSink;
+                ParsekLog.SuppressLogging = prevSuppress;
+            }
+        }
+
+        private struct Scenario
+        {
+            public string Name;
+            public Recording Traj;
+            public double WindowStart;
+            public double WindowEnd;
+            public IReadOnlyList<OrbitSegment> Override;
+            public string Ancestor;
+        }
+
+        private static List<Scenario> BuildScenarios(double kerbinR)
+        {
+            var list = new List<Scenario>();
+
+            // (1) Faithful ascent -> Kerbin parking orbit -> Mun arrival (the canonical full chain).
+            {
+                var rec = NewRec("shadow-fullchain");
+                AddPoints(rec, Kerbin, 0, 8, 5);   // ascent
+                AddPoints(rec, Mun, 320, 360, 3);  // arrival traced
+                rec.OrbitSegments.Add(Orbit(Kerbin, 10, 300, kerbinR + 100000, 0.0));
+                rec.TrackSections.Add(Sec(0, 8, SegmentEnvironment.Atmospheric));
+                rec.TrackSections.Add(Sec(10, 300, SegmentEnvironment.ExoBallistic));
+                rec.TrackSections.Add(Sec(320, 360, SegmentEnvironment.Approach));
+                list.Add(new Scenario { Name = "faithful-full-chain", Traj = rec, WindowStart = 0, WindowEnd = 400 });
+            }
+
+            // (2) Below-atmosphere descent: an orbit whose periapsis dips below Kerbin's surface must fall
+            // to TracedPath (FIX #27) - exercises the real body radius in the cover predicate.
+            {
+                var rec = NewRec("shadow-descent");
+                AddPoints(rec, Kerbin, 12, 28, 5);
+                rec.OrbitSegments.Add(Orbit(Kerbin, 10, 30, kerbinR - 100000, 0.0)); // peri below surface
+                rec.TrackSections.Add(Sec(12, 28, SegmentEnvironment.Atmospheric));
+                list.Add(new Scenario { Name = "below-surface-descent", Traj = rec, WindowStart = 0, WindowEnd = 40 });
+            }
+
+            // (3) BG on-rails: orbit-bridge OrbitSegments, NO env-class TrackSections, NO points. A
+            // Kerbin->Sun body change must produce an all-orbital chain (FlexibleSoi seam, no descent).
+            {
+                var rec = NewRec("shadow-bg-onrails");
+                rec.OrbitSegments.Add(Orbit(Kerbin, 10, 1000, kerbinR + 200000, 0.6));
+                rec.OrbitSegments.Add(Orbit(Sun, 1000, 5000, 13_000_000_000.0, 0.1));
+                list.Add(new Scenario { Name = "bg-on-rails-all-orbital", Traj = rec, WindowStart = 0, WindowEnd = 6000 });
+            }
+
+            // (4) Single-recording empty Points: conic-only chain.
+            {
+                var rec = NewRec("shadow-conic-only");
+                rec.OrbitSegments.Add(Orbit(Kerbin, 10, 300, kerbinR + 80000, 0.0));
+                list.Add(new Scenario { Name = "single-recording-conic-only", Traj = rec, WindowStart = 0, WindowEnd = 400 });
+            }
+
+            // (5) Re-aimed member: a recorded Sun heliocentric leg replaced by a reference-distinct re-aimed
+            // override (different sma); the override conic must flow through both paths identically.
+            {
+                var rec = NewRec("shadow-reaim");
+                AddPoints(rec, Kerbin, 0, 6, 4);
+                AddPoints(rec, Mun, 320, 340, 3);
+                rec.OrbitSegments.Add(Orbit(Sun, 10, 300, 9_000_000_000.0, 0.2));
+                var over = new List<OrbitSegment>
+                {
+                    Orbit(Sun, 10, 300, 7_777_000_000.0, 0.5, isPredicted: false),
+                };
+                list.Add(new Scenario
+                {
+                    Name = "reaimed-heliocentric-leg",
+                    Traj = rec, WindowStart = 0, WindowEnd = 400, Override = over, Ancestor = Sun,
+                });
+            }
+
+            // (6) Fully empty recording: empty chain on both sides.
+            {
+                var rec = NewRec("shadow-empty");
+                list.Add(new Scenario { Name = "fully-empty", Traj = rec, WindowStart = 0, WindowEnd = 40 });
+            }
+
+            // (7) Faithful parent-anchored controlled-decoupled CHILD (IsDebris=false,
+            // ParentAnchorRecordingId set) with a TracedPath leg near the parent + a conic. The child gets a
+            // ParentAnchoredChild anchor (NOT a BodyAnchor), so the traced leg has no BodyAnchor payload to
+            // resolve its frame body from; the factory must reproduce the assembler-stamped GEOMETRY body
+            // name losslessly anyway (the FrameBodyName round-trip fix), or factory-parity FALSE-fires on a
+            // correct factory. Regression-set member for the zero-factory-parity gate (it would have caught
+            // the bug); the headless byte-parity proof is PhaseFactoryTests.
+            {
+                var rec = NewRec("shadow-faithful-child");
+                rec.IsDebris = false;
+                rec.ParentAnchorRecordingId = "shadow-parent-anchor";
+                AddPoints(rec, Mun, 0, 6, 4);                 // traced leg near the parent (Mun)
+                rec.OrbitSegments.Add(Orbit(Mun, 10, 30, 250000.0, 0.0));
+                rec.TrackSections.Add(Sec(0, 6, SegmentEnvironment.Atmospheric));
+                rec.TrackSections.Add(Sec(10, 30, SegmentEnvironment.ExoBallistic));
+                list.Add(new Scenario { Name = "faithful-parent-anchored-child", Traj = rec, WindowStart = 0, WindowEnd = 40 });
+            }
+
+            return list;
+        }
+
+        private static Recording NewRec(string label)
+            => new Recording
+            {
+                RecordingId = label + "-" + System.Guid.NewGuid().ToString("N"),
+                VesselName = "Parsek " + label,
+                PlaybackEnabled = true,
+            };
+
+        private static void AddPoints(Recording rec, string body, double startUT, double endUT, int n)
+        {
+            if (n < 2) n = 2;
+            for (int i = 0; i < n; i++)
+            {
+                double t = startUT + (endUT - startUT) * i / (n - 1);
+                rec.Points.Add(new TrajectoryPoint
+                {
+                    ut = t,
+                    latitude = 0.0,
+                    longitude = i,
+                    altitude = 1000.0,
+                    rotation = Quaternion.identity,
+                    velocity = Vector3.zero,
+                    bodyName = body,
+                });
+            }
+        }
+
+        private static OrbitSegment Orbit(string body, double s, double e, double sma, double ecc,
+            bool isPredicted = false)
+            => new OrbitSegment
+            {
+                startUT = s, endUT = e, bodyName = body,
+                semiMajorAxis = sma, eccentricity = ecc, epoch = s, isPredicted = isPredicted,
+                orbitalFrameRotation = Quaternion.identity, angularVelocity = Vector3.zero,
+            };
+
+        private static TrackSection Sec(double s, double e, SegmentEnvironment env)
+            => new TrackSection { startUT = s, endUT = e, environment = env };
+    }
+}

--- a/Source/Parsek/MapRender/GeometryParityComparator.cs
+++ b/Source/Parsek/MapRender/GeometryParityComparator.cs
@@ -1,0 +1,227 @@
+using System.Collections.Generic;
+using System.Globalization;
+
+namespace Parsek.MapRender
+{
+    /// <summary>
+    /// Phase 2 (migration plan §4): a PURE, unit-testable byte-parity comparator over the GEOMETRY
+    /// fields of a <see cref="PhaseFactory"/>-built <see cref="PhaseChain"/> against the
+    /// <see cref="ChainAssembler"/>-built <see cref="GhostRenderChain"/>.
+    ///
+    /// <para><b>Parity scope (exactly the geometry, nothing else).</b> Per-segment the comparator checks
+    /// <c>Treatment</c>, <c>StartUt</c>, <c>EndUt</c>, <c>FrameBodyName</c>, and the conic-element payload
+    /// (<c>HasConic</c> + the Kepler elements when present); chain-level it checks <c>WindowStartUt</c>,
+    /// <c>WindowEndUt</c>, and <c>IsFaithfulFallback</c> (<c>GhostRenderChain.cs:24-27</c> — they drive
+    /// coverage/clip and matter for the trimmed-window route case). <see cref="PhaseKind"/> /
+    /// <see cref="SegmentProvenance"/> (and the legacy cosmetic <c>SegmentKind</c> / <c>IsGenerated</c>)
+    /// are DELIBERATELY NOT in the parity set — they are validated by the Phase-1 unit tests, not this
+    /// gate (design §6 / plan §4).</para>
+    ///
+    /// <para>The factory's geometry is obtained by projecting each phase through
+    /// <see cref="TrajectoryPhase.Emit"/> (a phase with no geometry — <see cref="HoldPhase"/> — yields
+    /// nothing, mirroring the assembler which never emits a hold segment). A COUNT mismatch is recorded
+    /// for diagnostics but the per-field geometry diff is the GATE: <see cref="Compare"/> returns the
+    /// first diverging field (or <see cref="ParityResult.Match"/>). All float compares use an exact
+    /// ordinal/bitwise match (byte-parity, not a tolerance) because the geometry is carried through the
+    /// factory unchanged from the same assembler call.</para>
+    /// </summary>
+    internal static class GeometryParityComparator
+    {
+        /// <summary>The outcome of a geometry parity compare: either a match or the first divergence.</summary>
+        internal readonly struct ParityResult
+        {
+            /// <summary>True iff every checked geometry field matched.</summary>
+            internal bool IsMatch { get; }
+            /// <summary>The diverging field token (grep-stable), or null on a match.</summary>
+            internal string DivergingField { get; }
+            /// <summary>The segment ordinal the divergence was found at, or -1 for a chain-level field.</summary>
+            internal int SegmentIndex { get; }
+            /// <summary>A human-readable "expected vs actual" detail, or null on a match.</summary>
+            internal string Detail { get; }
+            /// <summary>True when the factory's emitted geometry-segment COUNT differed from the assembler's
+            /// (recorded for diagnostics; a count mismatch always also yields a diverging field).</summary>
+            internal bool CountMismatch { get; }
+
+            private ParityResult(bool isMatch, string field, int segIndex, string detail, bool countMismatch)
+            {
+                IsMatch = isMatch;
+                DivergingField = field;
+                SegmentIndex = segIndex;
+                Detail = detail;
+                CountMismatch = countMismatch;
+            }
+
+            internal static ParityResult Match => new ParityResult(true, null, -1, null, false);
+
+            internal static ParityResult Diverge(string field, int segIndex, string detail, bool countMismatch = false)
+                => new ParityResult(false, field, segIndex, detail, countMismatch);
+
+            public override string ToString()
+                => IsMatch
+                    ? "match"
+                    : string.Format(CultureInfo.InvariantCulture,
+                        "field={0} seg={1} countMismatch={2} {3}",
+                        DivergingField, SegmentIndex, CountMismatch, Detail ?? string.Empty);
+        }
+
+        /// <summary>
+        /// Compare the factory's <paramref name="factoryChain"/> against the assembler's
+        /// <paramref name="assemblerChain"/> on the geometry fields only. Returns
+        /// <see cref="ParityResult.Match"/> when every field matches, or the first divergence.
+        /// </summary>
+        internal static ParityResult Compare(PhaseChain factoryChain, GhostRenderChain assemblerChain)
+        {
+            // Two nulls are vacuously equal; one null is a divergence.
+            if (factoryChain == null && assemblerChain == null)
+                return ParityResult.Match;
+            if (factoryChain == null)
+                return ParityResult.Diverge("chain-null", -1, "factory chain null, assembler non-null");
+            if (assemblerChain == null)
+                return ParityResult.Diverge("chain-null", -1, "assembler chain null, factory non-null");
+
+            // Chain-level geometry fields (drive coverage/clip; the trimmed-window route case).
+            if (!BitEquals(factoryChain.WindowStartUt, assemblerChain.WindowStartUT))
+                return ParityResult.Diverge("WindowStartUt", -1,
+                    Fmt(factoryChain.WindowStartUt, assemblerChain.WindowStartUT));
+            if (!BitEquals(factoryChain.WindowEndUt, assemblerChain.WindowEndUT))
+                return ParityResult.Diverge("WindowEndUt", -1,
+                    Fmt(factoryChain.WindowEndUt, assemblerChain.WindowEndUT));
+            if (factoryChain.IsFaithfulFallback != assemblerChain.IsFaithfulFallback)
+                return ParityResult.Diverge("IsFaithfulFallback", -1,
+                    Fmt(factoryChain.IsFaithfulFallback, assemblerChain.IsFaithfulFallback));
+
+            // Project the factory's phases to the geometry segments they emit (UT-ordered, mirroring the
+            // assembler's ordering). A HoldPhase yields nothing — the assembler never emits a hold, so the
+            // projected list still aligns 1:1 with the assembler's segments.
+            List<RenderSegment> factorySegs = ProjectGeometry(factoryChain);
+            IReadOnlyList<RenderSegment> assemblerSegs = assemblerChain.Segments;
+
+            bool countMismatch = factorySegs.Count != assemblerSegs.Count;
+
+            int n = factorySegs.Count < assemblerSegs.Count ? factorySegs.Count : assemblerSegs.Count;
+            for (int i = 0; i < n; i++)
+            {
+                ParityResult seg = CompareSegment(factorySegs[i], assemblerSegs[i], i, countMismatch);
+                if (!seg.IsMatch)
+                    return seg;
+            }
+
+            // If we got here the overlapping segments matched; a count difference is still a divergence.
+            if (countMismatch)
+                return ParityResult.Diverge("segment-count", -1,
+                    Fmt(factorySegs.Count, assemblerSegs.Count), countMismatch: true);
+
+            return ParityResult.Match;
+        }
+
+        /// <summary>
+        /// Project a <see cref="PhaseChain"/> into the geometry <see cref="RenderSegment"/>s its phases
+        /// emit, UT-ordered. The <see cref="SampleContext"/> carries the phase's resolved frame body so a
+        /// conic phase resolves its frame name the same way the assembler did. Pure (no Unity reads).
+        /// </summary>
+        internal static List<RenderSegment> ProjectGeometry(PhaseChain chain)
+        {
+            var outSegs = new List<RenderSegment>(chain?.PhaseCount ?? 0);
+            if (chain == null)
+                return outSegs;
+            for (int i = 0; i < chain.PhaseCount; i++)
+            {
+                TrajectoryPhase phase = chain.Phases[i];
+                if (phase == null)
+                    continue;
+                // The phase's anchor body is the frame the assembler stamped on the segment; pass it as the
+                // SampleContext fallback so a conic phase whose anchor/conic body is empty still resolves.
+                string frameBody = (phase.Anchor is AnchorFrame.BodyAnchor body) ? body.BodyName : null;
+                var ctx = new SampleContext(phase.StartUt, frameBody);
+                foreach (RenderSegment seg in phase.Emit(ctx))
+                    outSegs.Add(seg);
+            }
+            return outSegs;
+        }
+
+        private static ParityResult CompareSegment(
+            RenderSegment factory, RenderSegment assembler, int index, bool countMismatch)
+        {
+            if (factory.Treatment != assembler.Treatment)
+                return ParityResult.Diverge("Treatment", index,
+                    Fmt(factory.Treatment, assembler.Treatment), countMismatch);
+
+            if (!BitEquals(factory.StartUT, assembler.StartUT))
+                return ParityResult.Diverge("StartUt", index,
+                    Fmt(factory.StartUT, assembler.StartUT), countMismatch);
+
+            if (!BitEquals(factory.EndUT, assembler.EndUT))
+                return ParityResult.Diverge("EndUt", index,
+                    Fmt(factory.EndUT, assembler.EndUT), countMismatch);
+
+            if (!string.Equals(factory.FrameBodyName, assembler.FrameBodyName, System.StringComparison.Ordinal))
+                return ParityResult.Diverge("FrameBodyName", index,
+                    Fmt(factory.FrameBodyName ?? "(null)", assembler.FrameBodyName ?? "(null)"), countMismatch);
+
+            // Conic-element payload: HasConic must match, and when present every Kepler element.
+            if (factory.Payload.HasConic != assembler.Payload.HasConic)
+                return ParityResult.Diverge("HasConic", index,
+                    Fmt(factory.Payload.HasConic, assembler.Payload.HasConic), countMismatch);
+
+            if (factory.Payload.HasConic)
+            {
+                ParityResult conic = CompareConic(
+                    factory.Payload.Conic, assembler.Payload.Conic, index, countMismatch);
+                if (!conic.IsMatch)
+                    return conic;
+            }
+
+            return ParityResult.Match;
+        }
+
+        private static ParityResult CompareConic(
+            OrbitSegment factory, OrbitSegment assembler, int index, bool countMismatch)
+        {
+            if (!BitEquals(factory.startUT, assembler.startUT))
+                return ParityResult.Diverge("conic.startUT", index, Fmt(factory.startUT, assembler.startUT), countMismatch);
+            if (!BitEquals(factory.endUT, assembler.endUT))
+                return ParityResult.Diverge("conic.endUT", index, Fmt(factory.endUT, assembler.endUT), countMismatch);
+            if (!BitEquals(factory.inclination, assembler.inclination))
+                return ParityResult.Diverge("conic.inclination", index, Fmt(factory.inclination, assembler.inclination), countMismatch);
+            if (!BitEquals(factory.eccentricity, assembler.eccentricity))
+                return ParityResult.Diverge("conic.eccentricity", index, Fmt(factory.eccentricity, assembler.eccentricity), countMismatch);
+            if (!BitEquals(factory.semiMajorAxis, assembler.semiMajorAxis))
+                return ParityResult.Diverge("conic.semiMajorAxis", index, Fmt(factory.semiMajorAxis, assembler.semiMajorAxis), countMismatch);
+            if (!BitEquals(factory.longitudeOfAscendingNode, assembler.longitudeOfAscendingNode))
+                return ParityResult.Diverge("conic.longitudeOfAscendingNode", index, Fmt(factory.longitudeOfAscendingNode, assembler.longitudeOfAscendingNode), countMismatch);
+            if (!BitEquals(factory.argumentOfPeriapsis, assembler.argumentOfPeriapsis))
+                return ParityResult.Diverge("conic.argumentOfPeriapsis", index, Fmt(factory.argumentOfPeriapsis, assembler.argumentOfPeriapsis), countMismatch);
+            if (!BitEquals(factory.meanAnomalyAtEpoch, assembler.meanAnomalyAtEpoch))
+                return ParityResult.Diverge("conic.meanAnomalyAtEpoch", index, Fmt(factory.meanAnomalyAtEpoch, assembler.meanAnomalyAtEpoch), countMismatch);
+            if (!BitEquals(factory.epoch, assembler.epoch))
+                return ParityResult.Diverge("conic.epoch", index, Fmt(factory.epoch, assembler.epoch), countMismatch);
+            if (!string.Equals(factory.bodyName, assembler.bodyName, System.StringComparison.Ordinal))
+                return ParityResult.Diverge("conic.bodyName", index, Fmt(factory.bodyName ?? "(null)", assembler.bodyName ?? "(null)"), countMismatch);
+            // isPredicted is part of the recorded conic shape (it gates below-surface trimming), so it is a
+            // geometry-relevant payload field; keep it in the byte-parity set.
+            if (factory.isPredicted != assembler.isPredicted)
+                return ParityResult.Diverge("conic.isPredicted", index, Fmt(factory.isPredicted, assembler.isPredicted), countMismatch);
+            return ParityResult.Match;
+        }
+
+        // Exact bitwise double compare (byte-parity, not tolerance). NaN == NaN here (a recorded NaN
+        // element must round-trip as NaN), unlike the IEEE == operator.
+        private static bool BitEquals(double a, double b)
+            => System.BitConverter.DoubleToInt64Bits(a) == System.BitConverter.DoubleToInt64Bits(b);
+
+        private static string Fmt(double factory, double assembler)
+            => string.Format(CultureInfo.InvariantCulture, "factory={0:R} assembler={1:R}", factory, assembler);
+
+        private static string Fmt(int factory, int assembler)
+            => string.Format(CultureInfo.InvariantCulture, "factory={0} assembler={1}", factory, assembler);
+
+        private static string Fmt(bool factory, bool assembler)
+            => string.Format(CultureInfo.InvariantCulture, "factory={0} assembler={1}", factory, assembler);
+
+        private static string Fmt(string factory, string assembler)
+            => string.Format(CultureInfo.InvariantCulture, "factory={0} assembler={1}", factory, assembler);
+
+        private static string Fmt(Treatment factory, Treatment assembler)
+            => string.Format(CultureInfo.InvariantCulture, "factory={0} assembler={1}", factory, assembler);
+    }
+}

--- a/Source/Parsek/MapRender/PhaseFactory.cs
+++ b/Source/Parsek/MapRender/PhaseFactory.cs
@@ -1,0 +1,336 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using Parsek.Display;
+
+namespace Parsek.MapRender
+{
+    /// <summary>
+    /// Phase 2 (design §6 / migration plan §4): builds a <see cref="PhaseChain"/>
+    /// (<c>TrajectoryPhase[]</c>) from the SAME inputs <see cref="ChainAssembler.Build"/> consumes, and
+    /// runs in SHADOW behind the <c>mapRenderTracing</c> setting. It does NOT drive any draw — a gated
+    /// comparator (<see cref="GeometryParityComparator"/>) asserts byte-parity of the GEOMETRY fields
+    /// against the assembler's <see cref="GhostRenderChain"/>, emitting the <c>factory-parity</c>
+    /// Tier-C anomaly on a mismatch.
+    ///
+    /// <para><b>Geometry source.</b> The geometry fields (<c>Treatment</c>, <c>StartUt</c>, <c>EndUt</c>,
+    /// <c>FrameBodyName</c>, conic payload, and the chain-level window + faithful-fallback) are produced
+    /// by reusing the assembler's canonical geometry decision: the factory calls
+    /// <see cref="ChainAssembler.Build"/> to obtain the ordered <see cref="RenderSegment"/>s, then wraps
+    /// each one in a typed <see cref="TrajectoryPhase"/>. This guarantees geometry parity BY CONSTRUCTION
+    /// (the factory never re-derives the orbit-vs-traced split — the one place the design wants that
+    /// decision is the assembler). The NEW, independent work the factory adds is the CLASSIFICATION:
+    /// which phase subclass / <see cref="PhaseKind"/> / <see cref="SegmentProvenance"/> /
+    /// <see cref="AnchorFrame"/> each segment becomes. Those are NOT in the parity set (validated by the
+    /// Phase-1 unit tests), so a wrong classification never silently corrupts geometry — and the
+    /// comparator still gates the SHADOW hook because it proves the typed phases project (via
+    /// <see cref="TrajectoryPhase.Emit"/>) losslessly back to the assembler's geometry. When Phase 3
+    /// swaps the spine to consume phases, the factory becomes the geometry SOURCE and this comparator is
+    /// the regression gate.</para>
+    ///
+    /// <para><b>Faithful vs re-aimed identity split (design §6 / §7).</b> The classification of leaf
+    /// identity differs by member:
+    /// <list type="bullet">
+    ///   <item>FAITHFUL members: leaf phase identity comes from
+    ///     <see cref="SegmentPhaseClassifier.EnvironmentToPhase"/> +
+    ///     <see cref="RecordingOptimizer.SplitEnvironmentClass"/> (read off the recorded
+    ///     <see cref="TrackSection"/>s), NOT the re-aim plan.</item>
+    ///   <item>RE-AIMED members (a non-null <paramref name="orbitSegmentsOverride"/> that differs from the
+    ///     recorded list, mirroring <c>ShadowRenderDriver.GetOrBuildChain</c>'s reference-inequality
+    ///     signal): the heliocentric transfer leg is <see cref="SegmentProvenance.Synthesized"/> from the
+    ///     <see cref="Parsek.Reaim.ReaimMissionPlan"/>; the heliocentric-park variant becomes a
+    ///     synthesized <see cref="DepartureLoiterPhase"/>.</item>
+    /// </list></para>
+    ///
+    /// <para><b>Edge cases the factory tolerates (design §11.3):</b> a BG-on-rails member emits no
+    /// env-classified <see cref="TrackSection"/>s, so the faithful path falls through to an all-orbital
+    /// chain (Loiter/Transfer conics + FlexibleSoi at body changes) with NO Descent/Surface phase, never
+    /// asserting on absent <c>SegmentPhase</c> data; a single-recording empty-<c>Points</c> trajectory
+    /// produces a conic-only chain; a null trajectory produces an empty chain.</para>
+    /// </summary>
+    internal static class PhaseFactory
+    {
+        /// <summary>
+        /// Build the typed <see cref="PhaseChain"/> for one committed member + cycle instance from the
+        /// same inputs as <see cref="ChainAssembler.Build"/>. <paramref name="orbitSegmentsOverride"/>
+        /// non-null + reference-distinct from <c>traj.OrbitSegments</c> marks the member RE-AIMED (the
+        /// heliocentric transfer leg is synthesized); null keeps the FAITHFUL classification.
+        /// </summary>
+        internal static PhaseChain BuildPhaseChain(
+            IPlaybackTrajectory traj,
+            int committedIndex,
+            int instanceKey,
+            double windowStartUT,
+            double windowEndUT,
+            bool faithfulFallback = false,
+            GhostTrajectoryPolylineRenderer.BodySurfaceProvider surface = null,
+            IReadOnlyList<OrbitSegment> orbitSegmentsOverride = null,
+            string reaimAncestorBody = null)
+        {
+            if (traj == null)
+            {
+                return new PhaseChain(
+                    null, committedIndex, instanceKey, Array.Empty<TrajectoryPhase>(),
+                    windowStartUT, windowEndUT, faithfulFallback);
+            }
+
+            // Loud-assertion carry-forward (RenderSegment.cs:94-98 / AnchorFrame.cs): a parent-anchored
+            // child is NEVER handed a re-aimed/generated segment list. Keep that failure loud rather than
+            // silently body-framing it, so the §11.3 transfer-leg-debris fail-closed (Phase 7) degrades
+            // loudly. The factory/PlaybackResolver already skips IsDebris (it never reaches here), but a
+            // controlled-decoupled child (IsDebris=false, ParentAnchorRecordingId!=null) DOES render, so
+            // guard it explicitly.
+            bool isReaimedMember =
+                orbitSegmentsOverride != null
+                && !ReferenceEquals(orbitSegmentsOverride, traj.OrbitSegments);
+            if (isReaimedMember && !string.IsNullOrEmpty(traj.ParentAnchorRecordingId))
+            {
+                ParsekLog.Warn("MapRender", string.Format(CultureInfo.InvariantCulture,
+                    "PhaseFactory: parent-anchored child rec={0} handed a re-aimed segment override " +
+                    "(parent={1}) — refusing to body-frame a generated arc (design §6 loud-assertion); " +
+                    "building faithful chain instead",
+                    traj.RecordingId ?? "?", traj.ParentAnchorRecordingId));
+                isReaimedMember = false;
+                orbitSegmentsOverride = null;
+                reaimAncestorBody = null;
+            }
+
+            // GEOMETRY SOURCE: reuse the assembler's canonical orbit-vs-traced decision verbatim. This is
+            // the one place the orbit/traced split lives; the factory never re-derives it (byte-parity by
+            // construction). The classification below is the NEW, independent layer.
+            GhostRenderChain geometry = ChainAssembler.Build(
+                traj, committedIndex, instanceKey, windowStartUT, windowEndUT,
+                faithfulFallback, surface, orbitSegmentsOverride, reaimAncestorBody);
+
+            // Resolve the faithful env-class phase tokens once (per body run) so the leaf identity of a
+            // FAITHFUL traced/conic segment comes from EnvironmentToPhase + SplitEnvironmentClass, not the
+            // re-aim plan. BG-on-rails: TrackSections carry no env-class runs, so this resolves empty and
+            // every traced/conic segment falls to its geometry-default kind WITHOUT asserting.
+            var phases = new List<TrajectoryPhase>(geometry.SegmentCount);
+            for (int i = 0; i < geometry.SegmentCount; i++)
+            {
+                RenderSegment seg = geometry.Segments[i];
+                phases.Add(ClassifySegment(
+                    seg, i, traj, instanceKey, isReaimedMember, reaimAncestorBody));
+            }
+
+            ParsekLog.Verbose("MapRender", string.Format(CultureInfo.InvariantCulture,
+                "factory chain rec={0} idx={1} inst={2} phases={3} reaimed={4} window=[{5:F1},{6:F1}] faithfulFallback={7}",
+                traj.RecordingId ?? "?", committedIndex, instanceKey, phases.Count, isReaimedMember,
+                windowStartUT, windowEndUT, faithfulFallback));
+
+            return new PhaseChain(
+                traj.RecordingId, committedIndex, instanceKey, phases,
+                geometry.WindowStartUT, geometry.WindowEndUT, geometry.IsFaithfulFallback);
+        }
+
+        /// <summary>
+        /// Classify ONE geometry <see cref="RenderSegment"/> into a typed <see cref="TrajectoryPhase"/>.
+        /// The geometry fields (treatment / UTs / body / conic) are carried through unchanged so the
+        /// phase's <see cref="TrajectoryPhase.Emit"/> projects back to the same geometry. The NEW work is
+        /// the kind / provenance / anchor choice (NOT in the parity set).
+        ///
+        /// <para>Pure given the segment + classification flags (no Unity / scene reads), so it is unit
+        /// testable. The <paramref name="reaimAncestorBody"/> is the re-aim plan's common-ancestor (star)
+        /// body used to mark the synthesized heliocentric transfer.</para>
+        /// </summary>
+        internal static TrajectoryPhase ClassifySegment(
+            RenderSegment seg,
+            int ordinal,
+            IPlaybackTrajectory traj,
+            int instanceKey,
+            bool isReaimedMember,
+            string reaimAncestorBody)
+        {
+            var id = new PhaseId(traj?.RecordingId, instanceKey, ordinal);
+            var anchor = ResolveAnchorFrame(seg, traj);
+            SegmentProvenance provenance = ResolveProvenance(seg, isReaimedMember, reaimAncestorBody);
+
+            // NOTE: every phase below is built with default (null) leading/trailing PhaseSeams. Seams are
+            // DELIBERATELY OUTSIDE the Phase-2 byte-parity field set (GeometryParityComparator checks
+            // Treatment / UTs / FrameBodyName / conic payload, NOT seams); a null PhaseSeam projects to
+            // SeamKind.None via Emit, which does not match the assembler's Rigid/FlexibleSoi seam stamping,
+            // but that is intentional. Seam reproduction is a Phase-3 concern (the spine consumes phases and
+            // re-derives seams there), not a Phase-2 regression.
+
+            if (seg.Treatment == Treatment.TracedPath)
+            {
+                // Faithful leaf identity from env-class: a SURFACE run is a SurfacePhase, an ASCENT-shaped
+                // atmospheric run is an AscentPhase, a DESCENT-shaped one is a DescentPhase. The geometry
+                // carries no env token, so classify by the env-class phase of the segment's body run.
+                //
+                // Carry the assembler-stamped GEOMETRY body name (seg.FrameBodyName) onto the traced phase
+                // so Emit reproduces it losslessly for ANY anchor. A ParentAnchoredChild anchor has no
+                // BodyAnchor payload, so without this the traced leg's FrameBodyName would project as null
+                // (ctx fallback) while the assembler stamped the real recorded body -> factory-parity
+                // FALSE-fire on a correct factory. The body name is geometry, not the anchor.
+                PhaseKind tracedKind = ClassifyTracedKind(seg, traj);
+                switch (tracedKind)
+                {
+                    case PhaseKind.Surface:
+                        return new SurfacePhase(id, provenance, anchor, seg.StartUT, seg.EndUT, seg.FrameBodyName);
+                    case PhaseKind.Descent:
+                        return new DescentPhase(id, provenance, anchor, seg.StartUT, seg.EndUT, seg.FrameBodyName);
+                    default:
+                        return new AscentPhase(id, provenance, anchor, seg.StartUT, seg.EndUT, seg.FrameBodyName);
+                }
+            }
+
+            // StockConic: a generated transfer is the heliocentric transfer leg; a recorded conic is a
+            // departure or arrival loiter (the departure-vs-arrival split is NEW, from the conic's role).
+            OrbitSegment conic = seg.Payload.HasConic ? seg.Payload.Conic : default(OrbitSegment);
+            if (seg.IsGenerated)
+            {
+                return new HeliocentricTransferPhase(
+                    id, provenance, anchor, seg.StartUT, seg.EndUT, conic);
+            }
+
+            // Heliocentric-park variant: a re-aimed member whose conic is the common-ancestor (star) body
+            // but is NOT the generated transfer is the recorded park copy (LAN-re-phased upstream), a
+            // SYNTHESIZED DepartureLoiterPhase (design §6: s15).
+            if (isReaimedMember
+                && !string.IsNullOrEmpty(reaimAncestorBody)
+                && string.Equals(seg.FrameBodyName, reaimAncestorBody, StringComparison.Ordinal))
+            {
+                return new DepartureLoiterPhase(
+                    id, SegmentProvenance.Synthesized, anchor, seg.StartUT, seg.EndUT, conic);
+            }
+
+            // A recorded conic: departure loiter (before the transfer) vs arrival loiter (after). The
+            // geometry-only split uses the segment's body relative to the transfer ancestor: a conic on the
+            // re-aim ancestor frame is heliocentric; a conic on a non-launch body after a star-frame
+            // crossing is arrival. Without per-leg role data the v1 default is DepartureLoiter (the legacy
+            // SegmentKind.Loiter), matching the assembler's role-blind Loiter; arrival loiter is resolved
+            // when the env-class / transfer ordinal says so.
+            if (IsArrivalConic(seg, ordinal, traj))
+            {
+                return new ArrivalLoiterPhase(id, provenance, anchor, seg.StartUT, seg.EndUT, conic);
+            }
+            return new DepartureLoiterPhase(id, provenance, anchor, seg.StartUT, seg.EndUT, conic);
+        }
+
+        // Resolve the anchor frame for a segment. v1: a BodyAnchor on the frame body for ordinary
+        // members; a ParentAnchoredChild for a controlled-decoupled child (IsDebris=false,
+        // ParentAnchorRecordingId!=null). The re-aimed-override case never reaches here for a
+        // parent-anchored child (BuildPhaseChain strips it loudly above).
+        internal static AnchorFrame ResolveAnchorFrame(RenderSegment seg, IPlaybackTrajectory traj)
+        {
+            if (traj != null && !string.IsNullOrEmpty(traj.ParentAnchorRecordingId))
+                return new AnchorFrame.ParentAnchoredChild(traj.ParentAnchorRecordingId);
+            return new AnchorFrame.BodyAnchor(seg.FrameBodyName);
+        }
+
+        // Provenance: a generated transfer is Synthesized; a faithful-fallback chain's segments are
+        // FaithfulFallback; an isPredicted conic tail is FinalizedPredicted; everything else Recorded.
+        // (Provenance is NOT a parity field; it is validated by the Phase-1 unit tests.)
+        internal static SegmentProvenance ResolveProvenance(
+            RenderSegment seg, bool isReaimedMember, string reaimAncestorBody)
+        {
+            if (seg.IsGenerated)
+                return SegmentProvenance.Synthesized;
+            if (seg.Treatment == Treatment.StockConic && seg.Payload.HasConic && seg.Payload.Conic.isPredicted)
+                return SegmentProvenance.FinalizedPredicted;
+            return SegmentProvenance.Recorded;
+        }
+
+        // Classify a TracedPath segment's gameplay kind from the recorded env-class (design §6: faithful
+        // leaf identity is EnvironmentToPhase + SplitEnvironmentClass, NOT the re-aim plan). Reads the
+        // recorded TrackSections overlapping the segment window; a "surface" env => Surface, otherwise
+        // ascent-vs-descent by the segment's position relative to the recording's first conic (a traced
+        // run BEFORE the first orbit is ascent; one AFTER is descent). BG-on-rails has no env-class runs,
+        // so this returns the geometry default (Ascent) WITHOUT asserting — but BG-on-rails has no traced
+        // segments anyway (orbit-bridge-only), so that default is never observed there.
+        internal static PhaseKind ClassifyTracedKind(RenderSegment seg, IPlaybackTrajectory traj)
+        {
+            string env = ResolveEnvPhaseForWindow(traj, seg.StartUT, seg.EndUT);
+            if (string.Equals(env, "surface", StringComparison.Ordinal))
+                return PhaseKind.Surface;
+
+            // Ascent vs descent: a traced run that starts before the first above-surface conic is ascent;
+            // one that starts at/after it is descent (the deorbit/landing leg). With no conic at all
+            // (pure atmospheric recording) the v1 default is Ascent (matches the assembler's role-blind
+            // Surface kind, which is geometry-irrelevant).
+            double firstConicStart = FirstConicStartUT(traj);
+            if (!double.IsNaN(firstConicStart) && seg.StartUT >= firstConicStart)
+                return PhaseKind.Descent;
+            return PhaseKind.Ascent;
+        }
+
+        // Read the recorded env-class phase token (atmo / surface / approach / exo) for the section
+        // overlapping [startUT, endUT]. Tolerates a null/empty TrackSection list (BG-on-rails) by
+        // returning null. Uses the LAST overlapping section's environment so a multi-section run resolves
+        // to its terminal class (a descent run ending in atmo/surface reads surface).
+        internal static string ResolveEnvPhaseForWindow(
+            IPlaybackTrajectory traj, double startUT, double endUT)
+        {
+            var sections = traj?.TrackSections;
+            if (sections == null || sections.Count == 0)
+                return null;
+
+            string phase = null;
+            for (int i = 0; i < sections.Count; i++)
+            {
+                TrackSection s = sections[i];
+                // A section overlaps the window if it intersects [startUT, endUT].
+                if (s.endUT < startUT || s.startUT > endUT)
+                    continue;
+                phase = SegmentPhaseClassifier.EnvironmentToPhase(s.environment);
+            }
+            return phase;
+        }
+
+        // The UT of the recording's first above-surface conic (StockConic-eligible orbit), or NaN when
+        // there is none. Used to split ascent (before) vs descent (after) on the traced legs.
+        private static double FirstConicStartUT(IPlaybackTrajectory traj)
+        {
+            var orbits = traj?.OrbitSegments;
+            if (orbits == null) return double.NaN;
+            double best = double.NaN;
+            for (int i = 0; i < orbits.Count; i++)
+            {
+                OrbitSegment o = orbits[i];
+                if (o.endUT <= o.startUT) continue;
+                if (double.IsNaN(best) || o.startUT < best) best = o.startUT;
+            }
+            return best;
+        }
+
+        // A recorded conic is an ARRIVAL loiter when its env-class is approach OR it is the LAST conic in
+        // the chain on a body different from the recording's first conic body (the destination park). The
+        // v1 default is DepartureLoiter (legacy role-blind Loiter), so this only promotes the clear
+        // arrival case; the geometry is identical either way (kind is non-parity).
+        internal static bool IsArrivalConic(RenderSegment seg, int ordinal, IPlaybackTrajectory traj)
+        {
+            string env = ResolveEnvPhaseForWindow(traj, seg.StartUT, seg.EndUT);
+            if (string.Equals(env, "approach", StringComparison.Ordinal))
+                return true;
+
+            var orbits = traj?.OrbitSegments;
+            if (orbits == null || orbits.Count == 0)
+                return false;
+
+            // The first conic's body is the departure body; a conic on a different body that is the last
+            // conic in time is the arrival park.
+            string firstBody = null;
+            double firstStart = double.NaN;
+            double lastStart = double.NaN;
+            for (int i = 0; i < orbits.Count; i++)
+            {
+                OrbitSegment o = orbits[i];
+                if (o.endUT <= o.startUT) continue;
+                if (double.IsNaN(firstStart) || o.startUT < firstStart)
+                {
+                    firstStart = o.startUT;
+                    firstBody = o.bodyName;
+                }
+                if (double.IsNaN(lastStart) || o.startUT > lastStart)
+                    lastStart = o.startUT;
+            }
+            bool differentBody =
+                !string.IsNullOrEmpty(firstBody)
+                && !string.Equals(seg.FrameBodyName, firstBody, StringComparison.Ordinal);
+            bool isLastInTime = !double.IsNaN(lastStart) && seg.StartUT >= lastStart;
+            return differentBody && isLastInTime;
+        }
+    }
+}

--- a/Source/Parsek/MapRender/ShadowRenderDriver.cs
+++ b/Source/Parsek/MapRender/ShadowRenderDriver.cs
@@ -427,6 +427,16 @@ namespace Parsek.MapRender
             GhostRenderChain chain = ChainAssembler.Build(
                 traj, idx, instanceKey: 0, wStart, wEnd, faithfulFallback: false, surface: surface,
                 orbitSegmentsOverride: overrideSegs, reaimAncestorBody: reaimAncestor);
+
+            // Phase 2 SHADOW byte-parity hook (migration plan §4). Wholly gated on
+            // MapRenderTrace.IsEnabled, so normal play pays nothing and the live draw is unchanged: this
+            // ONLY builds the new typed PhaseChain via the SAME inputs and ASSERTS its emitted geometry
+            // byte-matches the assembler's chain. On a geometry mismatch it emits the factory-parity
+            // Tier-C anomaly (rate-limited per recording). It NEVER drives a draw or mutates any surface.
+            if (MapRenderTrace.IsEnabled)
+                RunShadowFactoryParity(
+                    traj, idx, wStart, wEnd, surface, overrideSegs, reaimAncestor, chain);
+
             chainByPid[pid] = new CachedChain
             {
                 Signature = sig,
@@ -434,6 +444,43 @@ namespace Parsek.MapRender
                 HasReaimedSegments = chainHasReaimedSegments,
             };
             return chain;
+        }
+
+        // Phase 2 SHADOW byte-parity (migration plan §4): build the new typed PhaseChain from the SAME
+        // inputs the assembler consumed, and assert its emitted geometry byte-matches the assembler's
+        // chain. SHADOW ONLY - never drives a draw or mutates a surface; the caller already gated on
+        // MapRenderTrace.IsEnabled. On a geometry mismatch emits the factory-parity Tier-C anomaly
+        // (rate-limited per recording, carrying the diverging field). Tolerant of any factory throw: a
+        // shadow assertion must never destabilize the live (assembler-driven) render path, so a factory
+        // exception is logged and swallowed.
+        private static void RunShadowFactoryParity(
+            IPlaybackTrajectory traj, int idx, double wStart, double wEnd,
+            GhostTrajectoryPolylineRenderer.BodySurfaceProvider surface,
+            IReadOnlyList<OrbitSegment> overrideSegs, string reaimAncestor,
+            GhostRenderChain assemblerChain)
+        {
+            try
+            {
+                PhaseChain factoryChain = PhaseFactory.BuildPhaseChain(
+                    traj, idx, instanceKey: 0, wStart, wEnd, faithfulFallback: false, surface: surface,
+                    orbitSegmentsOverride: overrideSegs, reaimAncestorBody: reaimAncestor);
+                GeometryParityComparator.ParityResult result =
+                    GeometryParityComparator.Compare(factoryChain, assemblerChain);
+                if (!result.IsMatch)
+                {
+                    MapRenderTrace.EmitFactoryParity(
+                        traj.RecordingId, wStart,
+                        string.Format(CultureInfo.InvariantCulture,
+                            "diverging={0} seg={1} countMismatch={2} {3}",
+                            result.DivergingField, result.SegmentIndex, result.CountMismatch,
+                            result.Detail ?? string.Empty));
+                }
+            }
+            catch (System.Exception ex)
+            {
+                ParsekLog.Warn("MapRender", string.Format(CultureInfo.InvariantCulture,
+                    "shadow factory-parity threw for rec={0}: {1}", traj?.RecordingId ?? "?", ex.Message));
+            }
         }
 
         // The chain cache signature. The window token (|w{windowIndex}) is the load-bearing discriminator

--- a/Source/Parsek/MapRender/TrajectoryPhases.cs
+++ b/Source/Parsek/MapRender/TrajectoryPhases.cs
@@ -73,10 +73,26 @@ namespace Parsek.MapRender
     /// </summary>
     internal abstract class TracedPhase : TrajectoryPhase
     {
+        /// <summary>
+        /// The body name the geometry was stamped with by the assembler (the recorded body of this
+        /// traced run). This is GEOMETRY, NOT the anchor: the assembler stamps
+        /// <see cref="RenderSegment.FrameBodyName"/> from the recorded point's body regardless of the
+        /// segment's <see cref="AnchorFrame"/>, so a parent-anchored child's traced leg still carries a
+        /// real body name. Carrying it here (and reproducing it first in
+        /// <see cref="ResolveFrameBodyName"/>) keeps the <see cref="Emit"/> projection LOSSLESS for ANY
+        /// anchor type (a <see cref="AnchorFrame.ParentAnchoredChild"/> would otherwise drop it and the
+        /// factory-parity comparator would false-fire on a correct factory).
+        /// </summary>
+        private protected string GeometryBodyName { get; }
+
         private protected TracedPhase(
             PhaseId id, PhaseKind kind, SegmentProvenance provenance, AnchorFrame anchor,
-            double startUt, double endUt, PhaseSeam leadingSeam, PhaseSeam trailingSeam)
-            : base(id, kind, provenance, anchor, startUt, endUt, leadingSeam, trailingSeam) { }
+            double startUt, double endUt, PhaseSeam leadingSeam, PhaseSeam trailingSeam,
+            string geometryBodyName)
+            : base(id, kind, provenance, anchor, startUt, endUt, leadingSeam, trailingSeam)
+        {
+            GeometryBodyName = geometryBodyName;
+        }
 
         internal override Treatment ResolveTreatment() => Treatment.TracedPath;
 
@@ -96,8 +112,13 @@ namespace Parsek.MapRender
 
         private protected abstract SegmentKind LegacyKind { get; }
 
+        // Reproduce the assembler-stamped GEOMETRY body name FIRST so the round-trip is lossless for any
+        // anchor type (a ParentAnchoredChild carries no BodyAnchor payload, but its traced leg still has a
+        // real recorded body name); fall back to the BodyAnchor payload, then the sample context.
         private protected string ResolveFrameBodyName(SampleContext ctx)
         {
+            if (!string.IsNullOrEmpty(GeometryBodyName))
+                return GeometryBodyName;
             if (Anchor is AnchorFrame.BodyAnchor body && !string.IsNullOrEmpty(body.BodyName))
                 return body.BodyName;
             return ctx.FrameBodyName;
@@ -115,8 +136,9 @@ namespace Parsek.MapRender
     {
         internal AscentPhase(
             PhaseId id, SegmentProvenance provenance, AnchorFrame anchor, double startUt, double endUt,
-            PhaseSeam leadingSeam = null, PhaseSeam trailingSeam = null)
-            : base(id, PhaseKind.Ascent, provenance, anchor, startUt, endUt, leadingSeam, trailingSeam) { }
+            string geometryBodyName = null, PhaseSeam leadingSeam = null, PhaseSeam trailingSeam = null)
+            : base(id, PhaseKind.Ascent, provenance, anchor, startUt, endUt, leadingSeam, trailingSeam,
+                   geometryBodyName) { }
 
         private protected override SegmentKind LegacyKind => SegmentKind.Ascent;
     }
@@ -209,8 +231,9 @@ namespace Parsek.MapRender
     {
         internal DescentPhase(
             PhaseId id, SegmentProvenance provenance, AnchorFrame anchor, double startUt, double endUt,
-            PhaseSeam leadingSeam = null, PhaseSeam trailingSeam = null)
-            : base(id, PhaseKind.Descent, provenance, anchor, startUt, endUt, leadingSeam, trailingSeam) { }
+            string geometryBodyName = null, PhaseSeam leadingSeam = null, PhaseSeam trailingSeam = null)
+            : base(id, PhaseKind.Descent, provenance, anchor, startUt, endUt, leadingSeam, trailingSeam,
+                   geometryBodyName) { }
 
         private protected override SegmentKind LegacyKind => SegmentKind.Landing;
     }
@@ -224,8 +247,9 @@ namespace Parsek.MapRender
     {
         internal SurfacePhase(
             PhaseId id, SegmentProvenance provenance, AnchorFrame anchor, double startUt, double endUt,
-            PhaseSeam leadingSeam = null, PhaseSeam trailingSeam = null)
-            : base(id, PhaseKind.Surface, provenance, anchor, startUt, endUt, leadingSeam, trailingSeam) { }
+            string geometryBodyName = null, PhaseSeam leadingSeam = null, PhaseSeam trailingSeam = null)
+            : base(id, PhaseKind.Surface, provenance, anchor, startUt, endUt, leadingSeam, trailingSeam,
+                   geometryBodyName) { }
 
         private protected override SegmentKind LegacyKind => SegmentKind.Surface;
     }

--- a/Source/Parsek/MapRenderTrace.cs
+++ b/Source/Parsek/MapRenderTrace.cs
@@ -63,11 +63,19 @@ namespace Parsek
         //    unresolvable parent trajectory) -> the phase fails closed to faithful rather than NRE.
         //  - clock-not-ready: the render path was sampled at UT<=0 (cold-load Planetarium UT=0); the
         //    sampler must defer rather than produce a degenerate ghost.
+        //  - factory-parity (Phase 2): the SHADOW PhaseFactory's emitted GEOMETRY (Treatment / StartUt /
+        //    EndUt / FrameBodyName / conic payload + chain-level WindowStartUt / WindowEndUt /
+        //    IsFaithfulFallback) diverged from the live ChainAssembler's GhostRenderChain. PhaseKind /
+        //    Provenance are NOT in this parity set (they are unit-tested). WIRED + LIVE: emitted by the
+        //    gated shadow hook in ShadowRenderDriver via EmitFactoryParity (rate-limited per recording)
+        //    whenever GeometryParityComparator.Compare reports a non-match. Shadow-only: it asserts, never
+        //    drives a draw, so a fire is a build-bug signal, not a rendered regression.
         internal const string AnomalyParityDrift = "parity-drift";
         internal const string AnomalyRigidSeamTangentDiscontinuity = "rigid-seam-tangent-discontinuity";
         internal const string AnomalyRetireNotHeld = "retire-not-held";
         internal const string AnomalyAnchorResolveFail = "anchor-resolve-fail";
         internal const string AnomalyClockNotReady = "clock-not-ready";
+        internal const string AnomalyFactoryParity = "factory-parity";
 
         // ---- Tier-C anomaly tuning ----
 
@@ -1046,6 +1054,31 @@ namespace Parsek
             string combined = "reason=" + Token(reason)
                 + (string.IsNullOrEmpty(details) ? string.Empty : " " + details);
             EmitRaw(true, "Anomaly", surface, pidKey, currentUT, effUT, combined, recId);
+        }
+
+        /// <summary>
+        /// Phase 2 shadow-comparator anomaly emit: the gated <see cref="MapRender.PhaseFactory"/>'s
+        /// emitted geometry diverged from the live <c>ChainAssembler</c>'s <c>GhostRenderChain</c>. Routes
+        /// the <see cref="AnomalyFactoryParity"/> reason + the diverging field detail through a
+        /// rate-limited Verbose sink keyed per recording id (so a per-frame shadow loop on a steadily
+        /// diverging member cannot flood the log) — distinct from <see cref="EmitAnomaly"/> (which is
+        /// Info + opens a detailed window per occurrence). The diverging field is in the
+        /// <paramref name="details"/> built by the caller (the comparator result). Gated by
+        /// <see cref="IsEnabled"/>; no-op in normal play.
+        /// </summary>
+        internal static void EmitFactoryParity(
+            string recordingId, double currentUT, string details, double minIntervalSeconds = 5.0)
+        {
+            if (!IsEnabled)
+                return;
+            string key = Token(recordingId);
+            string combined = "reason=" + AnomalyFactoryParity
+                + (string.IsNullOrEmpty(details) ? string.Empty : " " + details);
+            string message = BuildPrefix(
+                "Anomaly", RenderSurface.ProtoOrbitLine, key, currentUT, currentUT,
+                CurrentFrameCount(), recordingId) + " " + combined;
+            ParsekLog.VerboseRateLimited(
+                Tag, "factory-parity-" + key, message, minIntervalSeconds);
         }
 
         /// <summary>IMGUI marker-surface decision emit (<c>ImguiLabeledMarker</c> /


### PR DESCRIPTION
Phase 2 of the map/TS render overhaul. **Stacked on #1210 (Phase 1)** — base branch `maprender-phase1-pure-types`.

Builds the typed `PhaseChain` from the same inputs as `ChainAssembler` and asserts **byte-parity of the geometry fields** (`Treatment`/`StartUt`/`EndUt`/`FrameBodyName`/conic payload + chain `WindowStartUt`/`WindowEndUt`/`IsFaithfulFallback`) against the live assembler — in a **shadow hook fully gated behind `mapRenderTracing`** (no-op + try/caught when off; live draw untouched). `PhaseKind`/`Provenance` are deliberately excluded from the gate (Phase-1-unit-tested).

- **Classification:** faithful leaf identity from `SegmentPhaseClassifier.EnvironmentToPhase`; re-aimed via override reference-distinctness; BG-on-rails -> all-orbital; s15 heliocentric-park -> synthesized `DepartureLoiterPhase`. (Classification is non-geometry, so it's outside the byte-parity gate but unit-tested directly.)
- **Geometry is delegated to `ChainAssembler` this phase** — byte-parity is by-construction + a lossless `Emit` round-trip; independent geometry production is Phase 3 (gated there by the parity oracle). This deferral is documented in the new files.
- **Files:** `MapRender/PhaseFactory.cs`, `MapRender/GeometryParityComparator.cs` (new); `MapRenderTrace.cs` (`factory-parity` token + rate-limited emit), `ShadowRenderDriver.cs` (the gated hook). +35 headless tests + an in-game shadow-parity test.

## Review
Clean-context review verdict `minor-issues` -> fixed: a faithful **parent-anchored / controlled-decoupled child** with a traced leg false-fired `factory-parity` because the projection read `FrameBodyName` only from a `BodyAnchor`; the body name is geometry, so it's now carried as `TracedPhase.GeometryBodyName` (anchor-independent). Added a headless byte-parity test (verified to catch the bug when the fix is reverted) + an in-game parent-anchored-child regression scenario. Shadow safety and the comparator field set were confirmed clean.

`dotnet test` 16456 green (combined with Phase 1). No KSP deploy from this branch.