### PR TITLE
Remove dead "Clear Current Recording" stub

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -210,7 +210,7 @@ When a worktree's branch finishes its work, land it via a GitHub PR, NOT a local
 
 - **Toolbar button** - Toggle Parsek UI
 - **Ctrl+Shift+T** - Toggle in-game test runner (works in any scene). Results auto-export to `parsek-test-results.txt` in KSP root.
-- UI buttons: Start/Stop Recording, Preview Playback, Stop Preview, Clear Current Recording
+- UI buttons: Start/Stop Recording, Preview Playback, Stop Preview
 
 ## Debug
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,7 +159,7 @@ Pick `<target>` carefully: for new work from main, use `origin/main` because loc
 
 - **Toolbar button** - Toggle Parsek UI
 - **Ctrl+Shift+T** - Toggle in-game test runner (works in any scene). Results auto-export to `parsek-test-results.txt` in KSP root.
-- UI buttons: Start/Stop Recording, Preview Playback, Stop Preview, Clear Current Recording
+- UI buttons: Start/Stop Recording, Preview Playback, Stop Preview
 
 ## Debug
 

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -12865,14 +12865,6 @@ namespace Parsek
             }
         }
 
-        public void ClearRecording()
-        {
-            recorder = null;
-            lastPlaybackIndex = 0;
-            GameStateRecorder.PendingScienceSubjects.Clear();
-            Log("Recording cleared");
-        }
-
         /// <summary>
         /// Commits the active recording tree from the Commit Flight button.
         /// Finalizes all recordings, spawns leaf vessels, reserves crew.

--- a/Source/Parsek/UI/RecordingsTableUI.cs
+++ b/Source/Parsek/UI/RecordingsTableUI.cs
@@ -4111,30 +4111,6 @@ namespace Parsek
                 false, HighLogic.UISkin);
         }
 
-        internal void ShowClearRecordingConfirmation()
-        {
-            var flight = parentUI.Flight;
-            PopupDialog.SpawnPopupDialog(
-                new Vector2(0.5f, 0.5f),
-                new Vector2(0.5f, 0.5f),
-                new MultiOptionDialog(
-                    "ParsekClearRecordingConfirm",
-                    "Discard the current recording?\n\nThis cannot be undone.",
-                    "Confirm: Clear Recording",
-                    HighLogic.UISkin,
-                    new DialogGUIButton("Clear", () =>
-                    {
-                        ParsekLog.Info("UI", "User confirmed clear recording");
-                        flight.ClearRecording();
-                    }),
-                    new DialogGUIButton("Cancel", () =>
-                    {
-                        ParsekLog.Info("UI", "User cancelled clear recording");
-                    })
-                ),
-                false, HighLogic.UISkin);
-        }
-
         /// <summary>
         /// Deletes a ghost-only recording by index. No confirmation dialog — ghost-only
         /// recordings are low-commitment.


### PR DESCRIPTION
`ParsekFlight.ClearRecording()` and its sole caller `RecordingsTableUI.ShowClearRecordingConfirmation()` are **unreachable dead code**: a repo-wide grep finds zero callers of `ShowClearRecordingConfirmation`, so the "Clear Current Recording" button is no longer wired anywhere.

The method was also broken even if reached — it only nulled the recorder, never discarded the active tree, and blanket-cleared `GameStateRecorder.PendingScienceSubjects` (the same footgun #1212 removed from the live discard cores).

Removes both methods and drops the stale "Clear Current Recording" line from the In-Game Controls docs (`.claude/CLAUDE.md`, `AGENTS.md`). No behavior change (dead code); build clean, full suite green.

Found while investigating #1212's clean-context review. The separate `CommitTree` duplicate-skip blanket-clear that review also surfaced is handled on its own branch (`fix-committree-dup-pending-science`).