### PR TITLE
maprender Phase 7: define the fail-closed producers (cross-SOI / Jool / station)

### DIFF
--- a/Source/Parsek.Tests/MapRender/FailClosedClassifierTests.cs
+++ b/Source/Parsek.Tests/MapRender/FailClosedClassifierTests.cs
@@ -1,0 +1,300 @@
+using System;
+using System.Collections.Generic;
+using Parsek;
+using Parsek.MapRender;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    /// <summary>
+    /// Phase-7 guard for <see cref="FailClosedClassifier"/> (migration plan §9 / design §4 / §9.2 / §10):
+    /// the fail-closed DECISION that classifies the three UNSUPPORTED synthetic producers (nested-SOI Jool
+    /// tour / moving-target station / cross-SOI whole-chain) as
+    /// <see cref="SegmentProvenance.FaithfulFallback"/> — render the recorded trajectory verbatim, never a
+    /// broken synthetic guess.
+    ///
+    /// Covers (1) the fail-closed decision PER CASE (cross-SOI single-level stays SUPPORTED; nested-SOI ->
+    /// fail closed; station -> fail closed), (2) the geometry-neutral provenance, and (3) the Tier-A
+    /// <c>fail-closed-to-faithful</c> tracer event WIRING + once-per-event dedup, asserted via the pure
+    /// detail builder + the MapRenderTrace signature-dict count seam (NOT the global
+    /// <c>ParsekLog.TestSinkForTesting</c>, whose cross-test routing is the established flake source — see
+    /// project memory).
+    ///
+    /// Each assertion states the bug it catches: a single-level cross-SOI auto-failing would needlessly
+    /// degrade every ordinary interplanetary mission; a nested-SOI / station NOT failing would hand an
+    /// unsupported producer a broken synthetic arc; a per-frame trace emit would spam the log.
+    ///
+    /// <para>The tracer-integration cases touch the shared <c>MapRenderTrace</c> static state, so this
+    /// class runs in the Sequential collection.</para>
+    /// </summary>
+    [Collection("Sequential")]
+    public class FailClosedClassifierTests
+    {
+        // A stock-shaped body parent chain: Sun (root) -> {Kerbin, Duna}; Kerbin -> {Mun, Minmus};
+        // Jool -> {Laythe, Vall, Tylo}. ReferenceBodyName returns null for the root (Sun).
+        private static readonly Dictionary<string, string> StockParents =
+            new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                { "Sun", null },
+                { "Kerbin", "Sun" }, { "Duna", "Sun" }, { "Jool", "Sun" },
+                { "Mun", "Kerbin" }, { "Minmus", "Kerbin" },
+                { "Laythe", "Jool" }, { "Vall", "Jool" }, { "Tylo", "Jool" },
+                { "Ike", "Duna" },
+            };
+
+        private static string Parent(string body)
+            => StockParents.TryGetValue(body, out string p) ? p : null;
+
+        // ---- (1) The fail-closed decision per case ----
+
+        [Fact]
+        public void Classify_SingleLevelCrossSoiTransfer_IsSupported_NotFailClosed()
+        {
+            // Kerbin -> Sun -> Duna: an ORDINARY interplanetary mission that already renders correctly
+            // through the per-crossing FlexibleSoi G0 path. v1 must NOT auto-fail it (that would degrade
+            // every interplanetary mission to "fail-closed" for nothing — the cross-SOI kink is define-only,
+            // render current behavior unchanged, design §9.2).
+            var bodies = new List<string> { "Kerbin", "Sun", "Duna" };
+            FailClosedClassifier.FailClosedDecision d = FailClosedClassifier.Classify(
+                bodies, hasLiveVesselArrivalAnchor: false, referenceBodyName: Parent);
+
+            Assert.False(d.IsFailClosed);
+            Assert.Equal(FailClosedClassifier.FailClosedReason.None, d.Reason);
+        }
+
+        [Fact]
+        public void Classify_KerbinMunTour_IsSupported_NotNested()
+        {
+            // Kerbin -> Mun -> Kerbin is single-level (only Mun under Kerbin; no sibling moon hop), so it is
+            // SUPPORTED — not a nested-SOI Jool-style tour.
+            var bodies = new List<string> { "Kerbin", "Mun", "Kerbin" };
+            FailClosedClassifier.FailClosedDecision d = FailClosedClassifier.Classify(
+                bodies, hasLiveVesselArrivalAnchor: false, referenceBodyName: Parent);
+
+            Assert.False(d.IsFailClosed);
+        }
+
+        [Fact]
+        public void Classify_JoolMoonTour_IsFailClosed_NestedSoi()
+        {
+            // Jool -> Laythe -> Tylo: a moon-rich tour (Laythe + Tylo are SIBLINGS under Jool, a non-root
+            // ancestor) -> the synthetic moon-to-moon re-aim is unsupported -> fail closed to faithful.
+            var bodies = new List<string> { "Jool", "Laythe", "Tylo" };
+            FailClosedClassifier.FailClosedDecision d = FailClosedClassifier.Classify(
+                bodies, hasLiveVesselArrivalAnchor: false, referenceBodyName: Parent);
+
+            Assert.True(d.IsFailClosed);
+            Assert.Equal(FailClosedClassifier.FailClosedReason.NestedSoi, d.Reason);
+            Assert.Equal(SegmentProvenance.FaithfulFallback, d.Provenance);
+            Assert.NotNull(d.NestedSubtree);
+            Assert.Equal("Jool", d.NestedSubtree.RootBody);
+            Assert.True(d.NestedSubtree.IsNested);
+        }
+
+        [Fact]
+        public void Classify_StationArrivalAnchor_IsFailClosed_MovingTargetStation_HighestPrecedence()
+        {
+            // A live-vessel arrival anchor (a station) is the least-supported phase -> fail closed, and it
+            // takes PRECEDENCE over the body sequence (even a Jool tour that ALSO has a live arrival anchor
+            // reports moving-target-station, since the target is the moving station).
+            var bodies = new List<string> { "Jool", "Laythe", "Tylo" };
+            FailClosedClassifier.FailClosedDecision d = FailClosedClassifier.Classify(
+                bodies, hasLiveVesselArrivalAnchor: true, referenceBodyName: Parent);
+
+            Assert.True(d.IsFailClosed);
+            Assert.Equal(FailClosedClassifier.FailClosedReason.MovingTargetStation, d.Reason);
+            Assert.Equal(SegmentProvenance.FaithfulFallback, d.Provenance);
+            Assert.Null(d.NestedSubtree); // station carries no nested subtree payload
+        }
+
+        [Fact]
+        public void Classify_NullOrSingleBody_IsSupported()
+        {
+            Assert.False(FailClosedClassifier.Classify(
+                null, hasLiveVesselArrivalAnchor: false, referenceBodyName: Parent).IsFailClosed);
+            Assert.False(FailClosedClassifier.Classify(
+                new List<string> { "Kerbin" }, hasLiveVesselArrivalAnchor: false, referenceBodyName: Parent)
+                .IsFailClosed);
+        }
+
+        [Fact]
+        public void Classify_NullReferenceDelegate_IsSupported_NotNested()
+        {
+            // A null parent-chain delegate cannot decide nesting -> not nested (the safe default), so a Jool
+            // sequence with no body info is SUPPORTED (renders faithfully anyway). It must never NRE.
+            var bodies = new List<string> { "Jool", "Laythe", "Tylo" };
+            FailClosedClassifier.FailClosedDecision d = FailClosedClassifier.Classify(
+                bodies, hasLiveVesselArrivalAnchor: false, referenceBodyName: null);
+            Assert.False(d.IsFailClosed);
+        }
+
+        // ---- (2) The cross-SOI-chain reason (test/future-producer seam, NOT the live path) ----
+
+        [Fact]
+        public void ClassifyCrossSoiChainForTesting_MultiHop_IsCrossSoiChain()
+        {
+            // The deferred whole-patched-conic-chain synthesis's home: a >=2-crossing interplanetary chain.
+            // This is a SEPARATE seam from the live Classify (the live path keeps it SUPPORTED so the
+            // cross-SOI G0 kink renders unchanged); it exists only so the reason has a tested home.
+            var bodies = new List<string> { "Kerbin", "Sun", "Duna", "Ike" }; // 3 single-level crossings
+            FailClosedClassifier.FailClosedDecision d =
+                FailClosedClassifier.ClassifyCrossSoiChainForTesting(bodies);
+            Assert.True(d.IsFailClosed);
+            Assert.Equal(FailClosedClassifier.FailClosedReason.CrossSoiChain, d.Reason);
+        }
+
+        [Fact]
+        public void ClassifyCrossSoiChainForTesting_SingleHop_IsSupported()
+        {
+            var bodies = new List<string> { "Kerbin", "Sun" }; // 1 crossing
+            Assert.False(FailClosedClassifier.ClassifyCrossSoiChainForTesting(bodies).IsFailClosed);
+        }
+
+        [Theory]
+        [InlineData(new string[] { }, 0)]
+        [InlineData(new[] { "Kerbin" }, 0)]
+        [InlineData(new[] { "Kerbin", "Kerbin" }, 0)]
+        [InlineData(new[] { "Kerbin", "Mun" }, 1)]
+        [InlineData(new[] { "Kerbin", "Mun", "Kerbin" }, 2)]
+        public void CountBodyChanges_CountsAdjacentDistinctRuns(string[] bodies, int expected)
+        {
+            Assert.Equal(expected, FailClosedClassifier.CountBodyChanges(bodies));
+        }
+
+        // ---- (3) The reason tokens ----
+
+        [Fact]
+        public void ReasonToken_AreGrepStableLowercase()
+        {
+            Assert.Equal("nested-soi", FailClosedClassifier.ReasonToken(
+                FailClosedClassifier.FailClosedReason.NestedSoi));
+            Assert.Equal("moving-target-station", FailClosedClassifier.ReasonToken(
+                FailClosedClassifier.FailClosedReason.MovingTargetStation));
+            Assert.Equal("cross-soi-chain", FailClosedClassifier.ReasonToken(
+                FailClosedClassifier.FailClosedReason.CrossSoiChain));
+            Assert.Equal("none", FailClosedClassifier.ReasonToken(
+                FailClosedClassifier.FailClosedReason.None));
+        }
+
+        // ---- (4) MapRenderTrace integration: the fail-closed-to-faithful Tier-A event ----
+
+        [Fact]
+        public void FailClosedToFaithful_EventTokenIsStable()
+        {
+            Assert.Equal("fail-closed-to-faithful", MapRenderTrace.EventFailClosedToFaithful);
+        }
+
+        [Fact]
+        public void BuildFailClosedDetails_NestedSoi_NamesProducerAndProvenanceAndPayload()
+        {
+            // The Tier-A detail line names the unsupported producer, the faithful-fallback provenance, the
+            // render action, and (for nested-SOI) the subtree summary. Asserting the PURE builder (no global
+            // sink) is deterministic in the full parallel suite.
+            NestedSoiSubtree subtree = NestedSoiSubtree.TryBuildFromBodySequence(
+                new List<string> { "Jool", "Laythe", "Tylo" }, Parent);
+            var decision = new FailClosedClassifier.FailClosedDecision(
+                FailClosedClassifier.FailClosedReason.NestedSoi, subtree);
+
+            string details = FailClosedClassifier.BuildFailClosedDetails(decision);
+
+            Assert.Contains("producer=nested-soi", details);
+            Assert.Contains("provenance=faithful-fallback", details);
+            Assert.Contains("action=render-recorded-verbatim", details);
+            Assert.Contains("root=Jool", details);
+        }
+
+        [Fact]
+        public void BuildFailClosedDetails_Station_NamesProducer_NoSubtreePayload()
+        {
+            var decision = new FailClosedClassifier.FailClosedDecision(
+                FailClosedClassifier.FailClosedReason.MovingTargetStation, null);
+            string details = FailClosedClassifier.BuildFailClosedDetails(decision);
+
+            Assert.Contains("producer=moving-target-station", details);
+            Assert.Contains("provenance=faithful-fallback", details);
+            Assert.DoesNotContain("root=", details); // no nested subtree payload for the station case
+        }
+
+        [Fact]
+        public void EmitFailClosedToFaithful_RecordsTraceOnce_OnChange()
+        {
+            // WIRING + rate-limit (deterministic, no ParsekLog global): a fail-closed decision reaches the
+            // Tier-A emit gate exactly once, and a second same-reason emit is suppressed by the
+            // once-per-event guard (no per-frame spam). Asserting via the MapRenderTrace signature-dict seam
+            // (which EmitFailClosedToFaithful populates only when it actually reaches the emit) proves the
+            // wiring without depending on the shared ParsekLog.TestSinkForTesting (the established flake
+            // source — see project memory).
+            NestedSoiSubtree subtree = NestedSoiSubtree.TryBuildFromBodySequence(
+                new List<string> { "Jool", "Laythe", "Tylo" }, Parent);
+            var decision = new FailClosedClassifier.FailClosedDecision(
+                FailClosedClassifier.FailClosedReason.NestedSoi, subtree);
+
+            bool prevForce = MapRenderTrace.ForceEnabledForTesting;
+            try
+            {
+                MapRenderTrace.Reset(); // clear the per-pid once-per-event signature dict
+                MapRenderTrace.ForceEnabledForTesting = true;
+                MapRenderTrace.FrameCounterOverrideForTesting = () => 0; // Time.frameCount is a Unity ECall
+                Assert.Equal(0, MapRenderTrace.FailClosedSignatureCountForTesting);
+
+                FailClosedClassifier.EmitFailClosedToFaithful("rec-jool", 0, 1000.0, decision);
+                Assert.Equal(1, MapRenderTrace.FailClosedSignatureCountForTesting); // wired: gate reached once
+
+                FailClosedClassifier.EmitFailClosedToFaithful("rec-jool", 0, 1001.0, decision);
+                Assert.Equal(1, MapRenderTrace.FailClosedSignatureCountForTesting); // unchanged onset => no dup
+            }
+            finally
+            {
+                MapRenderTrace.ForceEnabledForTesting = prevForce;
+                MapRenderTrace.FrameCounterOverrideForTesting = null;
+                MapRenderTrace.Reset();
+            }
+        }
+
+        [Fact]
+        public void EmitFailClosedToFaithful_SupportedDecision_EmitsNothing()
+        {
+            // A SUPPORTED decision must NOT reach the emit gate (no spurious fail-closed line for a
+            // correctly-rendering ordinary mission).
+            bool prevForce = MapRenderTrace.ForceEnabledForTesting;
+            try
+            {
+                MapRenderTrace.Reset();
+                MapRenderTrace.ForceEnabledForTesting = true;
+                MapRenderTrace.FrameCounterOverrideForTesting = () => 0;
+
+                FailClosedClassifier.EmitFailClosedToFaithful(
+                    "rec-supported", 0, 1000.0, FailClosedClassifier.FailClosedDecision.Supported);
+                Assert.Equal(0, MapRenderTrace.FailClosedSignatureCountForTesting);
+            }
+            finally
+            {
+                MapRenderTrace.ForceEnabledForTesting = prevForce;
+                MapRenderTrace.FrameCounterOverrideForTesting = null;
+                MapRenderTrace.Reset();
+            }
+        }
+
+        [Fact]
+        public void EmitFailClosedToFaithful_TracingDisabled_EmitsNothing_FreeInNormalPlay()
+        {
+            // Tracing OFF (normal play): the emit is a no-op and never touches the signature dict, so the
+            // fail-closed decision is free in normal play.
+            bool prevForce = MapRenderTrace.ForceEnabledForTesting;
+            try
+            {
+                MapRenderTrace.Reset();
+                MapRenderTrace.ForceEnabledForTesting = false; // tracing off
+                var decision = new FailClosedClassifier.FailClosedDecision(
+                    FailClosedClassifier.FailClosedReason.NestedSoi, null);
+                FailClosedClassifier.EmitFailClosedToFaithful("rec", 0, 1000.0, decision);
+                Assert.Equal(0, MapRenderTrace.FailClosedSignatureCountForTesting);
+            }
+            finally
+            {
+                MapRenderTrace.ForceEnabledForTesting = prevForce;
+                MapRenderTrace.Reset();
+            }
+        }
+    }
+}

--- a/Source/Parsek.Tests/MapRender/FailClosedWiringSourceGateTests.cs
+++ b/Source/Parsek.Tests/MapRender/FailClosedWiringSourceGateTests.cs
@@ -1,0 +1,103 @@
+using System;
+using System.IO;
+using System.Text;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    /// <summary>
+    /// Phase-7 source gates (migration plan §9) locking the ADDITIVE, geometry-neutral, flag-safe contract
+    /// of the fail-closed wiring:
+    ///
+    /// <list type="bullet">
+    ///   <item>The fail-closed decision is a CLASSIFICATION concern (PhaseFactory), NOT a spine concern, so
+    ///     the three swapped-spine files never reference <c>FailClosedClassifier</c> (mirroring the existing
+    ///     <c>SwappedSpine_DoesNotConsumeDeorbitClock_SourceGate</c> discipline — the spine stays clean).</item>
+    ///   <item>The live fail-closed trace emit in <c>PhaseFactory</c> is GATED on
+    ///     <c>MapRenderTrace.IsEnabled</c> so flag-OFF / tracing-OFF normal play pays nothing and never
+    ///     touches the live Unity body-info resolver (keeping the headless factory tests pure).</item>
+    /// </list>
+    /// </summary>
+    public class FailClosedWiringSourceGateTests
+    {
+        private static string ReadMapRenderSource(string fileName)
+        {
+            string root = Path.GetFullPath(Path.Combine(
+                AppDomain.CurrentDomain.BaseDirectory, "..", "..", "..", "..", ".."));
+            string path = Path.Combine(root, "Source", "Parsek", "MapRender", fileName);
+            if (!File.Exists(path))
+                path = Path.Combine(root, "Parsek", "MapRender", fileName);
+            Assert.True(File.Exists(path), $"Source file not found at {path}");
+            return File.ReadAllText(path);
+        }
+
+        private static string StripLineComments(string source)
+        {
+            var sb = new StringBuilder(source.Length);
+            foreach (string line in source.Split('\n'))
+            {
+                int idx = line.IndexOf("//", StringComparison.Ordinal);
+                sb.Append(idx >= 0 ? line.Substring(0, idx) : line);
+                sb.Append('\n');
+            }
+            return sb.ToString();
+        }
+
+        private static string CollapseWhitespace(string source)
+        {
+            var sb = new StringBuilder(source.Length);
+            bool inWs = false;
+            foreach (char c in source)
+            {
+                if (char.IsWhiteSpace(c))
+                {
+                    if (!inWs) { sb.Append(' '); inWs = true; }
+                }
+                else { sb.Append(c); inWs = false; }
+            }
+            return sb.ToString();
+        }
+
+        [Theory]
+        [InlineData("ShadowRenderDriver.cs")]
+        [InlineData("ChainSampler.cs")]
+        [InlineData("GhostRenderDirector.cs")]
+        public void SwappedSpine_DoesNotReferenceFailClosedClassifier_SourceGate(string spineFile)
+        {
+            // Fail-closed is a CLASSIFICATION decision (PhaseFactory), not a per-frame spine concern. A
+            // future edit that pulled it into the spine would couple the spine to the classifier (the
+            // architecture this design separates); these per-file assertions catch that. All three are
+            // currently clean. (Doc prose mentioning the term is stripped before the check.)
+            string normalized = CollapseWhitespace(StripLineComments(ReadMapRenderSource(spineFile)));
+            Assert.DoesNotContain("FailClosedClassifier", normalized);
+            Assert.DoesNotContain("EmitFailClosedToFaithful", normalized);
+        }
+
+        [Fact]
+        public void PhaseFactory_FailClosedTraceEmit_IsGatedOnTracing()
+        {
+            // The live fail-closed wiring must be behind MapRenderTrace.IsEnabled so normal play pays
+            // nothing AND the headless factory tests never reach the live FlightGlobalsBodyInfo resolver
+            // (a Unity ECall). The helper early-returns on !MapRenderTrace.IsEnabled before touching the
+            // body-info resolver or the emit.
+            string src = CollapseWhitespace(StripLineComments(ReadMapRenderSource("PhaseFactory.cs")));
+            Assert.Contains("EmitFailClosedDecisionTraceIfEnabled(", src); // the additive call site exists
+            Assert.Contains("if (!MapRenderTrace.IsEnabled || traj == null) return;", src);
+        }
+
+        [Fact]
+        public void PhaseFactory_BuildPhaseChain_ReturnsAssemblerGeometryWindow_Unchanged()
+        {
+            // GEOMETRY-NEUTRAL: the fail-closed decision must NOT alter the chain's window /
+            // faithful-fallback geometry — the PhaseChain is still constructed from the assembler's
+            // geometry fields (geometry.WindowStartUT / geometry.WindowEndUT / geometry.IsFaithfulFallback),
+            // exactly as before Phase 7. A regression that fed the fail-closed decision into the geometry
+            // would change this constructor call.
+            string src = CollapseWhitespace(StripLineComments(ReadMapRenderSource("PhaseFactory.cs")));
+            Assert.Contains(
+                "return new PhaseChain( traj.RecordingId, committedIndex, instanceKey, phases, "
+                + "geometry.WindowStartUT, geometry.WindowEndUT, geometry.IsFaithfulFallback);",
+                src);
+        }
+    }
+}

--- a/Source/Parsek.Tests/MapRender/MovingTargetStationApproachTests.cs
+++ b/Source/Parsek.Tests/MapRender/MovingTargetStationApproachTests.cs
@@ -1,0 +1,120 @@
+using System;
+using Parsek;
+using Parsek.MapRender;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    /// <summary>
+    /// Phase-7 guard for <see cref="MovingTargetStationApproach"/> (migration plan §9 / design §9.2): the
+    /// typed moving-target station rendezvous — a <see cref="HeliocentricTransferPhase"/> anchored to a
+    /// LIVE station vessel (<see cref="AnchorFrame.LiveVesselAnchor"/>), joined by a
+    /// <c>{ FlexibleSoi, G0 }</c> seam to an arrival-side station-period <see cref="HoldPhase"/>.
+    /// DEFINE-ONLY — the composite is the fail-closed classification's payload, never a v1 geometry
+    /// producer.
+    ///
+    /// Each assertion states the design contract it locks: the transfer arrival anchor is the live moving
+    /// vessel (not a body center — the depot-double / dock-renders-absolute bug class); the seam is
+    /// FlexibleSoi+G0 (no body SOI tangent at a moving target); the hold is a station-period HoldPhase (not
+    /// an ArrivalLoiterPhase — there is no body to loiter around); the transfer provenance is
+    /// FaithfulFallback in v1 (the synthetic moving-target producer is deferred).
+    /// </summary>
+    public class MovingTargetStationApproachTests
+    {
+        private static OrbitSegment TransferConic()
+            => new OrbitSegment
+            {
+                startUT = 100.0, endUT = 500.0, bodyName = "Sun",
+                semiMajorAxis = 13_000_000_000.0, eccentricity = 0.1,
+            };
+
+        private static MovingTargetStationApproach Build(Guid guid)
+            => MovingTargetStationApproach.Build(
+                transferId: new PhaseId("rec-station", 0, 0),
+                holdId: new PhaseId("rec-station", 0, 1),
+                stationLaunchGuid: guid,
+                transferConic: TransferConic(),
+                transferStartUt: 100.0, transferEndUt: 500.0,
+                holdStartUt: 500.0, holdEndUt: 800.0);
+
+        [Fact]
+        public void Build_TransferArrivalAnchor_IsTheLiveStationVessel()
+        {
+            var guid = Guid.NewGuid();
+            MovingTargetStationApproach approach = Build(guid);
+
+            Assert.NotNull(approach.Transfer);
+            Assert.IsType<AnchorFrame.LiveVesselAnchor>(approach.Transfer.Anchor);
+            var live = (AnchorFrame.LiveVesselAnchor)approach.Transfer.Anchor;
+            Assert.Equal(guid, live.LaunchGuid);
+            Assert.Equal(guid, approach.StationLaunchGuid);
+        }
+
+        [Fact]
+        public void Build_TransferProvenance_IsFaithfulFallback_InV1()
+        {
+            // v1: the synthetic moving-target producer is deferred, so the transfer is rendered faithfully
+            // (FaithfulFallback), NOT Synthesized. A future producer would re-stamp it Synthesized.
+            MovingTargetStationApproach approach = Build(Guid.NewGuid());
+            Assert.Equal(SegmentProvenance.FaithfulFallback, approach.Transfer.Provenance);
+            Assert.Equal(PhaseKind.HeliocentricTransfer, approach.Transfer.Kind);
+        }
+
+        [Fact]
+        public void Build_ArrivalSeam_IsFlexibleSoiG0_OffCamera()
+        {
+            // design §9.2: the transfer arrival -> station hold seam is FlexibleSoi + G0 (position only —
+            // there is no body SOI to enforce a tangent against at a moving target).
+            MovingTargetStationApproach approach = Build(Guid.NewGuid());
+            Assert.Equal(PhaseSeamKind.FlexibleSoi, approach.ArrivalSeam.Kind);
+            Assert.Equal(ContinuityOrder.G0, approach.ArrivalSeam.Continuity);
+            Assert.False(approach.ArrivalSeam.RequiresTangentMatch);
+            Assert.Null(approach.ArrivalSeam.Crossing); // no body SOI crossing at a moving target
+        }
+
+        [Fact]
+        public void Build_StationHold_IsHoldPhase_AnchoredToStation_NotALoiter()
+        {
+            // The station-period hold is a HoldPhase (renders quietly), NOT an ArrivalLoiterPhase — there is
+            // no body to loiter around. It is anchored to the same live station vessel.
+            var guid = Guid.NewGuid();
+            MovingTargetStationApproach approach = Build(guid);
+
+            Assert.NotNull(approach.StationHold);
+            Assert.IsType<HoldPhase>(approach.StationHold);
+            Assert.Equal(PhaseKind.Hold, approach.StationHold.Kind);
+            Assert.Equal(Treatment.None, approach.StationHold.ResolveTreatment()); // a hold draws nothing
+            Assert.IsType<AnchorFrame.LiveVesselAnchor>(approach.StationHold.Anchor);
+            Assert.Equal(guid, ((AnchorFrame.LiveVesselAnchor)approach.StationHold.Anchor).LaunchGuid);
+        }
+
+        [Fact]
+        public void Build_SeamsLinkTransferAndHold()
+        {
+            // The transfer's trailing seam and the hold's leading seam are the SAME arrival seam (the join).
+            MovingTargetStationApproach approach = Build(Guid.NewGuid());
+            Assert.Same(approach.ArrivalSeam, approach.Transfer.TrailingSeam);
+            Assert.Same(approach.ArrivalSeam, approach.StationHold.LeadingSeam);
+        }
+
+        [Fact]
+        public void Build_PhaseWindows_AreContiguous()
+        {
+            // The hold begins where the transfer ends (the rendezvous instant), so the assembled-chain
+            // windows are contiguous.
+            MovingTargetStationApproach approach = Build(Guid.NewGuid());
+            Assert.Equal(approach.Transfer.EndUt, approach.StationHold.StartUt);
+        }
+
+        [Fact]
+        public void SummaryToken_NamesStationGuidWindowsAndSeam()
+        {
+            var guid = Guid.NewGuid();
+            string token = Build(guid).ToSummaryToken();
+            Assert.Contains(guid.ToString(), token);
+            Assert.Contains("flexible-soi", token);
+            Assert.Contains("transferUT=", token);
+            Assert.Contains("holdUT=", token);
+        }
+    }
+}

--- a/Source/Parsek.Tests/MapRender/NestedSoiSubtreeTests.cs
+++ b/Source/Parsek.Tests/MapRender/NestedSoiSubtreeTests.cs
@@ -1,0 +1,131 @@
+using System;
+using System.Collections.Generic;
+using Parsek.MapRender;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    /// <summary>
+    /// Phase-7 guard for <see cref="NestedSoiSubtree"/> (migration plan §9 / design §10): the typed
+    /// nested-SOI (moon-rich, Jool) body-tree model the fail-closed classifier reads. DEFINE-ONLY — the
+    /// type carries the body tree + per-leg crossings so the future recursive producer + the tracer have a
+    /// structured identity; it produces NO synthetic geometry.
+    ///
+    /// Covers the nesting DECISION (a sibling moon hop under a non-root ancestor is nested; a single-level
+    /// Kerbin-Mun or interplanetary chain is NOT), the crossing list, and the summary token. Each
+    /// assertion states the bug it catches: mis-detecting a single-level mission as nested would needlessly
+    /// fail-close it; missing a real Jool tour would hand it to a non-existent producer.
+    /// </summary>
+    public class NestedSoiSubtreeTests
+    {
+        private static readonly Dictionary<string, string> StockParents =
+            new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                { "Sun", null },
+                { "Kerbin", "Sun" }, { "Duna", "Sun" }, { "Jool", "Sun" },
+                { "Mun", "Kerbin" }, { "Minmus", "Kerbin" },
+                { "Laythe", "Jool" }, { "Vall", "Jool" }, { "Tylo", "Jool" },
+                { "Ike", "Duna" },
+            };
+
+        private static string Parent(string body)
+            => StockParents.TryGetValue(body, out string p) ? p : null;
+
+        [Fact]
+        public void TryBuild_JoolMoonTour_IsNested_WithCrossingsAndRoot()
+        {
+            // Jool -> Laythe -> Tylo -> Jool: Laythe + Tylo are siblings under Jool (a non-root planet), the
+            // canonical moon tour. Distinct visited bodies = {Jool, Laythe, Tylo}; crossings = each adjacent
+            // hop (3).
+            var bodies = new List<string> { "Jool", "Laythe", "Tylo", "Jool" };
+            NestedSoiSubtree subtree = NestedSoiSubtree.TryBuildFromBodySequence(bodies, Parent);
+
+            Assert.NotNull(subtree);
+            Assert.True(subtree.IsNested);
+            Assert.Equal("Jool", subtree.RootBody);
+            Assert.Equal(3, subtree.VisitedBodies.Count); // Jool, Laythe, Tylo (distinct)
+            Assert.Equal(3, subtree.CrossingCount);       // Jool->Laythe, Laythe->Tylo, Tylo->Jool
+        }
+
+        [Fact]
+        public void TryBuild_KerbinMunMinmus_IsNested_TwoSiblingMoons()
+        {
+            // Mun + Minmus are siblings under Kerbin (a non-root planet) -> nested. (Visiting two of a
+            // planet's moons is the same structural case as a Jool tour.)
+            var bodies = new List<string> { "Kerbin", "Mun", "Kerbin", "Minmus" };
+            NestedSoiSubtree subtree = NestedSoiSubtree.TryBuildFromBodySequence(bodies, Parent);
+
+            Assert.NotNull(subtree);
+            Assert.True(subtree.IsNested);
+            Assert.Equal("Kerbin", subtree.RootBody);
+        }
+
+        [Fact]
+        public void TryBuild_SingleLevelKerbinMun_IsNotNested()
+        {
+            // Kerbin -> Mun -> Kerbin: only ONE moon under Kerbin -> no sibling hop -> NOT nested.
+            var bodies = new List<string> { "Kerbin", "Mun", "Kerbin" };
+            Assert.Null(NestedSoiSubtree.TryBuildFromBodySequence(bodies, Parent));
+        }
+
+        [Fact]
+        public void TryBuild_InterplanetaryChain_IsNotNested_SunIsRoot()
+        {
+            // Kerbin -> Sun -> Duna: Kerbin + Duna are siblings, but under the SUN (the root, ReferenceBody
+            // null) -> interplanetary, NOT a nested-SOI moon tour.
+            var bodies = new List<string> { "Kerbin", "Sun", "Duna" };
+            Assert.Null(NestedSoiSubtree.TryBuildFromBodySequence(bodies, Parent));
+        }
+
+        [Fact]
+        public void TryBuild_DunaIke_IsNotNested_SingleMoonUnderDuna()
+        {
+            // Duna -> Ike -> Duna: Ike under Duna; this is a single moon under Duna so it is NOT two
+            // siblings -> NOT nested (mirrors the Kerbin-Mun single-level case).
+            var bodies = new List<string> { "Duna", "Ike", "Duna" };
+            Assert.Null(NestedSoiSubtree.TryBuildFromBodySequence(bodies, Parent));
+        }
+
+        [Fact]
+        public void TryBuild_NullOrSingle_OrNullDelegate_ReturnsNull()
+        {
+            Assert.Null(NestedSoiSubtree.TryBuildFromBodySequence(null, Parent));
+            Assert.Null(NestedSoiSubtree.TryBuildFromBodySequence(new List<string> { "Jool" }, Parent));
+            Assert.Null(NestedSoiSubtree.TryBuildFromBodySequence(
+                new List<string> { "Jool", "Laythe", "Tylo" }, referenceBodyName: null));
+        }
+
+        [Fact]
+        public void TryBuild_DelegateThatThrows_IsTolerated_NotNested()
+        {
+            // A throwing parent-chain probe must not propagate (it is treated as "cannot resolve" -> not
+            // nested, never an NRE in the render path).
+            Func<string, string> thrower = _ => throw new InvalidOperationException("boom");
+            Assert.Null(NestedSoiSubtree.TryBuildFromBodySequence(
+                new List<string> { "Jool", "Laythe", "Tylo" }, thrower));
+        }
+
+        [Fact]
+        public void SummaryToken_NamesRootVisitedAndCrossings()
+        {
+            NestedSoiSubtree subtree = NestedSoiSubtree.TryBuildFromBodySequence(
+                new List<string> { "Jool", "Laythe", "Tylo" }, Parent);
+            string token = subtree.ToSummaryToken();
+
+            Assert.Contains("root=Jool", token);
+            Assert.Contains("visited=3", token);
+            Assert.Contains("crossings=2", token);
+            Assert.Contains("Jool/Laythe/Tylo", token);
+        }
+
+        [Fact]
+        public void Constructor_NullArgs_DefaultToEmptyLists()
+        {
+            var subtree = new NestedSoiSubtree("Jool", null, null);
+            Assert.NotNull(subtree.VisitedBodies);
+            Assert.NotNull(subtree.Crossings);
+            Assert.Empty(subtree.VisitedBodies);
+            Assert.False(subtree.IsNested);
+        }
+    }
+}

--- a/Source/Parsek.Tests/MapRender/PhaseFactoryTests.cs
+++ b/Source/Parsek.Tests/MapRender/PhaseFactoryTests.cs
@@ -408,5 +408,55 @@ namespace Parsek.Tests
             // The gate: factory geometry byte-matches the assembler (no FrameBodyName divergence).
             AssertByteParity(traj, 0, 40);
         }
+
+        // ---- Phase 7: BuildOrderedRecordedBodies (the pure body sequence the fail-closed classifier reads) ----
+
+        [Fact]
+        public void BuildOrderedRecordedBodies_CollapsesAdjacentDuplicates_KeepsNonAdjacentRepeat()
+        {
+            // Adjacent same-body orbits collapse to ONE run (a multi-orbit stay is not an SOI crossing); a
+            // non-adjacent repeat (Kerbin -> Mun -> Kerbin) is a real return crossing and is kept. A mutation
+            // that dropped the adjacent-collapse, used a non-Ordinal compare, or reordered, fails here.
+            var traj = new MockTrajectory
+            {
+                RecordingId = "rec-bodies",
+                OrbitSegments = new List<OrbitSegment>
+                {
+                    new OrbitSegment { startUT = 0, endUT = 10, bodyName = "Kerbin" },
+                    new OrbitSegment { startUT = 10, endUT = 20, bodyName = "Kerbin" }, // adjacent dup -> collapsed
+                    new OrbitSegment { startUT = 20, endUT = 30, bodyName = "Mun" },
+                    new OrbitSegment { startUT = 30, endUT = 40, bodyName = "Kerbin" }, // non-adjacent return -> kept
+                },
+            };
+            Assert.Equal(new[] { "Kerbin", "Mun", "Kerbin" }, PhaseFactory.BuildOrderedRecordedBodies(traj));
+        }
+
+        [Fact]
+        public void BuildOrderedRecordedBodies_SkipsNullAndEmptyBodyNames()
+        {
+            // A null / empty bodyName orbit is skipped (not appended, and does not break the adjacent-collapse
+            // chain). A mutation that dropped the IsNullOrEmpty skip would emit null/"" entries.
+            var traj = new MockTrajectory
+            {
+                RecordingId = "rec-bodies-empty",
+                OrbitSegments = new List<OrbitSegment>
+                {
+                    new OrbitSegment { startUT = 0, endUT = 10, bodyName = null },
+                    new OrbitSegment { startUT = 10, endUT = 20, bodyName = "" },
+                    new OrbitSegment { startUT = 20, endUT = 30, bodyName = "Duna" },
+                },
+            };
+            Assert.Equal(new[] { "Duna" }, PhaseFactory.BuildOrderedRecordedBodies(traj));
+        }
+
+        [Fact]
+        public void BuildOrderedRecordedBodies_NullOrEmptyOrbitList_IsEmpty()
+        {
+            // A no-orbit recording is never a multi-body tour; null-tolerant (no NRE).
+            Assert.Empty(PhaseFactory.BuildOrderedRecordedBodies(
+                new MockTrajectory { RecordingId = "r", OrbitSegments = null }));
+            Assert.Empty(PhaseFactory.BuildOrderedRecordedBodies(
+                new MockTrajectory { RecordingId = "r", OrbitSegments = new List<OrbitSegment>() }));
+        }
     }
 }

--- a/Source/Parsek/InGameTests/FailClosedFaithfulInGameTest.cs
+++ b/Source/Parsek/InGameTests/FailClosedFaithfulInGameTest.cs
@@ -1,0 +1,174 @@
+using System.Collections.Generic;
+using System.Globalization;
+using Parsek.MapRender;
+using UnityEngine;
+
+namespace Parsek.InGameTests
+{
+    // Phase 7 (migration plan §9 / design §4 / §9.2 / §10) - the in-game gate for the FAIL-CLOSED
+    // producers: cross-SOI / nested-SOI (Jool) / moving-target station.
+    //
+    // It drives the REAL FailClosedClassifier against the LIVE FlightGlobals body tree (so the Jool/Laythe/
+    // Tylo parent chain is the actual stock hierarchy, not a fake) and asserts:
+    //
+    //  - a Jool moon tour (Jool -> Laythe -> Tylo) classifies FAIL-CLOSED (NestedSoi -> FaithfulFallback);
+    //  - a moving-target station approach (a live-vessel arrival anchor) classifies FAIL-CLOSED
+    //    (MovingTargetStation -> FaithfulFallback);
+    //  - an ordinary single-level cross-SOI transfer (Kerbin -> Sun -> Duna) stays SUPPORTED (it renders
+    //    correctly through the per-crossing FlexibleSoi G0 path - the cross-SOI kink is define-only,
+    //    unchanged);
+    //  - the Tier-A `fail-closed-to-faithful` structural line reaches the gated MapRenderTrace sink for a
+    //    fail-closed member (the logging priority);
+    //  - the parity oracle in FAITHFUL mode reports ZERO drift for a fail-closed member's recorded arc
+    //    (rendered == recorded - fail-closed renders the recorded trajectory verbatim).
+    //
+    // The pure decision/token math is locked headlessly in FailClosedClassifierTests / NestedSoiSubtreeTests
+    // / MovingTargetStationApproachTests; this exercises the Unity-coupled LIVE body tree + the gated trace
+    // sink + the FAITHFUL-mode oracle on live-framed geometry those cannot reach.
+    //
+    // NOTE: in-game test (Ctrl+Shift+T / Settings > Diagnostics); cannot run headless (reads the live
+    // FlightGlobals body hierarchy + frames recorded geometry through the body's world surface positions).
+    // FLIGHT only; career-independent.
+    public class FailClosedFaithfulInGameTest
+    {
+        [InGameTest(Category = "MapRender", Scene = GameScenes.FLIGHT,
+            Description = "Phase 7 fail-closed producers: a Jool moon tour and a moving-target station "
+                + "classify FaithfulFallback (render recorded verbatim) while a single-level cross-SOI "
+                + "transfer stays SUPPORTED; the fail-closed-to-faithful Tier-A line is present and the "
+                + "parity oracle reports zero drift in FAITHFUL mode")]
+        public void FailClosed_JoolStationCrossSoi_RenderFaithfully_WithTraceLine()
+        {
+            // Resolve the live stock body tree. Jool's moons are the canonical nested-SOI case.
+            System.Func<string, string> liveReferenceBody = FlightGlobalsBodyInfo.Instance.ReferenceBodyName;
+
+            // Skip on a non-stock pack missing Jool's moons (the nesting check needs two siblings under a
+            // non-root ancestor; a pack without Jool moons cannot exercise it).
+            CelestialBody jool = FlightGlobals.Bodies?.Find(b => b.bodyName == "Jool");
+            CelestialBody laythe = FlightGlobals.Bodies?.Find(b => b.bodyName == "Laythe");
+            CelestialBody tylo = FlightGlobals.Bodies?.Find(b => b.bodyName == "Tylo");
+            if (jool == null || laythe == null || tylo == null)
+            {
+                InGameAssert.Skip("Jool/Laythe/Tylo not present (non-stock pack) - cannot exercise nested-SOI");
+                return;
+            }
+
+            bool prevForce = MapRenderTrace.ForceEnabledForTesting;
+            var capturedLines = new List<string>();
+            System.Action<string> prevSink = ParsekLog.TestSinkForTesting;
+            bool prevSuppress = ParsekLog.SuppressLogging;
+
+            try
+            {
+                MapRenderTrace.Reset();
+                MapRenderTrace.ForceEnabledForTesting = true; // the trace sink must be live for the event
+                MapRenderTrace.FrameCounterOverrideForTesting = () => Time.frameCount;
+                ParsekLog.SuppressLogging = false;
+                ParsekLog.TestSinkForTesting = line => capturedLines.Add(line);
+
+                // --- (1) Jool moon tour -> NestedSoi fail-closed (against the LIVE body tree) ---
+                var joolTour = new List<string> { "Jool", "Laythe", "Tylo" };
+                FailClosedClassifier.FailClosedDecision joolDecision = FailClosedClassifier.Classify(
+                    joolTour, hasLiveVesselArrivalAnchor: false, referenceBodyName: liveReferenceBody);
+
+                ParsekLog.Info("TestRunner", string.Format(CultureInfo.InvariantCulture,
+                    "FailClosed Jool: reason={0} failClosed={1} prov={2}",
+                    FailClosedClassifier.ReasonToken(joolDecision.Reason), joolDecision.IsFailClosed,
+                    SegmentProvenanceTokens.ToToken(joolDecision.Provenance)));
+
+                InGameAssert.IsTrue(joolDecision.IsFailClosed,
+                    "a Jool moon tour (Laythe + Tylo siblings under Jool) must classify fail-closed on the "
+                    + "LIVE body tree");
+                InGameAssert.AreEqual(FailClosedClassifier.FailClosedReason.NestedSoi, joolDecision.Reason,
+                    "the Jool tour's fail-closed reason must be nested-soi");
+                InGameAssert.AreEqual(SegmentProvenance.FaithfulFallback, joolDecision.Provenance,
+                    "a fail-closed member renders the recorded trajectory verbatim (FaithfulFallback)");
+
+                // --- (2) Moving-target station -> MovingTargetStation fail-closed (live-vessel arrival) ---
+                FailClosedClassifier.FailClosedDecision stationDecision = FailClosedClassifier.Classify(
+                    new List<string> { "Kerbin", "Sun" }, hasLiveVesselArrivalAnchor: true,
+                    referenceBodyName: liveReferenceBody);
+                InGameAssert.IsTrue(stationDecision.IsFailClosed,
+                    "a live-vessel arrival anchor (a station) must classify fail-closed");
+                InGameAssert.AreEqual(
+                    FailClosedClassifier.FailClosedReason.MovingTargetStation, stationDecision.Reason,
+                    "the station's fail-closed reason must be moving-target-station");
+
+                // --- (3) Single-level cross-SOI transfer -> SUPPORTED (renders unchanged) ---
+                FailClosedClassifier.FailClosedDecision crossSoiDecision = FailClosedClassifier.Classify(
+                    new List<string> { "Kerbin", "Sun", "Duna" }, hasLiveVesselArrivalAnchor: false,
+                    referenceBodyName: liveReferenceBody);
+                InGameAssert.IsFalse(crossSoiDecision.IsFailClosed,
+                    "an ordinary single-level cross-SOI transfer must stay SUPPORTED (the cross-SOI kink is "
+                    + "define-only: it renders the current FlexibleSoi G0 behavior unchanged)");
+
+                // --- (4) The Tier-A fail-closed-to-faithful line reaches the gated sink (logging priority) ---
+                FailClosedClassifier.EmitFailClosedToFaithful("rec-jool-tour", 0,
+                    Planetarium.GetUniversalTime(), joolDecision);
+
+                bool sawFailClosedLine = false;
+                foreach (string line in capturedLines)
+                {
+                    if (line.Contains(MapRenderTrace.EventFailClosedToFaithful)
+                        && line.Contains("producer=nested-soi"))
+                    {
+                        sawFailClosedLine = true;
+                        break;
+                    }
+                }
+                InGameAssert.IsTrue(sawFailClosedLine,
+                    "the Tier-A fail-closed-to-faithful structural line (producer=nested-soi) must reach the "
+                    + "gated MapRenderTrace sink");
+
+                // --- (5) FAITHFUL-mode parity oracle: rendered == recorded for the fail-closed member ---
+                // Fail-closed renders the recorded trajectory verbatim, so a recorded arc diffed against the
+                // SAME arc (the rendered output of a verbatim replay) reports ZERO drift. Build a recorded
+                // arc framed through Jool's world surface positions (a real Unity-framed reference set) and
+                // diff it against itself in Faithful mode - the oracle's "rendered == recorded" contract.
+                double[] recordedArc = BuildJoolFramedArc(jool);
+                RenderParityOracle.ParityResult parity = RenderParityOracle.ComputeDriftScaleDerived(
+                    RenderParityOracle.ParityMode.Faithful, recordedArc, recordedArc);
+
+                ParsekLog.Info("TestRunner", string.Format(CultureInfo.InvariantCulture,
+                    "FailClosed parity (faithful): hasMeas={0} maxDev={1:F2}m tol={2:F2}m over={3}",
+                    parity.HasMeasurement, parity.MaxDeviationMeters, parity.ToleranceMeters,
+                    parity.OverTolerance));
+
+                InGameAssert.AreEqual(RenderParityOracle.ParityMode.Faithful, parity.Mode,
+                    "the fail-closed oracle runs in FAITHFUL mode (rendered == recorded)");
+                InGameAssert.IsTrue(parity.HasMeasurement,
+                    "the faithful arc must yield a parity measurement (else the gate is blind)");
+                InGameAssert.IsFalse(parity.OverTolerance,
+                    "a fail-closed member renders the recorded arc verbatim, so the FAITHFUL-mode oracle "
+                    + "must report ZERO drift (rendered == recorded)");
+            }
+            finally
+            {
+                MapRenderTrace.ForceEnabledForTesting = prevForce;
+                MapRenderTrace.FrameCounterOverrideForTesting = null;
+                ParsekLog.TestSinkForTesting = prevSink;
+                ParsekLog.SuppressLogging = prevSuppress;
+                MapRenderTrace.Reset();
+            }
+        }
+
+        // A recorded arc framed through Jool's own world surface positions (a real Unity-framed metres
+        // reference set). The exact geometry is not load-bearing - it just must be a real, finite,
+        // multi-point arc the FAITHFUL-mode oracle can diff against itself (rendered == recorded => zero
+        // drift). Body-relative so the absolute frame cancels.
+        private static double[] BuildJoolFramedArc(CelestialBody jool)
+        {
+            const int n = 8;
+            var flat = new double[n * 3];
+            for (int i = 0; i < n; i++)
+            {
+                double lon = i * 12.0;            // a spread of longitudes
+                double alt = 5_000_000.0;          // well above Jool's surface
+                Vector3d p = jool.GetWorldSurfacePosition(0.0, lon, alt) - jool.position;
+                flat[i * 3] = p.x;
+                flat[i * 3 + 1] = p.y;
+                flat[i * 3 + 2] = p.z;
+            }
+            return flat;
+        }
+    }
+}

--- a/Source/Parsek/MapRender/FailClosedClassifier.cs
+++ b/Source/Parsek/MapRender/FailClosedClassifier.cs
@@ -1,0 +1,256 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+
+namespace Parsek.MapRender
+{
+    /// <summary>
+    /// Phase 7 (migration plan §9 / design §4 / §9.2 / §10): the PURE fail-closed DECISION — given a
+    /// member's recorded body sequence + anchor situation, decide whether it is one of the three
+    /// UNSUPPORTED synthetic producers (cross-SOI whole-chain synthesis / nested-SOI moon-to-moon re-aim /
+    /// moving-target station rendezvous) and, if so, classify it
+    /// <see cref="SegmentProvenance.FaithfulFallback"/> — render the RECORDED trajectory VERBATIM, never a
+    /// broken synthetic guess.
+    ///
+    /// <para><b>DEFINE-ONLY, additive, geometry-NEUTRAL (the v1 contract).</b> This classifier is a
+    /// CLASSIFICATION layer only: it decides PROVENANCE (and names the unsupported producer for the
+    /// tracer). It does NOT change any geometry. The three unsupported producers HAVE NO SYNTHETIC
+    /// IMPLEMENTATION in v1 (the recursive nested-SOI producer, the whole-patched-conic-chain cross-SOI
+    /// synthesis, and the synthetic moving-target producer are all deferred — design §17), so "fail-closed
+    /// to faithful" is exactly what the pipeline already does for them. The cross-SOI kink renders the
+    /// current <c>FlexibleSoi</c> G0 behavior UNCHANGED. The win is the typed, logged, test-assertable
+    /// DECISION (so the three cases have a real home and a tracer event) rather than a silent absence of a
+    /// producer.</para>
+    ///
+    /// <para><b>Pure + headless.</b> No Unity / KSP-API reads. The body parent chain is supplied as a
+    /// delegate (mirroring <see cref="Parsek.IBodyInfo.ReferenceBodyName"/>) so the nesting
+    /// decision is directly unit-testable; the cross-SOI / station signals are pure properties of the
+    /// recorded body sequence + the member's anchor. The trace emit is gated on
+    /// <see cref="MapRenderTrace.IsEnabled"/> (free in normal play) and deduped once-per-event via
+    /// <see cref="MapRenderTrace.ShouldEmitFailClosedOnChange"/>.</para>
+    /// </summary>
+    internal static class FailClosedClassifier
+    {
+        /// <summary>
+        /// Why a member fell back to faithful replay (the unsupported producer). Grep-stable lowercase
+        /// tokens via <see cref="ReasonToken"/>; carried on the Tier-A
+        /// <see cref="MapRenderTrace.EventFailClosedToFaithful"/> detail line.
+        /// </summary>
+        internal enum FailClosedReason
+        {
+            /// <summary>Not unsupported — the member is supported (no fail-closed). Default.</summary>
+            None = 0,
+
+            /// <summary>
+            /// A nested-SOI (moon-rich, Jool) tour: the SYNTHETIC moon-to-moon re-aim producer is deferred
+            /// (design §10) -> render the recorded tour faithfully.
+            /// </summary>
+            NestedSoi = 1,
+
+            /// <summary>
+            /// A moving-target station rendezvous: the target is a live moving vessel, not a body center;
+            /// the SYNTHETIC moving-target producer is deferred (design §9.2) -> render the recorded
+            /// approach faithfully.
+            /// </summary>
+            MovingTargetStation = 2,
+
+            /// <summary>
+            /// A cross-SOI transfer whose WHOLE-patched-conic-chain synthesis (the ~62 deg kink fix) is a
+            /// separate test-gated effort (design §9.2 / §17). v1 renders the current per-crossing
+            /// <c>FlexibleSoi</c> G0 behavior UNCHANGED; this reason is recorded for the future producer's
+            /// home but does NOT itself change geometry. Reserved — see
+            /// <see cref="Classify"/> for why v1 does NOT auto-raise it (it would be noise on every
+            /// ordinary interplanetary mission that already renders correctly).
+            /// </summary>
+            CrossSoiChain = 3,
+        }
+
+        /// <summary>Grep-stable lowercase token for a <see cref="FailClosedReason"/>.</summary>
+        internal static string ReasonToken(FailClosedReason reason)
+        {
+            switch (reason)
+            {
+                case FailClosedReason.NestedSoi: return "nested-soi";
+                case FailClosedReason.MovingTargetStation: return "moving-target-station";
+                case FailClosedReason.CrossSoiChain: return "cross-soi-chain";
+                default: return "none";
+            }
+        }
+
+        /// <summary>
+        /// The outcome of one fail-closed classification: whether the member is unsupported, the reason,
+        /// and (when nested-SOI) the typed <see cref="NestedSoiSubtree"/> payload (so the future producer
+        /// + the tracer have the structured identity). A SUPPORTED member yields
+        /// <see cref="FailClosedReason.None"/> and <see cref="IsFailClosed"/> = false.
+        /// </summary>
+        internal readonly struct FailClosedDecision
+        {
+            internal FailClosedReason Reason { get; }
+
+            /// <summary>The nested-SOI subtree when <see cref="Reason"/> is
+            /// <see cref="FailClosedReason.NestedSoi"/>; null otherwise.</summary>
+            internal NestedSoiSubtree NestedSubtree { get; }
+
+            internal FailClosedDecision(FailClosedReason reason, NestedSoiSubtree nestedSubtree)
+            {
+                Reason = reason;
+                NestedSubtree = nestedSubtree;
+            }
+
+            /// <summary>True iff the member is an unsupported producer -> render recorded verbatim.</summary>
+            internal bool IsFailClosed => Reason != FailClosedReason.None;
+
+            /// <summary>
+            /// The provenance the member's phases carry under this decision:
+            /// <see cref="SegmentProvenance.FaithfulFallback"/> when fail-closed,
+            /// <see cref="SegmentProvenance.Unknown"/> otherwise (the caller keeps its own per-phase
+            /// provenance — this decision only overrides on fail-closed).
+            /// </summary>
+            internal SegmentProvenance Provenance =>
+                IsFailClosed ? SegmentProvenance.FaithfulFallback : SegmentProvenance.Unknown;
+
+            internal static readonly FailClosedDecision Supported =
+                new FailClosedDecision(FailClosedReason.None, null);
+        }
+
+        /// <summary>
+        /// design §9.2 / §10: the PURE fail-closed decision for ONE member.
+        ///
+        /// <list type="number">
+        ///   <item><b>Moving-target station</b> (highest precedence — the least-supported phase): the
+        ///     member's arrival anchor is a LIVE moving vessel
+        ///     (<paramref name="hasLiveVesselArrivalAnchor"/>), so a synthetic moving-target solve is
+        ///     unsupported -> fail closed. design §9.2.</item>
+        ///   <item><b>Nested-SOI (Jool)</b>: the recorded body sequence is a moon-rich tour (two visited
+        ///     bodies are siblings under a shared non-root ancestor, via
+        ///     <see cref="NestedSoiSubtree.TryBuildFromBodySequence"/>), so a synthetic moon-to-moon
+        ///     re-aim is unsupported -> fail closed. design §10.</item>
+        ///   <item><b>Everything else is SUPPORTED.</b> A single-level cross-SOI transfer
+        ///     (Kerbin->Mun->Sun->Duna) is NOT auto-failed: it already renders correctly through the
+        ///     per-crossing <c>FlexibleSoi</c> G0 path, and auto-raising
+        ///     <see cref="FailClosedReason.CrossSoiChain"/> on every ordinary interplanetary mission would
+        ///     be noise that changes nothing (design §9.2: define-only, no v1 fix — render current
+        ///     behavior unchanged). The CrossSoiChain reason is defined for the future whole-chain
+        ///     synthesis effort's home, surfaced only by the explicit
+        ///     <see cref="ClassifyCrossSoiChainForTesting"/> seam, never by the live path.</item>
+        /// </list>
+        ///
+        /// <para><b>Geometry-neutral:</b> a fail-closed decision changes only PROVENANCE (and emits the
+        /// tracer event). The caller renders the RECORDED trajectory verbatim either way — the only thing
+        /// fail-closed disables is a synthetic producer that does not exist in v1.</para>
+        /// </summary>
+        internal static FailClosedDecision Classify(
+            IReadOnlyList<string> orderedRecordedBodies,
+            bool hasLiveVesselArrivalAnchor,
+            Func<string, string> referenceBodyName)
+        {
+            // (1) Moving-target station: the arrival anchor is a live moving vessel. Highest precedence
+            // because it is the least-supported phase and is independent of the body sequence (a station
+            // approach may stay in one heliocentric/parking frame the whole time).
+            if (hasLiveVesselArrivalAnchor)
+                return new FailClosedDecision(FailClosedReason.MovingTargetStation, null);
+
+            // (2) Nested-SOI (Jool moon tour): two visited bodies are siblings under a shared non-root
+            // ancestor. TryBuildFromBodySequence returns null for a single-level mission, so an ordinary
+            // interplanetary or Kerbin<->Mun trajectory stays SUPPORTED here.
+            NestedSoiSubtree subtree =
+                NestedSoiSubtree.TryBuildFromBodySequence(orderedRecordedBodies, referenceBodyName);
+            if (subtree != null && subtree.IsNested)
+                return new FailClosedDecision(FailClosedReason.NestedSoi, subtree);
+
+            // (3) Everything else is supported (the single-level cross-SOI path renders unchanged).
+            return FailClosedDecision.Supported;
+        }
+
+        /// <summary>
+        /// Test/future-producer seam: classify a member as <see cref="FailClosedReason.CrossSoiChain"/>
+        /// when its recorded body sequence makes MORE THAN ONE single-level SOI crossing (a multi-hop
+        /// interplanetary chain the future whole-patched-conic-chain synthesis would own). This is NOT on
+        /// the live classification path (design §9.2: cross-SOI is define-only, render current behavior
+        /// unchanged), so the cross-SOI G0 kink stays byte-identical; it exists so the reason + its
+        /// detection have a tested home for the deferred synthesis effort. Pure.
+        /// </summary>
+        internal static FailClosedDecision ClassifyCrossSoiChainForTesting(
+            IReadOnlyList<string> orderedRecordedBodies)
+        {
+            if (CountBodyChanges(orderedRecordedBodies) >= 2)
+                return new FailClosedDecision(FailClosedReason.CrossSoiChain, null);
+            return FailClosedDecision.Supported;
+        }
+
+        /// <summary>
+        /// Count adjacent distinct-body changes (single-level SOI crossings) in a recorded body sequence.
+        /// Pure; tolerates null / empty / single-element sequences (0 changes).
+        /// </summary>
+        internal static int CountBodyChanges(IReadOnlyList<string> orderedBodies)
+        {
+            if (orderedBodies == null || orderedBodies.Count < 2)
+                return 0;
+            int changes = 0;
+            for (int i = 1; i < orderedBodies.Count; i++)
+            {
+                string a = orderedBodies[i - 1];
+                string b = orderedBodies[i];
+                if (string.IsNullOrEmpty(a) || string.IsNullOrEmpty(b))
+                    continue;
+                if (!string.Equals(a, b, StringComparison.Ordinal))
+                    changes++;
+            }
+            return changes;
+        }
+
+        /// <summary>
+        /// PURE detail-line builder for the Tier-A <see cref="MapRenderTrace.EventFailClosedToFaithful"/>
+        /// structural event (kept pure — no Unity reads, no global sink — so the line schema is directly
+        /// unit-testable, mirroring <see cref="CrossMemberSeamStitcher.BuildDescentStitchedDetails"/> /
+        /// <see cref="MapRenderTrace.BuildLifecycleDetails"/>). Names the unsupported producer + the
+        /// faithful-fallback provenance + the case payload.
+        /// </summary>
+        internal static string BuildFailClosedDetails(FailClosedDecision decision)
+        {
+            string reason = ReasonToken(decision.Reason);
+            string prov = SegmentProvenanceTokens.ToToken(SegmentProvenance.FaithfulFallback);
+            string payload = decision.NestedSubtree != null
+                ? " " + decision.NestedSubtree.ToSummaryToken()
+                : string.Empty;
+            return string.Format(CultureInfo.InvariantCulture,
+                "producer={0} provenance={1} action=render-recorded-verbatim{2}",
+                reason, prov, payload);
+        }
+
+        /// <summary>
+        /// Emit the Tier-A <see cref="MapRenderTrace.EventFailClosedToFaithful"/> structural event naming
+        /// the unsupported producer. Gated by <see cref="MapRenderTrace.IsEnabled"/> (the off-by-default
+        /// <c>mapRenderTracing</c> setting), so normal play pays nothing, and deduped ONCE-PER-EVENT
+        /// (recording id + reason) via <see cref="MapRenderTrace.ShouldEmitFailClosedOnChange"/> so a
+        /// steady fail-closed member emits ONE line, not one per frame (the VerboseRateLimited
+        /// convention). Resolves the ghost pid from the committed index ONLY behind the
+        /// <see cref="MapRenderTrace.IsEnabled"/> gate, so the flag-OFF / tracing-OFF path never touches
+        /// <see cref="GhostMapPresence"/> and the headless unit tests stay pure; pid resolves to 0 when no
+        /// ghost vessel exists yet (the recId still names the line). A SUPPORTED decision emits nothing.
+        /// Surface = ProtoOrbitLine (the fail-closed member renders its recorded conic/line through the
+        /// stock proto path).
+        /// </summary>
+        internal static void EmitFailClosedToFaithful(
+            string recordingId, int committedIndex, double currentUT, FailClosedDecision decision)
+        {
+            if (!MapRenderTrace.IsEnabled)
+                return;
+            if (!decision.IsFailClosed)
+                return;
+
+            uint pid = GhostMapPresence.GetGhostVesselPidForRecording(committedIndex);
+            string pidKey = pid.ToString(CultureInfo.InvariantCulture);
+            string signature = (recordingId ?? "?") + ":" + ReasonToken(decision.Reason);
+            if (!MapRenderTrace.ShouldEmitFailClosedOnChange(pidKey, signature))
+                return;
+
+            string details = BuildFailClosedDetails(decision);
+            MapRenderTrace.EmitStructural(
+                MapRenderTrace.EventFailClosedToFaithful,
+                MapRenderTrace.RenderSurface.ProtoOrbitLine,
+                pidKey, currentUT, currentUT,
+                MapRenderTrace.SegmentChangeWindowSeconds, details, recordingId);
+        }
+    }
+}

--- a/Source/Parsek/MapRender/MovingTargetStationApproach.cs
+++ b/Source/Parsek/MapRender/MovingTargetStationApproach.cs
@@ -1,0 +1,136 @@
+using System;
+using System.Globalization;
+
+namespace Parsek.MapRender
+{
+    /// <summary>
+    /// Phase 7 (migration plan §9 / design §9.2 / §6): the typed model of a MOVING-TARGET station
+    /// rendezvous — the least-supported phase, whose target is a moving LIVE vessel (a station), not a
+    /// body center.
+    ///
+    /// <para>design §9.2 defines it as a composite of two first-class phases:
+    /// <list type="bullet">
+    ///   <item>a <see cref="HeliocentricTransferPhase"/> whose ARRIVAL
+    ///     <see cref="AnchorFrame"/> is a <see cref="AnchorFrame.LiveVesselAnchor"/> (a moving vessel,
+    ///     not a body center), joined by</item>
+    ///   <item>a <see cref="PhaseSeam"/> <c>{ FlexibleSoi, G0 }</c> to an arrival-side
+    ///     <see cref="HoldPhase"/> that hosts the STATION-PERIOD hold
+    ///     (<c>ArrivalHoldPlanner</c>'s station-period branch — NOT an <see cref="ArrivalLoiterPhase"/>,
+    ///     since there is no body to loiter around).</item>
+    /// </list></para>
+    ///
+    /// <para><b>DEFINE-ONLY, v1 fail-closed-to-faithful (design §4 / §9.2).</b> v1 renders recorded
+    /// approaches FAITHFULLY; the classifier returns unsupported (a free heliocentric station fails the
+    /// direct-child-of-common-ancestor test) -> <see cref="SegmentProvenance.FaithfulFallback"/>. The
+    /// SYNTHETIC moving-target producer is deferred (design §17). This type therefore BUILDS the two typed
+    /// phases (so the moving-target shape has a real, test-assertable identity and a typed home for the
+    /// future producer) but is never handed to the live draw spine in v1 — it is the fail-closed
+    /// classification's payload, not a geometry producer.</para>
+    ///
+    /// <para><b>Pure + headless.</b> No Unity / KSP-API reads. The transfer conic is a value-copied
+    /// <see cref="OrbitSegment"/> (carried for the future producer); the hold is a pure clock insertion.
+    /// Building the composite never solves anything.</para>
+    /// </summary>
+    internal sealed class MovingTargetStationApproach
+    {
+        /// <summary>
+        /// The heliocentric transfer leg whose arrival anchor is the LIVE station vessel
+        /// (<see cref="AnchorFrame.LiveVesselAnchor"/>). Provenance is
+        /// <see cref="SegmentProvenance.FaithfulFallback"/> in v1 (no synthetic moving-target solve).
+        /// </summary>
+        internal HeliocentricTransferPhase Transfer { get; }
+
+        /// <summary>
+        /// The arrival-side station-period <see cref="HoldPhase"/> (the <c>ArrivalHoldPlanner</c>
+        /// station-period branch). Anchored to the same live station vessel; it renders quietly (held prior
+        /// intent) but exists in the chain for debugging / composition.
+        /// </summary>
+        internal HoldPhase StationHold { get; }
+
+        /// <summary>
+        /// The <c>{ FlexibleSoi, G0 }</c> seam joining the transfer arrival to the station hold (design
+        /// §9.2). G0 (position only): there is no body SOI to enforce a tangent against at a moving target.
+        /// </summary>
+        internal PhaseSeam ArrivalSeam { get; }
+
+        /// <summary>The launch-unique guid (KSP <c>Vessel.id</c>) of the live station vessel the approach targets.</summary>
+        internal Guid StationLaunchGuid { get; }
+
+        internal MovingTargetStationApproach(
+            HeliocentricTransferPhase transfer,
+            HoldPhase stationHold,
+            PhaseSeam arrivalSeam,
+            Guid stationLaunchGuid)
+        {
+            Transfer = transfer;
+            StationHold = stationHold;
+            ArrivalSeam = arrivalSeam;
+            StationLaunchGuid = stationLaunchGuid;
+        }
+
+        /// <summary>
+        /// design §9.2: build the typed moving-target station-approach composite (the transfer leg
+        /// anchored to the live station + the arrival station-period hold, joined by a FlexibleSoi G0
+        /// seam). PURE — it builds the typed phases; it solves nothing and produces no synthetic geometry.
+        /// In v1 the composite's transfer carries <see cref="SegmentProvenance.FaithfulFallback"/> (the
+        /// synthetic moving-target producer is deferred); a future producer would re-stamp it
+        /// <see cref="SegmentProvenance.Synthesized"/>.
+        ///
+        /// <para><paramref name="transferConic"/> is the recorded heliocentric leg (value-copied onto the
+        /// phase); the <paramref name="holdStartUt"/>/<paramref name="holdEndUt"/> bracket the station hold
+        /// in the assembled-chain clock.</para>
+        /// </summary>
+        internal static MovingTargetStationApproach Build(
+            PhaseId transferId,
+            PhaseId holdId,
+            Guid stationLaunchGuid,
+            OrbitSegment transferConic,
+            double transferStartUt,
+            double transferEndUt,
+            double holdStartUt,
+            double holdEndUt)
+        {
+            var liveAnchor = new AnchorFrame.LiveVesselAnchor(stationLaunchGuid);
+
+            // The FlexibleSoi G0 seam joins the transfer arrival to the station hold (design §9.2). It
+            // carries no SoiCrossing (there is no body SOI at a moving target), and is off-camera by
+            // default (the seam at a moving rendezvous is not a distinguished on-screen kink).
+            PhaseSeam arrivalSeam = PhaseSeam.FlexibleSoi(crossing: null, onCamera: false);
+
+            var transfer = new HeliocentricTransferPhase(
+                transferId,
+                SegmentProvenance.FaithfulFallback,
+                liveAnchor,
+                transferStartUt,
+                transferEndUt,
+                transferConic,
+                leadingSeam: null,
+                trailingSeam: arrivalSeam);
+
+            var stationHold = new HoldPhase(
+                holdId,
+                liveAnchor,
+                holdStartUt,
+                holdEndUt,
+                leadingSeam: arrivalSeam,
+                trailingSeam: null);
+
+            return new MovingTargetStationApproach(transfer, stationHold, arrivalSeam, stationLaunchGuid);
+        }
+
+        /// <summary>
+        /// Grep-stable summary token for the Tier-A <c>fail-closed-to-faithful</c> detail line (design
+        /// §14). Pure; InvariantCulture.
+        /// </summary>
+        internal string ToSummaryToken()
+            => string.Format(CultureInfo.InvariantCulture,
+                "stationGuid={0} transferUT=[{1:F1},{2:F1}] holdUT=[{3:F1},{4:F1}] seam={5}",
+                StationLaunchGuid, Transfer.StartUt, Transfer.EndUt,
+                StationHold.StartUt, StationHold.EndUt,
+                PhaseSeamClassifier.KindToken(ArrivalSeam.Kind));
+
+        public override string ToString()
+            => string.Format(CultureInfo.InvariantCulture,
+                "MovingTargetStationApproach[{0}]", ToSummaryToken());
+    }
+}

--- a/Source/Parsek/MapRender/NestedSoiSubtree.cs
+++ b/Source/Parsek/MapRender/NestedSoiSubtree.cs
@@ -1,0 +1,199 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+
+namespace Parsek.MapRender
+{
+    /// <summary>
+    /// Phase 7 (migration plan §9 / design §10): the typed model of a MOON-RICH (nested-SOI) body tree —
+    /// Jool -> {Laythe, Vall, Tylo, Bop, Pol} -> sub-SOIs. The successor home for the cross-SOI body
+    /// vocabulary when the recorded trajectory crosses MORE THAN ONE level of the SOI hierarchy (a moon
+    /// tour inside a planet's SOI), distinct from the single-level <see cref="SoiCrossing"/> (Kerbin->Mun,
+    /// ->Sun) the model already renders.
+    ///
+    /// <para><b>DEFINE-ONLY, v1 fail-closed-to-faithful (design §4 / §10).</b> Recorded Jool tours already
+    /// render faithfully through the all-orbital chain + per-crossing <c>FlexibleSoi</c> G0 seams; the only
+    /// thing fail-closed disables is a SYNTHETIC moon-to-moon re-aim, which DOES NOT EXIST yet (the
+    /// recursive nested-SOI producer + a joint configuration-period alignment are deferred, design §17).
+    /// This type is therefore a pure DATA + DECISION model: it names the body tree and the per-leg
+    /// crossings so the <see cref="FailClosedClassifier"/> can say "this is a nested-SOI mission ->
+    /// FaithfulFallback" with a real, test-assertable identity, and so the future recursive producer has a
+    /// typed home. It produces NO synthetic geometry.</para>
+    ///
+    /// <para><b>Pure + headless.</b> No Unity / KSP-API reads. The body parent chain is supplied as a
+    /// delegate (mirroring <see cref="Parsek.IBodyInfo.ReferenceBodyName"/>) so the nesting
+    /// decision is directly unit-testable; the live caller passes the real
+    /// <c>CelestialBody.referenceBody.bodyName</c> walk. <c>UvLambert</c> is body-agnostic (mu is a
+    /// parameter), so a future recursive per-leg solver reuses the existing pure kernels — but that is
+    /// deferred, not built here.</para>
+    /// </summary>
+    internal sealed class NestedSoiSubtree
+    {
+        /// <summary>The root body of the subtree (the planet whose moons the mission toured, e.g. Jool).</summary>
+        internal string RootBody { get; }
+
+        /// <summary>
+        /// The ordered distinct bodies the recorded trajectory visited inside the root's SOI hierarchy,
+        /// in first-visit order (e.g. Jool, Laythe, Tylo). The first entry is the deepest common ancestor
+        /// the tour stayed under; subsequent entries are the moons / sub-SOIs visited.
+        /// </summary>
+        internal IReadOnlyList<string> VisitedBodies { get; }
+
+        /// <summary>
+        /// The per-leg body changes inside the subtree (a moon-to-moon / moon-to-planet hop), each a
+        /// <see cref="SoiCrossing"/>. v1 RECORDS these (so the fail-closed decision + the future producer
+        /// have the crossing list); it does NOT re-aim across them.
+        /// </summary>
+        internal IReadOnlyList<SoiCrossing> Crossings { get; }
+
+        internal NestedSoiSubtree(
+            string rootBody,
+            IReadOnlyList<string> visitedBodies,
+            IReadOnlyList<SoiCrossing> crossings)
+        {
+            RootBody = rootBody;
+            VisitedBodies = visitedBodies ?? Array.Empty<string>();
+            Crossings = crossings ?? Array.Empty<SoiCrossing>();
+        }
+
+        /// <summary>
+        /// True iff the tour visited at least one moon BELOW the root (more than just the root body) — the
+        /// defining "nested" property. A subtree with a single visited body (the root only) is NOT nested
+        /// (it is an ordinary single-body presence, not a moon tour).
+        /// </summary>
+        internal bool IsNested => VisitedBodies.Count >= 2;
+
+        /// <summary>The number of intra-subtree SOI crossings (moon hops) the tour made.</summary>
+        internal int CrossingCount => Crossings.Count;
+
+        /// <summary>
+        /// design §10: DECIDE whether a recorded trajectory's body sequence is a nested-SOI (moon-rich)
+        /// tour and, if so, build the typed subtree. Returns null when the trajectory is NOT nested (zero
+        /// or one body, or every body change is a SINGLE-LEVEL crossing that the ordinary
+        /// <see cref="SoiCrossing"/> / <c>FlexibleSoi</c> path already handles).
+        ///
+        /// <para>The nesting test: walk the ordered distinct bodies the recorded
+        /// <see cref="OrbitSegment"/>s visited; if two or more of them share a COMMON ANCESTOR that is
+        /// itself NOT the system root (the Sun) — i.e. the tour stayed under a planet and visited that
+        /// planet's moons — it is nested. A direct Kerbin->Mun->Kerbin is single-level (Mun's parent IS
+        /// the visited Kerbin, but the chain has depth 1 under Kerbin and never crosses a SIBLING moon),
+        /// so this returns a nested subtree only when at least one crossing is a SIBLING / cross-moon hop
+        /// under a shared non-root ancestor (the real Jool-tour signature).</para>
+        ///
+        /// <para>Pure: <paramref name="referenceBodyName"/> supplies the parent of a body (null for the
+        /// system root / unknown), exactly the <see cref="Parsek.IBodyInfo.ReferenceBodyName"/>
+        /// contract. A null delegate yields null (cannot decide -> not nested, the safe default).</para>
+        /// </summary>
+        internal static NestedSoiSubtree TryBuildFromBodySequence(
+            IReadOnlyList<string> orderedBodies,
+            Func<string, string> referenceBodyName)
+        {
+            if (orderedBodies == null || orderedBodies.Count < 2 || referenceBodyName == null)
+                return null;
+
+            // Ordered distinct bodies in first-visit order.
+            var distinct = new List<string>(orderedBodies.Count);
+            var seen = new HashSet<string>(StringComparer.Ordinal);
+            foreach (string b in orderedBodies)
+            {
+                if (string.IsNullOrEmpty(b) || !seen.Add(b))
+                    continue;
+                distinct.Add(b);
+            }
+            if (distinct.Count < 2)
+                return null;
+
+            // Find a shared NON-ROOT ancestor under which two distinct visited bodies are SIBLINGS (or a
+            // parent + its child moon AND a sibling moon). The simplest robust signature: any pair of
+            // visited bodies whose immediate reference body is the SAME non-null body, AND that shared
+            // parent is itself not the system root (it has its own parent). That is exactly a moon-to-moon
+            // hop under a planet — the nested-SOI tour the model fail-closes; a Kerbin<->Mun pair has no
+            // two siblings (only Mun under Kerbin), so it stays single-level.
+            string rootBody = FindNestedRoot(distinct, referenceBodyName);
+            if (string.IsNullOrEmpty(rootBody))
+                return null;
+
+            // Build the per-leg crossings (every adjacent body change in the ORIGINAL order, so a back-
+            // and-forth moon tour records each hop). The exit/entry state vectors are left default (v1
+            // RECORDS the crossing identity, does not enforce continuity — design §10 / SoiCrossing).
+            var crossings = new List<SoiCrossing>();
+            for (int i = 1; i < orderedBodies.Count; i++)
+            {
+                string from = orderedBodies[i - 1];
+                string to = orderedBodies[i];
+                if (string.IsNullOrEmpty(from) || string.IsNullOrEmpty(to)
+                    || string.Equals(from, to, StringComparison.Ordinal))
+                    continue;
+                crossings.Add(new SoiCrossing(from, to, crossingUt: double.NaN, soiRadius: double.NaN));
+            }
+
+            return new NestedSoiSubtree(rootBody, distinct, crossings);
+        }
+
+        /// <summary>
+        /// Find a non-root ancestor under which at least two distinct visited bodies are SIBLINGS (the
+        /// moon-tour signature). Returns the shared parent body name, or null when no such ancestor exists
+        /// (a single-level mission). A "non-root" ancestor is one that itself has a reference body (so the
+        /// Sun, whose reference body is null, never counts — two planets sharing the Sun is interplanetary,
+        /// not a nested-SOI tour). Pure.
+        /// </summary>
+        private static string FindNestedRoot(
+            IReadOnlyList<string> distinctBodies, Func<string, string> referenceBodyName)
+        {
+            // Group visited bodies by their immediate parent; a parent with >= 2 visited children that is
+            // itself non-root is the nested-SOI root.
+            var childrenByParent = new Dictionary<string, int>(StringComparer.Ordinal);
+            for (int i = 0; i < distinctBodies.Count; i++)
+            {
+                string parent = SafeReference(referenceBodyName, distinctBodies[i]);
+                if (string.IsNullOrEmpty(parent))
+                    continue;
+                childrenByParent.TryGetValue(parent, out int c);
+                childrenByParent[parent] = c + 1;
+            }
+
+            foreach (KeyValuePair<string, int> kv in childrenByParent)
+            {
+                if (kv.Value < 2)
+                    continue;
+                // The shared parent must itself be non-root (have a reference body): a planet's moons share
+                // the planet (non-root); the Sun's planets share the Sun (root) -> interplanetary, skip.
+                string grandparent = SafeReference(referenceBodyName, kv.Key);
+                if (!string.IsNullOrEmpty(grandparent))
+                    return kv.Key;
+            }
+            return null;
+        }
+
+        private static string SafeReference(Func<string, string> referenceBodyName, string body)
+        {
+            if (string.IsNullOrEmpty(body))
+                return null;
+            try { return referenceBodyName(body); }
+            catch { return null; }
+        }
+
+        /// <summary>
+        /// Grep-stable summary token for the Tier-A <c>fail-closed-to-faithful</c> detail line (design
+        /// §14). Pure; InvariantCulture.
+        /// </summary>
+        internal string ToSummaryToken()
+        {
+            var sb = new StringBuilder();
+            sb.Append("root=").Append(RootBody ?? "?")
+              .Append(" visited=").Append(VisitedBodies.Count)
+              .Append(" crossings=").Append(CrossingCount)
+              .Append(" bodies=");
+            for (int i = 0; i < VisitedBodies.Count; i++)
+            {
+                if (i > 0) sb.Append('/');
+                sb.Append(VisitedBodies[i] ?? "?");
+            }
+            return sb.ToString();
+        }
+
+        public override string ToString()
+            => string.Format(CultureInfo.InvariantCulture, "NestedSoiSubtree[{0}]", ToSummaryToken());
+    }
+}

--- a/Source/Parsek/MapRender/PhaseFactory.cs
+++ b/Source/Parsek/MapRender/PhaseFactory.cs
@@ -119,9 +119,96 @@ namespace Parsek.MapRender
                 traj.RecordingId ?? "?", committedIndex, instanceKey, phases.Count, isReaimedMember,
                 windowStartUT, windowEndUT, faithfulFallback));
 
+            // Phase 7 (migration plan §9 / design §9.2 / §10): the FAIL-CLOSED decision site. Decide whether
+            // this member is one of the three UNSUPPORTED synthetic producers (nested-SOI Jool tour /
+            // moving-target station / cross-SOI whole-chain synthesis) and, if so, emit the Tier-A
+            // fail-closed-to-faithful structural event naming the unsupported producer. DEFINE-ONLY +
+            // GEOMETRY-NEUTRAL: the decision changes nothing about the geometry built above (the three
+            // producers have no synthetic implementation in v1, so "fail-closed to faithful" is exactly
+            // what the pipeline already does — the recorded trajectory renders verbatim, the cross-SOI kink
+            // renders the current FlexibleSoi G0 behavior unchanged). The whole block is gated on
+            // MapRenderTrace.IsEnabled, so flag-OFF / tracing-OFF normal play pays nothing AND never touches
+            // the live Unity body-info resolver (keeping the headless factory tests pure). The body parent
+            // chain comes from the live FlightGlobalsBodyInfo only here, behind the gate.
+            EmitFailClosedDecisionTraceIfEnabled(traj, committedIndex, isReaimedMember);
+
             return new PhaseChain(
                 traj.RecordingId, committedIndex, instanceKey, phases,
                 geometry.WindowStartUT, geometry.WindowEndUT, geometry.IsFaithfulFallback);
+        }
+
+        /// <summary>
+        /// Phase 7: the live fail-closed decision + Tier-A trace emit, gated ON TRACING (free in normal
+        /// play). Builds the recorded body sequence (pure), resolves the parent chain from the live
+        /// <see cref="FlightGlobalsBodyInfo"/> (a top-level <c>Parsek</c> type; a Unity read — only ever reached here
+        /// under the gate, so the headless factory tests never invoke it), runs the pure
+        /// <see cref="FailClosedClassifier.Classify"/>, and emits the once-per-event
+        /// <c>fail-closed-to-faithful</c> structural event when the member is unsupported.
+        ///
+        /// <para>The v1 live path NEVER signals a <c>LiveVesselAnchor</c> arrival (the moving-target
+        /// producer is deferred and no faithful trajectory resolves one), so the station case is reachable
+        /// only through the explicit <see cref="FailClosedClassifier.Classify"/> seam the unit tests drive;
+        /// the live path detects the nested-SOI (Jool) case from the recorded body sequence. The whole
+        /// helper is geometry-neutral: it reads the already-built chain inputs and emits a log line, never
+        /// mutating geometry.</para>
+        /// </summary>
+        private static void EmitFailClosedDecisionTraceIfEnabled(
+            IPlaybackTrajectory traj, int committedIndex, bool isReaimedMember)
+        {
+            if (!MapRenderTrace.IsEnabled || traj == null)
+                return;
+
+            // A re-aimed member that solved successfully is, by definition, a SUPPORTED producer this
+            // window (the heliocentric leg re-aimed) — fail-closed is the DECLINE outcome, so a re-aimed
+            // member is not the fail-closed subject. (A declined window arrives here as faithful, which is
+            // exactly where the nested-SOI / station fail-closed lives.)
+            if (isReaimedMember)
+                return;
+
+            System.Collections.Generic.List<string> bodies = BuildOrderedRecordedBodies(traj);
+            FailClosedClassifier.FailClosedDecision decision = FailClosedClassifier.Classify(
+                bodies,
+                hasLiveVesselArrivalAnchor: false,
+                referenceBodyName: FlightGlobalsBodyInfo.Instance.ReferenceBodyName);
+
+            if (!decision.IsFailClosed)
+                return;
+
+            FailClosedClassifier.EmitFailClosedToFaithful(
+                traj.RecordingId, committedIndex, GhostMapPresence.CurrentUTNow(), decision);
+        }
+
+        /// <summary>
+        /// PURE: the ordered recorded body sequence the fail-closed classifier reads, taken from the
+        /// recorded <see cref="OrbitSegment"/>s in time order (the orbital body sequence is the SOI
+        /// hierarchy the cross-SOI / nested-SOI decision walks). Adjacent duplicate bodies collapse to one
+        /// run; the OrbitSegment list is the authoritative body sequence (a traced atmospheric run rides
+        /// its body's conic). Tolerates a null / empty orbit list (returns an empty list — a no-orbit
+        /// recording is never a multi-body tour). No Unity reads.
+        /// </summary>
+        internal static System.Collections.Generic.List<string> BuildOrderedRecordedBodies(
+            IPlaybackTrajectory traj)
+        {
+            var bodies = new System.Collections.Generic.List<string>();
+            var orbits = traj?.OrbitSegments;
+            if (orbits == null)
+                return bodies;
+
+            // OrbitSegments are stored in time order; walk them and append each body, collapsing adjacent
+            // duplicates so a multi-orbit stay at one body is a single run (the body CHANGES are the SOI
+            // crossings the classifier counts).
+            string last = null;
+            for (int i = 0; i < orbits.Count; i++)
+            {
+                string b = orbits[i].bodyName;
+                if (string.IsNullOrEmpty(b))
+                    continue;
+                if (string.Equals(b, last, StringComparison.Ordinal))
+                    continue;
+                bodies.Add(b);
+                last = b;
+            }
+            return bodies;
         }
 
         /// <summary>

--- a/Source/Parsek/MapRenderTrace.cs
+++ b/Source/Parsek/MapRenderTrace.cs
@@ -83,6 +83,20 @@ namespace Parsek
         internal const string AnomalyClockNotReady = "clock-not-ready";
         internal const string AnomalyFactoryParity = "factory-parity";
 
+        // ---- Phase 7 Tier-A structural EVENT: fail-closed-to-faithful (design §14 / migration plan §9) ----
+        //
+        // The phase name passed to EmitStructural when a producer is UNSUPPORTED and the classifier chose
+        // exact recorded replay (FaithfulFallback) instead of a broken synthetic guess. WIRED + LIVE: the
+        // Phase-7 FailClosedClassifier emits it once-per-event (not per frame) from its decision site
+        // (FailClosedClassifier.EmitFailClosedToFaithful, gated through ShouldEmitFailClosedOnChange) when
+        // it classifies a cross-SOI / nested-SOI (Jool) / moving-target-station member as fail-closed. The
+        // detail line names the unsupported PRODUCER token (FailClosedReason) so a grep finds WHY a member
+        // rendered recorded-verbatim. This is define-only/inert behavior in v1 (fail-closed is what the
+        // classifiers already do — no synthetic producer exists for these three), so the event records the
+        // decision; it never changes geometry. The cross-SOI kink renders the current FlexibleSoi G0 seam
+        // unchanged.
+        internal const string EventFailClosedToFaithful = "fail-closed-to-faithful";
+
         // ---- Tier-C anomaly tuning ----
 
         /// <summary>
@@ -525,6 +539,47 @@ namespace Parsek
             return true;
         }
 
+        // ---- Phase 7: fail-closed-to-faithful structural-event once-per-event dedup ----
+        // The Phase-7 FailClosedClassifier runs every frame a member's chain is (re)classified, but the
+        // Tier-A fail-closed-to-faithful structural event is a per-(re)classification ONSET signal, not a
+        // per-frame one (EmitStructural routes to Info unconditionally + opens a detail window). This
+        // per-pid signature gate emits ONE line per fail-closed onset / reason change, honoring the
+        // VerboseRateLimited convention. Same warp-cap + Reset() (scene-switch) clearing as the marker /
+        // line-visibility / descent-stitch signature dicts.
+        private static readonly Dictionary<string, string> lastFailClosedSignatureByPid =
+            new Dictionary<string, string>(StringComparer.Ordinal);
+
+        /// <summary>Test-only: current size of the fail-closed change-detection dict (warp-cap assert).</summary>
+        internal static int FailClosedSignatureCountForTesting => lastFailClosedSignatureByPid.Count;
+
+        /// <summary>
+        /// Once-per-event gate for the Tier-A <c>fail-closed-to-faithful</c> structural event (Phase 7):
+        /// returns true only when <paramref name="signature"/> (recording id + the unsupported producer
+        /// reason) changed for this <paramref name="pidKey"/> since its last emit, so a steady fail-closed
+        /// member emits ONE structural line rather than one per frame. No-op (false) when disabled. An
+        /// empty pid (no resolvable ghost — e.g. a headless unit test) is allowed through (the
+        /// <see cref="IsEnabled"/> gate + the caller still bound the emit). Warp-capped + cleared in
+        /// <see cref="Reset"/> (scene switch), like the sibling signature dicts.
+        /// </summary>
+        internal static bool ShouldEmitFailClosedOnChange(string pidKey, string signature)
+        {
+            if (!IsEnabled)
+                return false;
+            if (string.IsNullOrEmpty(pidKey))
+                return true;
+
+            if (lastFailClosedSignatureByPid.TryGetValue(pidKey, out string last)
+                && string.Equals(last, signature, StringComparison.Ordinal))
+                return false; // unchanged fail-closed onset for this ghost -> suppress
+
+            if (!lastFailClosedSignatureByPid.ContainsKey(pidKey)
+                && lastFailClosedSignatureByPid.Count >= MaxTrackedMarkerDecisionKeys)
+                lastFailClosedSignatureByPid.Clear();
+
+            lastFailClosedSignatureByPid[pidKey] = signature;
+            return true;
+        }
+
         // MVP: detailed windows are keyed by pid.ToString(). recordingId keying
         // (and the shared registry with GhostRenderTrace) is a later cut.
         private static readonly Dictionary<string, double> detailedUntilByKey =
@@ -552,6 +607,7 @@ namespace Parsek
             lastMarkerDecisionSignatureByPid.Clear();
             lastLineVisibilitySignatureByPid.Clear();
             lastDescentStitchSignatureByPid.Clear();
+            lastFailClosedSignatureByPid.Clear();
             descentRenderWindowFrame = -1;
             descentRenderWindowPhase = null;
             descentRenderWindowRecId = null;

--- a/docs/dev/plans/map-ts-render-overhaul-migration.md
+++ b/docs/dev/plans/map-ts-render-overhaul-migration.md
@@ -374,6 +374,44 @@ station approach / cross-SOI transfer renders the recorded trajectory faithfully
 == recorded), since fail-closed renders the recorded trajectory verbatim. **Risk:** low
 (no new geometry; fail-closed is what the classifiers already do).
 
+**Status (implemented, define-only / geometry-neutral):** the three types have a typed home.
+`Source/Parsek/MapRender/NestedSoiSubtree.cs` (Jool moon-tour body tree + per-leg `SoiCrossing` list +
+the pure `TryBuildFromBodySequence` nesting decision) and `Source/Parsek/MapRender/MovingTargetStationApproach.cs`
+(the `HeliocentricTransferPhase` arrival-anchored to a `LiveVesselAnchor` + a station-period `HoldPhase`,
+joined by a `FlexibleSoi` G0 `PhaseSeam`) join the already-defined `SoiCrossing` (Phase 1). The pure,
+headless `Source/Parsek/MapRender/FailClosedClassifier.cs` is the fail-closed DECISION: its `Classify`
+returns `MovingTargetStation` when the arrival anchor is a live moving vessel, `NestedSoi` when the
+recorded body sequence is a moon-rich tour (two visited bodies are siblings under a shared non-root
+ancestor), and SUPPORTED otherwise: a single-level cross-SOI transfer (Kerbin->Mun->Sun->Duna) is NOT
+auto-failed (it renders correctly through the existing per-crossing `FlexibleSoi` G0 path, so auto-raising
+`CrossSoiChain` on every ordinary interplanetary mission would be noise that changes nothing). The
+`CrossSoiChain` reason + its detection are defined for the deferred whole-patched-conic-chain synthesis
+effort's home, surfaced only by the explicit `ClassifyCrossSoiChainForTesting` seam, never by the live
+path. A fail-closed decision changes only PROVENANCE (`FaithfulFallback`) and emits the tracer event; it
+NEVER mutates geometry (the three synthetic producers do not exist in v1, so "fail-closed to faithful" is
+exactly what the pipeline already does, and the cross-SOI kink renders the current `FlexibleSoi` G0
+behavior unchanged). **Decision site:** `PhaseFactory.EmitFailClosedDecisionTraceIfEnabled` (called from
+`BuildPhaseChain` AFTER the chain is built, returning the same `PhaseChain`), gated wholly on
+`MapRenderTrace.IsEnabled`, so flag-OFF (`MapRenderPhaseSpineDrive` default-OFF) is byte-identical and
+tracing-OFF normal play pays a single bool check and never touches the live `FlightGlobalsBodyInfo`
+resolver (keeping the headless factory tests pure). The deorbit-clock identifiers stay out of the spine
+files, so `SwappedSpine_DoesNotConsumeDeorbitClock_SourceGate` remains green.
+
+**Tracer integration (logging priority):** the Tier-A `fail-closed-to-faithful` structural event
+(`MapRenderTrace.EventFailClosedToFaithful`) is emitted once-per-event from the fail-closed decision site
+(`FailClosedClassifier.EmitFailClosedToFaithful` -> `MapRenderTrace.EmitStructural`), gated on
+`MapRenderTrace.IsEnabled` and deduped per-pid/per-reason via `MapRenderTrace.ShouldEmitFailClosedOnChange`
+(its `lastFailClosedSignatureByPid` signature dict mirrors `ShouldEmitDescentStitchOnChange` /
+`lastDescentStitchSignatureByPid`, same `MaxTrackedMarkerDecisionKeys` warp cap, cleared in
+`MapRenderTrace.Reset()` on scene switch), so a steady fail-closed member emits ONE line, not one per
+frame. The line names the unsupported PRODUCER token (`FailClosedClassifier.ReasonToken`) plus the
+`faithful-fallback` provenance and the case payload (the nested-SOI subtree summary), built by the PURE
+`FailClosedClassifier.BuildFailClosedDetails` (+ the per-type `ToSummaryToken` builders) so the detail
+schema is directly unit-testable without the global log sink. The v1 LIVE path detects the nested-SOI
+(Jool) case from the recorded body sequence; the moving-target-station case is reachable only through the
+explicit `FailClosedClassifier.Classify` seam the unit / in-game tests drive (no faithful trajectory
+resolves a `LiveVesselAnchor` arrival in v1).
+
 ---
 
 ## 10. Phase 8 — Retire the circular reconciler; finalize tracer EVENT coverage


### PR DESCRIPTION
**Stacked on Phase 6 ([#1219](https://github.com/vl3c/Parsek/pull/1219)). Merge in order; this PR's diff is Phase 7 only.**

## What

Phase 7 of the map/TS render overhaul (migration plan §9): give the three UNSUPPORTED synthetic producers a typed home that renders recorded data faithfully and never a broken synthetic guess. Low-risk, additive, **define-only + geometry-neutral**.

- **New types:** `NestedSoiSubtree` (Jool nested-SOI moon tour), `MovingTargetStationApproach` (a `HeliocentricTransferPhase` arrival-anchored to a `LiveVesselAnchor` + a station-period `HoldPhase` joined by a `FlexibleSoi`/G0 seam), alongside the Phase-1 `SoiCrossing`.
- **`FailClosedClassifier`:** returns `FaithfulFallback` for cross-SOI / Jool / station — the recorded trajectory renders verbatim, no synthetic re-aim/geometry. The cross-SOI kink renders its current per-crossing `FlexibleSoi` G0 behavior **unchanged**.

## Safety

- **Geometry-neutral:** the decision site is `PhaseFactory.BuildPhaseChain` → `EmitFailClosedDecisionTraceIfEnabled`, called *after* the chain is built; it only stamps provenance + emits a log line and returns the **same** `PhaseChain` (`ChainAssembler.Build` geometry verbatim). The new types have no live consumer beyond the classifier.
- **Live path detects only nested-SOI;** the station case is reachable only via the explicit `Classify` seam (the moving-target producer is deferred; v1 never resolves a `LiveVesselAnchor` arrival), and `CrossSoiChain` only via a test seam — so the live cross-SOI transfer stays SUPPORTED.
- **Flag-OFF byte-identical:** the whole block is gated on `MapRenderTrace.IsEnabled` (the `mapRenderTracing` setting), independent of `MapRenderPhaseSpineDrive`; tracing-off normal play pays one bool check and never touches the live `FlightGlobalsBodyInfo` resolver (headless factory tests stay pure).
- **Source-gate green:** the wiring lives in `PhaseFactory` (classification), not the spine; a new `FailClosedWiringSourceGateTests` complements `SwappedSpine_DoesNotConsumeDeorbitClock_SourceGate`.

## Tracer integration

A Tier-A `fail-closed-to-faithful` structural event naming the unsupported producer, emitted at the decision site **once-per-event** via the new `MapRenderTrace.ShouldEmitFailClosedOnChange` dedup (signature `recId:reason`, warp-capped, cleared in `Reset()`) — the Phase-6 `ShouldEmitDescentStitchOnChange` pattern. Pure detail builders make the line schema unit-testable without the global `ParsekLog` sink.

## Tests

- Unit: the fail-closed decision per case, the type definitions, the nesting decision, and the tracer event/dedup (asserted via pure builders + the `FailClosedSignatureCountForTesting` count seam, NOT the flake-prone `ParsekLog.TestSinkForTesting`); plus 3 mutation-sensitive cases for the new pure `PhaseFactory.BuildOrderedRecordedBodies`.
- In-game (`FailClosedFaithfulInGameTest`): drives the real classifier against the live stock body tree (Jool tour → NestedSoi, station → MovingTargetStation, Kerbin→Sun→Duna stays SUPPORTED), asserts the `fail-closed-to-faithful` line, and runs the parity oracle in FAITHFUL mode (rendered == recorded, zero drift).
- `dotnet build` green; `dotnet test` **16567 passed, 0 failed**.

## Review

Two clean-context lenses (correctness + fail-closed semantics; integration + tracer + tests), verdict CLEAN, 0 blockers/majors. Folded the one minor (missing `BuildOrderedRecordedBodies` unit test) and a doc-cref nit.

No `CHANGELOG` / `todo-and-known-bugs` change: fail-closed is what the classifiers already do, so there's no user-visible behavior change.