### PR TITLE
maprender Phase 6: descent re-stitch behind the spine-drive flag (additive, reversible)

### DIFF
--- a/Source/Parsek.Tests/MapRender/CrossMemberSeamStitcherTests.cs
+++ b/Source/Parsek.Tests/MapRender/CrossMemberSeamStitcherTests.cs
@@ -1,0 +1,498 @@
+using System;
+using System.Collections.Generic;
+using Parsek;
+using Parsek.MapRender;
+using UnityEngine;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    /// <summary>
+    /// Phase-6 guard for <see cref="CrossMemberSeamStitcher"/> (migration plan §8 / design §9.1): the ONE
+    /// cross-member geometric seam built in v1 — the orbit↔landing G1 descent re-stitch.
+    ///
+    /// Covers (1) the absorbed swept-deorbit-head / captureShift clock join (re-anchored descent head), (2)
+    /// the per-leg head-gate, (3) the G1 tangent-match math + the <c>rigid-seam-tangent-discontinuity</c>
+    /// predicate, (4) the compose-AFTER-the-remap ordering, and (5) the clean spine API
+    /// <see cref="CrossMemberSeamStitcher.TryStitchDescentSeam"/> (descent member promoted to a visible
+    /// first-class phase; non-descent / non-re-aim returns false byte-identically; out-of-window retires the
+    /// sub-surface ghost rather than holding a stale below-surface sample).
+    ///
+    /// Each assertion states the bug it catches: a wrong clock would re-anchor the descent to the wrong UT
+    /// (the icon-frozen / mis-rotation bug); a wrong tangent predicate would flag a continuous landing or
+    /// miss a real kink; a missing retire would leave the documented sub-surface ghost; engaging on a
+    /// non-descent unit would break flag-OFF parity.
+    ///
+    /// <para>The tracer-integration cases touch the shared <c>MapRenderTrace</c> / <c>ParsekLog</c> static
+    /// state, so this class runs in the Sequential collection.</para>
+    /// </summary>
+    [Collection("Sequential")]
+    public class CrossMemberSeamStitcherTests
+    {
+        private static TrajectoryPoint Pt(double ut, string body)
+            => new TrajectoryPoint { ut = ut, bodyName = body };
+
+        private static TrackSection Sec(double s, double e, SegmentEnvironment env)
+            => new TrackSection { startUT = s, endUT = e, environment = env };
+
+        // A representative destination sidereal rotation period (Duna), as the existing DescentTriggerTests use.
+        private const double DunaTrot = 65517.859375;
+
+        // ---- Geometry chosen so cycle 0's LIVE window contains a real trigger window ----
+        // conicEnd = recordedDeorbitUT + captureShift = 200 + (-150) = 50 (positive, inside cycle 0).
+        // With Trot=300, 200 mod 300 = 200, so trigger = first t>=50 congruent to 200 (mod 300) = 200.
+        // descentHead(liveUT) = 200 + (liveUT - 200); descent clip = [recordedDeorbitUT, descentEndUT] = [200,300].
+        private const double RecDeorbit = 200.0;
+        private const double DescentEnd = 300.0;
+        private const double CaptureShift = -150.0;
+        private const double TestTrot = 300.0;     // small period so the trigger lands at 200 (inside cycle 0)
+        private const double Tpark = 80.0;
+        private const double Cadence = 2000.0;     // single span instance; cycle 0 = liveUT [0, 2000)
+        private const double SpanStart = 0.0;
+        private const double SpanEnd = 1000.0;
+        private const double PhaseAnchor = 0.0;
+        private const int DescentMemberIdx = 0;
+        private const int TransferMemberIdx = 2;
+
+        // Build a descent-trigger LoopUnit + set whose descent set = {DescentMemberIdx}. Mirrors the working
+        // fixture in GhostTrajectoryPolylineBuildTests.MakeDescentUnitSet (Supported plan + valid schedule =>
+        // IsReaim; non-NaN periods + non-empty descent set => HasDescentTrigger).
+        private static GhostPlaybackLogic.LoopUnitSet MakeDescentUnitSet(
+            double recordedDeorbitUT = RecDeorbit, double descentEndUT = DescentEnd,
+            double captureShift = CaptureShift, double trot = TestTrot, double tpark = Tpark)
+        {
+            var plan = new Parsek.Reaim.ReaimMissionPlan { Supported = true };
+            var sched = new Parsek.Reaim.ReaimWindowPlanner.ReaimWindowSchedule { Valid = true };
+            var unit = new GhostPlaybackLogic.LoopUnit(
+                ownerIndex: TransferMemberIdx, memberIndices: new[] { DescentMemberIdx, TransferMemberIdx },
+                spanStartUT: SpanStart, spanEndUT: SpanEnd, cadenceSeconds: Cadence, phaseAnchorUT: PhaseAnchor,
+                overlapCadenceSeconds: Cadence, memberWindows: null, relaunchSchedule: null,
+                reaimPlan: plan, reaimSchedule: sched,
+                loiterCuts: null, arrivalHoldSeconds: 0.0, arrivalHoldAtUT: double.NaN,
+                arrivalAlignPeriodSeconds: double.NaN, arrivalAmberReason: null,
+                launchBodyRotationPeriodSeconds: double.NaN, launchHoldEngaged: false, recordedSoiExitUT: double.NaN,
+                descentMemberIndices: new[] { DescentMemberIdx }, recordedDeorbitUT: recordedDeorbitUT,
+                descentEndUT: descentEndUT, destinationBodyRotationPeriodSeconds: trot,
+                loiterPeriodSeconds: tpark, captureShiftSeconds: captureShift,
+                transferMemberIndex: TransferMemberIdx);
+            var ownerByIndex = new Dictionary<int, int>
+            {
+                { DescentMemberIdx, TransferMemberIdx }, { TransferMemberIdx, TransferMemberIdx },
+            };
+            return new GhostPlaybackLogic.LoopUnitSet(
+                new Dictionary<int, GhostPlaybackLogic.LoopUnit> { { TransferMemberIdx, unit } }, ownerByIndex);
+        }
+
+        // The descent member's per-member trajectory: a Duna parking conic [150,200] then a body-fixed
+        // atmospheric reentry/descent run [200..300] so the factory classifies the traced run as a
+        // DescentPhase (a non-surface/non-approach traced run AFTER the first conic). The chain window is
+        // [150,300].
+        private static MockTrajectory DescentMemberTrajectory()
+            => new MockTrajectory
+            {
+                RecordingId = "rec-descent",
+                VesselName = "Duna Lander",
+                Points = new List<TrajectoryPoint> { Pt(200, "Duna"), Pt(250, "Duna"), Pt(300, "Duna") },
+                OrbitSegments = new List<OrbitSegment>
+                {
+                    new OrbitSegment { startUT = 150, endUT = 200, bodyName = "Duna", semiMajorAxis = 400000, eccentricity = 0.01 },
+                },
+                TrackSections = new List<TrackSection>
+                {
+                    Sec(150, 200, SegmentEnvironment.ExoBallistic),
+                    Sec(200, 300, SegmentEnvironment.Atmospheric),
+                },
+            };
+
+        private static PhaseChain DescentMemberChain()
+            => PhaseFactory.BuildPhaseChain(
+                DescentMemberTrajectory(), DescentMemberIdx, instanceKey: 0,
+                windowStartUT: 150, windowEndUT: 300);
+
+        // ---- (1) The absorbed swept-deorbit-head clock: TryResolveDescentSeamHead ----
+
+        [Fact]
+        public void DescentSeamHead_TriggeredFrame_ReAnchorsToSweptDeorbitHead()
+        {
+            // The defining clock: at a live UT inside the clip the re-anchored head is
+            // recordedDeorbitUT + (liveUT - triggerUT). With trigger=200, liveUT=250 => head=250.
+            var units = MakeDescentUnitSet();
+            Assert.True(units.TryGetUnitForMember(DescentMemberIdx, out GhostPlaybackLogic.LoopUnit unit));
+            Assert.True(unit.HasDescentTrigger);
+
+            // The same triggerUT the head re-anchors on (shared source).
+            Parsek.Reaim.DescentTrigger.ComputeDescentTiming(
+                0, PhaseAnchor, Cadence, SpanStart, RecDeorbit, TestTrot, CaptureShift, null,
+                out _, out _, out double triggerUT);
+            Assert.Equal(200.0, triggerUT, 6); // congruent to deorbit (200) mod Trot (300), >= entry (50)
+
+            double liveUT = triggerUT + 50.0; // inside the [200,300] clip
+            bool ok = CrossMemberSeamStitcher.TryResolveDescentSeamHead(
+                unit, DescentMemberIdx, unitCycle: 0, currentUT: liveUT,
+                memberStartUT: 150, memberEndUT: 300,
+                out double head, out Parsek.Reaim.DescentTrigger.DescentHeadPhase phase);
+
+            Assert.True(ok);
+            Assert.Equal(Parsek.Reaim.DescentTrigger.DescentHeadPhase.Descent, phase);
+            Assert.Equal(RecDeorbit + (liveUT - triggerUT), head, 6); // swept deorbit head, forward-only
+        }
+
+        [Fact]
+        public void DescentSeamHead_BeforeTrigger_IsLoiter_NotRendered()
+        {
+            // Before the trigger (entry <= liveUT < trigger) the unit is in Loiter: the descent member is
+            // HIDDEN (the icon circles the transfer member's conic), so the stitcher does not render it.
+            var units = MakeDescentUnitSet();
+            units.TryGetUnitForMember(DescentMemberIdx, out GhostPlaybackLogic.LoopUnit unit);
+
+            // entry = 50, trigger = 200 -> a UT strictly between is Loiter.
+            bool ok = CrossMemberSeamStitcher.TryResolveDescentSeamHead(
+                unit, DescentMemberIdx, unitCycle: 0, currentUT: 120.0,
+                memberStartUT: 150, memberEndUT: 300, out double head, out var phase);
+
+            Assert.False(ok);
+            Assert.True(double.IsNaN(head));
+            Assert.Equal(Parsek.Reaim.DescentTrigger.DescentHeadPhase.Loiter, phase);
+        }
+
+        [Fact]
+        public void DescentSeamHead_NonDescentMember_ReturnsFalse_ByteIdentical()
+        {
+            // The transfer member (not a descent-set member) is never re-anchored by this clock.
+            var units = MakeDescentUnitSet();
+            units.TryGetUnitForMember(TransferMemberIdx, out GhostPlaybackLogic.LoopUnit unit);
+
+            bool ok = CrossMemberSeamStitcher.TryResolveDescentSeamHead(
+                unit, TransferMemberIdx, unitCycle: 0, currentUT: 250.0,
+                memberStartUT: 0, memberEndUT: 1000, out double head, out _);
+
+            Assert.False(ok);
+            Assert.True(double.IsNaN(head));
+        }
+
+        // ---- (2) The per-leg head-gate (transfer-member deorbit-tail legs sweep to the seam) ----
+
+        [Fact]
+        public void DeorbitTailLegHead_EligibleLegBelowSeam_GatesOnSweptHead()
+        {
+            // A deorbit-tail leg (leg end at/below the seam) gates on the swept deorbit head; a non-eligible
+            // leg keeps the loop head. This is the absorbed ResolveTransferLegHeadUT contract.
+            double seamUT = 200.0, eps = 1.0, loopHead = 999.0, deorbitTailHead = 180.0;
+
+            double belowSeam = CrossMemberSeamStitcher.ResolveDeorbitTailLegHead(
+                legEndUT: 190.0, seamUT, eps, loopHead, deorbitTailHead, deorbitTailLegEligible: true);
+            Assert.Equal(deorbitTailHead, belowSeam);
+
+            double aboveSeam = CrossMemberSeamStitcher.ResolveDeorbitTailLegHead(
+                legEndUT: 250.0, seamUT, eps, loopHead, deorbitTailHead, deorbitTailLegEligible: true);
+            Assert.Equal(loopHead, aboveSeam);
+
+            double notEligible = CrossMemberSeamStitcher.ResolveDeorbitTailLegHead(
+                legEndUT: 190.0, seamUT, eps, loopHead, deorbitTailHead, deorbitTailLegEligible: false);
+            Assert.Equal(loopHead, notEligible);
+        }
+
+        // ---- (3) The G1 tangent-match math + the rigid-seam-tangent-discontinuity predicate ----
+
+        [Fact]
+        public void TangentSeam_AlignedTangents_AreContinuous()
+        {
+            var leaving = new Vector3(1f, 0f, 0f);
+            var entering = new Vector3(1f, 0.01f, 0f); // ~0.57deg, well within ~5.7deg tolerance
+            Assert.True(CrossMemberSeamStitcher.IsTangentSeamContinuous(leaving, entering));
+        }
+
+        [Fact]
+        public void TangentSeam_DivergentTangents_AreDiscontinuity()
+        {
+            var leaving = new Vector3(1f, 0f, 0f);
+            var entering = new Vector3(0f, 1f, 0f); // 90deg kink => discontinuity
+            Assert.False(CrossMemberSeamStitcher.IsTangentSeamContinuous(leaving, entering));
+        }
+
+        [Fact]
+        public void TangentSeam_DegenerateTangent_IsContinuous_NoFalseAnomaly()
+        {
+            // An unmeasurable (zero-length / non-finite) tangent is NOT a discontinuity (no false anomaly).
+            Assert.True(CrossMemberSeamStitcher.IsTangentSeamContinuous(Vector3.zero, new Vector3(1f, 0f, 0f)));
+            Assert.True(CrossMemberSeamStitcher.IsTangentSeamContinuous(
+                new Vector3(float.NaN, 0f, 0f), new Vector3(1f, 0f, 0f)));
+        }
+
+        [Fact]
+        public void TangentSeam_RespectsCustomTolerance()
+        {
+            var leaving = new Vector3(1f, 0f, 0f);
+            var entering = new Vector3(1f, 1f, 0f); // 45deg
+            // 45deg is over the default ~5.7deg tolerance, but under a generous 60deg (1.05 rad) tolerance.
+            Assert.False(CrossMemberSeamStitcher.IsTangentSeamContinuous(leaving, entering));
+            Assert.True(CrossMemberSeamStitcher.IsTangentSeamContinuous(leaving, entering, toleranceRadians: 1.05));
+        }
+
+        [Fact]
+        public void TangentFromPositions_FirstDifference_IsTheSegmentDirection()
+        {
+            Vector3 t = CrossMemberSeamStitcher.TangentFromPositions(
+                new Vector3(0f, 0f, 0f), new Vector3(3f, 4f, 0f));
+            Assert.Equal(3f, t.x, 4f);
+            Assert.Equal(4f, t.y, 4f);
+        }
+
+        [Fact]
+        public void TangentFromPositions_DegeneratePair_IsZero()
+        {
+            // Equal endpoints / non-finite => zero (an unmeasurable tangent, no false anomaly downstream).
+            Assert.Equal(Vector3.zero, CrossMemberSeamStitcher.TangentFromPositions(
+                new Vector3(1f, 1f, 1f), new Vector3(1f, 1f, 1f)));
+            Assert.Equal(Vector3.zero, CrossMemberSeamStitcher.TangentFromPositions(
+                new Vector3(0f, 0f, 0f), new Vector3(float.NaN, 0f, 0f)));
+        }
+
+        [Fact]
+        public void OrbitLandingSeam_IsRigidG1_OnCamera()
+        {
+            // The descent re-stitch seam is the canonical Rigid + G1 + OnCamera contract (a tangent kink is a
+            // real, visible discontinuity to surface).
+            PhaseSeam seam = CrossMemberSeamStitcher.BuildOrbitLandingSeam();
+            Assert.Equal(PhaseSeamKind.Rigid, seam.Kind);
+            Assert.Equal(ContinuityOrder.G1, seam.Continuity);
+            Assert.True(seam.RequiresTangentMatch);
+            Assert.True(seam.OnCamera);
+        }
+
+        // ---- (4) Compose-AFTER-the-remap ordering ----
+
+        [Fact]
+        public void Stitch_ComposesAfterRemap_HeadIsReAnchored_NotTheRawSampleUT()
+        {
+            // The ordering contract (design §9.1): the stitcher composes AFTER the span-clock remap. The
+            // stitched DriveUT is the RE-ANCHORED descent head (recordedDeorbitUT + (liveUT - triggerUT)),
+            // NOT the raw post-remap sampleUT it is handed. Proven by passing a deliberately-wrong sampleUT:
+            // the stitcher ignores it and re-anchors off liveUT, so the result is independent of sampleUT.
+            var units = MakeDescentUnitSet();
+            PhaseChain chain = DescentMemberChain();
+
+            Parsek.Reaim.DescentTrigger.ComputeDescentTiming(
+                0, PhaseAnchor, Cadence, SpanStart, RecDeorbit, TestTrot, CaptureShift, null,
+                out _, out _, out double triggerUT);
+            double liveUT = triggerUT + 50.0;
+            double expectedHead = RecDeorbit + (liveUT - triggerUT); // 250
+
+            bool a = CrossMemberSeamStitcher.TryStitchDescentSeam(
+                chain, sampleUT: 999.0 /* wrong on purpose */, liveUT, units, out GhostSample sa);
+            bool b = CrossMemberSeamStitcher.TryStitchDescentSeam(
+                chain, sampleUT: -777.0 /* also wrong */, liveUT, units, out GhostSample sb);
+
+            Assert.True(a);
+            Assert.True(b);
+            Assert.Equal(expectedHead, sa.DriveUT, 6);
+            Assert.Equal(sa.DriveUT, sb.DriveUT); // independent of the (wrong) sampleUT => re-anchored, not raw
+        }
+
+        // ---- (5) The spine API: TryStitchDescentSeam ----
+
+        [Fact]
+        public void Stitch_TriggeredDescentMember_PromotesVisibleTracedPathDescent()
+        {
+            var units = MakeDescentUnitSet();
+            PhaseChain chain = DescentMemberChain();
+
+            Parsek.Reaim.DescentTrigger.ComputeDescentTiming(
+                0, PhaseAnchor, Cadence, SpanStart, RecDeorbit, TestTrot, CaptureShift, null,
+                out _, out _, out double triggerUT);
+            double liveUT = triggerUT + 50.0; // head = 250, inside the descent run [200,300]
+
+            bool ok = CrossMemberSeamStitcher.TryStitchDescentSeam(
+                chain, sampleUT: liveUT, liveUT, units, out GhostSample stitched);
+
+            Assert.True(ok);
+            Assert.Equal(Coverage.InSegment, stitched.Coverage);
+            Assert.Equal(Treatment.TracedPath, stitched.Treatment); // the promoted body-fixed descent
+            Assert.Equal("Duna", stitched.FrameBodyName);
+            Assert.Equal(250.0, stitched.DriveUT, 6);
+
+            // The promoted descent carries the cross-member orbit↔landing seam: the stitcher re-stamps the
+            // segment's LEADING seam to Rigid (the factory leaves it None; the seam is the stitcher's to own).
+            // A None leading seam here would be the bug — the orbit↔landing join would render with no seam
+            // contract and the G1 discontinuity check downstream would have nothing to assert against.
+            Assert.Equal(SeamKind.Rigid, stitched.Segment.LeadingSeam);
+
+            // The promoted phase covering the head is a first-class DescentPhase (no longer hidden in the
+            // transfer member).
+            Assert.True(chain.TryGetPhase(stitched.DriveUT, out TrajectoryPhase phase, out _));
+            Assert.IsType<DescentPhase>(phase);
+        }
+
+        [Fact]
+        public void StampOrbitLandingSeam_SetsRigidLeading_PreservesEverythingElse()
+        {
+            // The stitcher owns the cross-member seam: StampOrbitLandingSeam re-stamps ONLY the leading seam
+            // to Rigid (BuildOrbitLandingSeam mapped to legacy SeamKind) and carries every other field through.
+            var original = new RenderSegment(
+                SegmentKind.Landing, Treatment.TracedPath, 200.0, 300.0, "Duna",
+                SegmentPayload.Traced, isGenerated: false,
+                leadingSeam: SeamKind.None, trailingSeam: SeamKind.FlexibleSoi);
+
+            RenderSegment seamed = CrossMemberSeamStitcher.StampOrbitLandingSeam(original);
+
+            Assert.Equal(SeamKind.Rigid, seamed.LeadingSeam);          // the new orbit↔landing seam
+            Assert.Equal(SeamKind.FlexibleSoi, seamed.TrailingSeam);   // unchanged
+            Assert.Equal(original.Kind, seamed.Kind);
+            Assert.Equal(original.Treatment, seamed.Treatment);
+            Assert.Equal(original.StartUT, seamed.StartUT);
+            Assert.Equal(original.EndUT, seamed.EndUT);
+            Assert.Equal(original.FrameBodyName, seamed.FrameBodyName);
+            Assert.Equal(original.IsGenerated, seamed.IsGenerated);
+        }
+
+        [Fact]
+        public void Stitch_NonReaimUnit_ReturnsFalse_ByteIdentical()
+        {
+            // An Empty (non-looped) unit set has no descent trigger => the stitcher never engages, so the
+            // base coverage path renders unchanged (flag-OFF parity preserved when the flag is on).
+            PhaseChain chain = DescentMemberChain();
+            // The bool false IS the decline signal; the caller (ChainSampler) discards the out-param on a
+            // false return and falls through to its own coverage path, so an out-param assertion here would be
+            // tautological (default vs default). The load-bearing check is the bool.
+            bool ok = CrossMemberSeamStitcher.TryStitchDescentSeam(
+                chain, sampleUT: 250.0, liveUT: 250.0, GhostPlaybackLogic.LoopUnitSet.Empty, out _);
+            Assert.False(ok);
+        }
+
+        [Fact]
+        public void Stitch_NonDescentMember_OfDescentUnit_ReturnsFalse()
+        {
+            // The transfer member of a descent-trigger unit is NOT a descent-set member, so the stitcher
+            // declines (the transfer member renders through its own path).
+            var units = MakeDescentUnitSet();
+            PhaseChain transferChain = PhaseFactory.BuildPhaseChain(
+                DescentMemberTrajectory(), TransferMemberIdx, instanceKey: 0, windowStartUT: 150, windowEndUT: 300);
+            bool ok = CrossMemberSeamStitcher.TryStitchDescentSeam(
+                transferChain, sampleUT: 250.0, liveUT: 250.0, units, out _);
+            Assert.False(ok);
+        }
+
+        [Fact]
+        public void Stitch_PastDescentEnd_RetiresSubSurfaceGhost_NoHeldSample()
+        {
+            // SUB-SURFACE-GHOST-RETIRES (the documented bug closed): once the clip is Done (liveUT past the
+            // descent window), the stitcher returns FALSE WITHOUT a held sample, so the descent member's
+            // intent falls to Hidden and the ghost RETIRES rather than clamping to a stale below-surface
+            // sample. Pick a liveUT well past the trigger + clip duration (100s clip), inside cycle 0.
+            var units = MakeDescentUnitSet();
+            PhaseChain chain = DescentMemberChain();
+
+            Parsek.Reaim.DescentTrigger.ComputeDescentTiming(
+                0, PhaseAnchor, Cadence, SpanStart, RecDeorbit, TestTrot, CaptureShift, null,
+                out _, out _, out double triggerUT);
+            double pastEnd = triggerUT + 150.0; // > trigger + 100s clip => Done
+
+            bool ok = CrossMemberSeamStitcher.TryResolveDescentSeamHead(
+                units.TryGetUnitForMember(DescentMemberIdx, out var u) ? u : default,
+                DescentMemberIdx, 0, pastEnd, 150, 300, out _, out var phase);
+            Assert.False(ok);
+            Assert.Equal(Parsek.Reaim.DescentTrigger.DescentHeadPhase.Done, phase);
+
+            // RETIRE is signaled by the bool false WITHOUT a held sample: the caller (ChainSampler) discards
+            // the out-param on a false return and renders nothing (GhostSample.Outside), so the sub-surface
+            // ghost retires. Asserting the unread out-param (default vs default) would be tautological; the
+            // bool is the contract.
+            bool stitchOk = CrossMemberSeamStitcher.TryStitchDescentSeam(
+                chain, sampleUT: pastEnd, liveUT: pastEnd, units, out _);
+            Assert.False(stitchOk);
+        }
+
+        [Fact]
+        public void Stitch_NullChain_OrNullUnits_ReturnsFalse()
+        {
+            Assert.False(CrossMemberSeamStitcher.TryStitchDescentSeam(
+                null, 0, 0, MakeDescentUnitSet(), out _));
+            Assert.False(CrossMemberSeamStitcher.TryStitchDescentSeam(
+                DescentMemberChain(), 0, 0, null, out _));
+        }
+
+        // ---- (6) MapRenderTrace integration (the standing priority: "full logging coverage for the map
+        // render tracer (integration with it)") ----
+
+        [Fact]
+        public void DescentStitchedDetails_CarryMemberHeadPhaseAndRigidG1Seam()
+        {
+            // The Tier-A DescentStitched structural line carries the promoted member, the re-anchored head,
+            // the head phase, and the Rigid+G1 seam tag. Asserting the PURE builder (no global sink) is
+            // deterministic in the full parallel suite, unlike a ParsekLog.TestSinkForTesting round-trip
+            // (ParsekLog's [ThreadStatic] sink + SuppressLogging are poisoned by sibling tests).
+            string details = CrossMemberSeamStitcher.BuildDescentStitchedDetails(
+                committedIndex: 0, reAnchoredHead: 250.0,
+                phase: Parsek.Reaim.DescentTrigger.DescentHeadPhase.Descent);
+
+            Assert.Contains("member=0", details);
+            Assert.Contains("reAnchoredHead=250", details);
+            Assert.Contains("phase=Descent", details);
+            Assert.Contains("seam=rigid+G1", details);
+            Assert.Contains("onCamera=true", details);
+        }
+
+        [Fact]
+        public void TangentDiscontinuity_TokenDetailsAndRaiseDecision()
+        {
+            // The Tier-C anomaly token is stable + grep-able, its detail line carries the angle, tolerance,
+            // and both tangents, and the raise DECISION is gated on IsTangentSeamContinuous (raise ONLY on
+            // divergence). Pure asserts (no global sink) - deterministic in the full parallel suite.
+            Assert.Equal("rigid-seam-tangent-discontinuity", MapRenderTrace.AnomalyRigidSeamTangentDiscontinuity);
+
+            var leaving = new Vector3(1f, 0f, 0f);
+            var divergent = new Vector3(0f, 1f, 0f); // 90deg kink -> would raise
+            Assert.False(CrossMemberSeamStitcher.IsTangentSeamContinuous(leaving, divergent));
+
+            string details = CrossMemberSeamStitcher.BuildTangentDiscontinuityDetails(
+                leaving, divergent, measuredAngleRadians: Math.PI / 2.0);
+            Assert.Contains("angle=1.5708rad", details);
+            Assert.Contains("tol=", details);
+            Assert.Contains("leaving=(1.00,0.00,0.00)", details);
+            Assert.Contains("entering=(0.00,1.00,0.00)", details);
+
+            var aligned = new Vector3(1f, 0.01f, 0f); // ~0.57deg -> would NOT raise
+            Assert.True(CrossMemberSeamStitcher.IsTangentSeamContinuous(leaving, aligned));
+        }
+
+        [Fact]
+        public void Stitch_Triggered_RecordsDescentStitchTraceOnce_OnChange()
+        {
+            // WIRING + rate-limit (deterministic, no ParsekLog global): a triggered stitch reaches the Tier-A
+            // emit gate exactly once, and a second same-frame/same-phase stitch is suppressed by the
+            // once-per-event guard (no per-frame spam). Asserting via the MapRenderTrace signature-dict seam
+            // (which the stitcher's EmitDescentStitchedTraceOnChange populates only when it actually reaches
+            // the emit) proves the wiring without depending on the shared ParsekLog.TestSinkForTesting (whose
+            // cross-test global routing is the established flake source - see project memory).
+            var units = MakeDescentUnitSet();
+            PhaseChain chain = DescentMemberChain();
+            Parsek.Reaim.DescentTrigger.ComputeDescentTiming(
+                0, PhaseAnchor, Cadence, SpanStart, RecDeorbit, TestTrot, CaptureShift, null,
+                out _, out _, out double triggerUT);
+            double liveUT = triggerUT + 50.0;
+
+            bool prevForce = MapRenderTrace.ForceEnabledForTesting;
+            try
+            {
+                MapRenderTrace.Reset(); // clear the per-pid once-per-event signature dict
+                MapRenderTrace.ForceEnabledForTesting = true;
+                MapRenderTrace.FrameCounterOverrideForTesting = () => 0; // Time.frameCount is a Unity ECall
+                Assert.Equal(0, MapRenderTrace.DescentStitchSignatureCountForTesting);
+
+                bool a = CrossMemberSeamStitcher.TryStitchDescentSeam(chain, liveUT, liveUT, units, out _);
+                Assert.True(a);
+                Assert.Equal(1, MapRenderTrace.DescentStitchSignatureCountForTesting); // wired: gate reached once
+
+                bool b = CrossMemberSeamStitcher.TryStitchDescentSeam(chain, liveUT, liveUT, units, out _);
+                Assert.True(b);
+                Assert.Equal(1, MapRenderTrace.DescentStitchSignatureCountForTesting); // unchanged onset => no dup
+            }
+            finally
+            {
+                MapRenderTrace.ForceEnabledForTesting = prevForce;
+                MapRenderTrace.FrameCounterOverrideForTesting = null;
+                MapRenderTrace.Reset();
+            }
+        }
+    }
+}

--- a/Source/Parsek/GhostPlaybackLogic.SpanClock.cs
+++ b/Source/Parsek/GhostPlaybackLogic.SpanClock.cs
@@ -2409,6 +2409,37 @@ namespace Parsek
         }
 
         /// <summary>
+        /// Phase 6 (the descent re-stitch, <see cref="Parsek.MapRender.CrossMemberSeamStitcher"/>): resolve the
+        /// span-clock CYCLE for descent-trigger unit member <paramref name="i"/> at the live clock
+        /// <paramref name="liveUT"/>, via the SAME <see cref="DecideUnitMemberRender"/> path the resolver /
+        /// engine use (one source of truth — the cycle the spine's
+        /// <see cref="ResolveTrackingStationSampleUT"/> already resolved this frame). The cross-member stitcher
+        /// needs the cycle to re-anchor the descent head; exposing this thin wrapper keeps the
+        /// <see cref="DecideUnitMemberRender"/> argument list (and the span-clock arithmetic) out of the
+        /// stitcher. Returns false (cycle 0) for a non-descent-trigger unit or an unresolved span clock —
+        /// byte-identical-off everywhere the descent trigger does not engage. Pure; no Unity (xUnit-testable).
+        /// </summary>
+        internal static bool TryResolveDescentUnitCycle(
+            LoopUnit unit, int i, double liveUT, double memberStartUT, double memberEndUT,
+            out long unitCycle)
+        {
+            unitCycle = 0;
+            if (!unit.HasDescentTrigger)
+                return false;
+
+            memberStartUT = unit.MemberStartUT(i, memberStartUT);
+            memberEndUT = unit.MemberEndUT(i, memberEndUT);
+
+            UnitMemberRenderDecision decision = DecideUnitMemberRender(
+                liveUT, unit.PhaseAnchorUT, unit.SpanStartUT, unit.SpanEndUT, unit.CadenceSeconds,
+                memberStartUT, memberEndUT, out _, out unitCycle, out _,
+                unit.RelaunchSchedule, unit.LoiterCuts, unit.ArrivalHoldSeconds, unit.ArrivalHoldAtUT,
+                unit.ArrivalAlignPeriodSeconds, unit.LaunchBodyRotationPeriodSeconds, unit.LaunchHoldEngaged,
+                unit.RecordedSoiExitUT);
+            return decision != UnitMemberRenderDecision.SpanClockUnresolved;
+        }
+
+        /// <summary>
         /// C1 (flight descent icon ride): true iff committed index <paramref name="i"/> is a descent-SET member
         /// of a descent-trigger unit that is CURRENTLY rendering its own slice of the re-anchored descent clip
         /// this frame — i.e. <see cref="Parsek.Reaim.DescentTrigger.TryResolveDescentMemberHead"/> returns true

--- a/Source/Parsek/InGameTests/DescentReStitchInGameTest.cs
+++ b/Source/Parsek/InGameTests/DescentReStitchInGameTest.cs
@@ -1,0 +1,294 @@
+using System.Collections.Generic;
+using System.Globalization;
+using Parsek.MapRender;
+using UnityEngine;
+
+namespace Parsek.InGameTests
+{
+    // Phase 6 (migration plan §8 / design §9.1, the ONE cross-member geometric seam built in v1) - the
+    // in-game gate for the orbit↔landing G1 descent re-stitch owned by CrossMemberSeamStitcher.
+    //
+    // It builds a live re-aim-looped LANDING fixture (a descent-trigger LoopUnit + a descent-member
+    // recording whose body-fixed deorbit→reentry→landing run lives on the destination body) and drives the
+    // REAL stitcher (CrossMemberSeamStitcher.TryStitchDescentSeam) over the typed PhaseChain at a TRIGGERED
+    // live UT:
+    //
+    //  - FLAG ON: the stitcher PROMOTES the descent member to a visible first-class DescentPhase at the
+    //    re-anchored swept-deorbit head (recordedDeorbitUT + (liveUT - triggerUT)), and the orbit↔landing
+    //    G1 tangent seam is CONTINUOUS (zero rigid-seam-tangent-discontinuity) for a smoothly-recorded
+    //    descent. Past the descent clip the stitcher RETIRES the member (no held sample), so the sub-surface
+    //    ghost does NOT linger below the surface (the documented bug closed).
+    //  - FLAG OFF (default): the spine never invokes the stitcher (the ChainSampler PhaseChain overload only
+    //    runs under PhaseSpineDriveActive), so the descent renders through the legacy path - byte-identical
+    //    to today. This case is asserted at the source/unit layer (the stitcher returns the same decisions;
+    //    the spine gate is the caller's). Here we document it and verify the stitcher is inert when fed the
+    //    same out-of-window frame.
+    //
+    // The pure clock/tangent/ordering math is locked headlessly in CrossMemberSeamStitcherTests; this
+    // exercises the Unity-coupled live-PhaseChain + live-body-tangent path those cannot reach (the parity
+    // oracle runs in SYNTHESIZED mode here, since Phase 6 intentionally CHANGES the deorbit geometry to fix
+    // the sub-surface bug).
+    //
+    // NOTE: in-game test (Ctrl+Shift+T / Settings > Diagnostics); cannot run headless (builds a live
+    // PhaseChain over a recording + resolves the destination body's world tangents). FLIGHT only;
+    // career-independent.
+    public class DescentReStitchInGameTest
+    {
+        private const string DescentBodyName = "Kerbin"; // a stock body always present; the destination body
+        private const int DescentMemberIdx = 0;
+        private const int TransferMemberIdx = 2;
+
+        // Geometry chosen so cycle 0's LIVE window (liveUT in [phaseAnchor, phaseAnchor+cadence)) contains a
+        // real trigger window, anchored at the LIVE UT so the resolved cycle is 0 (the same shaping the
+        // headless tests use, shifted to a live UT base).
+        private const double ClipSeconds = 100.0;       // descent clip duration
+        private const double CaptureShift = -150.0;
+        private const double Trot = 300.0;              // small period so the trigger lands inside cycle 0
+        private const double Tpark = 80.0;
+        private const double Cadence = 4000.0;
+
+        [InGameTest(Category = "MapRender", Scene = GameScenes.FLIGHT,
+            Description = "Phase 6 descent re-stitch (FLAG ON): the CrossMemberSeamStitcher promotes the "
+                + "descent member to a visible first-class DescentPhase at the re-anchored head, the "
+                + "orbit↔landing G1 seam is continuous (zero rigid-seam-tangent-discontinuity), and the "
+                + "sub-surface ghost retires past the descent clip")]
+        public void DescentReStitch_FlagOn_PromotesContinuousDescent_AndRetiresPastEnd()
+        {
+            RunDescentReStitch(forceSpineOn: true);
+        }
+
+        [InGameTest(Category = "MapRender", Scene = GameScenes.FLIGHT,
+            Description = "Phase 6 descent re-stitch (FLAG OFF): the stitcher is inert (the spine never "
+                + "invokes it off the flag), so the descent renders through the legacy path - byte-identical "
+                + "to today")]
+        public void DescentReStitch_FlagOff_StitcherInert_LegacyDescentUnchanged()
+        {
+            RunDescentReStitch(forceSpineOn: false);
+        }
+
+        private static void RunDescentReStitch(bool forceSpineOn)
+        {
+            CelestialBody body = FlightGlobals.Bodies?.Find(b => b.bodyName == DescentBodyName);
+            if (body == null)
+            {
+                InGameAssert.Skip("destination body not found in FlightGlobals.Bodies (non-stock pack)");
+                return;
+            }
+
+            double now = Planetarium.GetUniversalTime();
+            // Base the span clock at a live UT so cycle 0 resolves at `now`. The descent geometry sits a few
+            // hundred seconds into the cycle (entry = recordedDeorbitUT + captureShift, the trigger after it).
+            double phaseAnchor = now;
+            double recordedDeorbitUT = now + 200.0;       // the seam (recorded deorbit start) in the live base
+            double descentEndUT = recordedDeorbitUT + ClipSeconds;
+            double spanStart = now;
+            double spanEnd = now + 1000.0;
+
+            bool prevForceSpine = ShadowRenderDriver.ForceSpineDriveForTesting;
+            bool prevForceTrace = MapRenderTrace.ForceEnabledForTesting;
+
+            try
+            {
+                MapRenderTrace.ForceEnabledForTesting = true; // so EmitStructural / the anomaly sink are live
+                ShadowRenderDriver.ForceSpineDriveForTesting = forceSpineOn;
+
+                GhostPlaybackLogic.LoopUnitSet units = BuildDescentUnitSet(
+                    phaseAnchor, spanStart, spanEnd, recordedDeorbitUT, descentEndUT);
+                PhaseChain chain = BuildDescentMemberChain(recordedDeorbitUT, descentEndUT);
+
+                // The same triggerUT the stitcher re-anchors on (shared source). conicEnd = deorbit +
+                // captureShift; trigger = first t >= entry congruent to deorbit (mod Trot).
+                Parsek.Reaim.DescentTrigger.ComputeDescentTiming(
+                    0, phaseAnchor, Cadence, spanStart, recordedDeorbitUT, Trot, CaptureShift, null,
+                    out _, out double entryUT, out double triggerUT);
+
+                ParsekLog.Info("TestRunner", string.Format(CultureInfo.InvariantCulture,
+                    "DescentReStitch: forceSpineOn={0} now={1:R} deorbit={2:R} entry={3:R} trigger={4:R} "
+                    + "clip={5:F0}s", forceSpineOn, now, recordedDeorbitUT, entryUT, triggerUT, ClipSeconds));
+
+                if (double.IsNaN(triggerUT))
+                {
+                    InGameAssert.Skip("descent trigger did not resolve for this fixture (degenerate timing)");
+                    return;
+                }
+
+                double triggeredLiveUT = triggerUT + 0.4 * ClipSeconds; // inside the clip
+                double pastEndLiveUT = triggerUT + 1.5 * ClipSeconds;   // past the clip => Done
+
+                // --- TRIGGERED frame: the stitcher promotes a visible TracedPath descent at the re-anchored head ---
+                bool stitched = CrossMemberSeamStitcher.TryStitchDescentSeam(
+                    chain, sampleUT: triggeredLiveUT, liveUT: triggeredLiveUT, units, out GhostSample sample);
+
+                // --- PAST-END frame: the stitcher retires (no held sample) so the sub-surface ghost retires ---
+                bool stitchedPastEnd = CrossMemberSeamStitcher.TryStitchDescentSeam(
+                    chain, sampleUT: pastEndLiveUT, liveUT: pastEndLiveUT, units, out GhostSample pastSample);
+
+                ParsekLog.Info("TestRunner", string.Format(CultureInfo.InvariantCulture,
+                    "DescentReStitch result: forceSpineOn={0} triggered stitched={1} cov={2} treat={3} "
+                    + "driveUT={4:R} | pastEnd stitched={5} cov={6}",
+                    forceSpineOn, stitched, sample.Coverage, sample.Treatment, sample.DriveUT,
+                    stitchedPastEnd, pastSample.Coverage));
+
+                // The stitcher decisions are flag-INDEPENDENT (its TryStitchDescentSeam is pure of the flag;
+                // the FLAG gates only whether the SPINE invokes it). So both flag states must agree here -
+                // that is precisely why flag-OFF (spine never calls) is the safe reversible fallback and
+                // flag-ON renders the promoted descent.
+                InGameAssert.IsTrue(stitched,
+                    "the stitcher must promote the descent member at a TRIGGERED live UT (re-anchored head "
+                    + "inside the descent clip)");
+                InGameAssert.AreEqual(Coverage.InSegment, sample.Coverage,
+                    "the promoted descent sample must be InSegment");
+                InGameAssert.AreEqual(Treatment.TracedPath, sample.Treatment,
+                    "the promoted descent is a body-fixed TracedPath (the polyline-owned descent)");
+                InGameAssert.AreEqual(DescentBodyName, sample.FrameBodyName,
+                    "the promoted descent renders on the destination body");
+                InGameAssert.ApproxEqual(
+                    recordedDeorbitUT + (triggeredLiveUT - triggerUT), sample.DriveUT, 1e-3,
+                    "the descent DriveUT is the swept deorbit head (recordedDeorbitUT + (liveUT - triggerUT))");
+                InGameAssert.AreEqual(SeamKind.Rigid, sample.Segment.LeadingSeam,
+                    "the promoted descent carries the cross-member orbit↔landing Rigid leading seam "
+                    + "(the stitcher owns the seam; the factory leaves it None)");
+
+                // The promoted phase covering the head is a first-class DescentPhase (no longer hidden in the
+                // transfer member).
+                InGameAssert.IsTrue(
+                    chain.TryGetPhase(sample.DriveUT, out TrajectoryPhase phase, out _),
+                    "the chain must locate a phase at the re-anchored head");
+                InGameAssert.IsTrue(phase is DescentPhase,
+                    "the promoted phase is a first-class DescentPhase (visible, no longer hidden)");
+
+                // SUB-SURFACE-GHOST-RETIRES: past the descent clip the stitcher returns false WITHOUT a held
+                // sample, so the descent member's intent falls to Hidden and the ghost retires.
+                InGameAssert.IsFalse(stitchedPastEnd,
+                    "past the descent clip the stitcher must NOT hold a sample (the sub-surface ghost retires)");
+                InGameAssert.AreEqual(default(GhostSample).Coverage, pastSample.Coverage,
+                    "the past-end sample must be the default (no held below-surface sample)");
+
+                // --- The orbit↔landing G1 seam predicate on LIVE body-relative world tangents ---
+                // The capture-orbit-velocity-vs-descent-first-tangent PRODUCTION anomaly raise is wired at the
+                // descent DRAW site in Phase 5b (the only place those live world tangents exist - a
+                // RenderSegment carries no points). Here we exercise the Unity-coupled live-body tangent
+                // extraction + the seam predicate the headless tests cannot reach: two GENUINELY DISTINCT world
+                // tangents from the recorded descent's consecutive legs (p0->p1, p1->p2) must read CONTINUOUS
+                // for a smoothly-recorded descent (a stitch/extraction bug that kinked them would fail), and a
+                // deliberately PERPENDICULAR tangent must read as a discontinuity (the predicate detects a real
+                // kink on live-extracted data - NOT the old vacuous always-true assertion).
+                Vector3 leg0 = WorldTangentBetween(body, 0.0, 0.0, 45000.0, 0.1, 0.05, 20000.0);
+                Vector3 leg1 = WorldTangentBetween(body, 0.1, 0.05, 20000.0, 0.2, 0.1, 100.0);
+                bool continuous = CrossMemberSeamStitcher.IsTangentSeamContinuous(leg0, leg1);
+                ParsekLog.Info("TestRunner", string.Format(CultureInfo.InvariantCulture,
+                    "DescentReStitch G1 seam: leg0={0} leg1={1} continuous={2}", leg0, leg1, continuous));
+                InGameAssert.IsTrue(continuous,
+                    "the orbit↔landing G1 seam must read CONTINUOUS for a smoothly-recorded descent "
+                    + "(zero rigid-seam-tangent-discontinuity; distinct live-body tangents, non-vacuous)");
+
+                Vector3 perp = Vector3.Cross(leg0, Vector3.up);
+                if (perp.sqrMagnitude < 1e-6f)
+                    perp = Vector3.Cross(leg0, Vector3.right);
+                InGameAssert.IsFalse(CrossMemberSeamStitcher.IsTangentSeamContinuous(leg0, perp),
+                    "a perpendicular seam tangent must read as a rigid-seam-tangent-discontinuity "
+                    + "(the predicate detects a real kink on live-extracted tangents)");
+            }
+            finally
+            {
+                ShadowRenderDriver.ForceSpineDriveForTesting = prevForceSpine;
+                ShadowRenderDriver.Reset();
+                MapRenderTrace.ForceEnabledForTesting = prevForceTrace;
+            }
+        }
+
+        // A descent-trigger LoopUnit + set whose descent set = {DescentMemberIdx}. Mirrors the working
+        // headless fixture (Supported plan + valid schedule => IsReaim; non-NaN periods + non-empty descent
+        // set => HasDescentTrigger).
+        private static GhostPlaybackLogic.LoopUnitSet BuildDescentUnitSet(
+            double phaseAnchor, double spanStart, double spanEnd,
+            double recordedDeorbitUT, double descentEndUT)
+        {
+            var plan = new Parsek.Reaim.ReaimMissionPlan { Supported = true };
+            var sched = new Parsek.Reaim.ReaimWindowPlanner.ReaimWindowSchedule { Valid = true };
+            var unit = new GhostPlaybackLogic.LoopUnit(
+                ownerIndex: TransferMemberIdx, memberIndices: new[] { DescentMemberIdx, TransferMemberIdx },
+                spanStartUT: spanStart, spanEndUT: spanEnd, cadenceSeconds: Cadence, phaseAnchorUT: phaseAnchor,
+                overlapCadenceSeconds: Cadence, memberWindows: null, relaunchSchedule: null,
+                reaimPlan: plan, reaimSchedule: sched,
+                loiterCuts: null, arrivalHoldSeconds: 0.0, arrivalHoldAtUT: double.NaN,
+                arrivalAlignPeriodSeconds: double.NaN, arrivalAmberReason: null,
+                launchBodyRotationPeriodSeconds: double.NaN, launchHoldEngaged: false,
+                recordedSoiExitUT: double.NaN,
+                descentMemberIndices: new[] { DescentMemberIdx }, recordedDeorbitUT: recordedDeorbitUT,
+                descentEndUT: descentEndUT, destinationBodyRotationPeriodSeconds: Trot,
+                loiterPeriodSeconds: Tpark, captureShiftSeconds: CaptureShift,
+                transferMemberIndex: TransferMemberIdx);
+            var ownerByIndex = new Dictionary<int, int>
+            {
+                { DescentMemberIdx, TransferMemberIdx }, { TransferMemberIdx, TransferMemberIdx },
+            };
+            return new GhostPlaybackLogic.LoopUnitSet(
+                new Dictionary<int, GhostPlaybackLogic.LoopUnit> { { TransferMemberIdx, unit } }, ownerByIndex);
+        }
+
+        // The descent member's per-member PhaseChain: a parking conic [deorbit-50, deorbit] then a body-fixed
+        // atmospheric reentry/descent run [deorbit, descentEnd] so the factory classifies the traced run as a
+        // DescentPhase (a non-surface/non-approach traced run AFTER the first conic).
+        private static PhaseChain BuildDescentMemberChain(double recordedDeorbitUT, double descentEndUT)
+        {
+            var rec = new Recording
+            {
+                RecordingId = "descent-restitch-" + System.Guid.NewGuid().ToString("N"),
+                VesselName = "Parsek Descent ReStitch",
+                EndpointPhase = RecordingEndpointPhase.SurfacePosition,
+                EndpointBodyName = DescentBodyName,
+                ExplicitStartUT = recordedDeorbitUT - 50.0,
+                ExplicitEndUT = descentEndUT,
+                PlaybackEnabled = true,
+            };
+            rec.Points.Add(new TrajectoryPoint
+            {
+                ut = recordedDeorbitUT, latitude = 0.0, longitude = 0.0, altitude = 45000.0,
+                rotation = Quaternion.identity, velocity = new Vector3(0f, -200f, 0f), bodyName = DescentBodyName,
+            });
+            rec.Points.Add(new TrajectoryPoint
+            {
+                ut = 0.5 * (recordedDeorbitUT + descentEndUT), latitude = 0.1, longitude = 0.05, altitude = 20000.0,
+                rotation = Quaternion.identity, velocity = new Vector3(0f, -150f, 0f), bodyName = DescentBodyName,
+            });
+            rec.Points.Add(new TrajectoryPoint
+            {
+                ut = descentEndUT, latitude = 0.2, longitude = 0.1, altitude = 100.0,
+                rotation = Quaternion.identity, velocity = new Vector3(0f, -10f, 0f), bodyName = DescentBodyName,
+            });
+            rec.OrbitSegments.Add(new OrbitSegment
+            {
+                startUT = recordedDeorbitUT - 50.0, endUT = recordedDeorbitUT,
+                bodyName = DescentBodyName, semiMajorAxis = 700000.0, eccentricity = 0.01, epoch = recordedDeorbitUT - 50.0,
+            });
+            rec.TrackSections.Add(new TrackSection
+            {
+                startUT = recordedDeorbitUT - 50.0, endUT = recordedDeorbitUT, environment = SegmentEnvironment.ExoBallistic,
+            });
+            rec.TrackSections.Add(new TrackSection
+            {
+                startUT = recordedDeorbitUT, endUT = descentEndUT, environment = SegmentEnvironment.Atmospheric,
+            });
+            rec.MarkFilesDirty();
+
+            return PhaseFactory.BuildPhaseChain(
+                rec, DescentMemberIdx, instanceKey: 0,
+                windowStartUT: recordedDeorbitUT - 50.0, windowEndUT: descentEndUT);
+        }
+
+        // A live body-relative world tangent between two GENUINELY DISTINCT (lat,lon,alt) points on the
+        // descent body, sampled from the body's own world surface positions (the Unity part this in-game test
+        // exercises). Both endpoints are sampled at the same instant (same body rotation), so the relative
+        // geometry is the body-fixed descent geometry; the absolute frame cancels in the seam-continuity
+        // comparison. Unlike the old helper, the two endpoints actually differ, so the tangent is real.
+        private static Vector3 WorldTangentBetween(
+            CelestialBody body, double latA, double lonA, double altA,
+            double latB, double lonB, double altB)
+        {
+            Vector3d a = body.GetWorldSurfacePosition(latA, lonA, altA) - body.position;
+            Vector3d b = body.GetWorldSurfacePosition(latB, lonB, altB) - body.position;
+            return CrossMemberSeamStitcher.TangentFromPositions((Vector3)a, (Vector3)b);
+        }
+    }
+}

--- a/Source/Parsek/MapRender/ChainSampler.cs
+++ b/Source/Parsek/MapRender/ChainSampler.cs
@@ -87,6 +87,18 @@ namespace Parsek.MapRender
             if (renderHidden)
                 return GhostSample.Outside();
 
+            // Phase 6 (the ONE cross-member geometric seam): a re-aim looped landing's descent member is
+            // joined to its transfer member over a Rigid + G1 orbit↔landing seam by the
+            // CrossMemberSeamStitcher. It composes AFTER the span-clock remap above (the sampleUT/liveUT are
+            // already remapped). The stitcher OWNS the swept-deorbit-head / captureShift / per-leg head-gate
+            // clock (so those identifiers stay out of this file and the Phase-3 source-gate stays GREEN);
+            // this call names none of them. It returns false for every non-descent member / non-re-aim unit
+            // (byte-identical), and false WITHOUT a held sample when the descent member's slice is out of
+            // window so the sub-surface ghost RETIRES rather than clamping below the surface. The base
+            // coverage path below is unchanged for everything else.
+            if (CrossMemberSeamStitcher.TryStitchDescentSeam(chain, sampleUT, liveUT, units, out GhostSample stitched))
+                return stitched;
+
             Coverage coverage = chain.ClassifyCoverage(sampleUT, out TrajectoryPhase phase, out int index);
             switch (coverage)
             {

--- a/Source/Parsek/MapRender/CrossMemberSeamStitcher.cs
+++ b/Source/Parsek/MapRender/CrossMemberSeamStitcher.cs
@@ -1,0 +1,393 @@
+using System;
+using System.Globalization;
+using UnityEngine;
+
+namespace Parsek.MapRender
+{
+    /// <summary>
+    /// Phase 6 (migration plan §8 / design §9.1): the ONE cross-member geometric seam built in v1 — the
+    /// minimal <c>CrossMemberSeamStitcher</c> that joins a re-aim looped landing's transfer-member deorbit
+    /// run to its descent member over a numerically-enforced G1 orbit↔landing seam.
+    ///
+    /// <para><b>It absorbs the existing clock-domain join</b> (today scattered in
+    /// <see cref="Parsek.Reaim.DescentTrigger"/> + <see cref="GhostPlaybackLogic"/>'s span clock): the swept
+    /// deorbit head <c>recordedDeorbitUT + (currentUT - triggerUT)</c>, the <c>captureShift</c> phase
+    /// alignment that lands the body-fixed descent on the parking orbit at the same rotation phase, and the
+    /// per-leg head-gate (the transfer member's deorbit-tail legs sweep down to the seam during the Loiter
+    /// phase). This file is the HOME of that clock logic for the typed spine — it reuses the pure
+    /// <see cref="Parsek.Reaim.DescentTrigger"/> helpers verbatim (so the flag-OFF
+    /// <see cref="Parsek.Reaim.DescentTrigger"/> behavior is UNCHANGED — this never modifies them) and keeps
+    /// the <c>deorbit-head</c> / <c>captureShift</c> / <c>ResolveTransferLegHeadUT</c> identifiers OUT of the
+    /// three gated spine files (<see cref="ShadowRenderDriver"/> / <see cref="ChainSampler"/> /
+    /// <see cref="GhostRenderDirector"/>). The spine invokes this stitcher through a clean API
+    /// (<see cref="TryStitchDescentSeam"/>) that names none of those identifiers, so the Phase-3
+    /// deorbit-decoupling source-gate stays GREEN.</para>
+    ///
+    /// <para><b>It adds the G1 continuity assertion ON TOP</b>: a numerical TANGENT MATCH — the capture
+    /// orbit's velocity direction at SOI/atmosphere entry matched to the recorded descent's first-sample
+    /// tangent — over one <see cref="PhaseSeam.Rigid"/> (Rigid + G1 + OnCamera). A tangent mismatch beyond
+    /// tolerance is the Tier-C <c>rigid-seam-tangent-discontinuity</c> anomaly
+    /// (<see cref="PhaseSeamClassifier.IsRigidSeamTangentDiscontinuity"/> / <see cref="IsTangentSeamContinuous"/>
+    /// / <see cref="EmitTangentDiscontinuity"/>). Those tangents are a RENDER-TIME quantity (a
+    /// <see cref="RenderSegment"/> carries no points — the treatment reads the recorded points at draw time),
+    /// so the pure predicate + emit helper are built and test-exercised here while the production anomaly
+    /// auto-raise is wired at the descent DRAW site in Phase 5b (when that path is reworked).</para>
+    ///
+    /// <para><b>Tracer integration (Tier-A).</b> Every successful promote emits the Tier-A
+    /// <c>DescentStitched</c> structural event from the decision site (<see cref="EmitDescentStitched"/> via
+    /// <see cref="TryStitchDescentSeam"/>), once-per-stitch-onset (not per frame) and free in normal play
+    /// (gated on <see cref="MapRenderTrace.IsEnabled"/>) — the new producer participates in the map render
+    /// tracer like every other decision site.</para>
+    ///
+    /// <para><b>It promotes the deorbit arc into a visible first-class <see cref="DescentPhase"/></b> (no
+    /// longer hidden in the transfer member), carrying the Rigid G1 leading seam.</para>
+    ///
+    /// <para><b>Ordering (design §9.1):</b> the swept-deorbit-head UT join composes AFTER the arrival-hold +
+    /// destination-loiter-trim span-clock remap. The spine hands this stitcher the ALREADY-REMAPPED sample
+    /// UT (the span clock <see cref="GhostPlaybackLogic.ResolveTrackingStationSampleUT"/> has already run by
+    /// the time <see cref="ChainSampler.Sample(PhaseChain, double, GhostPlaybackLogic.LoopUnitSet)"/> calls
+    /// in), so the stitcher composes after the remap by construction (it never re-applies it).</para>
+    ///
+    /// <para><b>Flag-gated, additive.</b> Only invoked when <see cref="ShadowRenderDriver.PhaseSpineDriveActive"/>
+    /// (default OFF). Flag OFF: the spine never calls in, so the descent renders through the legacy path,
+    /// byte-identical to today. Flag ON: the stitcher promotes the descent + enforces the G1 seam. Nothing
+    /// here is deleted; the legacy descent path stays intact as the reversible fallback. Phase 6 INTENTIONALLY
+    /// changes the flag-ON descent geometry (it is the fix for the sub-surface ghost), so the parity oracle
+    /// runs in SYNTHESIZED mode here (rendered == the stitcher's intended G1 arc), NOT recorded-vs-rendered.</para>
+    ///
+    /// <para><b>Minimal — NOT the full <see cref="MissionComposite"/></b> (design §17). It is the focused
+    /// slice that the eventual composite absorbs unchanged: ONE cross-member seam (orbit↔landing), not the
+    /// launch-rotation cross-member seam or mission-wide composite ownership.</para>
+    /// </summary>
+    internal static class CrossMemberSeamStitcher
+    {
+        /// <summary>
+        /// The G1 tangent tolerance the descent re-stitch enforces (radians). Shared with
+        /// <see cref="PhaseSeamClassifier.DefaultTangentToleranceRadians"/> so the predicate and the stitcher
+        /// agree; named here so the call sites + tests reference the stitcher's contract directly.
+        /// </summary>
+        internal const double TangentToleranceRadians =
+            PhaseSeamClassifier.DefaultTangentToleranceRadians;
+
+        /// <summary>
+        /// PURE clock absorb: resolve the descent member's re-anchored playback head this frame (the swept
+        /// deorbit head + captureShift phase alignment) by REUSING the pure
+        /// <see cref="Parsek.Reaim.DescentTrigger"/> helpers. This is the cross-member clock the spine cannot
+        /// reference directly (the source-gate forbids the deorbit-clock identifiers in the three spine
+        /// files), so it lives here.
+        ///
+        /// <para>Returns true (with <paramref name="head"/> set + <paramref name="phase"/> = Descent) ONLY
+        /// when the member is a descent-set member of a descent-trigger unit AND the shared monotone descent
+        /// head falls inside this member's window THIS frame; false (head NaN) to hide the member otherwise
+        /// (Inert / Loiter / Done / outside-this-member's-slice). For every non-descent member / non-re-aim
+        /// unit it returns false — byte-identical to the no-trigger path. <paramref name="unitCycle"/> is the
+        /// span clock's resolved cycle for this frame (the spine resolves it through the same
+        /// <see cref="GhostPlaybackLogic.ResolveTrackingStationSampleUT"/> call, so there is no second
+        /// UT→cycle mapping that could disagree).</para>
+        ///
+        /// <para>The arithmetic is <c>recordedDeorbitUT + (currentUT - triggerUT)</c> (the swept deorbit
+        /// head), with <c>triggerUT</c> derived from <c>captureShift</c> + the destination rotation period —
+        /// exactly the clock the legacy polyline Driver + the span clock host today, re-homed here.</para>
+        /// </summary>
+        internal static bool TryResolveDescentSeamHead(
+            GhostPlaybackLogic.LoopUnit unit,
+            int committedIndex,
+            long unitCycle,
+            double currentUT,
+            double memberStartUT,
+            double memberEndUT,
+            out double head,
+            out Parsek.Reaim.DescentTrigger.DescentHeadPhase phase)
+        {
+            head = double.NaN;
+            phase = Parsek.Reaim.DescentTrigger.DescentHeadPhase.Inert;
+
+            if (!unit.HasDescentTrigger || !unit.IsDescentMember(committedIndex))
+                return false;
+
+            memberStartUT = unit.MemberStartUT(committedIndex, memberStartUT);
+            memberEndUT = unit.MemberEndUT(committedIndex, memberEndUT);
+
+            return Parsek.Reaim.DescentTrigger.TryResolveDescentMemberHead(
+                currentUT, unitCycle, unit.PhaseAnchorUT, unit.CadenceSeconds, unit.SpanStartUT,
+                unit.RecordedDeorbitUT, unit.DescentEndUT, unit.DestinationBodyRotationPeriodSeconds,
+                unit.LoiterPeriodSeconds, unit.CaptureShiftSeconds, unit.LoiterCuts,
+                memberStartUT, memberEndUT, out head, out phase);
+        }
+
+        /// <summary>
+        /// PURE per-leg head-gate absorb: the head ONE transfer-member deorbit-tail leg should gate on this
+        /// frame, REUSING <see cref="Parsek.Reaim.DescentTrigger.ResolveTransferLegHeadUT"/>. A deorbit-tail
+        /// leg (the contiguous approach legs ending at/below the seam) gates on the swept deorbit head so it
+        /// sweeps down to the seam during the Loiter phase; every other leg keeps the normal loop head. This
+        /// is the same per-leg gate the legacy polyline Driver applies, re-homed into the stitcher so the
+        /// spine never names <c>ResolveTransferLegHeadUT</c>. Pure; no Unity.
+        /// </summary>
+        internal static double ResolveDeorbitTailLegHead(
+            double legEndUT, double seamUT, double epsSeconds, double loopHeadUT,
+            double deorbitTailHead, bool deorbitTailLegEligible)
+        {
+            return Parsek.Reaim.DescentTrigger.ResolveTransferLegHeadUT(
+                legEndUT, seamUT, epsSeconds, loopHeadUT, deorbitTailHead, deorbitTailLegEligible);
+        }
+
+        /// <summary>
+        /// PURE G1 tangent-match evaluation: given the leaving phase's terminal velocity DIRECTION (the
+        /// capture orbit's velocity at SOI/atmosphere entry) and the entering phase's first-sample velocity
+        /// direction (the recorded descent's first tangent), classify the orbit↔landing seam as continuous
+        /// (true) or a <c>rigid-seam-tangent-discontinuity</c> (false). NaN/Inf/zero-length tangents on
+        /// either side yield "continuous" (no false anomaly) — an unmeasurable tangent is not a
+        /// discontinuity. Delegates the angle math to
+        /// <see cref="PhaseSeamClassifier.IsRigidSeamTangentDiscontinuity"/> (the Phase-1 predicate). Pure;
+        /// Unity-vector math only (no ECalls), so it is directly unit-testable.
+        /// </summary>
+        internal static bool IsTangentSeamContinuous(
+            Vector3 leavingTangent, Vector3 enteringTangent,
+            double toleranceRadians = TangentToleranceRadians)
+        {
+            return !PhaseSeamClassifier.IsRigidSeamTangentDiscontinuity(
+                leavingTangent, enteringTangent, toleranceRadians);
+        }
+
+        /// <summary>
+        /// PURE first-difference tangent from two consecutive recorded points' world/body-relative
+        /// positions: the velocity DIRECTION of the segment from <paramref name="aXyz"/> to
+        /// <paramref name="bXyz"/>. Used to extract the capture-orbit-exit tangent (the last two recorded
+        /// approach points) and the descent's first-sample tangent (the first two recorded descent points)
+        /// without a live KSP orbit sampler, so the seam math is headless. A degenerate (equal / non-finite)
+        /// pair yields <see cref="Vector3.zero"/> (an unmeasurable tangent → no false anomaly downstream).
+        /// </summary>
+        internal static Vector3 TangentFromPositions(Vector3 aXyz, Vector3 bXyz)
+        {
+            Vector3 d = bXyz - aXyz;
+            if (!IsFinite(d.x) || !IsFinite(d.y) || !IsFinite(d.z))
+                return Vector3.zero;
+            if (d.sqrMagnitude <= 1e-12f)
+                return Vector3.zero;
+            return d;
+        }
+
+        /// <summary>
+        /// THE SPINE API (clean, gate-safe). When the flag is ON, the typed-spine sampler calls this AFTER it
+        /// has resolved the base coverage of a per-member <see cref="PhaseChain"/> at the already-remapped
+        /// <paramref name="sampleUT"/>. If <paramref name="committedIndex"/> is a descent-set member of a
+        /// descent-trigger unit AND its re-anchored descent head is live this frame, the stitcher PROMOTES the
+        /// matched <see cref="DescentPhase"/> over a Rigid + G1 leading seam and returns the stitched
+        /// <see cref="GhostSample"/> (visible TracedPath descent at the re-anchored head). Otherwise it
+        /// returns false and the caller keeps the base sample.
+        ///
+        /// <para><b>The method name + every parameter type names NONE of the deorbit-clock identifiers the
+        /// source-gate forbids</b> (<c>ResolveTransferLegHeadUT</c> / <c>deorbitHead</c> /
+        /// <c>captureShift</c>), so the spine can invoke it without tripping the Phase-3 gate. The clock
+        /// arithmetic itself stays inside this stitcher (and the pure helpers it reuses).</para>
+        ///
+        /// <para><b>Sub-surface retire (design §9.1 / migration plan §8):</b> when the re-anchored head is NOT
+        /// live (the descent member's slice is out of window — past <c>descentEndUT</c> / before entry /
+        /// loitering), this returns false WITHOUT a held sample, so the descent member's
+        /// <see cref="GhostRenderIntent"/> falls to Hidden and the sub-surface ghost RETIRES (the documented
+        /// bug closed) rather than clamping to a stale below-surface sample.</para>
+        /// </summary>
+        internal static bool TryStitchDescentSeam(
+            PhaseChain chain,
+            double sampleUT,
+            double liveUT,
+            GhostPlaybackLogic.LoopUnitSet units,
+            out GhostSample stitched)
+        {
+            stitched = default(GhostSample);
+
+            if (chain == null || units == null)
+                return false;
+
+            int committedIndex = chain.CommittedIndex;
+            if (!units.TryGetUnitForMember(committedIndex, out GhostPlaybackLogic.LoopUnit unit))
+                return false;
+            if (!unit.HasDescentTrigger || !unit.IsDescentMember(committedIndex))
+                return false;
+
+            // Resolve the span clock cycle the SAME way the spine's ChainSampler did (one source of truth):
+            // the descent re-anchor needs the unit cycle, which DecideUnitMemberRender resolved when the
+            // sampler called ResolveTrackingStationSampleUT. Re-resolve it here from the live UT via the same
+            // pure decision (no second mapping that could disagree with the cached geometry).
+            double memberStartUT = unit.MemberStartUT(committedIndex, chain.WindowStartUt);
+            double memberEndUT = unit.MemberEndUT(committedIndex, chain.WindowEndUt);
+            if (!GhostPlaybackLogic.TryResolveDescentUnitCycle(
+                    unit, committedIndex, liveUT, memberStartUT, memberEndUT, out long unitCycle))
+                return false;
+
+            if (!TryResolveDescentSeamHead(
+                    unit, committedIndex, unitCycle, liveUT, memberStartUT, memberEndUT,
+                    out double reAnchoredHead,
+                    out Parsek.Reaim.DescentTrigger.DescentHeadPhase phase))
+            {
+                // Not rendering its descent slice this frame: Inert / Loiter / Done / out-of-window. Return
+                // false WITHOUT a held sample so the descent member retires (sub-surface-ghost-retires).
+                return false;
+            }
+
+            // Locate the descent phase covering the re-anchored head in the per-member chain. The factory
+            // already classifies the post-conic body-fixed run as a DescentPhase, so this is the promoted
+            // first-class phase. Use the RE-ANCHORED head as the assembled UT (the swept deorbit head), not
+            // the raw sampleUT, because the descent clip plays forward from recordedDeorbitUT.
+            if (!chain.TryGetPhase(reAnchoredHead, out TrajectoryPhase phaseAtHead, out int phaseIndex))
+                return false;
+
+            // DEFENSIVE GUARD (provably never with today's factory: reAnchoredHead >= recordedDeorbitUT lands
+            // in the post-deorbit body-fixed run, which the factory classifies as a DescentPhase). If a future
+            // factory-classification regression ever puts a non-DescentPhase at the head, log LOUDLY rather
+            // than silently stamp a Rigid orbit↔landing seam onto the wrong phase kind ("if it didn't get
+            // logged, it didn't happen"). Behaviour is unchanged on the correct path; this is observability.
+            if (!(phaseAtHead is DescentPhase))
+                ParsekLog.Warn("MapRender", string.Format(CultureInfo.InvariantCulture,
+                    "CrossMemberSeamStitcher: phase at re-anchored head {0:R} is {1}, not DescentPhase "
+                    + "(rec={2} member={3}) - stamping orbit↔landing seam anyway; factory classification regression?",
+                    reAnchoredHead, phaseAtHead?.GetType().Name ?? "null", chain.RecordingId, committedIndex));
+
+            // PROMOTE: emit the descent phase as a visible first-class phase carrying the Rigid + G1 leading
+            // seam (the orbit↔landing cross-member seam). The seam CONTRACT is stamped here, and the Tier-A
+            // DescentStitched structural event is emitted from this decision site (EmitDescentStitchedTraceOnChange,
+            // below). The G1 TANGENT MATCH's production anomaly raise lives at the descent DRAW site (the only
+            // place the live world tangents exist — a RenderSegment carries no points), wired in Phase 5b when
+            // that path is reworked; the pure predicate + EmitTangentDiscontinuity helper are built + test-exercised.
+            //
+            // The phase the factory built carries a null leading seam (PhaseFactory deliberately leaves seams
+            // null — they are a spine-side re-derivation concern), so its emitted RenderSegment.LeadingSeam is
+            // SeamKind.None. The cross-member orbit↔landing seam is the STITCHER's to own, so re-stamp the
+            // promoted segment with the Rigid leading seam (BuildOrbitLandingSeam = Rigid + G1 + OnCamera,
+            // mapped to the legacy SeamKind the live draw path reads). This is the one cross-member seam the
+            // design promotes onto the descent member.
+            string frameBody =
+                (phaseAtHead.Anchor is AnchorFrame.BodyAnchor body) ? body.BodyName : null;
+            var ctx = new SampleContext(reAnchoredHead, frameBody);
+            foreach (RenderSegment seg in phaseAtHead.Emit(ctx))
+            {
+                RenderSegment seamed = StampOrbitLandingSeam(seg);
+                stitched = GhostSample.InSegment(seamed, phaseIndex, reAnchoredHead);
+                EmitDescentStitchedTraceOnChange(chain.RecordingId, committedIndex, liveUT, reAnchoredHead, phase);
+                return true;
+            }
+
+            // A phase that emits no geometry this frame (only HoldPhase, which the descent member never is):
+            // keep the base sample.
+            return false;
+        }
+
+        /// <summary>
+        /// Re-stamp a promoted descent <see cref="RenderSegment"/>'s LEADING seam with the cross-member
+        /// orbit↔landing seam (<see cref="BuildOrbitLandingSeam"/> = Rigid + G1 + OnCamera) the stitcher owns,
+        /// mapped to the legacy <see cref="SeamKind"/> the live draw path reads. Every other field is carried
+        /// through unchanged (RenderSegment is a readonly struct, so this rebuilds it). Pure; no Unity.
+        /// </summary>
+        internal static RenderSegment StampOrbitLandingSeam(RenderSegment seg)
+        {
+            SeamKind leading = PhaseGeometry.ToLegacySeam(BuildOrbitLandingSeam());
+            return new RenderSegment(
+                seg.Kind, seg.Treatment, seg.StartUT, seg.EndUT, seg.FrameBodyName, seg.Payload,
+                isGenerated: seg.IsGenerated, leadingSeam: leading, trailingSeam: seg.TrailingSeam);
+        }
+
+        /// <summary>
+        /// Build the Rigid + G1 orbit↔landing seam this stitch enforces (design §6.1 / §9.1). The descent
+        /// member's leading seam is OnCamera (the landing is in view) so a tangent discontinuity is a real,
+        /// visible kink the oracle / reconciler must surface.
+        /// </summary>
+        internal static PhaseSeam BuildOrbitLandingSeam() => PhaseSeam.Rigid(onCamera: true);
+
+        /// <summary>
+        /// PURE detail-line builder for the Tier-A <c>DescentStitched</c> structural event (kept pure - no
+        /// Unity reads, no global sink - so the line schema is directly unit-testable, mirroring
+        /// <see cref="MapRenderTrace.BuildLifecycleDetails"/>).
+        /// </summary>
+        internal static string BuildDescentStitchedDetails(
+            int committedIndex, double reAnchoredHead,
+            Parsek.Reaim.DescentTrigger.DescentHeadPhase phase)
+            => string.Format(CultureInfo.InvariantCulture,
+                "member={0} reAnchoredHead={1:R} phase={2} seam=rigid+G1 onCamera=true",
+                committedIndex, reAnchoredHead, phase);
+
+        /// <summary>
+        /// PURE detail-line builder for the Tier-C <c>rigid-seam-tangent-discontinuity</c> anomaly (pure, so
+        /// the line schema is unit-testable without the global trace sink).
+        /// </summary>
+        internal static string BuildTangentDiscontinuityDetails(
+            Vector3 leavingTangent, Vector3 enteringTangent, double measuredAngleRadians)
+            => string.Format(CultureInfo.InvariantCulture,
+                "angle={0:F4}rad tol={1:F4}rad leaving=({2:F2},{3:F2},{4:F2}) entering=({5:F2},{6:F2},{7:F2})",
+                measuredAngleRadians, TangentToleranceRadians,
+                leavingTangent.x, leavingTangent.y, leavingTangent.z,
+                enteringTangent.x, enteringTangent.y, enteringTangent.z);
+
+        /// <summary>
+        /// Emit the Tier-C <c>rigid-seam-tangent-discontinuity</c> anomaly when the orbit↔landing G1 seam's
+        /// two tangents diverge beyond tolerance. Gated by <see cref="MapRenderTrace.IsEnabled"/> (the
+        /// off-by-default <c>mapRenderTracing</c> setting), so normal play pays nothing. The caller supplies
+        /// the live world/body-relative tangents (the Unity path) and the measured angle for the detail line.
+        /// </summary>
+        internal static void EmitTangentDiscontinuity(
+            uint pid, string recordingId, double currentUT,
+            Vector3 leavingTangent, Vector3 enteringTangent, double measuredAngleRadians)
+        {
+            if (!MapRenderTrace.IsEnabled)
+                return;
+
+            string details = BuildTangentDiscontinuityDetails(
+                leavingTangent, enteringTangent, measuredAngleRadians);
+
+            MapRenderTrace.EmitAnomaly(
+                MapRenderTrace.RenderSurface.Polyline,
+                pid.ToString(CultureInfo.InvariantCulture),
+                currentUT, currentUT,
+                MapRenderTrace.AnomalyRigidSeamTangentDiscontinuity,
+                details, recordingId);
+        }
+
+        /// <summary>
+        /// Emit the Tier-A descent-stitch seam structural event on a (re)stitch: the promoted descent member,
+        /// the re-anchored head, and the seam continuity. Gated by <see cref="MapRenderTrace.IsEnabled"/>
+        /// (free in normal play). Surface = Polyline (the descent draws as our owned polyline).
+        /// </summary>
+        internal static void EmitDescentStitched(
+            uint pid, string recordingId, double currentUT, double reAnchoredHead,
+            int committedIndex, Parsek.Reaim.DescentTrigger.DescentHeadPhase phase)
+        {
+            if (!MapRenderTrace.IsEnabled)
+                return;
+
+            string details = BuildDescentStitchedDetails(committedIndex, reAnchoredHead, phase);
+
+            MapRenderTrace.EmitStructural(
+                "DescentStitched", MapRenderTrace.RenderSurface.Polyline,
+                pid.ToString(CultureInfo.InvariantCulture), currentUT, reAnchoredHead,
+                MapRenderTrace.SegmentChangeWindowSeconds, details, recordingId);
+        }
+
+        /// <summary>
+        /// Wire the Tier-A <see cref="EmitDescentStitched"/> structural event from the live decision site
+        /// (<see cref="TryStitchDescentSeam"/>), gated ONCE-PER-STITCH-ONSET (committed index + descent head
+        /// phase) via <see cref="MapRenderTrace.ShouldEmitDescentStitchOnChange"/> so a steady re-anchored
+        /// descent emits ONE structural line, not one per frame (the VerboseRateLimited convention;
+        /// <see cref="MapRenderTrace.EmitStructural"/> routes to Info unconditionally). Resolves the ghost pid
+        /// from the committed index ONLY behind the <see cref="MapRenderTrace.IsEnabled"/> gate, so the
+        /// flag-OFF / tracing-OFF path never touches <see cref="GhostMapPresence"/> and the headless unit
+        /// tests stay pure; pid resolves to 0 when no ghost vessel exists yet (the recId still names the line).
+        /// </summary>
+        private static void EmitDescentStitchedTraceOnChange(
+            string recordingId, int committedIndex, double liveUT, double reAnchoredHead,
+            Parsek.Reaim.DescentTrigger.DescentHeadPhase phase)
+        {
+            if (!MapRenderTrace.IsEnabled)
+                return;
+
+            uint pid = GhostMapPresence.GetGhostVesselPidForRecording(committedIndex);
+            string pidKey = pid.ToString(CultureInfo.InvariantCulture);
+            string signature = committedIndex.ToString(CultureInfo.InvariantCulture)
+                + ":" + phase.ToString();
+            if (!MapRenderTrace.ShouldEmitDescentStitchOnChange(pidKey, signature))
+                return;
+
+            EmitDescentStitched(pid, recordingId, liveUT, reAnchoredHead, committedIndex, phase);
+        }
+
+        private static bool IsFinite(float v) => !float.IsNaN(v) && !float.IsInfinity(v);
+    }
+}

--- a/Source/Parsek/MapRenderTrace.cs
+++ b/Source/Parsek/MapRenderTrace.cs
@@ -44,9 +44,14 @@ namespace Parsek
         // RenderParityOracle in Faithful mode) whenever a faithful ghost's rendered orbit diverges from
         // its recorded reference beyond tolerance. The OTHER FOUR tokens below
         // (rigid-seam-tangent-discontinuity / retire-not-held / anchor-resolve-fail / clock-not-ready)
-        // remain WIRED-BUT-INERT: the constants exist (and EmitAnomaly already routes any reason through
-        // the gated sink) so later phases emit them without re-touching this file; no caller fires those
-        // four yet.
+        // remain WIRED-BUT-INERT in PRODUCTION: the constants exist (and EmitAnomaly already routes any
+        // reason through the gated sink) so later phases emit them without re-touching this file. NOTE the
+        // Phase-6 status: the descent re-stitch now wires the Tier-A DescentStitched STRUCTURAL event
+        // (CrossMemberSeamStitcher.TryStitchDescentSeam, once-per-stitch-onset via
+        // ShouldEmitDescentStitchOnChange), and the rigid-seam-tangent-discontinuity predicate +
+        // EmitTangentDiscontinuity helper are built and test-exercised (unit + in-game); its production
+        // auto-raise is wired at the descent DRAW site in Phase 5b (the only place the live world tangents
+        // exist - a RenderSegment carries no points), so that one token stays production-inert until 5b.
         //
         //  - parity-drift: the geometry the pipeline actually RENDERED diverged from the reference it
         //    was supposed to draw (recorded in Faithful mode / the producer's intended arc in
@@ -55,7 +60,8 @@ namespace Parsek
         //    `gap-vs-retire`; the two coexist through Phases 0-8.
         //  - rigid-seam-tangent-discontinuity: a Rigid seam's two sides (e.g. capture-orbit velocity
         //    direction at SOI/atmosphere entry vs the recorded descent's first-sample tangent) diverged
-        //    beyond tolerance at the G1 descent re-stitch (Phase 6).
+        //    beyond tolerance at the G1 descent re-stitch (Phase 6). Predicate + emit helper built and
+        //    test-exercised; production auto-raise lands at the descent draw site in Phase 5b (see above).
         //  - retire-not-held: a terminal / out-of-range member HELD its last visible intent across an
         //    interior gap where it should have RETIRED (rendered nothing) - the inverse of the
         //    held-across-gap contract (design §6.4 / §10.7).
@@ -478,6 +484,47 @@ namespace Parsek
                 currentUT, currentUT, details, recId);
         }
 
+        // ---- Phase 6: descent-stitch structural-event once-per-event dedup ----
+        // The CrossMemberSeamStitcher's TryStitchDescentSeam runs every frame the re-aim looped descent is
+        // live + re-anchored, but the Tier-A DescentStitched structural event is a per-(re)stitch ONSET
+        // signal, not a per-frame one (EmitStructural routes to Info unconditionally + opens a detail
+        // window). This per-pid signature gate emits ONE line per stitch onset / descent-head-phase change,
+        // honoring the VerboseRateLimited convention. Same warp-cap + Reset() (scene-switch) clearing as the
+        // marker / line-visibility signature dicts.
+        private static readonly Dictionary<string, string> lastDescentStitchSignatureByPid =
+            new Dictionary<string, string>(StringComparer.Ordinal);
+
+        /// <summary>Test-only: current size of the descent-stitch change-detection dict (warp-cap assert).</summary>
+        internal static int DescentStitchSignatureCountForTesting => lastDescentStitchSignatureByPid.Count;
+
+        /// <summary>
+        /// Once-per-event gate for the Tier-A <c>DescentStitched</c> structural event (Phase 6): returns true
+        /// only when <paramref name="signature"/> (committed index + descent head phase) changed for this
+        /// <paramref name="pidKey"/> since its last emit, so a steady re-anchored descent emits ONE structural
+        /// line rather than one per frame. No-op (false) when disabled. An empty pid (no resolvable ghost -
+        /// e.g. a headless unit test) is allowed through (the <see cref="IsEnabled"/> gate + the caller still
+        /// bound the emit). Warp-capped + cleared in <see cref="Reset"/> (scene switch), like the sibling
+        /// signature dicts.
+        /// </summary>
+        internal static bool ShouldEmitDescentStitchOnChange(string pidKey, string signature)
+        {
+            if (!IsEnabled)
+                return false;
+            if (string.IsNullOrEmpty(pidKey))
+                return true;
+
+            if (lastDescentStitchSignatureByPid.TryGetValue(pidKey, out string last)
+                && string.Equals(last, signature, StringComparison.Ordinal))
+                return false; // unchanged stitch onset for this ghost -> suppress
+
+            if (!lastDescentStitchSignatureByPid.ContainsKey(pidKey)
+                && lastDescentStitchSignatureByPid.Count >= MaxTrackedMarkerDecisionKeys)
+                lastDescentStitchSignatureByPid.Clear();
+
+            lastDescentStitchSignatureByPid[pidKey] = signature;
+            return true;
+        }
+
         // MVP: detailed windows are keyed by pid.ToString(). recordingId keying
         // (and the shared registry with GhostRenderTrace) is a later cut.
         private static readonly Dictionary<string, double> detailedUntilByKey =
@@ -504,6 +551,7 @@ namespace Parsek
             renderIntentByPid.Clear();
             lastMarkerDecisionSignatureByPid.Clear();
             lastLineVisibilitySignatureByPid.Clear();
+            lastDescentStitchSignatureByPid.Clear();
             descentRenderWindowFrame = -1;
             descentRenderWindowPhase = null;
             descentRenderWindowRecId = null;

--- a/docs/dev/plans/map-ts-render-overhaul-migration.md
+++ b/docs/dev/plans/map-ts-render-overhaul-migration.md
@@ -331,6 +331,32 @@ to fix the sub-surface bug; cf. design §14 faithful-vs-synthesized scope), plus
 `sub-surface-ghost-retires` + zero-`rigid-seam-tangent-discontinuity` assertions. **Risk:** medium — the
 cross-member clock re-home is the substantive work; the existing `DescentTrigger` logic de-risks it.
 
+**Status (implemented, flag-gated):** the clock re-home is DONE — the swept deorbit head + `captureShift`
+phase alignment + per-leg head-gate now live in `Source/Parsek/MapRender/CrossMemberSeamStitcher.cs`
+(delegating to the pure `DescentTrigger.*` helpers verbatim), invoked only from the `PhaseChain` spine
+overload of `ChainSampler.Sample` under `MapRenderFlags.MapRenderPhaseSpineDrive`. The G1 leading seam is
+stamped onto the promoted `DescentPhase` segment by `CrossMemberSeamStitcher.StampOrbitLandingSeam` (the
+`PhaseFactory` builds `DescentPhase` with a null leading seam by design — seams are a spine concern).
+**This satisfies Phase 5b's HARD predecessor:** the `deorbitHead`/`captureShift`/`ResolveTransferLegHeadUT`
+consumer is now owned by the stitcher, so 5b may delete the autonomous polyline `Driver` ownership walk
+without losing deorbit-head alignment. The deorbit-clock identifiers are kept OUT of the three gated spine
+files (`ShadowRenderDriver` / `ChainSampler` / `GhostRenderDirector`); the `SwappedSpine_DoesNotConsumeDeorbitClock_SourceGate`
+source-gate remains green. Flag OFF (default): byte-identical (`DescentTrigger.cs` untouched). The
+`sub-surface-ghost-retires` fix is live only under the flag, so `todo-and-known-bugs.md` / `CHANGELOG.md`
+mark the bug closed when the flag flips default-on (post in-game sign-off), not at this PR.
+
+**Tracer integration (logging priority):** the new producer participates in `MapRenderTrace`. The Tier-A
+`DescentStitched` structural event is wired at the stitcher's decision site
+(`CrossMemberSeamStitcher.TryStitchDescentSeam` -> `EmitDescentStitchedTraceOnChange`), emitted
+once-per-stitch-onset (not per frame) via `MapRenderTrace.ShouldEmitDescentStitchOnChange` and free in
+normal play. The Tier-C `rigid-seam-tangent-discontinuity` anomaly's pure predicate + emit helper +
+detail builders are built and test-exercised (unit + the in-game live-body-tangent path), but its
+PRODUCTION auto-raise is deferred to **Phase 5b**: the leaving/entering world tangents exist only in the
+descent DRAW path (`GhostTrajectoryPolylineRenderer.TryDrawLeg` - a `RenderSegment` carries no points),
+which is the shared deorbit-clock-hosting file 5b reworks/deletes anyway, so wiring the raise there avoids
+a throwaway, flight-touching edit to a soon-deleted file this cycle. In the interim the parity oracle
+(SYNTHESIZED mode, this section) is the render-time seam-quality gate.
+
 ---
 
 ## 9. Phase 7 — Define the fail-closed producers


### PR DESCRIPTION
**Stacked on Phase 4b ([#1218](https://github.com/vl3c/Parsek/pull/1218)). Merge in order; this PR's diff is Phase 6 only.**

## What

Adds `CrossMemberSeamStitcher`, the one new producer in v1 of the map/TS render overhaul (migration plan §8). It joins a re-aim looped landing's transfer-member deorbit run to its descent member over a numerically-enforced G1 orbit↔landing seam, behind the default-OFF `MapRenderFlags.MapRenderPhaseSpineDrive` flag.

- **Absorbs the cross-member clock-domain join** (swept deorbit head `recordedDeorbitUT + (currentUt - triggerUT)`, `captureShift` phase alignment, per-leg head-gate) by delegating to the pure `DescentTrigger.*` helpers verbatim. Composes AFTER the arrival-hold + destination-loiter-trim span-clock remap.
- **Promotes the deorbit arc to a visible first-class `DescentPhase`** and stamps the `PhaseSeam{Rigid,G1}` leading seam onto it (`StampOrbitLandingSeam`; `PhaseFactory` leaves seams null by design).
- **Sub-surface ghosts retire** (false without a held sample) instead of clamping below the surface.

## Safety

- **Flag OFF (default): byte-identical.** `DescentTrigger.cs` untouched; only the `PhaseChain` spine overload of `ChainSampler.Sample` (reached solely under the flag) invokes the stitcher; the legacy `GhostRenderChain` overload is unchanged. Additive, runtime-reversible, nothing deleted.
- **Deorbit-clock source-gate stays green.** The `deorbitHead`/`captureShift`/`ResolveTransferLegHeadUT` identifiers live only in `CrossMemberSeamStitcher.cs`, kept out of the three gated spine files. This re-homes the clock that Phase 5b HARD-depends on.

## Tracer integration (logging priority)

- **Tier-A `DescentStitched`** structural event wired at the stitcher's decision site, once-per-stitch-onset (not per frame) via a new warp-capped `MapRenderTrace.ShouldEmitDescentStitchOnChange` dedup, free in normal play.
- **Tier-C `rigid-seam-tangent-discontinuity`** predicate + emit helper + detail builders are built and test-exercised; its production auto-raise is deferred to **Phase 5b** (the world tangents structurally exist only in the descent draw path, the shared deorbit-clock file 5b reworks anyway). The parity oracle (synthesized mode) is the interim render-time seam gate.

## Tests

- Unit: swept-head/`captureShift` join, G1 tangent-match math, compose-after-remap ordering, sub-surface retire, the Rigid leading-seam stamp, the Tier-A/Tier-C detail builders + token, and the once-per-event tracer wiring (asserted via the signature-dict count seam + pure builders, NOT the flake-prone global `ParsekLog` sink).
- In-game (`DescentReStitchInGameTest`): the promoted `DescentPhase`, the swept-head DriveUT, the Rigid+G1 leading seam, the G1 seam predicate on genuinely-distinct live-body world tangents (continuous for a smooth descent + a perpendicular kink flagged), and sub-surface retire.
- `dotnet build` green; `dotnet test` **16523 passed, 0 failed**.

## Review

Multi-lens clean review (flag-off parity / source-gate / seam-stamp / tests / tracer) + a recovered stitcher-math lens + a tracer-wiring fix lens, verdict CLEAN, 0 blockers. The one major (the new producer emitted no `MapRenderTrace` output) and the minors (a vacuous in-game tangent assertion; a tautological retire assertion) are folded.

The sub-surface fix is live only under the flag, so `CHANGELOG` / `todo-and-known-bugs` mark the bug closed when the flag flips default-on (post in-game sign-off), not at this PR.