### PR TITLE
maprender Phase 4b: re-source the marker decision to the spine intent (flag-gated)

### DIFF
--- a/Source/Parsek.Tests/MapRender/ShadowRenderDriverTests.cs
+++ b/Source/Parsek.Tests/MapRender/ShadowRenderDriverTests.cs
@@ -612,5 +612,152 @@ namespace Parsek.Tests
                 + ": IsDirectorTracedPathActive(pid, currentFrame);",
                 normalized);
         }
+
+        // ---- Phase 4b: re-home the IMGUI marker draw's TracedPath disjunct to the spine intent ----
+        // The marker-draw decision (GhostMapPresence.ShouldDrawNonProtoMarkerForGhost, routed by both
+        // the flight-map + TS marker call sites) composes THREE disjuncts; only the directorTracedPath
+        // one is something the spine's intent decides. Phase 4b re-sources THAT disjunct through the SAME
+        // flag-aware selector 4a routes the polyline Driver on (IsTracedPathOwnedThisFrame), so the marker
+        // decision, the polyline owned-draw, and the proto/marker consumers all read a byte-identical
+        // TracedPath signal on the flag - no double-marker, no gap, flag-OFF byte-identical to today. The
+        // other two disjuncts (polylineOwning actual-draw, iconSuppressed = the KEPT no-conic floor) have
+        // no intent equivalent and stay legacy. These tests lock the SELECTOR the marker site now reads
+        // (the selector itself is the load-bearing 4a sibling); the Unity-coupled wrapper's static reads
+        // are covered by the in-game test (project rule: Unity-coupled -> in-game).
+
+        [Fact]
+        public void MarkerTracedPathDisjunct_FlagOff_TracksLegacySideChannel_NotIntent()
+        {
+            // FLAG OFF (default): the marker decision's TracedPath disjunct source
+            // (IsTracedPathOwnedThisFrame) reads the LEGACY side-channel - byte-identical to today. An
+            // intent-only stamp (which never exists off the flag in production) must NOT make the disjunct
+            // true. This is the marker-side mirror of the polyline Driver's flag-OFF parity.
+            const uint pid = 4101u;
+            bool prev = ShadowRenderDriver.ForceSpineDriveForTesting;
+            try
+            {
+                ShadowRenderDriver.ForceSpineDriveForTesting = false; // flag OFF
+                Assert.False(ShadowRenderDriver.PhaseSpineDriveActive);
+
+                // Legacy stamp present, intent absent -> disjunct true (today's marker behavior).
+                ShadowRenderDriver.SetTracedPathStampsForTesting(pid, legacyFrame: 80, intentFrame: -1);
+                Assert.True(ShadowRenderDriver.IsTracedPathOwnedThisFrame(pid, 80));
+
+                // Intent stamp present, legacy absent -> disjunct FALSE off the flag (it ignores intent),
+                // so the marker decision falls back to its other disjuncts only.
+                ShadowRenderDriver.SetTracedPathStampsForTesting(pid, legacyFrame: -1, intentFrame: 80);
+                Assert.False(ShadowRenderDriver.IsTracedPathOwnedThisFrame(pid, 80));
+            }
+            finally
+            {
+                ShadowRenderDriver.ForceSpineDriveForTesting = prev;
+                ShadowRenderDriver.Reset();
+            }
+        }
+
+        [Fact]
+        public void MarkerTracedPathDisjunct_FlagOn_TracksIntentSource_NotLegacySideChannel()
+        {
+            // FLAG ON: the marker decision's TracedPath disjunct is RE-HOMED onto the spine's intent
+            // (IsDirectorTracedPathActiveFromIntent). An intent stamp makes the disjunct true; a
+            // legacy-only stamp (without the intent sibling) does NOT - proving the marker's TracedPath
+            // source moved off the autonomous walk's side-channel onto the intent, design §8.
+            const uint pid = 4102u;
+            bool prev = ShadowRenderDriver.ForceSpineDriveForTesting;
+            try
+            {
+                ShadowRenderDriver.ForceSpineDriveForTesting = true; // flag ON
+                Assert.True(ShadowRenderDriver.PhaseSpineDriveActive);
+
+                ShadowRenderDriver.SetTracedPathStampsForTesting(pid, legacyFrame: -1, intentFrame: 90);
+                Assert.True(ShadowRenderDriver.IsTracedPathOwnedThisFrame(pid, 90));
+
+                ShadowRenderDriver.SetTracedPathStampsForTesting(pid, legacyFrame: 90, intentFrame: -1);
+                Assert.False(ShadowRenderDriver.IsTracedPathOwnedThisFrame(pid, 90));
+            }
+            finally
+            {
+                ShadowRenderDriver.ForceSpineDriveForTesting = prev;
+                ShadowRenderDriver.Reset();
+            }
+        }
+
+        [Fact]
+        public void MarkerTracedPathDisjunct_BothStampsEqual_SameInEitherFlagState_NoDesyncNoDoubleNoGap()
+        {
+            // Production INVARIANT (the no-desync proof for the marker site): RunFrame stamps the legacy +
+            // intent maps from the SAME intent in the SAME pass on the SAME frame whenever the flag is on,
+            // so the two are byte-identical. Modeling that, the marker's TracedPath disjunct is the SAME
+            // regardless of the flag - which is precisely why the flag-ON marker decision (sources intent)
+            // can never disagree with the proto-icon suppression in GhostOrbitLinePatch (reads the legacy
+            // IsDirectorTracedPathActive): exactly one of {proto icon, our marker} draws - no double, no gap.
+            const uint pid = 4103u;
+            bool prev = ShadowRenderDriver.ForceSpineDriveForTesting;
+            try
+            {
+                ShadowRenderDriver.SetTracedPathStampsForTesting(pid, legacyFrame: 210, intentFrame: 210);
+
+                ShadowRenderDriver.ForceSpineDriveForTesting = false;
+                bool offDisjunct = ShadowRenderDriver.IsTracedPathOwnedThisFrame(pid, 210);
+                // Marker decision with only the TracedPath disjunct true, off the flag.
+                bool offDecision = GhostMapPresence.ResolveMarkerDrawDecision(
+                    directorTracedPathActive: offDisjunct, polylineOwning: false, iconSuppressedLegacy: false);
+
+                ShadowRenderDriver.ForceSpineDriveForTesting = true;
+                bool onDisjunct = ShadowRenderDriver.IsTracedPathOwnedThisFrame(pid, 210);
+                bool onDecision = GhostMapPresence.ResolveMarkerDrawDecision(
+                    directorTracedPathActive: onDisjunct, polylineOwning: false, iconSuppressedLegacy: false);
+
+                Assert.True(offDisjunct);
+                Assert.True(onDisjunct);
+                Assert.Equal(offDisjunct, onDisjunct);   // the source is byte-identical on the flag
+                Assert.True(offDecision);
+                Assert.True(onDecision);
+                Assert.Equal(offDecision, onDecision);   // so the marker decision can never desync
+            }
+            finally
+            {
+                ShadowRenderDriver.ForceSpineDriveForTesting = prev;
+                ShadowRenderDriver.Reset();
+            }
+        }
+
+        [Fact]
+        public void MarkerSite_TracedPathDisjunct_ReadsFlagAwareSelector_NotRawLegacy_SourceGate()
+        {
+            // The marker-draw site (GhostMapPresence.ShouldDrawNonProtoMarkerForGhost) must resolve its
+            // directorTracedPathActive disjunct through the flag-aware selector IsTracedPathOwnedThisFrame
+            // (the same source the polyline Driver routes on), NOT the raw legacy IsDirectorTracedPathActive.
+            // A regression that reverted the marker site to the raw legacy read (re-coupling it to the
+            // autonomous side-channel and breaking the flag-ON re-home) is caught here.
+            string normalized = CollapseWhitespace(StripLineComments(ReadGhostMapPresenceSource()));
+
+            // The disjunct is assigned from the flag-aware selector.
+            Assert.Contains(
+                "directorTracedPathActive = Parsek.MapRender.ShadowRenderDriver.IsTracedPathOwnedThisFrame(",
+                normalized);
+            // And the raw legacy read is NOT used to assign that disjunct at the marker site (the legacy
+            // predicate still EXISTS and is read by GhostOrbitLinePatch - a different file - so this gate
+            // is scoped to GhostMapPresence.cs only).
+            Assert.DoesNotContain(
+                "directorTracedPathActive = Parsek.MapRender.ShadowRenderDriver.IsDirectorTracedPathActive(",
+                normalized);
+        }
+
+        // Read Source/Parsek/<fileName> for a source-text gate (a top-level source file, NOT under
+        // MapRender/). Mirrors ReadMapRenderSource's root resolution + the Parsek/-rooted fallback.
+        private static string ReadParsekSource(string fileName)
+        {
+            string root = Path.GetFullPath(Path.Combine(
+                AppDomain.CurrentDomain.BaseDirectory, "..", "..", "..", "..", ".."));
+            string path = Path.Combine(root, "Source", "Parsek", fileName);
+            if (!File.Exists(path))
+                path = Path.Combine(root, "Parsek", fileName);
+            Assert.True(File.Exists(path), $"Source file not found at {path}");
+            return File.ReadAllText(path);
+        }
+
+        private static string ReadGhostMapPresenceSource()
+            => ReadParsekSource("GhostMapPresence.cs");
     }
 }

--- a/Source/Parsek/GhostMapPresence.cs
+++ b/Source/Parsek/GhostMapPresence.cs
@@ -1065,7 +1065,12 @@ namespace Parsek
         /// <paramref name="directorTracedPathActive"/> disjunct), so it can never be false on a frame the
         /// proto icon is hidden. No double marker: whenever <paramref name="directorTracedPathActive"/> is
         /// true the orbit-line Postfix's first branch has set the proto <c>drawIcons=NONE</c>, so the proto
-        /// icon is not also drawn.</para>
+        /// icon is not also drawn. (Phase 4b sources this disjunct through the flag-aware
+        /// <see cref="Parsek.MapRender.ShadowRenderDriver.IsTracedPathOwnedThisFrame"/>; the no-double
+        /// argument holds in BOTH flag states because that selector is byte-identical-on-the-flag to the
+        /// raw <c>IsDirectorTracedPathActive</c> the orbit-line Postfix still reads - same stamp, same
+        /// frame - so the marker and the proto-icon suppression can never disagree. This pure core is
+        /// itself flag-agnostic: it just ORs the three resolved booleans.)</para>
         /// </summary>
         internal static bool ResolveMarkerDrawDecision(
             bool directorTracedPathActive,
@@ -1094,6 +1099,38 @@ namespace Parsek
         /// <c>out</c> values let the call site emit a per-pid change-based trace line explaining WHY
         /// the marker drew or was skipped. (8e S4 dropped the director-drive gate, so the former
         /// <c>gateOn</c> out is gone.)
+        ///
+        /// <para><b>Phase 4b (migration plan §6.6b — re-home the IMGUI marker draw to the spine intent,
+        /// behind <see cref="Parsek.MapRender.MapRenderFlags.MapRenderPhaseSpineDrive"/>, ADDITIVE /
+        /// flag-reversible):</b> the <paramref name="directorTracedPathActive"/> disjunct - the ONE
+        /// disjunct of this decision the Director's <c>GhostRenderIntent</c> actually decides - is now
+        /// resolved through the FLAG-AWARE selector
+        /// <see cref="Parsek.MapRender.ShadowRenderDriver.IsTracedPathOwnedThisFrame"/> (the SAME
+        /// selector 4a routes the polyline Driver through), NOT the raw legacy
+        /// <see cref="Parsek.MapRender.ShadowRenderDriver.IsDirectorTracedPathActive"/>:
+        /// <list type="bullet">
+        /// <item>Flag OFF (default): the selector falls through to the legacy
+        /// <c>IsDirectorTracedPathActive</c> side-channel - BYTE-IDENTICAL to today.</item>
+        /// <item>Flag ON: the selector sources the disjunct from the spine's intent
+        /// (<c>IsDirectorTracedPathActiveFromIntent</c>) - the design §8 "scene.Apply(intent)" sourcing,
+        /// re-homed off the autonomous walk's side-channel.</item>
+        /// </list>
+        /// Because <c>RunFrame</c> stamps the legacy + intent maps from the SAME intent in the SAME pass
+        /// on the SAME frame whenever the flag is on, the two stamps are byte-identical on the flag, so
+        /// the flag flip NEVER changes WHICH frames this disjunct is true - it only re-points the SOURCE.
+        /// That is exactly why the marker call sites (flight-map + TS, which route through this) stay in
+        /// lockstep with BOTH the polyline Driver (also reads <c>IsTracedPathOwnedThisFrame</c>) AND the
+        /// proto/marker consumers in <c>GhostOrbitLinePatch</c> (which keep reading the legacy
+        /// <c>IsDirectorTracedPathActive</c> to set <c>drawIcons=NONE</c>): no double-marker, no gap.</para>
+        ///
+        /// <para><b>KEPT, NOT moved (Phase 5):</b> the <paramref name="polylineOwning"/> (actual-draw,
+        /// downstream of the intent) and <paramref name="iconSuppressed"/>
+        /// (<c>ghostsWithSuppressedIcon</c> / <see cref="IsIconSuppressed"/>) disjuncts have NO intent
+        /// equivalent today (the director emits only None/StockConic/TracedPath; there is no
+        /// <c>SuppressedMarker</c> treatment value, so the spine does not decide the no-conic floor case),
+        /// so they stay on their legacy sources. The icon floor is the ONLY marker signal for
+        /// below-atmosphere / off-arc / no-bounds ghosts and is a KEPT permanent fallback - re-sourcing
+        /// it would need the director to learn the SuppressedMarker treatment (out of Phase-4 scope).</para>
         /// </summary>
         internal static bool ShouldDrawNonProtoMarkerForGhost(
             uint ghostPid,
@@ -1101,7 +1138,10 @@ namespace Parsek
             out bool polylineOwning,
             out bool iconSuppressed)
         {
-            directorTracedPathActive = Parsek.MapRender.ShadowRenderDriver.IsDirectorTracedPathActive(
+            // Phase 4b: flag-aware source for the TracedPath disjunct (flag ON -> intent;
+            // flag OFF -> legacy IsDirectorTracedPathActive, byte-identical to today). Same selector the
+            // polyline Driver routes on, so the marker decision never desyncs from the owned draw.
+            directorTracedPathActive = Parsek.MapRender.ShadowRenderDriver.IsTracedPathOwnedThisFrame(
                 ghostPid, UnityEngine.Time.frameCount);
             polylineOwning = IsPolylineOwningGhostPhase(ghostPid);
             iconSuppressed = IsIconSuppressed(ghostPid);

--- a/Source/Parsek/InGameTests/SuppressedMarkerOwnedDrawInGameTest.cs
+++ b/Source/Parsek/InGameTests/SuppressedMarkerOwnedDrawInGameTest.cs
@@ -1,0 +1,232 @@
+using System.Collections.Generic;
+using System.Globalization;
+using Parsek.MapRender;
+using UnityEngine;
+
+namespace Parsek.InGameTests
+{
+    // Phase 4b (migration plan §6.6b - re-home the IMGUI marker draw to the spine intent): the in-game
+    // gate that drives the REAL wired ShadowRenderDriver.RunFrame over a live BELOW-ATMOSPHERE / no-bounds
+    // (non-orbital) ghost with the typed PhaseChain spine ON vs OFF and asserts the marker-draw contract
+    // both marker call sites route through (GhostMapPresence.ShouldDrawNonProtoMarkerForGhost):
+    //
+    //  - NEVER A BLANK ICON: a below-atmosphere / no-bounds ghost (no faithful conic to seed) must draw
+    //    OUR non-proto marker - the marker decision is true - in BOTH flag states. The icon floor
+    //    (ghostsWithSuppressedIcon / IsIconSuppressed) is the KEPT no-conic fallback and is untouched here;
+    //    this test proves re-sourcing the TracedPath disjunct did not open a blank-icon gap.
+    //  - NO DOUBLE-MARKER, NO GAP: the marker decision's TracedPath disjunct source
+    //    (IsTracedPathOwnedThisFrame, the flag-aware selector 4a routes the polyline Driver on) must AGREE
+    //    with the proto/marker consumer signal in GhostOrbitLinePatch (IsDirectorTracedPathActive) for the
+    //    ghost pid. Because RunFrame stamps the legacy side-channel (tracedPathByPid) and the intent sibling
+    //    (tracedPathIntentByPid) from the SAME intent in the SAME pass, the marker site agrees with the
+    //    proto-line consumer in BOTH flag states - exactly one of {proto icon, our marker} per ghost.
+    //  - FLAG ON sources the disjunct from the intent (IsDirectorTracedPathActiveFromIntent); FLAG OFF
+    //    falls through to the legacy side-channel - byte-identical to today.
+    //
+    // NOTE: in-game test (Ctrl+Shift+T / Settings > Diagnostics); cannot run headless (drives RunFrame
+    // against a live MapViewScene over a live ghost ProtoVessel + reads the Unity-coupled marker wrapper).
+    // FLIGHT only; career-independent. The pure flag-aware selection + the pure marker decision are locked
+    // headlessly in ShadowRenderDriverTests + MarkerDrawDecisionTests; this exercises the Unity-coupled
+    // RunFrame -> stamp -> marker-wrapper path those cannot reach.
+    public class SuppressedMarkerOwnedDrawInGameTest
+    {
+        private const string KerbinBodyName = "Kerbin";
+        private const double KerbinRadiusFallback = 600000.0;
+
+        [InGameTest(Category = "MapRender", Scene = GameScenes.FLIGHT,
+            Description = "Phase 4b marker draw (FLAG ON): RunFrame over a live below-atmosphere ghost draws "
+                + "our non-proto marker (never a blank icon), sources the TracedPath disjunct from the intent, "
+                + "and stays in sync with the proto-line consumer - no double-marker, no gap")]
+        public void MarkerDraw_FlagOn_SourcedFromIntent_NeverBlankNoDouble()
+        {
+            RunMarkerOwnership(forceSpineOn: true);
+        }
+
+        [InGameTest(Category = "MapRender", Scene = GameScenes.FLIGHT,
+            Description = "Phase 4b marker draw (FLAG OFF): RunFrame over a live below-atmosphere ghost draws "
+                + "our non-proto marker on the legacy side-channel - byte-identical to today")]
+        public void MarkerDraw_FlagOff_LegacySideChannel_Unchanged()
+        {
+            RunMarkerOwnership(forceSpineOn: false);
+        }
+
+        // Build a live below-atmosphere (non-orbital) ghost, drive RunFrame with the spine forced the
+        // requested way, and assert the marker-draw contract. Shared invariants in BOTH flag states:
+        //  (1) the marker decision (ShouldDrawNonProtoMarkerForGhost) draws our marker - never a blank icon;
+        //  (2) the marker's TracedPath disjunct source (IsTracedPathOwnedThisFrame) equals the proto-line
+        //      consumer signal (IsDirectorTracedPathActive) - exactly one painter, no double, no gap.
+        // Additionally: flag-OFF reads the legacy side-channel (intent stamp absent off the flag); flag-ON
+        // reads the intent source.
+        private static void RunMarkerOwnership(bool forceSpineOn)
+        {
+            CelestialBody kerbin = FlightGlobals.Bodies?.Find(b => b.bodyName == KerbinBodyName);
+            if (kerbin == null)
+            {
+                InGameAssert.Skip("Kerbin not found in FlightGlobals.Bodies (non-stock pack)");
+                return;
+            }
+
+            double liveUT = Planetarium.GetUniversalTime();
+            double startUT = liveUT - 60.0;
+            double endUT = liveUT + 60.0;
+
+            bool prevForceSpine = ShadowRenderDriver.ForceSpineDriveForTesting;
+            bool prevForceTrace = MapRenderTrace.ForceEnabledForTesting;
+            System.Func<double> prevUTNow = GhostMapPresence.CurrentUTNow;
+            List<Recording> prevRecordings = RecordingStore.CommittedRecordings != null
+                ? new List<Recording>(RecordingStore.CommittedRecordings)
+                : new List<Recording>();
+            List<RecordingTree> prevTrees = RecordingStore.CommittedTrees != null
+                ? new List<RecordingTree>(RecordingStore.CommittedTrees)
+                : new List<RecordingTree>();
+
+            Recording rec = BuildNonOrbitalRecording(startUT, endUT, kerbin);
+            RecordingStore.ClearCommittedInternal();
+            RecordingStore.ClearCommittedTreesInternal();
+            RecordingStore.AddCommittedInternal(rec);
+            int recordingIndex = RecordingStore.CommittedRecordings.Count - 1;
+            GhostMapPresence.CurrentUTNow = () => liveUT;
+            GhostMapPresence.RemoveAllGhostVessels("suppressedmarker-own-start");
+            ShadowRenderDriver.Reset();
+
+            uint pid = 0u;
+            try
+            {
+                MapRenderTrace.ForceEnabledForTesting = true; // so the spine + intent path are live
+
+                uint resolvedPid = GhostMapPresence.GetGhostVesselPidForRecording(recordingIndex);
+                Vessel ghost = null;
+                if (resolvedPid != 0u)
+                    FlightGlobals.FindVessel(resolvedPid, out ghost);
+                if (ghost == null)
+                {
+                    InGameAssert.Skip("non-orbital recording produced no ghost proto in this context");
+                    return;
+                }
+                pid = ghost.persistentId;
+
+                var scene = new MapViewScene();
+                scene.SetFrameInputs(GhostPlaybackLogic.LoopUnitSet.Empty, liveUT);
+                if (!scene.IsActive)
+                {
+                    InGameAssert.Skip("MapViewScene not active (not in FLIGHT)");
+                    return;
+                }
+
+                ShadowRenderDriver.ForceSpineDriveForTesting = forceSpineOn;
+                ShadowRenderDriver.Reset();
+                ShadowRenderDriver.RunFrame(scene);
+                int frame = Time.frameCount;
+
+                bool legacyActive = ShadowRenderDriver.IsDirectorTracedPathActive(pid, frame);
+                bool intentActive = ShadowRenderDriver.IsDirectorTracedPathActiveFromIntent(pid, frame);
+                bool ownedRouting = ShadowRenderDriver.IsTracedPathOwnedThisFrame(pid, frame);
+
+                // The full marker decision (the SAME wrapper both marker call sites route through).
+                bool shouldDraw = GhostMapPresence.ShouldDrawNonProtoMarkerForGhost(
+                    pid, out bool decDirectorTraced, out bool decPolylineOwning, out bool decIconSuppressed);
+
+                ParsekLog.Info("TestRunner", string.Format(CultureInfo.InvariantCulture,
+                    "SuppressedMarkerOwned: forceSpineOn={0} pid={1} legacyActive={2} intentActive={3} "
+                    + "ownedRouting={4} shouldDraw={5} decDirectorTraced={6} decPolylineOwning={7} "
+                    + "decIconSuppressed={8}",
+                    forceSpineOn, pid, legacyActive, intentActive, ownedRouting, shouldDraw,
+                    decDirectorTraced, decPolylineOwning, decIconSuppressed));
+
+                // The marker site's TracedPath disjunct (decDirectorTraced) IS the flag-aware selector
+                // output - the Phase-4b re-home. Assert that wiring directly.
+                InGameAssert.AreEqual(ownedRouting, decDirectorTraced,
+                    "the marker site's directorTracedPathActive disjunct must be the flag-aware selector "
+                    + "(IsTracedPathOwnedThisFrame) output - the Phase-4b re-home");
+
+                // EXACTLY-ONE-PAINTER / NO-GAP across the marker<->proto-line boundary: the marker's
+                // TracedPath disjunct source must AGREE with the proto-line consumer signal
+                // (IsDirectorTracedPathActive). True in BOTH flag states because the two stamps come from the
+                // same intent in the same pass. A disagreement would either double-draw (marker + proto) or
+                // gap (neither).
+                InGameAssert.AreEqual(legacyActive, ownedRouting,
+                    "marker TracedPath disjunct source (IsTracedPathOwnedThisFrame) must agree with the "
+                    + "proto-line consumer signal (IsDirectorTracedPathActive) - no double-marker, no gap");
+
+                // NEVER A BLANK ICON: a below-atmosphere / no-bounds ghost has no faithful conic to seed, so
+                // the marker decision MUST draw our non-proto marker. The decision is a SUPERSET (TracedPath
+                // OR polyline-owns OR the kept icon floor), so as long as ANY of those is set the marker
+                // draws. We assert the decision is true; if it were false the ghost would show a blank icon.
+                InGameAssert.IsTrue(shouldDraw,
+                    "a below-atmosphere / no-bounds ghost must draw our non-proto marker (never a blank "
+                    + "icon) - the marker decision is the dual of 'proto icon hidden'");
+
+                if (forceSpineOn)
+                {
+                    // FLAG ON: the marker's TracedPath disjunct is SOURCED FROM THE INTENT. When the spine
+                    // decided TracedPath this frame (legacyActive), the intent stamp is present and the
+                    // disjunct equals it.
+                    if (legacyActive)
+                    {
+                        InGameAssert.IsTrue(intentActive,
+                            "FLAG ON: the intent-sourced stamp must be present (RunFrame stamps it from the "
+                            + "same intent as the legacy side-channel)");
+                        InGameAssert.AreEqual(intentActive, decDirectorTraced,
+                            "FLAG ON: the marker TracedPath disjunct must equal the intent-sourced signal "
+                            + "(re-homed)");
+                    }
+                }
+                else
+                {
+                    // FLAG OFF: the intent stamp is NEVER written, so the marker disjunct reads the legacy
+                    // side-channel - byte-identical to today.
+                    InGameAssert.IsFalse(intentActive,
+                        "FLAG OFF: the intent-sourced stamp must NOT be written (flag-gated), so the marker "
+                        + "disjunct falls through to the legacy side-channel - byte-identical to today");
+                    InGameAssert.AreEqual(legacyActive, decDirectorTraced,
+                        "FLAG OFF: the marker TracedPath disjunct must equal the legacy side-channel signal");
+                }
+            }
+            finally
+            {
+                if (pid != 0u)
+                    GhostMapPresence.RemoveAllGhostVessels("suppressedmarker-own-cleanup");
+                ShadowRenderDriver.ForceSpineDriveForTesting = prevForceSpine;
+                ShadowRenderDriver.Reset();
+                MapRenderTrace.ForceEnabledForTesting = prevForceTrace;
+                RecordingStore.ClearCommittedInternal();
+                RecordingStore.ClearCommittedTreesInternal();
+                for (int i = 0; i < prevRecordings.Count; i++)
+                    RecordingStore.AddCommittedInternal(prevRecordings[i]);
+                for (int i = 0; i < prevTrees.Count; i++)
+                    RecordingStore.AddCommittedTreeInternal(prevTrees[i]);
+                GhostMapPresence.CurrentUTNow = prevUTNow;
+            }
+        }
+
+        // A short below-orbit (atmospheric / non-orbital) recording: flat low-altitude Points only, NO
+        // OrbitSegment, so the spine classifies it as a TracedPath leg rather than a StockConic - the
+        // below-atmosphere / no-bounds case whose marker the icon floor would otherwise carry.
+        private static Recording BuildNonOrbitalRecording(double startUT, double endUT, CelestialBody kerbin)
+        {
+            double radius = kerbin != null ? kerbin.Radius : KerbinRadiusFallback;
+            var rec = new Recording
+            {
+                RecordingId = "suppressedmarker-own-" + System.Guid.NewGuid().ToString("N"),
+                VesselName = "Parsek SuppressedMarker Own",
+                EndpointPhase = RecordingEndpointPhase.SurfacePosition,
+                EndpointBodyName = KerbinBodyName,
+                ExplicitStartUT = startUT,
+                ExplicitEndUT = endUT,
+                PlaybackEnabled = true,
+            };
+            rec.Points.Add(new TrajectoryPoint
+            {
+                ut = startUT, latitude = 0.0, longitude = 0.0, altitude = 5000.0,
+                rotation = Quaternion.identity, velocity = new Vector3(0f, 300f, 0f), bodyName = KerbinBodyName,
+            });
+            rec.Points.Add(new TrajectoryPoint
+            {
+                ut = endUT, latitude = 0.5, longitude = 0.5, altitude = 25000.0,
+                rotation = Quaternion.identity, velocity = new Vector3(0f, 800f, 0f), bodyName = KerbinBodyName,
+            });
+            rec.MarkFilesDirty();
+            return rec;
+        }
+    }
+}

--- a/docs/dev/plans/map-ts-render-overhaul-migration.md
+++ b/docs/dev/plans/map-ts-render-overhaul-migration.md
@@ -240,6 +240,43 @@ scenarios.
 `seedByPid` re-assert into an explicit MANAGED-treatment contract, but the `GhostOrbitLinePatch:396`
 prefix read with `±SeedFreshnessFrames=2` STAYS (KSP owns the icon-drive site). No deletion here.
 
+**IMPLEMENTED (Phase 4b, behind `MapRenderPhaseSpineDrive`, ADDITIVE / flag-reversible — side-channel
+deletions stay Phase 5):** the marker-draw decision is re-sourced to the spine's `GhostRenderIntent`
+*under the flag* without deleting anything.
+- **Entanglement (anticipated by the phase brief).** The marker decision
+  (`GhostMapPresence.ShouldDrawNonProtoMarkerForGhost` → pure `ResolveMarkerDrawDecision`, read by the
+  flight-map `ParsekUI.DrawMapMarkers` and the TS `ParsekTrackingStation.ClassifyAtmosphericMarkerSkip`)
+  composes THREE disjuncts — `directorTracedPathActive || polylineOwning || iconSuppressedLegacy`. Only
+  the FIRST is something the spine's intent decides. `polylineOwning` (`IsPolylineOwningGhostPhase`) is the
+  downstream ACTUAL-draw set, not an intent field; `iconSuppressedLegacy` (`ghostsWithSuppressedIcon` /
+  `IsIconSuppressed`) is the KEPT no-conic floor, set by `GhostOrbitLinePatch` — and the director emits
+  only `None`/`StockConic`/`TracedPath` (there is NO `SuppressedMarker` `Treatment` value yet), so the
+  spine does not decide the no-conic floor case. Re-sourcing the floor would require the director to learn
+  a new `SuppressedMarker` treatment + producer (out of Phase-4 scope). So 4b re-homes the one
+  intent-decided disjunct and KEEPS the other two on their legacy sources — exactly the 4a outcome
+  (re-source the intent-decided signal, keep the rest).
+- **What 4b actually changed (additive).** `ShouldDrawNonProtoMarkerForGhost` now resolves its
+  `directorTracedPathActive` disjunct through the FLAG-AWARE selector
+  `ShadowRenderDriver.IsTracedPathOwnedThisFrame` (flag ON → the intent source
+  `IsDirectorTracedPathActiveFromIntent`; flag OFF → the legacy `IsDirectorTracedPathActive`,
+  byte-identical to today), instead of the raw legacy `IsDirectorTracedPathActive`. This is the SAME
+  selector 4a routes the polyline Driver on, so the marker call sites, the polyline owned-draw, and the
+  proto/marker consumers in `GhostOrbitLinePatch` (which keep reading the legacy `IsDirectorTracedPathActive`
+  to set `drawIcons=NONE` + add to `ghostsWithSuppressedIcon`) all read a byte-identical TracedPath signal
+  on the flag — exactly one of {proto icon, our marker} per ghost, no double-marker, no gap, and flag-OFF
+  byte-identical. NOTHING was deleted — `ghostsWithSuppressedIcon`, `IsIconSuppressed`, `seedByPid`, the
+  legacy marker anchoring all stay intact for the flag-OFF path and Phase 5. **No NEW side-channel was
+  added:** 4b reuses 4a's `tracedPathIntentByPid` / `IsTracedPathOwnedThisFrame` (so there is nothing new
+  for the Phase-5 deletion list beyond what 4a already recorded; reusing the one selector is what keeps the
+  marker site in lockstep with the polyline Driver). The `icon-suppressed` EVENT is NOT re-pointed in 4b —
+  it tracks `IsIconSuppressed` (the kept floor, unchanged); re-pointing it onto a `SuppressedMarker`
+  treatment is the Phase-5+ cutover when the director learns that treatment. Tests:
+  `ShadowRenderDriverTests` (the marker-decision flag-aware selection, the equal-stamp no-desync/no-double/
+  no-gap invariant, a marker-site source-gate that the disjunct reads the flag-aware selector not the raw
+  legacy) + `MarkerDrawDecisionTests` (the pure decision, unchanged) + the
+  `SuppressedMarkerOwnedDrawInGameTest` (flag ON/OFF over a live below-atmosphere ghost: never a blank
+  icon, marker disjunct agrees with the proto-line consumer).
+
 ---
 
 ## 7. Phase 5 — Delete the legacy draw, in TWO parts with different dependencies (cutover-complete) ⚠️


### PR DESCRIPTION
Phase 4b of the map/TS render overhaul - re-home the marker decision. **Stacked on #1214 (Phase 4a)** - base `maprender-phase4a-tracedpath`.

One load-bearing line: `GhostMapPresence.ShouldDrawNonProtoMarkerForGhost` now resolves its `directorTracedPathActive` disjunct via the flag-aware `IsTracedPathOwnedThisFrame` selector (4a's sibling) instead of the raw legacy `IsDirectorTracedPathActive`. Flag OFF (default): **byte-identical** (selector returns the legacy value). Flag ON: intent-sourced, **byte-identical-on-the-flag** (both stamps written from the same intent/frame/branch in `RunFrame`), so the marker site, the polyline Driver, and the proto-icon suppression all read one identical signal - exactly one of {proto icon, our marker}, no double-draw, no gap. The other two disjuncts (`polylineOwning`, `iconSuppressed`/the no-conic floor) stay on legacy and the floor is KEPT. No new side-channel (reuses 4a's). Additive + flag-reversible; nothing deleted.

## Review
Clean-context review: **`solid`, no findings**. Flag-off byte-identity and flag-on no-desync confirmed; +4 marker-specific headless tests + an in-game flag-on/off test. `dotnet test` 16502 green; no KSP deploy.

## Plan note (5a dependency, confirmed)
The line-visibility cascade Phase 5a deletes is the **writer** of `ghostsWithSuppressedIcon` (the no-conic floor that 4b's `iconSuppressed` disjunct keeps reading - the only marker signal for below-atmosphere/off-arc/no-bounds ghosts). So the plan's 6b (re-home the floor write into a director-emitted `SuppressedMarker` treatment) is a **hard predecessor of 5a** and is sequenced as a new Phase 4c before the cascade delete - else those ghosts regress to a blank icon.