### PR TITLE
Remove remaining PendingScienceSubjects blanket-clear footguns (dead ClearRecording + CommitTree duplicate-skip)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -210,7 +210,7 @@ When a worktree's branch finishes its work, land it via a GitHub PR, NOT a local
 
 - **Toolbar button** - Toggle Parsek UI
 - **Ctrl+Shift+T** - Toggle in-game test runner (works in any scene). Results auto-export to `parsek-test-results.txt` in KSP root.
-- UI buttons: Start/Stop Recording, Preview Playback, Stop Preview, Clear Current Recording
+- UI buttons: Start/Stop Recording, Preview Playback, Stop Preview
 
 ## Debug
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,7 +159,7 @@ Pick `<target>` carefully: for new work from main, use `origin/main` because loc
 
 - **Toolbar button** - Toggle Parsek UI
 - **Ctrl+Shift+T** - Toggle in-game test runner (works in any scene). Results auto-export to `parsek-test-results.txt` in KSP root.
-- UI buttons: Start/Stop Recording, Preview Playback, Stop Preview, Clear Current Recording
+- UI buttons: Start/Stop Recording, Preview Playback, Stop Preview
 
 ## Debug
 

--- a/Source/Parsek.Tests/TreeCommitTests.cs
+++ b/Source/Parsek.Tests/TreeCommitTests.cs
@@ -1947,5 +1947,56 @@ namespace Parsek.Tests
         //   2. Triggering OnVesselSwitching (vessel switch in flight)
         //   3. Verifying that the subsequent OnLoad does NOT run revert cleanup
         // This must be verified via in-game integration testing, not unit tests.
+
+        // ============================================================
+        // CommitTree duplicate-skip must not wipe another recording's science
+        // ============================================================
+
+        // A redundant re-commit of an already-committed tree hits CommitTree's
+        // duplicate-skip early return. It must NOT blanket-clear
+        // PendingScienceSubjects: a DIFFERENT live recording's uncommitted science
+        // would be silently dropped (same footgun the discard-scoped-clear fix
+        // addressed). The commit caller's scoped NotifyLedgerTreeCommitted handles
+        // pending science.
+        [Fact]
+        public void CommitTree_DuplicateSkip_PreservesOtherRecordingUncommittedScience()
+        {
+            GameStateRecorder.PendingScienceSubjects.Clear();
+            try
+            {
+                var rec = MakeRecording("rec-dup", "tree-dup");
+                var tree = new RecordingTree
+                {
+                    Id = "tree-dup",
+                    TreeName = "Dup Tree",
+                    RootRecordingId = rec.RecordingId,
+                    ActiveRecordingId = rec.RecordingId,
+                };
+                tree.Recordings[rec.RecordingId] = rec;
+                // Commit the SAME object so the re-commit below hits ReferenceEquals.
+                RecordingStore.AddCommittedTreeForTesting(tree);
+
+                // A DIFFERENT live recording's still-uncommitted science.
+                GameStateRecorder.PendingScienceSubjects.Add(new PendingScienceSubject
+                {
+                    subjectId = "sci-other",
+                    science = 4f,
+                    subjectMaxValue = 20f,
+                    captureUT = 120.0,
+                    reasonKey = "RecoveryAsh",
+                    recordingId = "rec-other-live",
+                });
+
+                // Re-commit the same tree object: ReferenceEquals duplicate-skip early return.
+                RecordingStore.CommitTree(tree);
+
+                Assert.Contains(GameStateRecorder.PendingScienceSubjects,
+                    s => s.subjectId == "sci-other");
+            }
+            finally
+            {
+                GameStateRecorder.PendingScienceSubjects.Clear();
+            }
+        }
     }
 }

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -12865,14 +12865,6 @@ namespace Parsek
             }
         }
 
-        public void ClearRecording()
-        {
-            recorder = null;
-            lastPlaybackIndex = 0;
-            GameStateRecorder.PendingScienceSubjects.Clear();
-            Log("Recording cleared");
-        }
-
         /// <summary>
         /// Commits the active recording tree from the Commit Flight button.
         /// Finalizes all recordings, spawns leaf vessels, reserves crew.

--- a/Source/Parsek/RecordingStore.cs
+++ b/Source/Parsek/RecordingStore.cs
@@ -972,7 +972,11 @@ namespace Parsek
                     if (ReferenceEquals(committedTrees[i], tree))
                     {
                         Log($"[Parsek] WARNING: Tree '{tree.Id}' already committed — skipping duplicate");
-                        GameStateRecorder.PendingScienceSubjects.Clear();
+                        // Do NOT blanket-Clear PendingScienceSubjects here: this is a no-op
+                        // duplicate skip (nothing was committed), and every commit caller runs
+                        // the scoped LedgerOrchestrator.NotifyLedgerTreeCommitted right after,
+                        // which routes this tree's pending science and PRESERVES a DIFFERENT live
+                        // recording's uncommitted science. A blanket clear silently dropped it.
                         ClearRewindReplayTargetScope();
                         return;
                     }
@@ -1027,7 +1031,9 @@ namespace Parsek
                         Log($"[Parsek] WARNING: Tree '{tree.Id}' already committed — skipping duplicate");
                         ParsekLog.Verbose("RecordingStore",
                             $"CommitTree: duplicate tree id='{tree.Id}' skipped reason={replaceReason}");
-                        GameStateRecorder.PendingScienceSubjects.Clear();
+                        // Do NOT blanket-Clear PendingScienceSubjects here (see the ReferenceEquals
+                        // duplicate-skip above): the caller's scoped NotifyLedgerTreeCommitted handles
+                        // pending science and preserves a different recording's uncommitted science.
                         ClearRewindReplayTargetScope();
                         return;
                     }

--- a/Source/Parsek/UI/RecordingsTableUI.cs
+++ b/Source/Parsek/UI/RecordingsTableUI.cs
@@ -4111,30 +4111,6 @@ namespace Parsek
                 false, HighLogic.UISkin);
         }
 
-        internal void ShowClearRecordingConfirmation()
-        {
-            var flight = parentUI.Flight;
-            PopupDialog.SpawnPopupDialog(
-                new Vector2(0.5f, 0.5f),
-                new Vector2(0.5f, 0.5f),
-                new MultiOptionDialog(
-                    "ParsekClearRecordingConfirm",
-                    "Discard the current recording?\n\nThis cannot be undone.",
-                    "Confirm: Clear Recording",
-                    HighLogic.UISkin,
-                    new DialogGUIButton("Clear", () =>
-                    {
-                        ParsekLog.Info("UI", "User confirmed clear recording");
-                        flight.ClearRecording();
-                    }),
-                    new DialogGUIButton("Cancel", () =>
-                    {
-                        ParsekLog.Info("UI", "User cancelled clear recording");
-                    })
-                ),
-                false, HighLogic.UISkin);
-        }
-
         /// <summary>
         /// Deletes a ghost-only recording by index. No confirmation dialog — ghost-only
         /// recordings are low-commitment.


### PR DESCRIPTION
Follow-up to #1212 (which scoped the blanket `PendingScienceSubjects.Clear()` in the two non-rewind discard cores). A clean-context review of #1212 surfaced two more instances of the same footgun outside that PR's scope. This PR removes both.

`PendingScienceSubjects` is a static, per-recordingId-tagged list of science collected while a recording is live. A blanket `Clear()` next to a scoped consumer drops a **different** live recording's still-uncommitted science (ledger then under-credits what KSP already banked).

## 1. Dead `ClearRecording` stub (commit 1)

`ParsekFlight.ClearRecording()` and its sole caller `RecordingsTableUI.ShowClearRecordingConfirmation()` are **unreachable dead code** — a repo-wide grep finds zero callers of `ShowClearRecordingConfirmation`, so the "Clear Current Recording" button is no longer wired. The method is also broken even if reached: it only nulls the recorder, never discards the active tree, and blanket-clears `PendingScienceSubjects`. Removed both, plus the stale In-Game Controls doc line. No behavior change (dead code).

## 2. `CommitTree` duplicate-skip blanket clear (commit 2)

`CommitTree`'s two duplicate-skip early returns (`RecordingStore.cs:975`, `:1030` — fired on a redundant re-commit of an already-committed tree id) called `PendingScienceSubjects.Clear()` before returning. That wipes a different live recording's uncommitted science. It is also redundant: **every** commit caller runs the scoped `LedgerOrchestrator.NotifyLedgerTreeCommitted` immediately after `CommitTree`/`CommitPendingTree`:
- `ParsekFlight.CommitTreeFlight` (`:12929`)
- `MergeDialog.Commit` via `CommitPendingTree` (`:91`)
- the `CommitPendingTreeAsApplied` auto-commit seam (documented contract: callers chain `NotifyLedgerTreeCommitted` themselves)

That scoped consumer routes pending science per-recording and preserves unrelated subjects. So the duplicate-skip clears are dropped entirely (a no-op skip should not touch the global pending list); removal can only improve over the old wipe (worst case is a benign leak the next commit routes, never data loss). This also makes the duplicate-skip path consistent with the success path, which never clears.

## Tests

- New `TreeCommitTests.CommitTree_DuplicateSkip_PreservesOtherRecordingUncommittedScience`, **verified to FAIL against the pre-fix blanket clear** and pass after.
- Full suite **16270 green**; the dead-code removal breaks no build/test reference.

No CHANGELOG entry: no user-facing behavior change (dead code + a degenerate-path internal hardening; the 0.10.2 discard-economy line already covers the principle).