### PR TITLE
maprender Phase 4a: re-home TracedPath owned-draw to the spine intent (flag-gated)

### DIFF
--- a/Source/Parsek.Tests/GhostTrajectoryPolylineBuildTests.cs
+++ b/Source/Parsek.Tests/GhostTrajectoryPolylineBuildTests.cs
@@ -750,6 +750,63 @@ namespace Parsek.Tests
                 Parsek.MapRender.TracedPathTreatment.ShouldOwnLeg(directorActive));
         }
 
+        // --- Phase 4a: the Driver routes the owned-draw decision on the FLAG-AWARE signal ---
+
+        [Fact]
+        public void Driver_RoutesOwnedDrawOnFlagAwareSignal_NotRawSideChannel_SourceGate()
+        {
+            // Phase 4a re-homes the TracedPath owned-draw decision to the intent UNDER THE FLAG. The
+            // Driver's per-recording routing must read the flag-aware IsTracedPathOwnedThisFrame (which
+            // returns the legacy side-channel off the flag - byte-identical to today - and the intent
+            // source on the flag), NOT the raw IsDirectorTracedPathActive. A regression that reverted the
+            // routing to the raw side-channel (dropping the flag-ON re-home) is caught here.
+            string normalized = CollapseWhitespace(StripLineComments(ReadPolylineRendererSource()));
+            Assert.Contains(
+                "bool directorOwnsTracedPath = Parsek.MapRender.ShadowRenderDriver"
+                + ".IsTracedPathOwnedThisFrame(ghostPid, drawFrame);",
+                normalized);
+        }
+
+        private static string ReadPolylineRendererSource()
+        {
+            string root = System.IO.Path.GetFullPath(System.IO.Path.Combine(
+                AppDomain.CurrentDomain.BaseDirectory, "..", "..", "..", "..", ".."));
+            string path = System.IO.Path.Combine(
+                root, "Source", "Parsek", "Display", "GhostTrajectoryPolylineRenderer.cs");
+            if (!System.IO.File.Exists(path))
+                path = System.IO.Path.Combine(
+                    root, "Parsek", "Display", "GhostTrajectoryPolylineRenderer.cs");
+            Assert.True(System.IO.File.Exists(path), $"Source file not found at {path}");
+            return System.IO.File.ReadAllText(path);
+        }
+
+        private static string StripLineComments(string source)
+        {
+            var sb = new System.Text.StringBuilder(source.Length);
+            foreach (string line in source.Split('\n'))
+            {
+                int idx = line.IndexOf("//", StringComparison.Ordinal);
+                sb.Append(idx >= 0 ? line.Substring(0, idx) : line);
+                sb.Append('\n');
+            }
+            return sb.ToString();
+        }
+
+        private static string CollapseWhitespace(string source)
+        {
+            var sb = new System.Text.StringBuilder(source.Length);
+            bool inWs = false;
+            foreach (char c in source)
+            {
+                if (char.IsWhiteSpace(c))
+                {
+                    if (!inWs) { sb.Append(' '); inWs = true; }
+                }
+                else { sb.Append(c); inWs = false; }
+            }
+            return sb.ToString();
+        }
+
         // --- Phase 8b.2 / 8e S3b / 8e S4: ownership-signal authority (sole actual-draw set) ---
 
         [Theory]

--- a/Source/Parsek.Tests/MapRender/ShadowRenderDriverTests.cs
+++ b/Source/Parsek.Tests/MapRender/ShadowRenderDriverTests.cs
@@ -470,5 +470,147 @@ namespace Parsek.Tests
             // increments WITHOUT a continue), proving the member flows into the normal pipeline.
             Assert.Contains("overlapShadowed++", normalized);
         }
+
+        // ---- Phase 4a: re-home the TracedPath owned-draw decision to the intent (flag-gated) ----
+
+        [Fact]
+        public void IsDirectorTracedPathActiveFromIntent_FreshIntentStamp_IsActive()
+        {
+            // The intent-sourced sibling honors the SAME +/-SeedFreshnessFrames freshness window the
+            // legacy side-channel uses, so the flag-ON owned-draw routing reads the same shape.
+            const uint pid = 4001u;
+            try
+            {
+                ShadowRenderDriver.SetTracedPathStampsForTesting(pid, legacyFrame: -1, intentFrame: 100);
+                Assert.True(ShadowRenderDriver.IsDirectorTracedPathActiveFromIntent(pid, 100));
+                Assert.True(ShadowRenderDriver.IsDirectorTracedPathActiveFromIntent(
+                    pid, 100 + ShadowRenderDriver.SeedFreshnessFrames));
+                // Beyond the freshness window: stale, not active.
+                Assert.False(ShadowRenderDriver.IsDirectorTracedPathActiveFromIntent(
+                    pid, 100 + ShadowRenderDriver.SeedFreshnessFrames + 1));
+                // A pid with no intent stamp is never active.
+                Assert.False(ShadowRenderDriver.IsDirectorTracedPathActiveFromIntent(pid + 1, 100));
+            }
+            finally
+            {
+                ShadowRenderDriver.Reset();
+            }
+        }
+
+        [Fact]
+        public void IsTracedPathOwnedThisFrame_FlagOff_ReadsLegacySideChannel_NotIntent()
+        {
+            // FLAG OFF (default): the owned-draw routing reads the LEGACY side-channel (tracedPathByPid),
+            // byte-identical to today. An intent-only stamp (which never exists off the flag in production,
+            // but the seam lets us prove the SOURCE) must NOT make the leg owned when the flag is off.
+            const uint pid = 4002u;
+            bool prev = ShadowRenderDriver.ForceSpineDriveForTesting;
+            try
+            {
+                ShadowRenderDriver.ForceSpineDriveForTesting = false; // flag OFF
+                Assert.False(ShadowRenderDriver.PhaseSpineDriveActive);
+
+                // Legacy stamp present, intent stamp absent -> owned (today's behavior).
+                ShadowRenderDriver.SetTracedPathStampsForTesting(pid, legacyFrame: 50, intentFrame: -1);
+                Assert.True(ShadowRenderDriver.IsTracedPathOwnedThisFrame(pid, 50));
+
+                // Intent stamp present, legacy stamp absent -> NOT owned off the flag (it ignores intent).
+                ShadowRenderDriver.SetTracedPathStampsForTesting(pid, legacyFrame: -1, intentFrame: 50);
+                Assert.False(ShadowRenderDriver.IsTracedPathOwnedThisFrame(pid, 50));
+            }
+            finally
+            {
+                ShadowRenderDriver.ForceSpineDriveForTesting = prev;
+                ShadowRenderDriver.Reset();
+            }
+        }
+
+        [Fact]
+        public void IsTracedPathOwnedThisFrame_FlagOn_ReadsIntentSource_NotLegacySideChannel()
+        {
+            // FLAG ON: the owned-draw routing is RE-HOMED onto the spine's intent
+            // (IsDirectorTracedPathActiveFromIntent). An intent stamp owns the leg; a legacy-only stamp
+            // (without the intent sibling) does NOT - proving the source moved off the autonomous walk's
+            // side-channel onto the intent.
+            const uint pid = 4003u;
+            bool prev = ShadowRenderDriver.ForceSpineDriveForTesting;
+            try
+            {
+                ShadowRenderDriver.ForceSpineDriveForTesting = true; // flag ON
+                Assert.True(ShadowRenderDriver.PhaseSpineDriveActive);
+
+                // Intent stamp present -> owned (the re-homed source).
+                ShadowRenderDriver.SetTracedPathStampsForTesting(pid, legacyFrame: -1, intentFrame: 70);
+                Assert.True(ShadowRenderDriver.IsTracedPathOwnedThisFrame(pid, 70));
+
+                // Legacy-only stamp (no intent sibling) -> NOT owned on the flag (it reads the intent).
+                ShadowRenderDriver.SetTracedPathStampsForTesting(pid, legacyFrame: 70, intentFrame: -1);
+                Assert.False(ShadowRenderDriver.IsTracedPathOwnedThisFrame(pid, 70));
+            }
+            finally
+            {
+                ShadowRenderDriver.ForceSpineDriveForTesting = prev;
+                ShadowRenderDriver.Reset();
+            }
+        }
+
+        [Fact]
+        public void IsTracedPathOwnedThisFrame_BothStampsEqual_OwnedInEitherFlagState_NoDoubleNoGap()
+        {
+            // Production INVARIANT: RunFrame stamps the legacy + intent maps from the SAME intent in the
+            // SAME pass on the SAME frame whenever the flag is on, so the two signals are byte-identical.
+            // Modeling that (both stamped to the same frame), the owned decision is the SAME regardless of
+            // the flag - which is exactly why the flag-ON routing (reads intent) can never disagree with the
+            // proto/marker consumers (read legacy): no double-draw, no gap, in either flag state.
+            const uint pid = 4004u;
+            bool prev = ShadowRenderDriver.ForceSpineDriveForTesting;
+            try
+            {
+                ShadowRenderDriver.SetTracedPathStampsForTesting(pid, legacyFrame: 200, intentFrame: 200);
+
+                ShadowRenderDriver.ForceSpineDriveForTesting = false;
+                bool ownedOff = ShadowRenderDriver.IsTracedPathOwnedThisFrame(pid, 200);
+                ShadowRenderDriver.ForceSpineDriveForTesting = true;
+                bool ownedOn = ShadowRenderDriver.IsTracedPathOwnedThisFrame(pid, 200);
+
+                Assert.True(ownedOff);
+                Assert.True(ownedOn);
+                Assert.Equal(ownedOff, ownedOn);
+            }
+            finally
+            {
+                ShadowRenderDriver.ForceSpineDriveForTesting = prev;
+                ShadowRenderDriver.Reset();
+            }
+        }
+
+        [Fact]
+        public void RunFrame_StampsLegacyAlways_IntentOnlyUnderFlag_SourceGate()
+        {
+            // The intent stamp must be FLAG-GATED (so flag-OFF never grows it and stays byte-identical),
+            // while the legacy stamp is UNCONDITIONAL (every proto/marker consumer + flag-OFF routing reads
+            // it). A regression that stamped the intent map unconditionally (breaking flag-OFF parity) or
+            // gated the legacy stamp (breaking the proto/marker consumers) is caught here.
+            string normalized = CollapseWhitespace(StripLineComments(ReadShadowRenderDriverSource()));
+
+            // Legacy stamp is unconditional (assigned to the captured frame, no flag guard around it).
+            Assert.Contains("tracedPathByPid[pid] = tracedFrame;", normalized);
+            // Intent stamp is written ONLY inside the flag guard.
+            Assert.Contains("if (PhaseSpineDriveActive) tracedPathIntentByPid[pid] = tracedFrame;",
+                normalized);
+        }
+
+        [Fact]
+        public void OwnedDrawSource_IsFlagAware_NotRawLegacyOrRawIntent_SourceGate()
+        {
+            // The flag-aware selector chooses the intent source on the flag and the legacy source off it.
+            // A regression that hard-wired EITHER source (dropping the flag awareness) would change one of
+            // the two flag states and is caught here.
+            string normalized = CollapseWhitespace(StripLineComments(ReadShadowRenderDriverSource()));
+            Assert.Contains(
+                "return PhaseSpineDriveActive ? IsDirectorTracedPathActiveFromIntent(pid, currentFrame) "
+                + ": IsDirectorTracedPathActive(pid, currentFrame);",
+                normalized);
+        }
     }
 }

--- a/Source/Parsek/Display/GhostTrajectoryPolylineRenderer.cs
+++ b/Source/Parsek/Display/GhostTrajectoryPolylineRenderer.cs
@@ -3764,13 +3764,24 @@ namespace Parsek.Display
                     // Phase 8b.1: resolve this recording's live ghost map pid ONCE (committed-list
                     // index -> ghost vessel pid; 0 when the recording has no proto-vessel ghost, e.g. an
                     // atmospheric-only recording). The TracedPath treatment ownership decision below is
-                    // pid-keyed (ShadowRenderDriver.IsDirectorTracedPathActive), the SAME predicate the
-                    // icon-drive / orbit-line patches read to suppress the stock proto. Resolving here,
-                    // outside the leg loop, keeps the per-leg routing cheap. pid 0 (no ghost) is never
-                    // stamped by the shadow, so those recordings always take the Driver-direct path.
+                    // pid-keyed, the SAME freshness contract the icon-drive / orbit-line patches read to
+                    // suppress the stock proto. Resolving here, outside the leg loop, keeps the per-leg
+                    // routing cheap. pid 0 (no ghost) is never stamped by the shadow, so those recordings
+                    // always take the Driver-direct path.
+                    //
+                    // Phase 4a (migration plan §6.6a - re-home the TracedPath draw to the intent): the
+                    // owned-draw routing reads the FLAG-AWARE IsTracedPathOwnedThisFrame. Flag OFF
+                    // (default): it returns IsDirectorTracedPathActive (the legacy side-channel) so this is
+                    // BYTE-IDENTICAL to today - the prior-rewrite routing is untouched. Flag ON: it sources
+                    // the decision from the spine's GhostRenderIntent (IsDirectorTracedPathActiveFromIntent),
+                    // so the owned TracedPath leg is drawn from the intent rather than the autonomous walk's
+                    // side-channel, and the autonomous Driver-direct draw stands down for it. The two
+                    // underlying stamps are written from the SAME intent in the SAME shadow pass, so the
+                    // proto/marker consumers (which keep reading IsDirectorTracedPathActive) never disagree
+                    // with this routing - no double-draw, no gap, in either flag state.
                     uint ghostPid = GhostMapPresence.GetGhostVesselPidForRecording(recordingIndex);
                     bool directorOwnsTracedPath =
-                        Parsek.MapRender.ShadowRenderDriver.IsDirectorTracedPathActive(ghostPid, drawFrame);
+                        Parsek.MapRender.ShadowRenderDriver.IsTracedPathOwnedThisFrame(ghostPid, drawFrame);
 
                     bool anyDrawn = false;
                     // Disjoint-leg guard (plan 4.2): the leg index the PRIMARY head landed on this frame (-1 when

--- a/Source/Parsek/InGameTests/TracedPathOwnedDrawInGameTest.cs
+++ b/Source/Parsek/InGameTests/TracedPathOwnedDrawInGameTest.cs
@@ -1,0 +1,218 @@
+using System.Collections.Generic;
+using System.Globalization;
+using Parsek.Display;
+using Parsek.MapRender;
+using UnityEngine;
+
+namespace Parsek.InGameTests
+{
+    // Phase 4a (migration plan §6.6a - re-home the TracedPath polyline draw to the intent): the in-game
+    // gate that drives the REAL wired ShadowRenderDriver.RunFrame over a live NON-ORBITAL (TracedPath)
+    // ghost with the typed PhaseChain spine ON vs OFF and asserts the EXACTLY-ONE-PAINTER contract for the
+    // TracedPath polyline leg:
+    //
+    //  - FLAG ON (ForceSpineDriveForTesting): the owned-draw routing
+    //    (ShadowRenderDriver.IsTracedPathOwnedThisFrame) is SOURCED FROM THE INTENT
+    //    (IsDirectorTracedPathActiveFromIntent). Because RunFrame stamps the legacy side-channel
+    //    (tracedPathByPid) and the intent sibling (tracedPathIntentByPid) from the SAME intent in the SAME
+    //    pass, the owned-draw routing AGREES with the proto/marker consumers (which read
+    //    IsDirectorTracedPathActive): exactly one painter (the owned treatment), the autonomous Driver-
+    //    direct draw stands down for that leg, no double-draw, no gap.
+    //  - FLAG OFF (default): the owned-draw routing returns the LEGACY side-channel
+    //    (IsDirectorTracedPathActive) - BYTE-IDENTICAL to today; the intent stamp is never written, so the
+    //    routing is the prior-rewrite behavior unchanged.
+    //
+    // It asserts the FLAG-AWARE selector against the live RunFrame stamps - not an inlined copy - so it
+    // catches a regression that hard-wired either source or desynced the owned routing from the consumers.
+    //
+    // NOTE: in-game test (Ctrl+Shift+T / Settings > Diagnostics); cannot run headless (drives RunFrame
+    // against a live MapViewScene over a live ghost ProtoVessel). FLIGHT only; career-independent. The pure
+    // flag-aware selection + the flag-gated stamp are locked headlessly in ShadowRenderDriverTests; this
+    // exercises the Unity-coupled RunFrame -> stamp -> selector path those cannot reach.
+    public class TracedPathOwnedDrawInGameTest
+    {
+        private const string KerbinBodyName = "Kerbin";
+        private const double KerbinRadiusFallback = 600000.0;
+
+        [InGameTest(Category = "MapRender", Scene = GameScenes.FLIGHT,
+            Description = "Phase 4a TracedPath owned-draw (FLAG ON): RunFrame over a live non-orbital ghost "
+                + "sources the owned-draw decision from the intent and agrees with the proto/marker consumers "
+                + "- exactly one polyline painter, no double-draw, no gap")]
+        public void TracedPathOwnedDraw_FlagOn_SourcedFromIntent_ExactlyOnePainter()
+        {
+            RunTracedPathOwnership(forceSpineOn: true);
+        }
+
+        [InGameTest(Category = "MapRender", Scene = GameScenes.FLIGHT,
+            Description = "Phase 4a TracedPath owned-draw (FLAG OFF): RunFrame over a live non-orbital ghost "
+                + "routes the owned-draw decision on the legacy side-channel - byte-identical to today")]
+        public void TracedPathOwnedDraw_FlagOff_LegacySideChannel_Unchanged()
+        {
+            RunTracedPathOwnership(forceSpineOn: false);
+        }
+
+        // Build a live non-orbital ghost, drive RunFrame with the spine forced the requested way, and assert
+        // the flag-aware owned-draw signal contract. The shared invariant in BOTH flag states: the owned-
+        // draw routing (IsTracedPathOwnedThisFrame) equals the proto/marker consumer signal
+        // (IsDirectorTracedPathActive) for the ghost pid, so exactly one painter owns the leg (no double,
+        // no gap). Additionally: flag-OFF must read the legacy side-channel (intent stamp absent off the
+        // flag); flag-ON must read the intent source.
+        private static void RunTracedPathOwnership(bool forceSpineOn)
+        {
+            CelestialBody kerbin = FlightGlobals.Bodies?.Find(b => b.bodyName == KerbinBodyName);
+            if (kerbin == null)
+            {
+                InGameAssert.Skip("Kerbin not found in FlightGlobals.Bodies (non-stock pack)");
+                return;
+            }
+
+            double liveUT = Planetarium.GetUniversalTime();
+            double startUT = liveUT - 60.0;
+            double endUT = liveUT + 60.0;
+
+            bool prevForceSpine = ShadowRenderDriver.ForceSpineDriveForTesting;
+            bool prevForceTrace = MapRenderTrace.ForceEnabledForTesting;
+            System.Func<double> prevUTNow = GhostMapPresence.CurrentUTNow;
+            List<Recording> prevRecordings = RecordingStore.CommittedRecordings != null
+                ? new List<Recording>(RecordingStore.CommittedRecordings)
+                : new List<Recording>();
+            List<RecordingTree> prevTrees = RecordingStore.CommittedTrees != null
+                ? new List<RecordingTree>(RecordingStore.CommittedTrees)
+                : new List<RecordingTree>();
+
+            Recording rec = BuildNonOrbitalRecording(startUT, endUT, kerbin);
+            RecordingStore.ClearCommittedInternal();
+            RecordingStore.ClearCommittedTreesInternal();
+            RecordingStore.AddCommittedInternal(rec);
+            int recordingIndex = RecordingStore.CommittedRecordings.Count - 1;
+            GhostMapPresence.CurrentUTNow = () => liveUT;
+            GhostMapPresence.RemoveAllGhostVessels("tracedpath-own-start");
+            ShadowRenderDriver.Reset();
+
+            uint pid = 0u;
+            try
+            {
+                MapRenderTrace.ForceEnabledForTesting = true; // so the spine + intent path are live
+
+                // A non-orbital recording's ghost has no faithful orbit drive; it may still create a proto
+                // for the marker. Resolve the recording's ghost pid; skip gracefully if none materialized.
+                uint resolvedPid = GhostMapPresence.GetGhostVesselPidForRecording(recordingIndex);
+                Vessel ghost = null;
+                if (resolvedPid != 0u)
+                    FlightGlobals.FindVessel(resolvedPid, out ghost);
+                if (ghost == null)
+                {
+                    InGameAssert.Skip("non-orbital recording produced no ghost proto in this context");
+                    return;
+                }
+                pid = ghost.persistentId;
+
+                var scene = new MapViewScene();
+                scene.SetFrameInputs(GhostPlaybackLogic.LoopUnitSet.Empty, liveUT);
+                if (!scene.IsActive)
+                {
+                    InGameAssert.Skip("MapViewScene not active (not in FLIGHT)");
+                    return;
+                }
+
+                ShadowRenderDriver.ForceSpineDriveForTesting = forceSpineOn;
+                ShadowRenderDriver.Reset();
+                ShadowRenderDriver.RunFrame(scene);
+                int frame = Time.frameCount;
+
+                bool legacyActive = ShadowRenderDriver.IsDirectorTracedPathActive(pid, frame);
+                bool intentActive = ShadowRenderDriver.IsDirectorTracedPathActiveFromIntent(pid, frame);
+                bool ownedRouting = ShadowRenderDriver.IsTracedPathOwnedThisFrame(pid, frame);
+
+                ParsekLog.Info("TestRunner", string.Format(CultureInfo.InvariantCulture,
+                    "TracedPathOwned: forceSpineOn={0} pid={1} legacyActive={2} intentActive={3} "
+                    + "ownedRouting={4}",
+                    forceSpineOn, pid, legacyActive, intentActive, ownedRouting));
+
+                if (!legacyActive)
+                {
+                    // The spine did not decide TracedPath for this ghost this frame (e.g. coverage gap or the
+                    // ghost is orbital here). Nothing to assert about owned routing; skip rather than false-
+                    // pass.
+                    InGameAssert.Skip("spine did not decide TracedPath for the ghost this frame "
+                        + "(legacy side-channel not active)");
+                    return;
+                }
+
+                // EXACTLY-ONE-PAINTER: the owned-draw routing must AGREE with the proto/marker consumers
+                // (which read IsDirectorTracedPathActive). If they disagreed, either the owned treatment AND
+                // the autonomous direct draw would both run (double-draw), or neither would (gap). True in
+                // BOTH flag states because the two stamps come from the same intent in the same pass.
+                InGameAssert.AreEqual(legacyActive, ownedRouting,
+                    "owned-draw routing (IsTracedPathOwnedThisFrame) must agree with the proto/marker "
+                    + "consumer signal (IsDirectorTracedPathActive) - exactly one painter, no double, no gap");
+
+                if (forceSpineOn)
+                {
+                    // FLAG ON: the routing is SOURCED FROM THE INTENT, and the intent stamp is present (it
+                    // matches the legacy stamp by construction).
+                    InGameAssert.IsTrue(intentActive,
+                        "FLAG ON: the intent-sourced stamp must be present (RunFrame stamps it from the same "
+                        + "intent as the legacy side-channel)");
+                    InGameAssert.AreEqual(intentActive, ownedRouting,
+                        "FLAG ON: the owned-draw routing must equal the intent-sourced signal (re-homed)");
+                }
+                else
+                {
+                    // FLAG OFF: the intent stamp is NEVER written, so the routing reads the legacy side-
+                    // channel - byte-identical to today.
+                    InGameAssert.IsFalse(intentActive,
+                        "FLAG OFF: the intent-sourced stamp must NOT be written (flag-gated), so the routing "
+                        + "falls through to the legacy side-channel - byte-identical to today");
+                    InGameAssert.AreEqual(legacyActive, ownedRouting,
+                        "FLAG OFF: the owned-draw routing must equal the legacy side-channel signal");
+                }
+            }
+            finally
+            {
+                if (pid != 0u)
+                    GhostMapPresence.RemoveAllGhostVessels("tracedpath-own-cleanup");
+                ShadowRenderDriver.ForceSpineDriveForTesting = prevForceSpine;
+                ShadowRenderDriver.Reset();
+                MapRenderTrace.ForceEnabledForTesting = prevForceTrace;
+                RecordingStore.ClearCommittedInternal();
+                RecordingStore.ClearCommittedTreesInternal();
+                for (int i = 0; i < prevRecordings.Count; i++)
+                    RecordingStore.AddCommittedInternal(prevRecordings[i]);
+                for (int i = 0; i < prevTrees.Count; i++)
+                    RecordingStore.AddCommittedTreeInternal(prevTrees[i]);
+                GhostMapPresence.CurrentUTNow = prevUTNow;
+            }
+        }
+
+        // A short below-orbit (atmospheric / non-orbital) recording: flat Points only, NO OrbitSegment, so
+        // the spine classifies it as a TracedPath leg rather than a StockConic.
+        private static Recording BuildNonOrbitalRecording(double startUT, double endUT, CelestialBody kerbin)
+        {
+            double radius = kerbin != null ? kerbin.Radius : KerbinRadiusFallback;
+            var rec = new Recording
+            {
+                RecordingId = "tracedpath-own-" + System.Guid.NewGuid().ToString("N"),
+                VesselName = "Parsek TracedPath Own",
+                EndpointPhase = RecordingEndpointPhase.SurfacePosition,
+                EndpointBodyName = KerbinBodyName,
+                ExplicitStartUT = startUT,
+                ExplicitEndUT = endUT,
+                PlaybackEnabled = true,
+            };
+            // Two low-altitude points (an ascent stretch); no OrbitSegment -> non-orbital TracedPath leg.
+            rec.Points.Add(new TrajectoryPoint
+            {
+                ut = startUT, latitude = 0.0, longitude = 0.0, altitude = 5000.0,
+                rotation = Quaternion.identity, velocity = new Vector3(0f, 300f, 0f), bodyName = KerbinBodyName,
+            });
+            rec.Points.Add(new TrajectoryPoint
+            {
+                ut = endUT, latitude = 0.5, longitude = 0.5, altitude = 25000.0,
+                rotation = Quaternion.identity, velocity = new Vector3(0f, 800f, 0f), bodyName = KerbinBodyName,
+            });
+            rec.MarkFilesDirty();
+            return rec;
+        }
+    }
+}

--- a/Source/Parsek/MapRender/ShadowRenderDriver.cs
+++ b/Source/Parsek/MapRender/ShadowRenderDriver.cs
@@ -99,7 +99,23 @@ namespace Parsek.MapRender
         // legacy gap-glide can't stock-propagate a per-frame synthesized orbit and teleport the icon
         // across it (the s15 escape-burn teleport). Mirrors seedByPid: written each shadow frame, read
         // with the same +/-SeedFreshnessFrames tolerance, keyed on the intent (not a FixedUpdate stamp).
+        // KEPT (migration plan Phase 5): this is the legacy side-channel stamp the flag-OFF owned-draw
+        // routing + every proto/marker consumer reads via IsDirectorTracedPathActive. Phase 4a adds an
+        // intent-sourced sibling (tracedPathIntentByPid) for the flag-ON path WITHOUT touching this.
         private static readonly Dictionary<uint, int> tracedPathByPid = new Dictionary<uint, int>();
+
+        // Phase 4a (migration plan §6.6a — re-home the TracedPath polyline draw to the intent): the
+        // INTENT-SOURCED sibling of tracedPathByPid, written ONLY when the typed-spine flag is ON
+        // (PhaseSpineDriveActive). Same frame-stamp + same +/-SeedFreshnessFrames freshness contract, so
+        // the flag-ON owned-draw routing reads the SAME shape the legacy side-channel offers - but the
+        // stamp is sourced from the spine's GhostRenderIntent (intent.Treatment == TracedPath), the design
+        // §8 "scene.Apply(intent)" sourcing, not the autonomous walk. By construction it is stamped from
+        // the SAME intent, in the SAME RunFrame pass, on the SAME frame as tracedPathByPid, so the two are
+        // byte-identical when the flag is on - which is exactly why the flag-ON owned-draw routing can read
+        // it WITHOUT desyncing the proto/marker consumers that still read tracedPathByPid (no double-draw,
+        // no gap). Flag OFF: never written, so the flag-OFF routing falls through to tracedPathByPid and is
+        // byte-identical to today. Additive; nothing here is deleted (the Phase-5 cutover removes both).
+        private static readonly Dictionary<uint, int> tracedPathIntentByPid = new Dictionary<uint, int>();
 
         internal static void Reset()
         {
@@ -107,6 +123,7 @@ namespace Parsek.MapRender
             chainByPid.Clear();
             seedByPid.Clear();
             tracedPathByPid.Clear();
+            tracedPathIntentByPid.Clear();
         }
 
         /// <summary>The shadow always runs: the Director pipeline is unconditional (8e S4 dropped the
@@ -190,6 +207,61 @@ namespace Parsek.MapRender
         {
             return tracedPathByPid.TryGetValue(pid, out int f)
                 && System.Math.Abs(currentFrame - f) <= SeedFreshnessFrames;
+        }
+
+        /// <summary>
+        /// Phase 4a (migration plan §6.6a): the INTENT-SOURCED TracedPath-active signal - true when the
+        /// spine's <see cref="GhostRenderIntent"/> for <paramref name="pid"/> was a visible TracedPath
+        /// within <see cref="SeedFreshnessFrames"/> of <paramref name="currentFrame"/>, as stamped from
+        /// the intent into <see cref="tracedPathIntentByPid"/>. Written ONLY when
+        /// <see cref="PhaseSpineDriveActive"/> is on, so this returns false in flag-OFF play (no stamp).
+        /// Same freshness contract as <see cref="IsDirectorTracedPathActive"/>; the flag-ON owned-draw
+        /// routing reads THIS (the intent) instead of the legacy side-channel, while the proto/marker
+        /// consumers keep reading <see cref="IsDirectorTracedPathActive"/> - the two are byte-identical
+        /// when the flag is on (same intent, same pass, same frame), so the consumers never disagree.
+        /// </summary>
+        internal static bool IsDirectorTracedPathActiveFromIntent(uint pid, int currentFrame)
+        {
+            return tracedPathIntentByPid.TryGetValue(pid, out int f)
+                && System.Math.Abs(currentFrame - f) <= SeedFreshnessFrames;
+        }
+
+        /// <summary>
+        /// Phase 4a (migration plan §6.6a): the FLAG-AWARE "does the OWNED TracedPath treatment draw this
+        /// ghost's leg this frame (and the autonomous Driver-direct draw stand down for it)?" signal the
+        /// polyline Driver routes on. Flag ON (<see cref="PhaseSpineDriveActive"/>): source the decision
+        /// from the spine's intent (<see cref="IsDirectorTracedPathActiveFromIntent"/>) - the design §8
+        /// "scene.Apply(intent)" sourcing, re-homed off the autonomous walk's side-channel. Flag OFF
+        /// (default): fall through to the legacy <see cref="IsDirectorTracedPathActive"/> side-channel -
+        /// BYTE-IDENTICAL to today (the prior-rewrite routing is untouched). The two underlying stamps are
+        /// written from the SAME intent in the SAME pass, so the flag flip never changes WHICH frames own
+        /// the leg; it only re-points the SOURCE of the decision, keeping flag-ON consistent with the
+        /// proto/marker consumers (no double-draw, no gap) and flag-OFF unchanged.
+        /// </summary>
+        internal static bool IsTracedPathOwnedThisFrame(uint pid, int currentFrame)
+        {
+            return PhaseSpineDriveActive
+                ? IsDirectorTracedPathActiveFromIntent(pid, currentFrame)
+                : IsDirectorTracedPathActive(pid, currentFrame);
+        }
+
+        /// <summary>
+        /// Test-only seam (Phase 4a): stamps the two per-pid TracedPath frame maps the Unity-coupled
+        /// <see cref="RunFrame"/> populates, so the freshness predicates + the flag-aware selector
+        /// (<see cref="IsTracedPathOwnedThisFrame"/>) can be exercised from xUnit without a live KSP.
+        /// <paramref name="legacyFrame"/> stamps the legacy side-channel (<c>tracedPathByPid</c>, the
+        /// flag-OFF + proto/marker source); <paramref name="intentFrame"/> stamps the intent-sourced
+        /// sibling (<c>tracedPathIntentByPid</c>, the flag-ON source). A negative frame removes the stamp.
+        /// Mirrors the production contract (RunFrame stamps BOTH on the flag, only the legacy off it), but
+        /// the seam lets a test stamp them independently to prove the selector reads the right one.
+        /// Cleared by <see cref="Reset"/>.
+        /// </summary>
+        internal static void SetTracedPathStampsForTesting(uint pid, int legacyFrame, int intentFrame)
+        {
+            if (legacyFrame < 0) tracedPathByPid.Remove(pid);
+            else tracedPathByPid[pid] = legacyFrame;
+            if (intentFrame < 0) tracedPathIntentByPid.Remove(pid);
+            else tracedPathIntentByPid[pid] = intentFrame;
         }
 
         /// <summary>
@@ -375,7 +447,20 @@ namespace Parsek.MapRender
                     // line patches suppress the stock proto icon + line under the gate (the polyline owns
                     // it). Mutually exclusive with the StockConic seed above (one treatment per intent).
                     else if (intent.Visible && intent.Treatment == Treatment.TracedPath)
-                        tracedPathByPid[pid] = UnityFrame();
+                    {
+                        int tracedFrame = UnityFrame();
+                        // KEPT (legacy side-channel): every proto/marker consumer + the flag-OFF owned-draw
+                        // routing reads this via IsDirectorTracedPathActive. Stamped in BOTH flag states so
+                        // flag-OFF is byte-identical to today.
+                        tracedPathByPid[pid] = tracedFrame;
+                        // Phase 4a (intent-sourced sibling): stamp the flag-ON owned-draw signal from the
+                        // SAME intent in the SAME pass. Written ONLY under the flag so flag-OFF never grows
+                        // a stamp here (its routing keeps falling through to tracedPathByPid). On the flag
+                        // these two stamps are identical by construction, so the flag-ON owned routing and
+                        // the proto/marker consumers (which read tracedPathByPid) can never disagree.
+                        if (PhaseSpineDriveActive)
+                            tracedPathIntentByPid[pid] = tracedFrame;
+                    }
 
                     GhostRenderReconciler.NoteIntent(pid, intent);
                     EmitLocateIntent(pid, currentUT, sample, intent);
@@ -660,6 +745,7 @@ namespace Parsek.MapRender
                 chainByPid.Remove(stalePidScratch[i]);
                 seedByPid.Remove(stalePidScratch[i]);
                 tracedPathByPid.Remove(stalePidScratch[i]);
+                tracedPathIntentByPid.Remove(stalePidScratch[i]);
             }
         }
 

--- a/docs/dev/plans/map-ts-render-overhaul-migration.md
+++ b/docs/dev/plans/map-ts-render-overhaul-migration.md
@@ -199,6 +199,34 @@ to the treatment. **Tests:** in-game — polyline renders identically (oracle gr
 atmospheric/non-orbital regression scenarios. **Grep gate:** `grep-audit-traced-path-bypid` covering
 **both files** (zero `tracedPathByPid` AND zero `drewNonOrbitalLegRecordings` refs after delete).
 
+**IMPLEMENTED (Phase 4a, behind `MapRenderPhaseSpineDrive`, ADDITIVE / flag-reversible — side-channel
+deletions stay Phase 5):** the TracedPath owned-draw decision is re-homed to the spine's
+`GhostRenderIntent` *under the flag* without deleting anything.
+- **Important entanglement discovered.** A prior, fully-merged rewrite (the 8b.1 / 8e-S4 path) already
+  routes the TracedPath leg through the OWNED `TracedPathTreatment.TryDrawOwnedLeg` (the `onPreCull` host)
+  whenever the always-on shadow decides Visible+TracedPath for the ghost, keyed on `tracedPathByPid` via
+  `IsDirectorTracedPathActive`. So the BEHAVIORAL re-home (owned draw + autonomous direct stand-down +
+  proto/marker suppression) is ALREADY live in flag-OFF play; `tracedPathByPid` is stamped unconditionally
+  by `RunFrame`, independent of the spine flag. A clean "stand down the autonomous draw only when flag-ON"
+  branch is therefore either a no-op (both states already take the owned path) or a flag-OFF parity break
+  (re-routing flag-OFF to the autonomous-direct path, which would also desync the orbit-line/marker
+  consumers that read the same `IsDirectorTracedPathActive`). This is the entanglement the phase brief
+  flagged; rather than force it, 4a delivers the meaningful, non-no-op part:
+- **What 4a actually changed (additive).** `ShadowRenderDriver` gained an intent-sourced sibling stamp
+  `tracedPathIntentByPid` (written ONLY when `PhaseSpineDriveActive`, from the SAME intent in the SAME
+  `RunFrame` pass as the legacy `tracedPathByPid`), the predicate
+  `IsDirectorTracedPathActiveFromIntent`, and the FLAG-AWARE selector `IsTracedPathOwnedThisFrame` (flag ON
+  → intent source; flag OFF → legacy `IsDirectorTracedPathActive`, byte-identical to today). The polyline
+  `Driver`'s per-recording routing now reads `IsTracedPathOwnedThisFrame` instead of the raw side-channel.
+  Because the two stamps are byte-identical on the flag, the flag-ON owned routing never disagrees with the
+  proto/marker consumers (which still read `IsDirectorTracedPathActive`): exactly one painter, no
+  double-draw, no gap. NOTHING was deleted — `tracedPathByPid`, `drewNonOrbitalLegRecordings`, the
+  autonomous Driver, `TryDrawOwnedLeg`, the legacy marker anchoring all stay intact for the flag-OFF path
+  and Phase 5. Tests: `ShadowRenderDriverTests` (flag-aware selection, flag-gated stamp source-gates,
+  the equal-stamp no-double/no-gap invariant) + a `GhostTrajectoryPolylineBuildTests` Driver routing
+  source-gate + the `TracedPathOwnedDrawInGameTest` (flag ON/OFF, exactly-one-painter over a live
+  non-orbital ghost). Phase 5's `tracedPathIntentByPid` must be deleted alongside `tracedPathByPid`.
+
 ### 6b — IMGUI marker → `SuppressedMarker` treatment-owned
 **What changes:** the marker draw moves into a `SuppressedMarker` treatment; the
 `ghostsWithSuppressedIcon`/`IsIconSuppressed` floor becomes that treatment's input (KEPT, re-homed —


### PR DESCRIPTION
Phase 4a of the map/TS render overhaul - re-home the TracedPath polyline draw. **Stacked on #1213 (Phase 3)** - base `maprender-phase3-spine-swap`.

Sources the OWNED polyline-draw decision from the new spine's `GhostRenderIntent` (new `tracedPathIntentByPid` + `IsTracedPathOwnedThisFrame` selector) when `MapRenderFlags.MapRenderPhaseSpineDrive` is ON. Flag OFF (default): resolves to the legacy `tracedPathByPid` path, **byte-identical** (the intent stamp is written only under the flag). Additive + flag-reversible; **nothing deleted** (the side-channels + autonomous Driver stay for the flag-off path and Phase 5).

**No double-draw / no desync:** both stamps are written from the same frame in the same `RunFrame` branch, so the intent-sourced owned signal is byte-identical to the legacy signal on the flag - the proto-orbit-line suppression + marker consumers (still reading the legacy signal) can never disagree with the owned routing. Exactly one painter.

**Context:** a prior merged rewrite (8b.1/8e-S4) already made the TracedPath owned-draw live unconditionally, so 4a re-*sources* it to the new spine's intent under the flag rather than a first-time re-home (the dossier's "already cut over, not greenfield" framing).

## Review
Clean-context review: **`solid`, no blockers** - flag-off byte-identity and flag-on no-desync confirmed structurally airtight; only 2 cosmetic NICEs (em-dash/section-sign in docs/comments, consistent with existing convention). `dotnet test` 16498 green; no KSP deploy from this branch. The flag-on owned-draw is exercised in-game (Ctrl+Shift+T) as part of the deferred batch sign-off.