### PR TITLE
maprender Phase 3: spine swap behind a default-off flag (additive, reversible)

### DIFF
--- a/Source/Parsek.Tests/MapRender/ChainSamplerTests.cs
+++ b/Source/Parsek.Tests/MapRender/ChainSamplerTests.cs
@@ -32,7 +32,7 @@ namespace Parsek.Tests
         [Fact]
         public void NullChain_IsOutside()
         {
-            Assert.Equal(Coverage.OutsideWindow, ChainSampler.Sample(null, 105, NonLooped).Coverage);
+            Assert.Equal(Coverage.OutsideWindow, ChainSampler.Sample((GhostRenderChain)null, 105, NonLooped).Coverage);
         }
 
         [Fact]
@@ -133,6 +133,72 @@ namespace Parsek.Tests
             var s = ChainSampler.Sample(chain, liveUT, units);
             Assert.Equal(Coverage.InSegment, s.Coverage);
             Assert.Equal(expected, s.DriveUT, 6);
+        }
+
+        // ---- Phase 3: the PhaseChain overload routes coverage the same way (HoldPhase -> gap) ----
+
+        // A minimal PhaseChain whose single ConicPhase covers [100,110] and an interior gap [110,120]
+        // before a second ConicPhase [120,130], built from real phases (so Emit projects geometry).
+        private static PhaseChain PhaseChainTwoConics()
+        {
+            var anchor = new Parsek.MapRender.AnchorFrame.BodyAnchor("Kerbin");
+            var p0 = new DepartureLoiterPhase(
+                new PhaseId("rec-P", 0, 0), SegmentProvenance.Recorded, anchor, 100, 110,
+                new OrbitSegment { startUT = 100, endUT = 110, bodyName = "Kerbin", semiMajorAxis = 700000 });
+            var p1 = new DepartureLoiterPhase(
+                new PhaseId("rec-P", 0, 1), SegmentProvenance.Recorded, anchor, 120, 130,
+                new OrbitSegment { startUT = 120, endUT = 130, bodyName = "Kerbin", semiMajorAxis = 700000 });
+            return new PhaseChain("rec-P", committedIndex: 0, instanceKey: 0,
+                phases: new List<TrajectoryPhase> { p0, p1 }, windowStartUt: 100, windowEndUt: 130);
+        }
+
+        [Fact]
+        public void PhaseChain_NullChain_IsOutside()
+        {
+            Assert.Equal(Coverage.OutsideWindow, ChainSampler.Sample((PhaseChain)null, 105, NonLooped).Coverage);
+        }
+
+        [Fact]
+        public void PhaseChain_InSegment_ProjectsTreatmentAndConic()
+        {
+            var s = ChainSampler.Sample(PhaseChainTwoConics(), 105, NonLooped);
+            Assert.Equal(Coverage.InSegment, s.Coverage);
+            Assert.Equal(105, s.DriveUT);
+            Assert.Equal(Treatment.StockConic, s.Treatment);
+            Assert.Equal("Kerbin", s.FrameBodyName);
+            Assert.Equal(0, s.SegmentIndex);
+            Assert.True(s.Segment.Payload.HasConic);
+        }
+
+        [Fact]
+        public void PhaseChain_MidGap_Holds_NotRetire()
+        {
+            var s = ChainSampler.Sample(PhaseChainTwoConics(), 115, NonLooped);
+            Assert.Equal(Coverage.InInteriorGap, s.Coverage);
+            Assert.Equal(Treatment.None, s.Treatment);
+        }
+
+        [Fact]
+        public void PhaseChain_PastEnd_IsOutside()
+        {
+            var s = ChainSampler.Sample(PhaseChainTwoConics(), 200, NonLooped);
+            Assert.Equal(Coverage.OutsideWindow, s.Coverage);
+        }
+
+        [Fact]
+        public void PhaseChain_MatchedHoldPhase_FallsToGap()
+        {
+            // A HoldPhase emits no geometry; if the sampler locates it as the in-segment owner it must fall
+            // to the gap (hold prior) rather than emit an empty/garbage segment. A HoldPhase covering the
+            // whole window means any in-window UT classifies InSegment-on-a-Hold -> the sampler returns Gap.
+            var anchor = new Parsek.MapRender.AnchorFrame.BodyAnchor("Kerbin");
+            var hold = new HoldPhase(new PhaseId("rec-H", 0, 0), anchor, 100, 130);
+            var chain = new PhaseChain("rec-H", 0, 0,
+                new List<TrajectoryPhase> { hold }, windowStartUt: 100, windowEndUt: 130);
+
+            var s = ChainSampler.Sample(chain, 115, NonLooped);
+            Assert.Equal(Coverage.InInteriorGap, s.Coverage); // hold, not a bogus in-segment draw
+            Assert.Equal(Treatment.None, s.Treatment);
         }
 
         [Fact]

--- a/Source/Parsek.Tests/MapRender/PhaseSpineParityTests.cs
+++ b/Source/Parsek.Tests/MapRender/PhaseSpineParityTests.cs
@@ -1,0 +1,350 @@
+using System.Collections.Generic;
+using Parsek;
+using Parsek.Display;
+using Parsek.MapRender;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    /// <summary>
+    /// Phase-3 guard for THE SPINE SWAP (migration plan §5): the typed-spine sampler/director path
+    /// (<see cref="ChainSampler.Sample(PhaseChain, double, GhostPlaybackLogic.LoopUnitSet)"/> +
+    /// <see cref="GhostRenderDirector.Decide(PhaseChain, double, GhostPlaybackLogic.LoopUnitSet,
+    /// GhostRenderIntent, string)"/>) must produce the SAME <see cref="GhostRenderIntent"/> as the legacy
+    /// <see cref="GhostRenderChain"/> spine for the same geometry, across the whole live-UT sweep. This is
+    /// the headless analogue of the in-game parity-oracle gate: the factory geometry byte-matches the
+    /// assembler (proven by <c>PhaseFactoryTests</c>), and here we prove the SAMPLER + DIRECTOR consuming
+    /// that factory chain emit a byte-identical intent (visible / treatment / driveUT / body / coverage),
+    /// so flag-ON renders identically to flag-OFF.
+    ///
+    /// A regression here is a subtle sampling / coverage / gap-hold difference between the two spines —
+    /// exactly the HIGH-RISK failure mode the plan calls out for Phase 3.
+    /// </summary>
+    public class PhaseSpineParityTests
+    {
+        private static TrajectoryPoint Pt(double ut, string body)
+            => new TrajectoryPoint { ut = ut, bodyName = body };
+
+        // ascent (Kerbin points 0..8, TracedPath) -> orbit (Kerbin 10..30, StockConic)
+        //  -> arrival (Mun points 32..36, TracedPath). The exact fixture the assembler/factory parity
+        // tests use, so the geometry round-trip is already proven; here we sweep the intent.
+        private static MockTrajectory FaithfulChain()
+            => new MockTrajectory
+            {
+                RecordingId = "rec-spine",
+                VesselName = "Jeb's Ride",
+                Points = new List<TrajectoryPoint>
+                {
+                    Pt(0, "Kerbin"), Pt(2, "Kerbin"), Pt(4, "Kerbin"), Pt(6, "Kerbin"), Pt(8, "Kerbin"),
+                    Pt(32, "Mun"), Pt(34, "Mun"), Pt(36, "Mun"),
+                },
+                OrbitSegments = new List<OrbitSegment>
+                {
+                    new OrbitSegment { startUT = 10, endUT = 30, bodyName = "Kerbin", semiMajorAxis = 700000, eccentricity = 0 },
+                },
+            };
+
+        private static GhostPlaybackLogic.LoopUnitSet NonLooped => GhostPlaybackLogic.LoopUnitSet.Empty;
+
+        private static GhostRenderChain BuildAssemblerChain(IPlaybackTrajectory traj, double wStart, double wEnd)
+            => ChainAssembler.Build(
+                traj, committedIndex: 0, instanceKey: 0, wStart, wEnd,
+                faithfulFallback: false, surface: null);
+
+        private static PhaseChain BuildFactoryChain(IPlaybackTrajectory traj, double wStart, double wEnd)
+            => PhaseFactory.BuildPhaseChain(
+                traj, committedIndex: 0, instanceKey: 0, wStart, wEnd,
+                faithfulFallback: false, surface: null);
+
+        // Override-/fallback-aware overloads: both spines must be built from the SAME inputs (the re-aimed
+        // override + ancestor, or the faithfulFallback flag) so the intent parity proof exercises the exact
+        // geometry the production GetOrBuildChain feeds (it passes the SAME override + ancestor to BOTH
+        // ChainAssembler.Build and PhaseFactory.BuildPhaseChain).
+        private static GhostRenderChain BuildAssemblerChain(
+            IPlaybackTrajectory traj, double wStart, double wEnd,
+            IReadOnlyList<OrbitSegment> overrideSegs, string ancestor, bool faithfulFallback)
+            => ChainAssembler.Build(
+                traj, committedIndex: 0, instanceKey: 0, wStart, wEnd,
+                faithfulFallback, surface: null,
+                orbitSegmentsOverride: overrideSegs, reaimAncestorBody: ancestor);
+
+        private static PhaseChain BuildFactoryChain(
+            IPlaybackTrajectory traj, double wStart, double wEnd,
+            IReadOnlyList<OrbitSegment> overrideSegs, string ancestor, bool faithfulFallback)
+            => PhaseFactory.BuildPhaseChain(
+                traj, committedIndex: 0, instanceKey: 0, wStart, wEnd,
+                faithfulFallback, surface: null,
+                orbitSegmentsOverride: overrideSegs, reaimAncestorBody: ancestor);
+
+        // Assert the two spines' intents are byte-identical on the load-bearing fields (the only ones that
+        // flow downstream into the side-channel stamps + draw): Visible, Treatment, DriveUT, FrameBodyName,
+        // and the conic payload (HasConic + the elements). Prior intent is shared so the gap-hold matches.
+        private static void AssertIntentParity(GhostRenderIntent assembler, GhostRenderIntent factory)
+        {
+            Assert.Equal(assembler.Visible, factory.Visible);
+            Assert.Equal(assembler.Treatment, factory.Treatment);
+            Assert.Equal(assembler.DriveUT, factory.DriveUT);
+            Assert.Equal(assembler.FrameBodyName, factory.FrameBodyName);
+            Assert.Equal(assembler.Payload.HasConic, factory.Payload.HasConic);
+            if (assembler.Payload.HasConic)
+            {
+                Assert.Equal(assembler.Payload.Conic.semiMajorAxis, factory.Payload.Conic.semiMajorAxis);
+                Assert.Equal(assembler.Payload.Conic.eccentricity, factory.Payload.Conic.eccentricity);
+                Assert.Equal(assembler.Payload.Conic.startUT, factory.Payload.Conic.startUT);
+                Assert.Equal(assembler.Payload.Conic.endUT, factory.Payload.Conic.endUT);
+                Assert.Equal(assembler.Payload.Conic.bodyName, factory.Payload.Conic.bodyName);
+            }
+        }
+
+        // ---- ChainSampler: PhaseChain overload matches the GhostRenderChain overload (same GhostSample) ----
+
+        [Fact]
+        public void Sampler_NullPhaseChain_IsOutside()
+        {
+            Assert.Equal(Coverage.OutsideWindow, ChainSampler.Sample((PhaseChain)null, 105, NonLooped).Coverage);
+        }
+
+        [Theory]
+        [InlineData(4.0)]   // ascent traced run (Kerbin)
+        [InlineData(20.0)]  // orbit conic (Kerbin)
+        [InlineData(31.0)]  // interior gap [30,32]
+        [InlineData(34.0)]  // Mun arrival traced run
+        [InlineData(50.0)]  // past window end
+        public void Sampler_PhaseChain_MatchesGhostRenderChain_Sample(double liveUT)
+        {
+            var traj = FaithfulChain();
+            GhostRenderChain assembler = BuildAssemblerChain(traj, 0, 40);
+            PhaseChain factory = BuildFactoryChain(traj, 0, 40);
+
+            GhostSample a = ChainSampler.Sample(assembler, liveUT, NonLooped);
+            GhostSample f = ChainSampler.Sample(factory, liveUT, NonLooped);
+
+            Assert.Equal(a.Coverage, f.Coverage);
+            Assert.Equal(a.Treatment, f.Treatment);
+            Assert.Equal(a.DriveUT, f.DriveUT);
+            Assert.Equal(a.FrameBodyName, f.FrameBodyName);
+            Assert.Equal(a.SegmentIndex, f.SegmentIndex);
+            Assert.Equal(a.Segment.Payload.HasConic, f.Segment.Payload.HasConic);
+        }
+
+        // ---- GhostRenderDirector: PhaseChain Decide matches the GhostSample Decide across the sweep ----
+
+        [Theory]
+        [InlineData(4.0)]
+        [InlineData(20.0)]
+        [InlineData(34.0)]
+        [InlineData(50.0)]
+        public void Director_PhaseChain_MatchesGhostRenderChain_Intent_NoPrior(double liveUT)
+        {
+            var traj = FaithfulChain();
+            GhostRenderChain assembler = BuildAssemblerChain(traj, 0, 40);
+            PhaseChain factory = BuildFactoryChain(traj, 0, 40);
+
+            GhostRenderIntent aIntent = GhostRenderDirector.Decide(
+                ChainSampler.Sample(assembler, liveUT, NonLooped), default(GhostRenderIntent), traj.VesselName);
+            GhostRenderIntent fIntent = GhostRenderDirector.Decide(
+                factory, liveUT, NonLooped, default(GhostRenderIntent), traj.VesselName);
+
+            AssertIntentParity(aIntent, fIntent);
+        }
+
+        [Fact]
+        public void Director_PhaseChain_HoldsAcrossInteriorGap_LikeAssembler()
+        {
+            // The HIGH-RISK gap-hold contract: both spines, fed the same visible prior, must HOLD it across
+            // the [30,32] interior gap (not blink/retire). Drive both with the same prior built at UT 20.
+            var traj = FaithfulChain();
+            GhostRenderChain assembler = BuildAssemblerChain(traj, 0, 40);
+            PhaseChain factory = BuildFactoryChain(traj, 0, 40);
+
+            GhostRenderIntent aPrior = GhostRenderDirector.Decide(
+                ChainSampler.Sample(assembler, 20.0, NonLooped), default(GhostRenderIntent), traj.VesselName);
+            GhostRenderIntent fPrior = GhostRenderDirector.Decide(
+                factory, 20.0, NonLooped, default(GhostRenderIntent), traj.VesselName);
+            AssertIntentParity(aPrior, fPrior); // the priors themselves must already match
+
+            GhostRenderIntent aHeld = GhostRenderDirector.Decide(
+                ChainSampler.Sample(assembler, 31.0, NonLooped), aPrior, traj.VesselName);
+            GhostRenderIntent fHeld = GhostRenderDirector.Decide(
+                factory, 31.0, NonLooped, fPrior, traj.VesselName);
+
+            Assert.True(aHeld.Visible); // sanity: the assembler spine holds
+            AssertIntentParity(aHeld, fHeld);
+        }
+
+        // ---- Full live-UT sweep: the two spines never disagree on a frame (the parity-oracle analogue) ----
+
+        [Fact]
+        public void FullSweep_TwoSpines_EmitIdenticalIntents_WithSharedPrior()
+        {
+            // Walk the whole [-5, 45] live-UT span at 0.5s steps, threading the SAME prior intent through
+            // BOTH spines exactly as RunFrame does (one priorIntentByPid map). A divergence on ANY frame
+            // (a coverage flip, a one-frame treatment swap, a held-vs-retired gap) fails here — the headless
+            // proof that flag-ON is byte-identical to flag-OFF over a continuous run.
+            var traj = FaithfulChain();
+            GhostRenderChain assembler = BuildAssemblerChain(traj, 0, 40);
+            PhaseChain factory = BuildFactoryChain(traj, 0, 40);
+
+            GhostRenderIntent aPrior = default(GhostRenderIntent);
+            GhostRenderIntent fPrior = default(GhostRenderIntent);
+            for (double ut = -5.0; ut <= 45.0; ut += 0.5)
+            {
+                GhostRenderIntent aIntent = GhostRenderDirector.Decide(
+                    ChainSampler.Sample(assembler, ut, NonLooped), aPrior, traj.VesselName);
+                GhostRenderIntent fIntent = GhostRenderDirector.Decide(
+                    factory, ut, NonLooped, fPrior, traj.VesselName);
+
+                AssertIntentParity(aIntent, fIntent);
+
+                aPrior = aIntent;
+                fPrior = fIntent;
+            }
+        }
+
+        // ---- Looped / overlap member: the shared span clock keeps the two spines glued (no per-instance) ----
+
+        private static GhostPlaybackLogic.LoopUnitSet OverlapUnitFullSpan()
+        {
+            var unit = new GhostPlaybackLogic.LoopUnit(
+                0, new[] { 0 }, spanStartUT: 0, spanEndUT: 40, cadenceSeconds: 40,
+                phaseAnchorUT: 0, overlapCadenceSeconds: 10);
+            Assert.True(GhostPlaybackLogic.UnitMemberOverlaps(unit));
+            var unitsByOwner = new Dictionary<int, GhostPlaybackLogic.LoopUnit> { { 0, unit } };
+            var ownerByIndex = new Dictionary<int, int> { { 0, 0 } };
+            return new GhostPlaybackLogic.LoopUnitSet(unitsByOwner, ownerByIndex);
+        }
+
+        [Theory]
+        [InlineData(60.0)]  // cycle 1, phase 20 -> loopUT 20 (in orbit segment)
+        [InlineData(44.0)]  // cycle 1, phase 4 -> loopUT 4 (ascent traced)
+        [InlineData(50.0)]  // before the anchor-resolved span yields a hidden/outside frame for both
+        public void OverlapMember_TwoSpines_MatchAtSpanClockHead(double liveUT)
+        {
+            // Both spines route the overlap member through the SAME span clock
+            // (ResolveTrackingStationSampleUT), so they pick the identical selected-cycle head-UT and emit
+            // the same intent. The map shows ONE ghost at that head, never N instances — and the two spines
+            // never diverge on which UT that is.
+            var traj = FaithfulChain();
+            var units = OverlapUnitFullSpan();
+            GhostRenderChain assembler = BuildAssemblerChain(traj, 0, 40);
+            PhaseChain factory = BuildFactoryChain(traj, 0, 40);
+
+            GhostRenderIntent aIntent = GhostRenderDirector.Decide(
+                ChainSampler.Sample(assembler, liveUT, units), default(GhostRenderIntent), traj.VesselName);
+            GhostRenderIntent fIntent = GhostRenderDirector.Decide(
+                factory, liveUT, units, default(GhostRenderIntent), traj.VesselName);
+
+            AssertIntentParity(aIntent, fIntent);
+        }
+
+        // ---- RE-AIM intent-layer parity (SHOULD 1): close the highest-risk gap ----
+        // Re-aim is the highest-risk geometry and a Phase-3-contract-enumerated representative, but the
+        // sweeps above only cover FAITHFUL chains (no override). Here BOTH spines are built from the SAME
+        // re-aimed override + ancestor (exactly as production GetOrBuildChain feeds them), so the new-spine
+        // intent must EQUAL the legacy-spine intent across the UT sweep. The path is correct by construction
+        // (the factory geometry byte-matches the assembler under the override - proven by
+        // PhaseFactoryTests.ReaimedMember_ClassifiesSynthesizedHeliocentricTransfer); these tests prove it at
+        // the INTENT layer (visible / treatment / driveUT / body / conic), removing the transitive argument.
+
+        // The exact re-aim fixture PhaseFactoryTests uses: a recorded heliocentric (Sun) conic, re-synthesized
+        // into a reference-distinct override aimed at the target's current position (sma differs, isPredicted
+        // false => the generated transfer), with the plan's common ancestor "Sun".
+        private static MockTrajectory ReaimedHeliocentricRecording()
+            => new MockTrajectory
+            {
+                RecordingId = "rec-reaim",
+                VesselName = "Kerbal X",
+                Points = new List<TrajectoryPoint>(),
+                OrbitSegments = new List<OrbitSegment>
+                {
+                    new OrbitSegment { startUT = 10, endUT = 30, bodyName = "Sun", semiMajorAxis = 9e9, eccentricity = 0.2 },
+                },
+            };
+
+        private static List<OrbitSegment> ReaimedOverride()
+            => new List<OrbitSegment>
+            {
+                new OrbitSegment { startUT = 10, endUT = 30, bodyName = "Sun", semiMajorAxis = 7.777e9, eccentricity = 0.5, isPredicted = false },
+            };
+
+        [Theory]
+        [InlineData(5.0)]   // before the transfer window -> outside/hidden for both
+        [InlineData(20.0)]  // on the re-aimed heliocentric transfer conic (the high-risk leg)
+        [InlineData(50.0)]  // past the window end -> hidden for both
+        public void Reaimed_TwoSpines_EmitIdenticalIntents(double liveUT)
+        {
+            var traj = ReaimedHeliocentricRecording();
+            List<OrbitSegment> overrideSegs = ReaimedOverride();
+            Assert.NotSame(traj.OrbitSegments, overrideSegs); // sanity: reference-distinct == re-aimed
+
+            GhostRenderChain assembler = BuildAssemblerChain(
+                traj, 0, 40, overrideSegs, ancestor: "Sun", faithfulFallback: false);
+            PhaseChain factory = BuildFactoryChain(
+                traj, 0, 40, overrideSegs, ancestor: "Sun", faithfulFallback: false);
+
+            GhostRenderIntent aIntent = GhostRenderDirector.Decide(
+                ChainSampler.Sample(assembler, liveUT, NonLooped), default(GhostRenderIntent), traj.VesselName);
+            GhostRenderIntent fIntent = GhostRenderDirector.Decide(
+                factory, liveUT, NonLooped, default(GhostRenderIntent), traj.VesselName);
+
+            AssertIntentParity(aIntent, fIntent);
+        }
+
+        [Fact]
+        public void Reaimed_FullSweep_TwoSpines_EmitIdenticalIntents_WithSharedPrior()
+        {
+            // The continuous-run re-aim proof: walk [-5, 45] at 0.5s threading the SAME prior through both
+            // spines (as RunFrame does), under the re-aimed override. A divergence on ANY frame (the conic the
+            // re-aim emits, the gap on either side of the trimmed transfer, the held-vs-retired choice) fails
+            // here - the headless proof that flag-ON renders the re-aimed geometry identically to flag-OFF.
+            var traj = ReaimedHeliocentricRecording();
+            List<OrbitSegment> overrideSegs = ReaimedOverride();
+            GhostRenderChain assembler = BuildAssemblerChain(
+                traj, 0, 40, overrideSegs, ancestor: "Sun", faithfulFallback: false);
+            PhaseChain factory = BuildFactoryChain(
+                traj, 0, 40, overrideSegs, ancestor: "Sun", faithfulFallback: false);
+
+            GhostRenderIntent aPrior = default(GhostRenderIntent);
+            GhostRenderIntent fPrior = default(GhostRenderIntent);
+            bool sawVisible = false;
+            for (double ut = -5.0; ut <= 45.0; ut += 0.5)
+            {
+                GhostRenderIntent aIntent = GhostRenderDirector.Decide(
+                    ChainSampler.Sample(assembler, ut, NonLooped), aPrior, traj.VesselName);
+                GhostRenderIntent fIntent = GhostRenderDirector.Decide(
+                    factory, ut, NonLooped, fPrior, traj.VesselName);
+
+                AssertIntentParity(aIntent, fIntent);
+                sawVisible |= aIntent.Visible;
+                aPrior = aIntent;
+                fPrior = fIntent;
+            }
+            Assert.True(sawVisible, "the re-aimed transfer leg must render visible somewhere in the sweep");
+        }
+
+        // ---- faithfulFallback parity (SHOULD 1): the producer-declined window ----
+        [Theory]
+        [InlineData(4.0)]
+        [InlineData(20.0)]
+        [InlineData(34.0)]
+        [InlineData(50.0)]
+        public void FaithfulFallback_TwoSpines_EmitIdenticalIntents(double liveUT)
+        {
+            // A producer-declined window assembles the recorded trajectory as-is (design §6.9 / §7). Both
+            // spines carry faithfulFallback=true and must still emit byte-identical intents across the sweep.
+            var traj = FaithfulChain();
+            GhostRenderChain assembler = BuildAssemblerChain(
+                traj, 0, 40, overrideSegs: null, ancestor: null, faithfulFallback: true);
+            PhaseChain factory = BuildFactoryChain(
+                traj, 0, 40, overrideSegs: null, ancestor: null, faithfulFallback: true);
+            Assert.True(factory.IsFaithfulFallback); // sanity: the flag propagated to the typed chain
+
+            GhostRenderIntent aIntent = GhostRenderDirector.Decide(
+                ChainSampler.Sample(assembler, liveUT, NonLooped), default(GhostRenderIntent), traj.VesselName);
+            GhostRenderIntent fIntent = GhostRenderDirector.Decide(
+                factory, liveUT, NonLooped, default(GhostRenderIntent), traj.VesselName);
+
+            AssertIntentParity(aIntent, fIntent);
+        }
+    }
+}

--- a/Source/Parsek.Tests/MapRender/ShadowRenderDriverTests.cs
+++ b/Source/Parsek.Tests/MapRender/ShadowRenderDriverTests.cs
@@ -323,14 +323,19 @@ namespace Parsek.Tests
         // ---- Source gate: RunFrame no longer DROPS an overlap member (the skip is lifted) ----
 
         private static string ReadShadowRenderDriverSource()
+            => ReadMapRenderSource("ShadowRenderDriver.cs");
+
+        // Read a Source/Parsek/MapRender/<fileName> file for a source-text gate. Shared by the spine-swap
+        // source gates that span the THREE spine files (ShadowRenderDriver + ChainSampler + GhostRenderDirector).
+        private static string ReadMapRenderSource(string fileName)
         {
             string root = Path.GetFullPath(Path.Combine(
                 AppDomain.CurrentDomain.BaseDirectory, "..", "..", "..", "..", ".."));
-            string path = Path.Combine(root, "Source", "Parsek", "MapRender", "ShadowRenderDriver.cs");
+            string path = Path.Combine(root, "Source", "Parsek", "MapRender", fileName);
             if (!File.Exists(path))
             {
                 // Fallback layout (mirrors MapPresenceSeamTests): some checkouts root at Parsek/.
-                path = Path.Combine(root, "Parsek", "MapRender", "ShadowRenderDriver.cs");
+                path = Path.Combine(root, "Parsek", "MapRender", fileName);
             }
             Assert.True(File.Exists(path), $"Source file not found at {path}");
             return File.ReadAllText(path);
@@ -365,6 +370,83 @@ namespace Parsek.Tests
                 else { sb.Append(c); inWs = false; }
             }
             return sb.ToString();
+        }
+
+        // ---- Phase 3 spine swap: the new default-OFF flag + the spine-select wiring ----
+
+        [Fact]
+        public void PhaseSpineDriveFlag_DefaultsOff()
+        {
+            // The migration plan REQUIRES the new spine be behind a default-OFF flag so flag-OFF play is
+            // byte-identical to today. A regression that flips the default to true would silently swap the
+            // live spine for every install.
+            Assert.False(MapRenderFlags.MapRenderPhaseSpineDrive);
+        }
+
+        [Fact]
+        public void PhaseSpineDriveActive_IsConstOrTestSeam_AndDefaultsOff()
+        {
+            // The single source of truth for "drive off the PhaseChain this frame" is the const OR the
+            // in-game test seam. With both off (normal play) it is false (flag-OFF). The seam flips it on
+            // for an in-game test without a rebuild; it must restore.
+            bool prev = ShadowRenderDriver.ForceSpineDriveForTesting;
+            try
+            {
+                ShadowRenderDriver.ForceSpineDriveForTesting = false;
+                Assert.False(ShadowRenderDriver.PhaseSpineDriveActive); // const false + seam false -> off
+                ShadowRenderDriver.ForceSpineDriveForTesting = true;
+                Assert.True(ShadowRenderDriver.PhaseSpineDriveActive);  // seam ON forces the spine on
+            }
+            finally
+            {
+                ShadowRenderDriver.ForceSpineDriveForTesting = prev;
+            }
+        }
+
+        [Fact]
+        public void RunFrame_FlagOffPath_SamplesAssemblerChain_NotPhaseChain_SourceGate()
+        {
+            // Flag-OFF must drive the LEGACY assembler GhostRenderChain (byte-identical to pre-Phase-3).
+            // The source carries BOTH spine branches behind PhaseSpineDriveActive; this gate proves the
+            // selector exists (the flag-ON branch samples the phaseChain) and the flag-OFF else-branch
+            // samples the assembler `chain`. A regression that hard-wired the PhaseChain spine (dropping
+            // the assembler else-branch) is caught here.
+            string normalized = CollapseWhitespace(StripLineComments(ReadShadowRenderDriverSource()));
+
+            // The selector reads PhaseSpineDriveActive (the const-OR-seam gate), not the raw const, and the
+            // flag-ON branch samples the phaseChain while the flag-OFF else-branch samples the assembler chain.
+            Assert.Contains("if (PhaseSpineDriveActive && phaseChain != null)", normalized);
+            Assert.Contains("ChainSampler.Sample(phaseChain, currentUT, units)", normalized);
+            Assert.Contains("ChainSampler.Sample(chain, currentUT, units)", normalized);
+        }
+
+        // The swapped spine is THREE files (ShadowRenderDriver + ChainSampler + GhostRenderDirector); the
+        // deorbit-decoupling gate must scan ALL of them, not just the driver. A future edit that pulled the
+        // deorbit clock into the sampler or the director (e.g. a sampler that consumed the transfer-leg head
+        // UT) would re-introduce the Phase-3<->Phase-6 coupling this gate forbids, and these per-file
+        // assertions would FAIL. All three are currently clean.
+        [Theory]
+        [InlineData("ShadowRenderDriver.cs")]
+        [InlineData("ChainSampler.cs")]
+        [InlineData("GhostRenderDirector.cs")]
+        public void SwappedSpine_DoesNotConsumeDeorbitClock_SourceGate(string spineFile)
+        {
+            // The deorbit-head / captureShift clock is consumed only by the legacy polyline Driver + the
+            // span clock, NOT the swapped spine (no Phase-3<->Phase-6 coupling). Confirm each spine file
+            // never references those symbols, so Phase 3 parity does not hide a clock coupling.
+            string normalized = CollapseWhitespace(StripLineComments(ReadMapRenderSource(spineFile)));
+            Assert.DoesNotContain("ResolveTransferLegHeadUT", normalized);
+            Assert.DoesNotContain("deorbitHead", normalized);
+            Assert.DoesNotContain("captureShift", normalized);
+        }
+
+        [Fact]
+        public void PhaseSpineDriveFlag_IsNotTheRemovedMapRenderDirectorDriveName()
+        {
+            // The new flag MUST NOT reuse the removed `mapRenderDirectorDrive` name (a grep-audit forbids
+            // it). Lock the new symbol name so a rename to the forbidden token is caught at the test layer
+            // too (the grep-audit catches the source; this documents the intent).
+            Assert.DoesNotContain("mapRenderDirectorDrive", nameof(MapRenderFlags.MapRenderPhaseSpineDrive));
         }
 
         [Fact]

--- a/Source/Parsek/InGameTests/PhaseSpineSwapInGameTest.cs
+++ b/Source/Parsek/InGameTests/PhaseSpineSwapInGameTest.cs
@@ -1,0 +1,262 @@
+using System.Collections.Generic;
+using System.Globalization;
+using Parsek.MapRender;
+using UnityEngine;
+
+namespace Parsek.InGameTests
+{
+    // Phase 3 (migration plan §5, the spine swap) - the in-game gate that drives the REAL wired
+    // ShadowRenderDriver.RunFrame over a live faithful ghost with the typed PhaseChain spine ON vs OFF and
+    // asserts the two are byte-identical AND both report ZERO parity-drift:
+    //
+    //  - FLAG OFF (default): RunFrame samples the legacy ChainAssembler-built GhostRenderChain and stamps
+    //    the StockConic seed the icon-drive patch reads. The ghost stays on its recorded orbit -> the
+    //    probe's ComputeFaithfulOrbitParity reports zero drift (unchanged from today).
+    //  - FLAG ON (ForceSpineDriveForTesting): RunFrame samples the typed PhaseChain (PhaseFactory output,
+    //    byte-matching the assembler from Phase 2) and stamps the SAME seed. The ghost renders identically
+    //    -> zero drift, and the stamped seed elements match the flag-OFF seed exactly.
+    //
+    // This complements the headless PhaseSpineParityTests (which prove the sampler/director intent parity
+    // pure) by exercising the Unity-coupled RunFrame -> seed-stamp -> probe path the pure tests cannot
+    // reach. Runs the SAME internal seam production uses (RunFrame + TryGetFreshStockConicSeed +
+    // ComputeFaithfulOrbitParity), so it is not a green-but-blind inlined copy.
+    //
+    // NOTE: in-game test (Ctrl+Shift+T / Settings > Diagnostics); cannot run headless (builds a live ghost
+    // ProtoVessel + reads its OrbitDriver + drives RunFrame against a live MapViewScene). FLIGHT only;
+    // career-independent.
+    public class PhaseSpineSwapInGameTest
+    {
+        private const string KerbinBodyName = "Kerbin";
+        private const double Sma = 850000.0;
+        private const double Ecc = 0.0;
+        private const double Inc = 0.0;
+        private const double KerbinRadiusFallback = 600000.0;
+
+        [InGameTest(Category = "MapRender", Scene = GameScenes.FLIGHT,
+            Description = "Phase 3 spine-swap (FLAG ON): RunFrame driving the typed PhaseChain spine over a "
+                + "live faithful ghost stamps a StockConic seed and reports ZERO parity-drift, identical to "
+                + "the legacy assembler spine")]
+        public void SpineSwap_FlagOn_DrivesPhaseChain_ZeroDrift_MatchesAssemblerSeed()
+        {
+            RunSpineSwapParity(forceSpineOn: true);
+        }
+
+        [InGameTest(Category = "MapRender", Scene = GameScenes.FLIGHT,
+            Description = "Phase 3 spine-swap (FLAG OFF): RunFrame driving the legacy assembler spine over a "
+                + "live faithful ghost reports ZERO parity-drift (unchanged baseline) - the flag-off path is "
+                + "byte-identical to pre-Phase-3 behavior")]
+        public void SpineSwap_FlagOff_DrivesAssembler_ZeroDrift()
+        {
+            // CLAIM SCOPE: this exercises the FLAG-OFF-WITH-TRACING-ON path. RunSpineSwapParity force-enables
+            // MapRenderTrace so the factory PhaseChain is always built (the parity sink + EmitStructural are
+            // live), which means the spine is built-but-not-consumed here, not fully inert. So this proves
+            // "flag-off renders identically to the assembler baseline" — NOT "the spine path is wholly
+            // elided." The TRACING-OFF full-inertness of flag-off normal play (the C# const-fold + the
+            // null-PhaseChain assembler fallback) is locked at the source/unit layer
+            // (ShadowRenderDriverTests.PhaseSpineDriveActive_*, RunFrame_FlagOffPath_*), not here.
+            RunSpineSwapParity(forceSpineOn: false);
+        }
+
+        // Build the live ghost once, then drive RunFrame with the spine forced OFF and ON, reading back the
+        // stamped StockConic seed each time + the parity result. Asserts: both stamp a seed, both report
+        // zero drift, and the flag-ON seed elements byte-match the flag-OFF seed (the spine produced the
+        // same drive).
+        private static void RunSpineSwapParity(bool forceSpineOn)
+        {
+            CelestialBody kerbin = FlightGlobals.Bodies?.Find(b => b.bodyName == KerbinBodyName);
+            if (kerbin == null)
+            {
+                InGameAssert.Skip("Kerbin not found in FlightGlobals.Bodies (non-stock pack)");
+                return;
+            }
+
+            double liveUT = Planetarium.GetUniversalTime();
+            double startUT = liveUT - 1800.0;
+            OrbitSegment seg = BuildSegment(startUT);
+
+            bool prevForceSpine = ShadowRenderDriver.ForceSpineDriveForTesting;
+            bool prevForceTrace = MapRenderTrace.ForceEnabledForTesting;
+            System.Func<double> prevUTNow = GhostMapPresence.CurrentUTNow;
+            List<Recording> prevRecordings = RecordingStore.CommittedRecordings != null
+                ? new List<Recording>(RecordingStore.CommittedRecordings)
+                : new List<Recording>();
+            List<RecordingTree> prevTrees = RecordingStore.CommittedTrees != null
+                ? new List<RecordingTree>(RecordingStore.CommittedTrees)
+                : new List<RecordingTree>();
+
+            Recording rec = BuildRecording(startUT, seg);
+            RecordingStore.ClearCommittedInternal();
+            RecordingStore.ClearCommittedTreesInternal();
+            RecordingStore.AddCommittedInternal(rec);
+            int recordingIndex = RecordingStore.CommittedRecordings.Count - 1;
+            GhostMapPresence.CurrentUTNow = () => liveUT;
+            GhostMapPresence.RemoveAllGhostVessels("spine-swap-start");
+            ShadowRenderDriver.Reset();
+
+            uint pid = 0u;
+            try
+            {
+                MapRenderTrace.ForceEnabledForTesting = true; // so EmitStructural / parity sink are live
+
+                Vessel ghost = GhostMapPresence.CreateGhostVesselFromSource(
+                    recordingIndex, rec, GhostMapPresence.TrackingStationGhostSource.Segment,
+                    seg, default(TrajectoryPoint), startUT, loopEpochShiftSeconds: 0.0);
+
+                if (ghost == null || ghost.orbitDriver == null || ghost.orbitDriver.orbit == null)
+                {
+                    InGameAssert.Skip("Faithful ghost did not create in this context (no proto)");
+                    return;
+                }
+                pid = ghost.persistentId;
+
+                var scene = new MapViewScene();
+                scene.SetFrameInputs(GhostPlaybackLogic.LoopUnitSet.Empty, liveUT);
+                if (!scene.IsActive)
+                {
+                    InGameAssert.Skip("MapViewScene not active (not in FLIGHT)");
+                    return;
+                }
+
+                // Drive the spine the requested way and read back the stamped seed.
+                ShadowRenderDriver.ForceSpineDriveForTesting = forceSpineOn;
+                ShadowRenderDriver.Reset();
+                ShadowRenderDriver.RunFrame(scene);
+                bool stamped = ShadowRenderDriver.TryGetFreshStockConicSeed(
+                    pid, Time.frameCount, out OrbitSegment drivenSeed, out string drivenBody);
+
+                // Also drive the OPPOSITE flag state so we can assert the two spines stamp the SAME seed
+                // (the byte-identical-drive proof). Build a fresh scene/seed each pass.
+                ShadowRenderDriver.ForceSpineDriveForTesting = !forceSpineOn;
+                ShadowRenderDriver.Reset();
+                ShadowRenderDriver.RunFrame(scene);
+                bool otherStamped = ShadowRenderDriver.TryGetFreshStockConicSeed(
+                    pid, Time.frameCount, out OrbitSegment otherSeed, out string otherBody);
+
+                ParsekLog.Info("TestRunner", string.Format(CultureInfo.InvariantCulture,
+                    "SpineSwap parity: forceSpineOn={0} stamped={1} body={2} sma={3:F0} ecc={4:F4} | "
+                    + "other stamped={5} body={6} sma={7:F0} ecc={8:F4}",
+                    forceSpineOn, stamped, drivenBody ?? "?", drivenSeed.semiMajorAxis, drivenSeed.eccentricity,
+                    otherStamped, otherBody ?? "?", otherSeed.semiMajorAxis, otherSeed.eccentricity));
+
+                InGameAssert.IsTrue(stamped,
+                    "RunFrame must stamp a StockConic seed for a faithful orbital ghost (the drive the "
+                    + "icon-drive patch reads); none stamped for forceSpineOn=" + forceSpineOn);
+                InGameAssert.IsTrue(otherStamped,
+                    "the opposite-flag RunFrame must ALSO stamp a seed (both spines drive the same ghost)");
+
+                // The two spines must stamp the SAME conic drive (byte-identical seed): same body + elements.
+                InGameAssert.AreEqual(drivenBody, otherBody,
+                    "the two spines must stamp the same seed body");
+                InGameAssert.ApproxEqual(drivenSeed.semiMajorAxis, otherSeed.semiMajorAxis, 1e-6,
+                    "the two spines must stamp the same seed semiMajorAxis (byte-identical drive)");
+                InGameAssert.ApproxEqual(drivenSeed.eccentricity, otherSeed.eccentricity, 1e-9,
+                    "the two spines must stamp the same seed eccentricity");
+                InGameAssert.ApproxEqual(drivenSeed.startUT, otherSeed.startUT, 1e-6,
+                    "the two spines must stamp the same seed startUT");
+                InGameAssert.ApproxEqual(drivenSeed.endUT, otherSeed.endUT, 1e-6,
+                    "the two spines must stamp the same seed endUT");
+
+                // Restore the requested flag state, drive once more so the live orbit reflects it, then run
+                // the production parity seam and assert ZERO drift (the ghost stays on its recorded orbit
+                // regardless of which spine drove it).
+                ShadowRenderDriver.ForceSpineDriveForTesting = forceSpineOn;
+                ShadowRenderDriver.Reset();
+                ShadowRenderDriver.RunFrame(scene);
+
+                Orbit renderedOrbit = ghost.orbitDriver.orbit;
+                Vector3d iconBodyRel = ghost.GetWorldPos3D() - kerbin.position;
+                MapRenderProbe.FaithfulParitySample sample = MapRenderProbe.ComputeFaithfulOrbitParity(
+                    renderedOrbit, kerbin, iconBodyRel, liveUT, 0.0, liveUT, rec.RecordingId);
+                RenderParityOracle.ParityResult result = sample.Result;
+
+                ParsekLog.Info("TestRunner", string.Format(CultureInfo.InvariantCulture,
+                    "SpineSwap parity-drift: forceSpineOn={0} sampled={1} skip={2} hasMeas={3} maxDev={4:F1}m "
+                    + "tol={5:F1}m over={6}",
+                    forceSpineOn, sample.Sampled, sample.SkipReason ?? "(none)", result.HasMeasurement,
+                    result.MaxDeviationMeters, result.ToleranceMeters, result.OverTolerance));
+
+                InGameAssert.IsTrue(sample.Sampled,
+                    "spine-swap parity must SAMPLE (not skip); skipReason=" + (sample.SkipReason ?? "(none)"));
+                InGameAssert.IsTrue(result.HasMeasurement,
+                    "spine-swap parity must yield a MEASUREMENT (else the gate is blind)");
+                InGameAssert.IsFalse(result.OverTolerance,
+                    string.Format(CultureInfo.InvariantCulture,
+                        "spine-swap (forceSpineOn={0}) must report ZERO drift; maxDev={1:F1}m exceeded "
+                        + "tol={2:F1}m - the swapped spine is rendering a different orbit than the assembler.",
+                        forceSpineOn, result.MaxDeviationMeters, result.ToleranceMeters));
+            }
+            finally
+            {
+                if (pid != 0u)
+                    GhostMapPresence.RemoveAllGhostVessels("spine-swap-cleanup");
+                ShadowRenderDriver.ForceSpineDriveForTesting = prevForceSpine;
+                ShadowRenderDriver.Reset();
+                MapRenderTrace.ForceEnabledForTesting = prevForceTrace;
+                RecordingStore.ClearCommittedInternal();
+                RecordingStore.ClearCommittedTreesInternal();
+                for (int i = 0; i < prevRecordings.Count; i++)
+                    RecordingStore.AddCommittedInternal(prevRecordings[i]);
+                for (int i = 0; i < prevTrees.Count; i++)
+                    RecordingStore.AddCommittedTreeInternal(prevTrees[i]);
+                GhostMapPresence.CurrentUTNow = prevUTNow;
+            }
+        }
+
+        private static OrbitSegment BuildSegment(double startUT)
+        {
+            return new OrbitSegment
+            {
+                startUT = startUT,
+                endUT = startUT + 3600.0,
+                inclination = Inc,
+                eccentricity = Ecc,
+                semiMajorAxis = Sma,
+                longitudeOfAscendingNode = 0.0,
+                argumentOfPeriapsis = 0.0,
+                meanAnomalyAtEpoch = 0.0,
+                epoch = startUT,
+                bodyName = KerbinBodyName,
+                isPredicted = false,
+                orbitalFrameRotation = Quaternion.identity,
+                angularVelocity = Vector3.zero,
+            };
+        }
+
+        private static Recording BuildRecording(double startUT, OrbitSegment seg)
+        {
+            double endUT = startUT + 3600.0;
+            var rec = new Recording
+            {
+                RecordingId = "spine-swap-" + System.Guid.NewGuid().ToString("N"),
+                VesselName = "Parsek Spine Swap",
+                TerminalStateValue = null,
+                EndpointPhase = RecordingEndpointPhase.OrbitSegment,
+                EndpointBodyName = KerbinBodyName,
+                TerminalOrbitBody = KerbinBodyName,
+                TerminalOrbitSemiMajorAxis = Sma,
+                TerminalOrbitEccentricity = Ecc,
+                TerminalOrbitInclination = Inc,
+                TerminalOrbitLAN = 0.0,
+                TerminalOrbitArgumentOfPeriapsis = 0.0,
+                TerminalOrbitMeanAnomalyAtEpoch = 0.0,
+                TerminalOrbitEpoch = startUT,
+                ExplicitStartUT = startUT,
+                ExplicitEndUT = endUT,
+                PlaybackEnabled = true,
+            };
+            rec.Points.Add(new TrajectoryPoint
+            {
+                ut = startUT, latitude = 0.0, longitude = 0.0, altitude = Sma - KerbinRadiusFallback,
+                rotation = Quaternion.identity, velocity = new Vector3(0f, 2200f, 0f), bodyName = KerbinBodyName,
+            });
+            rec.Points.Add(new TrajectoryPoint
+            {
+                ut = endUT, latitude = 0.0, longitude = 5.0, altitude = Sma - KerbinRadiusFallback,
+                rotation = Quaternion.identity, velocity = new Vector3(0f, 2200f, 0f), bodyName = KerbinBodyName,
+            });
+            rec.OrbitSegments.Add(seg);
+            rec.MarkFilesDirty();
+            return rec;
+        }
+    }
+}

--- a/Source/Parsek/MapRender/ChainSampler.cs
+++ b/Source/Parsek/MapRender/ChainSampler.cs
@@ -46,5 +46,90 @@ namespace Parsek.MapRender
                     return GhostSample.Outside();
             }
         }
+
+        /// <summary>
+        /// Phase 3 (migration plan §5): the typed-spine variant of <see cref="Sample(GhostRenderChain,
+        /// double, GhostPlaybackLogic.LoopUnitSet)"/> — maps live UT → assembled-chain UT with the SAME
+        /// span clock, then classifies coverage against a <see cref="PhaseChain"/> instead of a
+        /// <see cref="GhostRenderChain"/>, projecting the matched phase to the <see cref="RenderSegment"/>
+        /// it emits (via <see cref="TrajectoryPhase.Emit"/>) so the downstream <see cref="GhostSample"/> is
+        /// byte-identical to the legacy chain path for the same geometry.
+        ///
+        /// <para><b>ADDITIVE.</b> This does NOT replace the <see cref="GhostRenderChain"/> overload above
+        /// (the flag-OFF spine still uses it). The two share the exact same span-clock call
+        /// (<see cref="GhostPlaybackLogic.ResolveTrackingStationSampleUT"/>) and the same three-valued
+        /// <see cref="Coverage"/> classification (<see cref="PhaseChain.ClassifyCoverage"/> mirrors
+        /// <see cref="GhostRenderChain.ClassifyCoverage"/> exactly), so an InSegment frame projects the
+        /// SAME <c>Treatment</c> / <c>FrameBodyName</c> / conic payload the assembler chain carried (proven
+        /// by the Phase-2 byte-parity comparator), and the DriveUT / coverage / segment index match.</para>
+        ///
+        /// <para>The matched phase is projected through <see cref="TrajectoryPhase.Emit"/> with a
+        /// <see cref="SampleContext"/> carrying the phase's anchor body (the same context
+        /// <see cref="GeometryParityComparator.ProjectGeometry"/> uses), so a conic phase whose anchor /
+        /// conic body is empty still resolves its frame name identically. A matched phase that emits NO
+        /// geometry (only <see cref="HoldPhase"/>, which the factory never classifies as the in-segment
+        /// owner because the assembler never produces a hold segment) is treated as an interior gap (hold
+        /// the prior intent) rather than an in-segment draw — the same hold contract.</para>
+        /// </summary>
+        internal static GhostSample Sample(PhaseChain chain, double liveUT, GhostPlaybackLogic.LoopUnitSet units)
+        {
+            if (chain == null)
+                return GhostSample.Outside();
+
+            double sampleUT = GhostPlaybackLogic.ResolveTrackingStationSampleUT(
+                chain.CommittedIndex,
+                chain.WindowStartUt,
+                chain.WindowEndUt,
+                liveUT,
+                units,
+                out bool renderHidden);
+
+            if (renderHidden)
+                return GhostSample.Outside();
+
+            Coverage coverage = chain.ClassifyCoverage(sampleUT, out TrajectoryPhase phase, out int index);
+            switch (coverage)
+            {
+                case Coverage.InSegment:
+                    // Project the matched phase to the RenderSegment it emits — the SAME projection the
+                    // Phase-2 comparator uses (anchor body as the SampleContext fallback) so the geometry
+                    // fields are byte-identical to the assembler chain. A phase with no geometry this frame
+                    // (HoldPhase) yields nothing → fall to the gap (hold) contract.
+                    if (TryProjectInSegment(phase, sampleUT, index, out GhostSample inSegment))
+                        return inSegment;
+                    return GhostSample.Gap(sampleUT);
+                case Coverage.InInteriorGap:
+                    return GhostSample.Gap(sampleUT);
+                default:
+                    return GhostSample.Outside();
+            }
+        }
+
+        // Project the located phase's first emitted RenderSegment into an InSegment GhostSample. Returns
+        // false when the phase is null or emits no geometry (a HoldPhase), so the caller holds the prior
+        // intent. The SampleContext carries the phase's anchor body as the frame-name fallback, mirroring
+        // GeometryParityComparator.ProjectGeometry so the resolved FrameBodyName matches the assembler.
+        private static bool TryProjectInSegment(
+            TrajectoryPhase phase, double sampleUT, int index, out GhostSample sample)
+        {
+            sample = default(GhostSample);
+            if (phase == null)
+                return false;
+
+            string frameBody = (phase.Anchor is AnchorFrame.BodyAnchor body) ? body.BodyName : null;
+            // Pass the REAL per-frame sampleUT into the context. Emit is currently UT-INDEPENDENT (no Emit
+            // implementation reads ctx.SampleUt, so this is byte-neutral today and keeps every parity test
+            // green), but carrying the real sampling UT here is the correct contract: this is the live
+            // per-frame path, unlike the static whole-chain projection in
+            // GeometryParityComparator.ProjectGeometry, which has no per-frame UT and deliberately passes
+            // phase.StartUt instead (see the comment there).
+            var ctx = new SampleContext(sampleUT, frameBody);
+            foreach (RenderSegment seg in phase.Emit(ctx))
+            {
+                sample = GhostSample.InSegment(seg, index, sampleUT);
+                return true;
+            }
+            return false;
+        }
     }
 }

--- a/Source/Parsek/MapRender/GeometryParityComparator.cs
+++ b/Source/Parsek/MapRender/GeometryParityComparator.cs
@@ -131,6 +131,10 @@ namespace Parsek.MapRender
                     continue;
                 // The phase's anchor body is the frame the assembler stamped on the segment; pass it as the
                 // SampleContext fallback so a conic phase whose anchor/conic body is empty still resolves.
+                // This is a STATIC whole-chain projection (no per-frame sampling UT exists here), so
+                // phase.StartUt is the deliberate SampleUt substitution; it is byte-neutral because Emit is
+                // UT-independent (no Emit reads ctx.SampleUt). The live per-frame sampler
+                // (ChainSampler.TryProjectInSegment) passes its real sampleUT for the same reason.
                 string frameBody = (phase.Anchor is AnchorFrame.BodyAnchor body) ? body.BodyName : null;
                 var ctx = new SampleContext(phase.StartUt, frameBody);
                 foreach (RenderSegment seg in phase.Emit(ctx))

--- a/Source/Parsek/MapRender/GhostRenderDirector.cs
+++ b/Source/Parsek/MapRender/GhostRenderDirector.cs
@@ -44,5 +44,32 @@ namespace Parsek.MapRender
                     return GhostRenderIntent.Hidden(label);
             }
         }
+
+        /// <summary>
+        /// Phase 3 (migration plan §5): the typed-spine entry point. Samples a <see cref="PhaseChain"/>
+        /// (via <see cref="ChainSampler.Sample(PhaseChain, double, GhostPlaybackLogic.LoopUnitSet)"/>) and
+        /// runs the SAME three-case <see cref="Decide(GhostSample, GhostRenderIntent, string)"/> the legacy
+        /// chain spine runs. ADDITIVE — it does not change the existing
+        /// <see cref="GhostRenderChain"/>-fed sampler/director path (the flag-OFF spine). Because the
+        /// sampler projects the matched phase to the same <see cref="GhostSample"/> the assembler chain
+        /// produced (Phase-2 byte-parity), the emitted <see cref="GhostRenderIntent"/> is identical to the
+        /// legacy spine's for the same geometry.
+        ///
+        /// <para><b>Test/parity convenience overload — NOT the production call path.</b>
+        /// <see cref="ShadowRenderDriver.RunFrame"/> inlines the equivalent
+        /// <see cref="ChainSampler.Sample(PhaseChain, double, GhostPlaybackLogic.LoopUnitSet)"/> +
+        /// <see cref="Decide(GhostSample, GhostRenderIntent, string)"/> pair itself, because it needs the
+        /// intermediate <see cref="GhostSample"/> afterward for the per-active-segment re-aim skip
+        /// (<c>sample.Coverage == Coverage.InSegment</c>), which this overload hides. This convenience form
+        /// keeps the typed-spine sampler+director composition addressable in one call for the headless
+        /// parity sweep (<c>PhaseSpineParityTests</c>); it is behaviorally identical to the inlined pair.</para>
+        /// </summary>
+        internal static GhostRenderIntent Decide(
+            PhaseChain chain, double liveUT, GhostPlaybackLogic.LoopUnitSet units,
+            GhostRenderIntent priorIntent, string label)
+        {
+            GhostSample sample = ChainSampler.Sample(chain, liveUT, units);
+            return Decide(sample, priorIntent, label);
+        }
     }
 }

--- a/Source/Parsek/MapRender/PhaseChain.cs
+++ b/Source/Parsek/MapRender/PhaseChain.cs
@@ -62,6 +62,11 @@ namespace Parsek.MapRender
             var phases = Phases;
             int n = phases.Count;
             if (n == 0) return -1;
+            // INTENTIONAL HARDENING (deliberately stricter than the legacy GhostRenderChain.LocateSegmentIndex,
+            // which has no NaN/Inf guard): a non-finite UT cannot match any phase, so short-circuit to -1.
+            // Unreachable from the live span clock (ResolveTrackingStationSampleUT never yields NaN/Inf for a
+            // finite liveUT), so this is a no-op in production and the two intended-mirror chains stay
+            // byte-identical for every finite UT; it only closes a degenerate non-finite input deterministically.
             if (double.IsNaN(ut) || double.IsInfinity(ut)) return -1;
 
             // rightmost phase with StartUt <= ut
@@ -107,6 +112,11 @@ namespace Parsek.MapRender
         {
             phase = null;
             index = -1;
+            // INTENTIONAL HARDENING (deliberately stricter than the legacy GhostRenderChain.ClassifyCoverage,
+            // which lets a NaN UT fall through to InInteriorGap via the < / > comparisons): a non-finite UT
+            // classifies OutsideWindow -> Hidden. Unreachable from the live span clock (a finite liveUT never
+            // produces a non-finite assembled UT), so it never diverges from the legacy chain in production; it
+            // only fail-safes a degenerate non-finite input to Hidden rather than a held stale intent.
             if (double.IsNaN(ut) || double.IsInfinity(ut))
                 return Coverage.OutsideWindow;
             if (ut < WindowStartUt || ut > WindowEndUt)

--- a/Source/Parsek/MapRender/ShadowRenderDriver.cs
+++ b/Source/Parsek/MapRender/ShadowRenderDriver.cs
@@ -63,6 +63,13 @@ namespace Parsek.MapRender
         {
             public string Signature;
             public GhostRenderChain Chain;
+            // The typed PhaseChain successor (migration plan §5 / Phase 3). Built from the SAME inputs as
+            // Chain (PhaseFactory wraps the assembler's geometry), cached under the SAME signature, and
+            // consumed by the sampler/director ONLY when MapRenderFlags.MapRenderPhaseSpineDrive is ON. It
+            // is null when neither the flag is on NOR tracing is on (no consumer needs it). The Phase-2
+            // shadow already builds a factory chain when tracing is on for byte-parity; when the spine flag
+            // is on it is also built (regardless of tracing) so the spine has something to drive.
+            public PhaseChain PhaseChain;
             // True when this cached chain was assembled from RE-AIMED OrbitSegments (the override differed
             // from the recorded list by reference). Stored WITH the chain so the per-frame skip decision
             // (ShouldSkipReaimSegment) uses the SAME resolve the chain was built from - never a second
@@ -106,6 +113,32 @@ namespace Parsek.MapRender
         /// director-drive gate), so the StockConic seed is always populated for the patch (and the
         /// reconciler reads it when render tracing is on). Kept as a property for call-site stability.</summary>
         internal static bool Enabled => true;
+
+        /// <summary>
+        /// In-game test seam (migration plan §5 / Phase 3): force the typed-spine drive ON regardless of
+        /// the default-OFF compile-time <see cref="MapRenderFlags.MapRenderPhaseSpineDrive"/> const, so a
+        /// flag-ON in-game test can exercise the PhaseChain spine without a rebuild. ORed with the const in
+        /// <see cref="PhaseSpineDriveActive"/>. Default false (normal play reads only the const). Tests MUST
+        /// restore it in a finally; a leaked true would silently flip every later ghost onto the new spine.
+        ///
+        /// <para><b>Callers MUST <see cref="Reset"/> after flipping this</b> (or run with tracing on so the
+        /// PhaseChain is always built). <see cref="BuildChainSignature"/> intentionally OMITS the spine flag
+        /// from the cache key (the flag does not change the geometry, only which spine consumes it), so a
+        /// chain cached while the flag was off can carry a null <see cref="CachedChain.PhaseChain"/>; without
+        /// a <see cref="Reset"/> that stale cache entry would persist after the flip and the flag-ON branch
+        /// would silently fall back to the assembler chain (phaseChain == null). The in-game test seam
+        /// (<see cref="PhaseSpineSwapInGameTest"/>) calls <see cref="Reset"/> on every flip for this reason.</para>
+        /// </summary>
+        internal static bool ForceSpineDriveForTesting = false;
+
+        /// <summary>
+        /// The single source of truth for "drive the sampler/director off the typed PhaseChain this frame":
+        /// the default-OFF compile-time flag OR the in-game test seam. With BOTH off (normal play) the C#
+        /// const-fold elides the new spine branch entirely (the seam is a runtime read, so the JIT keeps the
+        /// branch, but the false seam means it is never taken), so flag-OFF behavior is byte-identical.
+        /// </summary>
+        internal static bool PhaseSpineDriveActive =>
+            MapRenderFlags.MapRenderPhaseSpineDrive || ForceSpineDriveForTesting;
 
         /// <summary>
         /// Max frame gap between the shadow recording a StockConic seed and the icon-drive patch reading
@@ -280,10 +313,28 @@ namespace Parsek.MapRender
 
                     GhostRenderChain chain = GetOrBuildChain(
                         pid, traj, idx, wStart, wEnd, currentUT, units, surface,
-                        out bool chainHasReaimedSegments);
-                    GhostSample sample = ChainSampler.Sample(chain, currentUT, units);
+                        out bool chainHasReaimedSegments, out PhaseChain phaseChain);
+
+                    // THE SPINE SWAP (migration plan §5 / Phase 3). Flag OFF (default): sample the legacy
+                    // ChainAssembler-built GhostRenderChain — byte-identical to pre-Phase-3 behavior. Flag
+                    // ON: sample the typed PhaseChain instead. Both run the SAME span clock + coverage
+                    // classify + 3-case Decide, and the factory geometry byte-matches the assembler
+                    // (Phase-2 parity), so the emitted intent + side-channel stamps + draw are identical.
+                    // The director's prior-intent gap-hold is shared (one priorIntentByPid map), so the swap
+                    // does not change the hold contract.
                     priorIntentByPid.TryGetValue(pid, out GhostRenderIntent prior);
-                    GhostRenderIntent intent = GhostRenderDirector.Decide(sample, prior, traj.VesselName);
+                    GhostSample sample;
+                    GhostRenderIntent intent;
+                    if (PhaseSpineDriveActive && phaseChain != null)
+                    {
+                        sample = ChainSampler.Sample(phaseChain, currentUT, units);
+                        intent = GhostRenderDirector.Decide(sample, prior, traj.VesselName);
+                    }
+                    else
+                    {
+                        sample = ChainSampler.Sample(chain, currentUT, units);
+                        intent = GhostRenderDirector.Decide(sample, prior, traj.VesselName);
+                    }
                     priorIntentByPid[pid] = intent;
 
                     // Per-ACTIVE-SEGMENT re-aim skip (design §4, refined from per-member): only the
@@ -396,7 +447,7 @@ namespace Parsek.MapRender
             uint pid, IPlaybackTrajectory traj, int idx, double wStart, double wEnd,
             double currentUT, GhostPlaybackLogic.LoopUnitSet units,
             GhostTrajectoryPolylineRenderer.BodySurfaceProvider surface,
-            out bool chainHasReaimedSegments)
+            out bool chainHasReaimedSegments, out PhaseChain phaseChain)
         {
             // Resolve the EFFECTIVE OrbitSegments for THIS frame: a re-aim owner's in-window heliocentric
             // leg comes back re-aimed (aimed at the target's CURRENT position), every faithful member /
@@ -415,6 +466,7 @@ namespace Parsek.MapRender
             if (chainByPid.TryGetValue(pid, out CachedChain cached) && cached.Signature == sig)
             {
                 chainHasReaimedSegments = cached.HasReaimedSegments;
+                phaseChain = cached.PhaseChain;
                 return cached.Chain;
             }
 
@@ -428,58 +480,134 @@ namespace Parsek.MapRender
                 traj, idx, instanceKey: 0, wStart, wEnd, faithfulFallback: false, surface: surface,
                 orbitSegmentsOverride: overrideSegs, reaimAncestorBody: reaimAncestor);
 
-            // Phase 2 SHADOW byte-parity hook (migration plan §4). Wholly gated on
-            // MapRenderTrace.IsEnabled, so normal play pays nothing and the live draw is unchanged: this
-            // ONLY builds the new typed PhaseChain via the SAME inputs and ASSERTS its emitted geometry
-            // byte-matches the assembler's chain. On a geometry mismatch it emits the factory-parity
-            // Tier-C anomaly (rate-limited per recording). It NEVER drives a draw or mutates any surface.
-            if (MapRenderTrace.IsEnabled)
-                RunShadowFactoryParity(
-                    traj, idx, wStart, wEnd, surface, overrideSegs, reaimAncestor, chain);
+            // Build the typed PhaseChain (migration plan §5 / Phase 3) when ANY consumer needs it: the
+            // spine flag is ON (the sampler/director drive off it), OR tracing is on (the Phase-2 shadow
+            // byte-parity comparator asserts against it). When neither is on it stays null and no factory
+            // work runs, so flag-OFF normal play pays nothing beyond the unchanged assembler build above.
+            // Tolerant of any factory throw: a phase-chain build must never destabilize the live render
+            // path, so an exception leaves phaseChain null (the spine falls back to the assembler chain in
+            // RunFrame) and is logged + swallowed.
+            phaseChain = null;
+            if (PhaseSpineDriveActive || MapRenderTrace.IsEnabled)
+            {
+                try
+                {
+                    phaseChain = PhaseFactory.BuildPhaseChain(
+                        traj, idx, instanceKey: 0, wStart, wEnd, faithfulFallback: false, surface: surface,
+                        orbitSegmentsOverride: overrideSegs, reaimAncestorBody: reaimAncestor);
+
+                    // Phase 2 SHADOW byte-parity assertion (migration plan §4): assert the factory's emitted
+                    // geometry byte-matches the assembler's chain, emitting the factory-parity Tier-C anomaly
+                    // on a mismatch. Gated on tracing (the anomaly sink is). Reuses the just-built phaseChain
+                    // so a single factory build serves both the assertion and the spine.
+                    if (MapRenderTrace.IsEnabled)
+                        AssertFactoryParity(traj, wStart, phaseChain, chain);
+
+                    // Tier-A structural event on a (re)build: the phase chain's count + kinds + provenance.
+                    // Emitted only when tracing is on (EmitStructural early-returns otherwise) so it is a
+                    // pure observability line, not a hot-path cost in flag-ON-tracing-off play.
+                    EmitPhaseChainAssembled(pid, currentUT, phaseChain);
+                }
+                catch (System.Exception ex)
+                {
+                    phaseChain = null;
+                    ParsekLog.Warn("MapRender", string.Format(CultureInfo.InvariantCulture,
+                        "phase-chain build threw for rec={0}: {1}", traj?.RecordingId ?? "?", ex.Message));
+                }
+            }
 
             chainByPid[pid] = new CachedChain
             {
                 Signature = sig,
                 Chain = chain,
+                PhaseChain = phaseChain,
                 HasReaimedSegments = chainHasReaimedSegments,
             };
             return chain;
         }
 
-        // Phase 2 SHADOW byte-parity (migration plan §4): build the new typed PhaseChain from the SAME
-        // inputs the assembler consumed, and assert its emitted geometry byte-matches the assembler's
-        // chain. SHADOW ONLY - never drives a draw or mutates a surface; the caller already gated on
-        // MapRenderTrace.IsEnabled. On a geometry mismatch emits the factory-parity Tier-C anomaly
-        // (rate-limited per recording, carrying the diverging field). Tolerant of any factory throw: a
-        // shadow assertion must never destabilize the live (assembler-driven) render path, so a factory
-        // exception is logged and swallowed.
-        private static void RunShadowFactoryParity(
-            IPlaybackTrajectory traj, int idx, double wStart, double wEnd,
-            GhostTrajectoryPolylineRenderer.BodySurfaceProvider surface,
-            IReadOnlyList<OrbitSegment> overrideSegs, string reaimAncestor,
-            GhostRenderChain assemblerChain)
+        // Tier-A `phase-chain-assembled` structural event (migration plan §5): one Info line on a
+        // (re)build carrying the phase count + kinds + provenance + seam summary, so a tracing-on run can
+        // confirm the typed spine assembled the expected phases. EmitStructural early-returns when tracing
+        // is off, so this is free in normal play. ProtoOrbitLine is the closest render surface (the spine
+        // ultimately drives the proto icon/line for a conic phase).
+        private static void EmitPhaseChainAssembled(uint pid, double currentUT, PhaseChain phaseChain)
         {
-            try
+            if (!MapRenderTrace.IsEnabled || phaseChain == null)
+                return;
+
+            string details = string.Format(CultureInfo.InvariantCulture,
+                "phases={0} window=[{1:F1},{2:F1}] faithfulFallback={3} kinds={4} prov={5} seams={6}",
+                phaseChain.PhaseCount, phaseChain.WindowStartUt, phaseChain.WindowEndUt,
+                phaseChain.IsFaithfulFallback,
+                SummarizePhaseKinds(phaseChain), SummarizeProvenance(phaseChain),
+                SummarizeSeams(phaseChain));
+
+            MapRenderTrace.EmitStructural(
+                "PhaseChainAssembled", MapRenderTrace.RenderSurface.ProtoOrbitLine,
+                pid.ToString(CultureInfo.InvariantCulture), currentUT, 0.0,
+                MapRenderTrace.SegmentChangeWindowSeconds, details, phaseChain.RecordingId);
+        }
+
+        private static string SummarizePhaseKinds(PhaseChain chain)
+        {
+            var sb = new System.Text.StringBuilder();
+            for (int i = 0; i < chain.PhaseCount; i++)
             {
-                PhaseChain factoryChain = PhaseFactory.BuildPhaseChain(
-                    traj, idx, instanceKey: 0, wStart, wEnd, faithfulFallback: false, surface: surface,
-                    orbitSegmentsOverride: overrideSegs, reaimAncestorBody: reaimAncestor);
-                GeometryParityComparator.ParityResult result =
-                    GeometryParityComparator.Compare(factoryChain, assemblerChain);
-                if (!result.IsMatch)
+                if (i > 0) sb.Append('+');
+                sb.Append(PhaseKindTokens.ToToken(chain.Phases[i].Kind));
+            }
+            return sb.Length == 0 ? "(none)" : sb.ToString();
+        }
+
+        private static string SummarizeProvenance(PhaseChain chain)
+        {
+            var sb = new System.Text.StringBuilder();
+            for (int i = 0; i < chain.PhaseCount; i++)
+            {
+                if (i > 0) sb.Append('+');
+                sb.Append(SegmentProvenanceTokens.ToToken(chain.Phases[i].Provenance));
+            }
+            return sb.Length == 0 ? "(none)" : sb.ToString();
+        }
+
+        private static string SummarizeSeams(PhaseChain chain)
+        {
+            int rigid = 0, flexibleSoi = 0, other = 0;
+            for (int i = 0; i < chain.PhaseCount; i++)
+            {
+                PhaseSeam seam = chain.Phases[i].TrailingSeam;
+                if (seam == null) continue;
+                switch (seam.Kind)
                 {
-                    MapRenderTrace.EmitFactoryParity(
-                        traj.RecordingId, wStart,
-                        string.Format(CultureInfo.InvariantCulture,
-                            "diverging={0} seg={1} countMismatch={2} {3}",
-                            result.DivergingField, result.SegmentIndex, result.CountMismatch,
-                            result.Detail ?? string.Empty));
+                    case PhaseSeamKind.Rigid: rigid++; break;
+                    case PhaseSeamKind.FlexibleSoi: flexibleSoi++; break;
+                    default: other++; break;
                 }
             }
-            catch (System.Exception ex)
+            return string.Format(CultureInfo.InvariantCulture,
+                "rigid={0} flexibleSoi={1} other={2}", rigid, flexibleSoi, other);
+        }
+
+        // Phase 2 SHADOW byte-parity assertion (migration plan §4), now run against the ALREADY-BUILT
+        // PhaseChain (Phase 3 builds it once for both the assertion and the spine). Asserts the factory's
+        // emitted geometry byte-matches the assembler's chain; on a mismatch emits the factory-parity
+        // Tier-C anomaly (rate-limited per recording, carrying the diverging field). The caller already
+        // gated on MapRenderTrace.IsEnabled and wrapped the build + this call in a try/catch, so a compare
+        // here never destabilizes the live (assembler-driven) render path.
+        private static void AssertFactoryParity(
+            IPlaybackTrajectory traj, double wStart, PhaseChain factoryChain, GhostRenderChain assemblerChain)
+        {
+            GeometryParityComparator.ParityResult result =
+                GeometryParityComparator.Compare(factoryChain, assemblerChain);
+            if (!result.IsMatch)
             {
-                ParsekLog.Warn("MapRender", string.Format(CultureInfo.InvariantCulture,
-                    "shadow factory-parity threw for rec={0}: {1}", traj?.RecordingId ?? "?", ex.Message));
+                MapRenderTrace.EmitFactoryParity(
+                    traj.RecordingId, wStart,
+                    string.Format(CultureInfo.InvariantCulture,
+                        "diverging={0} seg={1} countMismatch={2} {3}",
+                        result.DivergingField, result.SegmentIndex, result.CountMismatch,
+                        result.Detail ?? string.Empty));
             }
         }
 

--- a/Source/Parsek/ParsekConfig.cs
+++ b/Source/Parsek/ParsekConfig.cs
@@ -397,4 +397,35 @@ namespace Parsek
         /// </summary>
         internal const bool MapRenderWarpEnabled = false;
     }
+
+    /// <summary>
+    /// Map / Tracking-Station render-pipeline FEATURE flags (migration plan
+    /// <c>docs/dev/plans/map-ts-render-overhaul-migration.md</c>). These are NOT player-facing settings and
+    /// NOT debug aids that break gameplay — they are runtime-reversible cutover switches for the map/TS
+    /// render overhaul, default OFF so a normal install renders exactly as today. Code-only (rebuild to
+    /// flip) so the flip is deliberate and a player cannot toggle a mid-migration spine by accident; the
+    /// flag is removed once its migration phase lands (a <c>grep-audit-*</c> gate then locks the deletion).
+    /// </summary>
+    internal static class MapRenderFlags
+    {
+        /// <summary>
+        /// Phase 3 (migration plan §5, the spine swap): when <c>true</c>, the map/TS render decision spine
+        /// (<see cref="Parsek.MapRender.ShadowRenderDriver"/>) drives <see cref="Parsek.MapRender.ChainSampler"/>
+        /// + <see cref="Parsek.MapRender.GhostRenderDirector"/> off the typed
+        /// <see cref="Parsek.MapRender.PhaseChain"/> (built by <see cref="Parsek.MapRender.PhaseFactory"/>)
+        /// instead of the <see cref="Parsek.MapRender.GhostRenderChain"/> from
+        /// <see cref="Parsek.MapRender.ChainAssembler"/>. The downstream DRAW is unchanged (the same
+        /// side-channel stamps + reconciler + stock patches), and the factory geometry byte-matches the
+        /// assembler (Phase-2 parity), so a flag-ON render is identical to flag-OFF — the parity oracle is
+        /// the gate.
+        ///
+        /// <para><b>Default FALSE.</b> With the flag OFF the legacy assembler-driven spine drives unchanged
+        /// (byte-identical to pre-Phase-3 behavior); the new <see cref="Parsek.MapRender.PhaseChain"/>
+        /// build / sampler / director consumption is inert. The flag is an instant flip-back on a
+        /// regression; it is removed in Phase 5b (alongside the legacy-draw delete), at which point a
+        /// grep-audit gate locks the deletion of this symbol. This is a DISTINCT, new flag name: it does
+        /// not reuse the removed Phase-8e director-drive setting (a grep-audit forbids that literal).</para>
+        /// </summary>
+        internal const bool MapRenderPhaseSpineDrive = false;
+    }
 }


### PR DESCRIPTION
Phase 3 of the map/TS render overhaul - **the spine swap**. **Stacked on #1211 (Phase 2)** - base `maprender-phase2-phasefactory-shadow`.

Routes the decision spine (`ChainSampler` + `GhostRenderDirector`) through the typed `PhaseChain` from `PhaseFactory` instead of `RenderSegment[]` from `ChainAssembler` - **behind the new default-OFF flag `MapRenderFlags.MapRenderPhaseSpineDrive`**.

- **Flag OFF (default):** live behavior **byte-identical** to today - the legacy assembler path drives, unchanged, with no hot-path cost when tracing is also off. Additive / inert-by-default / runtime-reversible.
- **Flag ON:** the new spine drives, rendering **identically** - the factory geometry byte-matches the assembler (Phase 2), and the new sampler uses the same span clock + 3-valued coverage + `Emit` projection, so the emitted `GhostRenderIntent`, side-channel stamps, and draw match. The Phase-0 parity oracle is the gate.
- **Legacy path intact** (deleted only in Phase 5b); the deorbit-head/`captureShift` clock is proven **out** of the swapped spine by a source-gate over all 3 spine files (no Phase-3<->Phase-6 coupling).

## Review
Full 3-lens clean-context review: **`ship-with-fixes`, no blockers** (flag-off byte-identity, flag-on intent parity, and reversibility all confirmed). Folded: re-aimed + `faithfulFallback` intent-parity cases that prove the new spine emits identical intents *through the spine* (the sweep was faithful-only); widened the deorbit-decoupling source gate to `ChainSampler` + `GhostRenderDirector`; real `sampleUT` into `SampleContext`; doc notes (ForceSpineDriveForTesting Reset(), the NaN-guard asymmetry). `dotnet test` 16491 green; no KSP deploy from this branch.

## In-game gate (HIGH RISK)
The flag-ON / flag-OFF playtest (Ctrl+Shift+T) is the remaining sign-off this phase requires. It is deferred to the batch validation; the point of no return is Phase 5b (which deletes the legacy path + removes the flag).