### PR TITLE
maprender Phase 8: unwire the circular reconciler + finalize tracer EVENT coverage

### DIFF
--- a/Source/Parsek.Tests/GrepAuditRenderReconcilerUnwiredTests.cs
+++ b/Source/Parsek.Tests/GrepAuditRenderReconcilerUnwiredTests.cs
@@ -1,0 +1,190 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    /// <summary>
+    /// Phase 8 (map/TS render overhaul, migration plan section 10): regression gate locking the UNWIRING
+    /// of the now-circular intent-vs-old-truth comparator. Through Phases 0-7 the end-of-frame
+    /// <c>MapRenderProbe</c> called <c>GhostRenderReconciler.CheckIntentAgainstOldTruth</c> to compare the
+    /// new spine's intent against the OLD path's rendered truth; once the spine drives the render that OLD
+    /// truth IS the spine's own consequence, so the comparison became circular / self-confirming. The
+    /// Phase-0 recorded-vs-rendered RenderParityOracle (a DISTINCT axis since Phase 0) is now the SOLE
+    /// acceptance oracle, so the LIVE probe call site was removed.
+    ///
+    /// This is an UNWIRING, NOT a deletion of the type: <c>GhostRenderReconciler</c>, its pure predicates,
+    /// and the <c>CheckIntentAgainstOldTruth</c> METHOD are KEPT (exercised by
+    /// <see cref="GhostRenderReconcilerTests"/>). What must stay gone is any LIVE production CALL SITE. The
+    /// forbidden token is the CALL form <c>.CheckIntentAgainstOldTruth(</c> (a leading dot + a trailing open
+    /// paren): it matches an invocation but NOT the method DEFINITION (no leading dot) nor a doc-comment cref
+    /// (no trailing paren), so the kept method + its kept doc-comments are never flagged while a resurrected
+    /// live call site is. The audit scans only <c>Source/Parsek/</c> (production), so the xUnit
+    /// <see cref="GhostRenderReconcilerTests"/> call sites (which legitimately drive the kept method) are out
+    /// of scope.
+    ///
+    /// This test runs <c>scripts/grep-audit-render-reconciler-unwired.ps1</c> against the source tree and
+    /// asserts exit 0 - i.e. ANY file under <c>Source/Parsek/</c> that resurrects a live call site is a build
+    /// break. When <c>pwsh</c> is unavailable (non-Windows CI) it falls back to an equivalent managed scan so
+    /// the gate still runs. Mirrors <see cref="GrepAuditMapRenderDirectorDriveTests"/>.
+    /// </summary>
+    public class GrepAuditRenderReconcilerUnwiredTests
+    {
+        // The single forbidden token (case-sensitive substring): the CALL form (leading dot + trailing open
+        // paren). The method definition (no leading dot) and the doc-comment crefs (no trailing paren) do NOT
+        // contain this literal and are therefore never flagged.
+        private const string ForbiddenToken = ".CheckIntentAgainstOldTruth(";
+
+        [Fact]
+        public void RenderReconcilerComparator_StaysUnwiredRepoWide()
+        {
+            string repoRoot = ResolveRepoRoot();
+            string scriptPath = Path.Combine(
+                repoRoot, "scripts", "grep-audit-render-reconciler-unwired.ps1");
+            Assert.True(File.Exists(scriptPath),
+                "render-reconciler-unwired grep-audit script missing: " + scriptPath);
+
+            string pwshPath;
+            if (!TryFindExecutable("pwsh", out pwshPath)
+                && !TryFindExecutable("pwsh.exe", out pwshPath))
+            {
+                RunManagedRenderReconcilerUnwiredAudit(repoRoot);
+                return;
+            }
+
+            var psi = new ProcessStartInfo
+            {
+                FileName = pwshPath,
+                Arguments = string.Format(
+                    "-NoProfile -File \"{0}\" -RepoRoot \"{1}\"",
+                    scriptPath, repoRoot),
+                WorkingDirectory = repoRoot,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+            };
+
+            var stdout = new StringBuilder();
+            var stderr = new StringBuilder();
+            using (var proc = new Process { StartInfo = psi })
+            {
+                proc.OutputDataReceived += (_, e) => { if (e.Data != null) stdout.AppendLine(e.Data); };
+                proc.ErrorDataReceived += (_, e) => { if (e.Data != null) stderr.AppendLine(e.Data); };
+                proc.Start();
+                proc.BeginOutputReadLine();
+                proc.BeginErrorReadLine();
+                bool finished = proc.WaitForExit(60_000);
+                Assert.True(finished, "render-reconciler-unwired grep-audit script did not finish within 60s.");
+                proc.WaitForExit();
+
+                string combined = "stdout:\n" + stdout + "\nstderr:\n" + stderr;
+                Assert.True(proc.ExitCode == 0,
+                    "render-reconciler-unwired grep-audit script exited with " + proc.ExitCode + ".\n" + combined);
+            }
+        }
+
+        // The KEEP half of the Phase-8 contract: the unwiring removed only the LIVE call site, NOT the
+        // method. The grep-audit forbids the CALL form; this asserts the DEFINITION (no leading dot) still
+        // exists in production source, so a future "delete the method to trivially satisfy the gate" move
+        // (which would also break GhostRenderReconcilerTests) is caught here too. Together the two facts pin
+        // the exact intended end-state: method present, zero live call sites.
+        [Fact]
+        public void RenderReconcilerComparator_MethodIsKept_NotDeleted()
+        {
+            string repoRoot = ResolveRepoRoot();
+            string reconcilerPath = Path.Combine(
+                repoRoot, "Source", "Parsek", "MapRender", "GhostRenderReconciler.cs");
+            Assert.True(File.Exists(reconcilerPath),
+                "GhostRenderReconciler.cs missing: " + reconcilerPath);
+
+            bool sawDefinition = false;
+            foreach (string line in File.ReadLines(reconcilerPath))
+            {
+                // The method DEFINITION carries no leading dot, so it is NOT the forbidden call-form token.
+                if (line.IndexOf("void CheckIntentAgainstOldTruth(", StringComparison.Ordinal) >= 0)
+                {
+                    sawDefinition = true;
+                    break;
+                }
+            }
+
+            Assert.True(sawDefinition,
+                "the Phase-8 unwiring KEEPS the CheckIntentAgainstOldTruth method (exercised by "
+                    + "GhostRenderReconcilerTests); only its LIVE call site is removed. The method definition "
+                    + "must still be present in GhostRenderReconciler.cs.");
+        }
+
+        private static void RunManagedRenderReconcilerUnwiredAudit(string repoRoot)
+        {
+            string sourceRoot = Path.Combine(repoRoot, "Source", "Parsek");
+            Assert.True(Directory.Exists(sourceRoot),
+                "managed render-reconciler-unwired audit: source root not found: " + sourceRoot);
+
+            var violations = new List<string>();
+            foreach (string path in Directory.EnumerateFiles(sourceRoot, "*.cs", SearchOption.AllDirectories))
+            {
+                int lineNumber = 0;
+                foreach (string line in File.ReadLines(path))
+                {
+                    lineNumber++;
+                    if (line.IndexOf(ForbiddenToken, StringComparison.Ordinal) >= 0)
+                    {
+                        string rel = path;
+                        if (rel.StartsWith(repoRoot, StringComparison.OrdinalIgnoreCase))
+                            rel = rel.Substring(repoRoot.Length).TrimStart('\\', '/');
+                        violations.Add(string.Format(
+                            "{0}:{1}: {2}", rel.Replace('\\', '/'), lineNumber, line.Trim()));
+                    }
+                }
+            }
+
+            Assert.True(
+                violations.Count == 0,
+                "managed render-reconciler-unwired audit failed (resurrected '" + ForbiddenToken
+                    + "' call site under Source/Parsek/):\n" + string.Join("\n", violations));
+        }
+
+        private static bool TryFindExecutable(string fileName, out string path)
+        {
+            path = null;
+            string pathEnv = Environment.GetEnvironmentVariable("PATH") ?? string.Empty;
+            foreach (string dir in pathEnv.Split(Path.PathSeparator))
+            {
+                if (string.IsNullOrWhiteSpace(dir)) continue;
+                try
+                {
+                    string candidate = Path.Combine(dir, fileName);
+                    if (File.Exists(candidate))
+                    {
+                        path = candidate;
+                        return true;
+                    }
+                }
+                catch
+                {
+                }
+            }
+            return false;
+        }
+
+        private static string ResolveRepoRoot()
+        {
+            string dir = AppContext.BaseDirectory;
+            for (int i = 0; i < 10 && !string.IsNullOrEmpty(dir); i++)
+            {
+                if (Directory.Exists(Path.Combine(dir, "scripts"))
+                    && Directory.Exists(Path.Combine(dir, "Source")))
+                {
+                    return dir;
+                }
+                dir = Path.GetDirectoryName(dir);
+            }
+            throw new InvalidOperationException(
+                "Could not locate repo root from " + AppContext.BaseDirectory);
+        }
+    }
+}

--- a/Source/Parsek.Tests/MapRenderTracerCoverageTests.cs
+++ b/Source/Parsek.Tests/MapRenderTracerCoverageTests.cs
@@ -1,0 +1,194 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    /// <summary>
+    /// Phase 8 (map/TS render overhaul, migration plan section 10) - the HEADLESS half of the
+    /// tracer-coverage matrix guard. The in-game <c>MapRenderTracerCoverageInGameTest</c> proves the
+    /// production CALL SITES are wired (a mapRenderTracing-on session lights up every surface end-to-end);
+    /// this proves the tracer SCHEMA is complete without a live KSP:
+    ///
+    ///  - every <see cref="MapRenderTrace.RenderSurface"/> enum value (except <c>Unknown</c>) maps to a
+    ///    distinct, non-"unknown" <c>surface=</c> token, so a new surface added without a token mapping (the
+    ///    line would log <c>surface=unknown</c> and a grep slice would miss it) is caught here;
+    ///  - each Tier-A / Tier-B / Tier-C emit (driven through the real <see cref="MapRenderTrace"/> sink with
+    ///    the pure builders) lands a line carrying the expected <c>surface=</c> + <c>phase=</c> / <c>reason=</c>
+    ///    token, so a renamed phase token / dropped surface argument / inverted gate is caught.
+    ///
+    /// Pure-builder + global-sink assertions (the robust pattern; no Unity-runtime dependency). Touches the
+    /// shared <see cref="MapRenderTrace"/> registry + the <see cref="ParsekLog"/> sink, and sets
+    /// <see cref="MapRenderTrace.FrameCounterOverrideForTesting"/> (Time.frameCount is a Unity ECall), so it
+    /// runs Sequential, mirroring <c>MapRenderTraceTests</c>.
+    /// </summary>
+    [Collection("Sequential")]
+    public class MapRenderTracerCoverageTests : IDisposable
+    {
+        private readonly List<string> logLines = new List<string>();
+        private const string Pid = "424242";
+        private const string RecId = "tracer-matrix-rec";
+        private const double Ut = 1000.0;
+
+        public MapRenderTracerCoverageTests()
+        {
+            MapRenderTrace.Reset();
+            MapRenderTrace.FrameCounterOverrideForTesting = () => 42;
+            MapRenderTrace.ForceEnabledForTesting = true;
+            ParsekSettings.CurrentOverrideForTesting = null;
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.ResetRateLimitsForTesting();
+            ParsekLog.SuppressLogging = false;
+            ParsekLog.VerboseOverrideForTesting = true; // Tier-B lines route to Verbose
+            ParsekLog.TestSinkForTesting = line => logLines.Add(line);
+        }
+
+        public void Dispose()
+        {
+            MapRenderTrace.Reset();
+            MapRenderTrace.ForceEnabledForTesting = false;
+            MapRenderTrace.FrameCounterOverrideForTesting = null;
+            ParsekSettings.CurrentOverrideForTesting = null;
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.ResetRateLimitsForTesting();
+            ParsekLog.SuppressLogging = true;
+        }
+
+        // ---- Surface-token completeness: every RenderSurface maps to a distinct non-unknown token ----
+
+        [Fact]
+        public void EveryRenderSurface_HasDistinctNonUnknownToken()
+        {
+            var seen = new HashSet<string>(StringComparer.Ordinal);
+            foreach (MapRenderTrace.RenderSurface surface in
+                Enum.GetValues(typeof(MapRenderTrace.RenderSurface)))
+            {
+                if (surface == MapRenderTrace.RenderSurface.Unknown)
+                    continue;
+
+                string prefix = MapRenderTrace.FormatTracePrefixForTesting(
+                    "Probe", surface, Pid, Ut, Ut, RecId);
+
+                // The token slice the log grep relies on (surface=<token>).
+                Assert.Contains("surface=", prefix);
+                int idx = prefix.IndexOf("surface=", StringComparison.Ordinal) + "surface=".Length;
+                int end = prefix.IndexOf(' ', idx);
+                string token = end < 0 ? prefix.Substring(idx) : prefix.Substring(idx, end - idx);
+
+                Assert.False(string.Equals(token, "unknown", StringComparison.Ordinal),
+                    "RenderSurface." + surface + " has no surface= token (logs surface=unknown) - a grep "
+                        + "slice on this surface would miss every line. Add it to RenderSurfaceToken.");
+                Assert.True(seen.Add(token),
+                    "RenderSurface." + surface + " shares the surface= token '" + token + "' with another "
+                        + "value - the surfaces would be indistinguishable in the log.");
+            }
+
+            // Sanity floor: the v1 matrix has 6 named surfaces (ProtoOrbitLine / ProtoIcon / Polyline /
+            // ImguiLabeledMarker / AtmosphericMarker / PolylineForwardArc). A drop below that is a regression.
+            Assert.True(seen.Count >= 6,
+                "expected at least 6 distinct render-surface tokens, found " + seen.Count);
+        }
+
+        // ---- Tier-A structural events carry surface= + phase= ----
+
+        // RenderSurface is internal, so a public xUnit theory method cannot take it directly; pass the
+        // underlying byte and cast inside (the InlineData enum literal is a compile-time constant byte).
+        [Theory]
+        [InlineData("GhostCreated", (byte)MapRenderTrace.RenderSurface.ProtoOrbitLine)]
+        [InlineData("GhostDestroyed", (byte)MapRenderTrace.RenderSurface.ProtoOrbitLine)]
+        [InlineData("FirstPosition", (byte)MapRenderTrace.RenderSurface.ProtoOrbitLine)]
+        [InlineData("PhaseChainAssembled", (byte)MapRenderTrace.RenderSurface.ProtoOrbitLine)]
+        [InlineData("DescentStitched", (byte)MapRenderTrace.RenderSurface.Polyline)]
+        [InlineData("PolylineLegChange", (byte)MapRenderTrace.RenderSurface.Polyline)]
+        [InlineData("PolylineLegChange", (byte)MapRenderTrace.RenderSurface.PolylineForwardArc)]
+        [InlineData(MapRenderTrace.EventFailClosedToFaithful, (byte)MapRenderTrace.RenderSurface.ProtoOrbitLine)]
+        public void TierA_StructuralEvent_RoutesToInfoWithSurfaceAndPhase(string phase, byte surfaceByte)
+        {
+            var surface = (MapRenderTrace.RenderSurface)surfaceByte;
+            MapRenderTrace.EmitStructural(
+                phase, surface, Pid, Ut, Ut, MapRenderTrace.SegmentChangeWindowSeconds,
+                details: "k=v", recId: RecId);
+
+            string surfaceToken = SurfaceToken(surface);
+            Assert.Contains(logLines, l =>
+                l.Contains("[MapRenderTrace]")
+                && l.Contains("[INFO]")
+                && l.Contains("phase=" + phase)
+                && l.Contains("surface=" + surfaceToken)
+                && l.Contains("recId=" + RecId));
+        }
+
+        // ---- Tier-B change-based events carry surface= + phase= and route to Verbose ----
+
+        [Theory]
+        [InlineData("MarkerDecision", (byte)MapRenderTrace.RenderSurface.ImguiLabeledMarker)]
+        [InlineData("MarkerDecision", (byte)MapRenderTrace.RenderSurface.AtmosphericMarker)]
+        [InlineData("LineVisibilityChange", (byte)MapRenderTrace.RenderSurface.ProtoOrbitLine)]
+        [InlineData("icon-suppressed", (byte)MapRenderTrace.RenderSurface.ProtoIcon)]
+        public void TierB_OnChangeEvent_RoutesToVerboseWithSurfaceAndPhase(string phase, byte surfaceByte)
+        {
+            var surface = (MapRenderTrace.RenderSurface)surfaceByte;
+            MapRenderTrace.EmitOnChange(phase, surface, Pid, Ut, Ut, details: "k=v", recId: RecId);
+
+            string surfaceToken = SurfaceToken(surface);
+            Assert.Contains(logLines, l =>
+                l.Contains("[MapRenderTrace]")
+                && l.Contains("phase=" + phase)
+                && l.Contains("surface=" + surfaceToken));
+        }
+
+        // ---- Tier-C anomalies carry surface= + reason= ----
+
+        [Theory]
+        [InlineData("icon-off-orbit", (byte)MapRenderTrace.RenderSurface.ProtoOrbitLine)]
+        [InlineData("decision-vs-truth", (byte)MapRenderTrace.RenderSurface.ProtoOrbitLine)]
+        [InlineData(MapRenderTrace.AnomalyParityDrift, (byte)MapRenderTrace.RenderSurface.ProtoOrbitLine)]
+        [InlineData("polyline-orbit-overlap", (byte)MapRenderTrace.RenderSurface.Polyline)]
+        [InlineData(MapRenderTrace.AnomalyRigidSeamTangentDiscontinuity, (byte)MapRenderTrace.RenderSurface.Polyline)]
+        public void TierC_Anomaly_RoutesToInfoWithSurfaceAndReason(string reason, byte surfaceByte)
+        {
+            var surface = (MapRenderTrace.RenderSurface)surfaceByte;
+            MapRenderTrace.EmitAnomaly(surface, Pid, Ut, Ut, reason, details: "k=v", recId: RecId);
+
+            string surfaceToken = SurfaceToken(surface);
+            Assert.Contains(logLines, l =>
+                l.Contains("[MapRenderTrace]")
+                && l.Contains("phase=Anomaly")
+                && l.Contains("reason=" + reason)
+                && l.Contains("surface=" + surfaceToken));
+        }
+
+        // ---- The polyline appear/disappear diff is pure: it carries BOTH event tokens ----
+
+        [Fact]
+        public void PolylineLegChange_DiffDrawnSets_ProducesAppearAndDisappear()
+        {
+            var appeared = new List<string>();
+            var disappeared = new List<string>();
+
+            // {} -> {rec} => appear
+            Parsek.Display.GhostTrajectoryPolylineRenderer.DiffDrawnSets(
+                new HashSet<string>(), new HashSet<string> { RecId }, appeared, disappeared);
+            Assert.Contains(RecId, appeared);
+            Assert.Empty(disappeared);
+
+            // {rec} -> {} => disappear
+            appeared.Clear();
+            disappeared.Clear();
+            Parsek.Display.GhostTrajectoryPolylineRenderer.DiffDrawnSets(
+                new HashSet<string> { RecId }, new HashSet<string>(), appeared, disappeared);
+            Assert.Empty(appeared);
+            Assert.Contains(RecId, disappeared);
+        }
+
+        // The same token mapping production uses, so the matrix assertions match the live log slice exactly.
+        private static string SurfaceToken(MapRenderTrace.RenderSurface surface)
+        {
+            string prefix = MapRenderTrace.FormatTracePrefixForTesting("X", surface, Pid, Ut, Ut, RecId);
+            int idx = prefix.IndexOf("surface=", StringComparison.Ordinal) + "surface=".Length;
+            int end = prefix.IndexOf(' ', idx);
+            return end < 0 ? prefix.Substring(idx) : prefix.Substring(idx, end - idx);
+        }
+    }
+}

--- a/Source/Parsek/Display/GhostTrajectoryPolylineRenderer.cs
+++ b/Source/Parsek/Display/GhostTrajectoryPolylineRenderer.cs
@@ -500,6 +500,20 @@ namespace Parsek.Display
                 previous.Add(id);
         }
 
+        /// <summary>Test seam: drive the appear/disappear <c>PolylineLegChange</c> EVENT diff directly (the
+        /// production caller is the Driver's per-frame onPreCull / walk, which needs a live render frame). Used
+        /// by the Phase-8 tracer-coverage matrix in-game test to prove the Polyline / PolylineForwardArc
+        /// appear/disappear wiring lights up end-to-end. Clears the per-(surface, recordingId, event)
+        /// wall-clock floor first so a repeated in-game run is not suppressed by a stale onset timestamp.
+        /// No-op emit when tracing is off (the underlying structural emit early-returns).</summary>
+        internal static void EmitPolylineDrawSetChangesForTesting(
+            MapRenderTrace.RenderSurface surface,
+            HashSet<string> previous, HashSet<string> current, double currentUT)
+        {
+            legChangeLastEmitRealtime.Clear();
+            EmitPolylineDrawSetChanges(surface, previous, current, currentUT);
+        }
+
         private static void EmitPolylineLegChange(
             MapRenderTrace.RenderSurface surface, string recordingId, string ev, double currentUT)
         {

--- a/Source/Parsek/InGameTests/MapRenderTracerCoverageInGameTest.cs
+++ b/Source/Parsek/InGameTests/MapRenderTracerCoverageInGameTest.cs
@@ -1,0 +1,351 @@
+using System.Collections.Generic;
+using System.Globalization;
+using Parsek.MapRender;
+using UnityEngine;
+
+namespace Parsek.InGameTests
+{
+    // Phase 8 (map/TS render overhaul, migration plan section 10) - the in-game TRACER-COVERAGE MATRIX gate.
+    //
+    // The Phase-8 logging priority: a mapRenderTracing-on run over the regression set must emit the expected
+    // Tier-A/B/C lines for EVERY map/TS render surface and every NEW phase/seam/lifecycle event. This test is
+    // the standing "the tracer matrix is COMPLETE" assertion. Rather than wait for a live multi-ghost
+    // regression flight to incidentally exercise each surface (non-deterministic, and a missing surface would
+    // simply produce no line - a silent gap), it drives each surface + event class through its REAL emit
+    // ENTRY POINT (the production builders + the gated MapRenderTrace / GhostRenderTrace sinks) with the
+    // tracer forced on, captures every emitted line, and asserts a complete matrix:
+    //
+    //   surface=ProtoOrbitLine     appear/disappear: LineVisibilityChange (Tier-B)
+    //                              Tier-A:           GhostCreated / GhostDestroyed (lifecycle), FirstPosition,
+    //                                                PhaseChainAssembled, fail-closed-to-faithful
+    //                              Tier-C:           icon-off-orbit / decision-vs-truth / parity-drift
+    //   surface=ProtoIcon          Tier-B:           icon-suppressed
+    //   surface=Polyline           appear/disappear: PolylineLegChange appear|disappear (Tier-A)
+    //                              Tier-A:           DescentStitched
+    //                              Tier-C:           polyline-orbit-overlap
+    //   surface=PolylineForwardArc appear/disappear: PolylineLegChange appear|disappear (Tier-A)
+    //   surface=ImguiLabeledMarker Tier-B:           MarkerDecision (flight-map marker)
+    //   surface=AtmosphericMarker  Tier-B:           MarkerDecision (TS marker)
+    //   flight-scene mesh          appear/disappear: MeshSpawned / MeshDestroyed (Tier-A, the GhostRenderTrace
+    //                                                sibling instrument)
+    //
+    // NON-VACUOUS: every assertion drives a real production emit path (real builder + real Emit* sink). If a
+    // surface ever loses its appear/disappear or Tier-A/B/C wiring (a helper renamed, the RenderSurface enum
+    // entry dropped, an Emit* turned into a no-op, the gate inverted), the matching matrix line goes missing
+    // and this test fails - the exact "a surface is no longer instrumented" regression Phase 8 must guard.
+    //
+    // The pure per-line schema is locked headlessly in MapRenderTraceTests / MapRenderEventCoverageTests and
+    // the per-surface decision math in the surface tests; this in-game test is the integration assertion that
+    // a mapRenderTracing-on session lights up EVERY surface end-to-end (the Unity-coupled
+    // CurrentFrameCount() / Planetarium / live-sink path those cannot reach). FLIGHT only; career-independent.
+    //
+    // NOTE: in-game test (Ctrl+Shift+T / Settings > Diagnostics).
+    public class MapRenderTracerCoverageInGameTest
+    {
+        [InGameTest(Category = "MapRender", Scene = GameScenes.FLIGHT,
+            Description = "Phase 8 tracer-coverage matrix: with mapRenderTracing on, EVERY map/TS render "
+                + "surface (ProtoOrbitLine / ProtoIcon / Polyline / PolylineForwardArc / ImguiLabeledMarker / "
+                + "AtmosphericMarker / flight mesh) emits its appear/disappear + Tier-A/B/C lines through the "
+                + "real production emit paths - the tracer matrix is complete")]
+        public void TracerMatrix_EverySurface_EmitsAppearDisappearAndTiers()
+        {
+            bool prevMapForce = MapRenderTrace.ForceEnabledForTesting;
+            bool prevMeshForce = GhostRenderTrace.ForceEnabledForTesting;
+            System.Func<int> prevMapFrame = MapRenderTrace.FrameCounterOverrideForTesting;
+            System.Action<string> prevSink = ParsekLog.TestSinkForTesting;
+            bool prevSuppress = ParsekLog.SuppressLogging;
+            bool? prevVerbose = ParsekLog.VerboseOverrideForTesting;
+
+            var lines = new List<string>();
+
+            try
+            {
+                MapRenderTrace.Reset();
+                MapRenderTrace.ForceEnabledForTesting = true;
+                MapRenderTrace.FrameCounterOverrideForTesting = () => Time.frameCount;
+                GhostRenderTrace.ForceEnabledForTesting = true;
+                ParsekLog.SuppressLogging = false;
+                ParsekLog.VerboseOverrideForTesting = true; // Tier-B lines route to Verbose
+                ParsekLog.TestSinkForTesting = line => lines.Add(line);
+
+                double ut = Planetarium.GetUniversalTime();
+                if (ut <= 0.0)
+                    ut = 1000.0; // cold-load UT=0 guard: a positive UT so the windows / formatters are real
+
+                DriveAllSurfaces(ut);
+
+                // ---- The matrix: each entry MUST be present (a missing line = an uninstrumented surface) ----
+
+                // surface=ProtoOrbitLine -----------------------------------------------------------------
+                AssertHasMapLine(lines, "LineVisibilityChange", "ProtoOrbitLine",
+                    "ProtoOrbitLine appear/disappear (Tier-B LineVisibilityChange) missing");
+                AssertHasMapPhase(lines, "GhostCreated", "ProtoOrbitLine",
+                    "ProtoOrbitLine Tier-A lifecycle GhostCreated missing");
+                AssertHasMapPhase(lines, "GhostDestroyed", "ProtoOrbitLine",
+                    "ProtoOrbitLine Tier-A lifecycle GhostDestroyed missing");
+                AssertHasMapPhase(lines, "FirstPosition", "ProtoOrbitLine",
+                    "ProtoOrbitLine Tier-A FirstPosition missing");
+                AssertHasMapPhase(lines, "PhaseChainAssembled", "ProtoOrbitLine",
+                    "ProtoOrbitLine Tier-A PhaseChainAssembled (Phase 3) missing");
+                AssertHasReason(lines, MapRenderTrace.EventFailClosedToFaithful, "ProtoOrbitLine",
+                    "ProtoOrbitLine Tier-A fail-closed-to-faithful (Phase 7) missing");
+                AssertHasReason(lines, "icon-off-orbit", "ProtoOrbitLine",
+                    "ProtoOrbitLine Tier-C icon-off-orbit missing");
+                AssertHasReason(lines, "decision-vs-truth", "ProtoOrbitLine",
+                    "ProtoOrbitLine Tier-C decision-vs-truth missing");
+                AssertHasReason(lines, MapRenderTrace.AnomalyParityDrift, "ProtoOrbitLine",
+                    "ProtoOrbitLine Tier-C parity-drift missing");
+
+                // surface=ProtoIcon ----------------------------------------------------------------------
+                AssertHasMapLine(lines, "icon-suppressed", "ProtoIcon",
+                    "ProtoIcon Tier-B icon-suppressed missing");
+
+                // surface=Polyline -----------------------------------------------------------------------
+                AssertHasMapLine(lines, "PolylineLegChange", "Polyline",
+                    "Polyline appear/disappear (Tier-A PolylineLegChange) missing");
+                AssertContainsAll(lines, "Polyline appear/disappear must carry both event tokens",
+                    new[] { "surface=Polyline", "event=appear" });
+                AssertContainsAll(lines, "Polyline appear/disappear must carry both event tokens",
+                    new[] { "surface=Polyline", "event=disappear" });
+                AssertHasMapPhase(lines, "DescentStitched", "Polyline",
+                    "Polyline Tier-A DescentStitched (Phase 6) missing");
+                AssertHasReason(lines, "polyline-orbit-overlap", "Polyline",
+                    "Polyline Tier-C polyline-orbit-overlap missing");
+
+                // surface=PolylineForwardArc -----------------------------------------------------------
+                AssertHasMapLine(lines, "PolylineLegChange", "PolylineForwardArc",
+                    "PolylineForwardArc appear/disappear (Tier-A PolylineLegChange) missing");
+
+                // surface=ImguiLabeledMarker / AtmosphericMarker (Tier-B MarkerDecision) ----------------
+                AssertHasMapLine(lines, "MarkerDecision", "ImguiLabeledMarker",
+                    "ImguiLabeledMarker Tier-B MarkerDecision (flight-map marker) missing");
+                AssertHasMapLine(lines, "MarkerDecision", "AtmosphericMarker",
+                    "AtmosphericMarker Tier-B MarkerDecision (TS marker) missing");
+
+                // flight-scene mesh (the GhostRenderTrace sibling instrument) ---------------------------
+                AssertHasMeshPhase(lines, "MeshSpawned",
+                    "flight-scene mesh Tier-A MeshSpawned (appear) missing");
+                AssertHasMeshPhase(lines, "MeshDestroyed",
+                    "flight-scene mesh Tier-A MeshDestroyed (disappear) missing");
+
+                ParsekLog.Info("TestRunner", string.Format(CultureInfo.InvariantCulture,
+                    "TracerMatrix: complete - {0} captured lines cover all surfaces", lines.Count));
+            }
+            finally
+            {
+                MapRenderTrace.ForceEnabledForTesting = prevMapForce;
+                MapRenderTrace.FrameCounterOverrideForTesting = prevMapFrame;
+                GhostRenderTrace.ForceEnabledForTesting = prevMeshForce;
+                ParsekLog.TestSinkForTesting = prevSink;
+                ParsekLog.SuppressLogging = prevSuppress;
+                ParsekLog.VerboseOverrideForTesting = prevVerbose;
+                MapRenderTrace.Reset();
+            }
+        }
+
+        // Drives every surface + event class through its REAL production emit entry point. Each call routes a
+        // real builder through the gated sink, so a captured line proves the path is wired end-to-end.
+        private static void DriveAllSurfaces(double ut)
+        {
+            const string recId = "tracer-matrix-rec";
+            const uint pid = 424242u;
+            string pidKey = pid.ToString(CultureInfo.InvariantCulture);
+
+            // -- ProtoOrbitLine: Tier-B LineVisibilityChange (appear/disappear of the line decision) --
+            MapRenderTrace.EmitLineVisibilityOnChange(
+                pidKey, recId, ut, signature: "visible-body-frame",
+                details: "lineActive=true drawIcons=ALL reason=visible-body-frame");
+
+            // -- ProtoOrbitLine: Tier-A lifecycle (GhostCreated / GhostDestroyed) via the real builder --
+            MapRenderTrace.EmitStructural(
+                "GhostCreated", MapRenderTrace.RenderSurface.ProtoOrbitLine, pidKey, ut, ut,
+                MapRenderTrace.InitialWindowSeconds,
+                MapRenderTrace.BuildLifecycleDetails(
+                    "TracerMatrixGhost", "Kerbin", "FLIGHT", new Vector3d(1.0, 2.0, 3.0), "spawn"),
+                recId);
+            MapRenderTrace.EmitStructural(
+                "GhostDestroyed", MapRenderTrace.RenderSurface.ProtoOrbitLine, pidKey, ut, ut,
+                MapRenderTrace.DestroyWindowSeconds,
+                MapRenderTrace.BuildLifecycleDetails(
+                    "TracerMatrixGhost", "Kerbin", "FLIGHT", null, "retire"),
+                recId);
+
+            // -- ProtoOrbitLine: Tier-A FirstPosition via the real builder --
+            MapRenderTrace.EmitStructural(
+                "FirstPosition", MapRenderTrace.RenderSurface.ProtoOrbitLine, pidKey, ut, ut,
+                MapRenderTrace.InitialWindowSeconds,
+                MapRenderTrace.BuildFirstPositionDetails(
+                    new Vector3d(4.0, 5.0, 6.0), "Kerbin", 700000.0, 0.01, "first-truth"),
+                recId);
+
+            // -- ProtoOrbitLine: Tier-A PhaseChainAssembled (Phase 3) via the REAL ShadowRenderDriver hook --
+            // Build a real one-phase chain and drive the live emit so the Phase-3 structural wiring is proven.
+            PhaseChain chain = BuildTracerMatrixChain(recId, ut);
+            ShadowRenderDriver.EmitPhaseChainAssembledForTesting(pid, ut, chain);
+
+            // -- ProtoOrbitLine: Tier-A fail-closed-to-faithful (Phase 7) via the REAL classifier emit --
+            FailClosedClassifier.FailClosedDecision failClosed = FailClosedClassifier.Classify(
+                new List<string> { "Kerbin", "Sun" }, hasLiveVesselArrivalAnchor: true,
+                referenceBodyName: _ => null);
+            FailClosedClassifier.EmitFailClosedToFaithful(recId, committedIndex: 0, ut, failClosed);
+
+            // -- ProtoOrbitLine: Tier-C anomalies (icon-off-orbit / decision-vs-truth / parity-drift) --
+            MapRenderTrace.EmitAnomaly(
+                MapRenderTrace.RenderSurface.ProtoOrbitLine, pidKey, ut, ut,
+                "icon-off-orbit", "angleDeg=42.0", recId);
+            MapRenderTrace.EmitAnomaly(
+                MapRenderTrace.RenderSurface.ProtoOrbitLine, pidKey, ut, ut,
+                "decision-vs-truth",
+                "drawIcons-changed-after-decision(intended=ALL,actual=NONE) intentReason=test", recId);
+            MapRenderTrace.EmitAnomaly(
+                MapRenderTrace.RenderSurface.ProtoOrbitLine, pidKey, ut, ut,
+                MapRenderTrace.AnomalyParityDrift, "maxDev=999.0m tol=10.0m", recId);
+
+            // -- ProtoIcon: Tier-B icon-suppressed (on-change EVENT) --
+            MapRenderTrace.EmitOnChange(
+                "icon-suppressed", MapRenderTrace.RenderSurface.ProtoIcon, pidKey, ut, ut,
+                "iconSuppressed=true reason=below-atmosphere", recId);
+
+            // -- Polyline: appear/disappear (Tier-A PolylineLegChange) via the REAL polyline diff emitter --
+            // Two passes over the SAME previous-set so the first call emits appear, the second emits disappear.
+            var prev = new HashSet<string>();
+            var cur = new HashSet<string> { recId };
+            Parsek.Display.GhostTrajectoryPolylineRenderer.EmitPolylineDrawSetChangesForTesting(
+                MapRenderTrace.RenderSurface.Polyline, prev, cur, ut); // prev {} -> cur {rec} => appear
+            var curEmpty = new HashSet<string>();
+            Parsek.Display.GhostTrajectoryPolylineRenderer.EmitPolylineDrawSetChangesForTesting(
+                MapRenderTrace.RenderSurface.Polyline, prev, curEmpty, ut + 2.0); // {rec} -> {} => disappear
+
+            // -- Polyline: Tier-A DescentStitched (Phase 6) via the REAL stitcher emit --
+            CrossMemberSeamStitcher.EmitDescentStitched(
+                pid, recId, ut, reAnchoredHead: ut + 5.0, committedIndex: 0,
+                Parsek.Reaim.DescentTrigger.DescentHeadPhase.Descent);
+
+            // -- Polyline: Tier-C polyline-orbit-overlap --
+            MapRenderTrace.EmitAnomaly(
+                MapRenderTrace.RenderSurface.Polyline, pidKey, ut, ut,
+                "polyline-orbit-overlap",
+                "orbit-line-active-while-polyline-owns icon-on-orbit sma=700000 ecc=0.0100", recId);
+
+            // -- PolylineForwardArc: appear/disappear (Tier-A PolylineLegChange) via the REAL diff emitter --
+            var prevArc = new HashSet<string>();
+            var curArc = new HashSet<string> { recId };
+            Parsek.Display.GhostTrajectoryPolylineRenderer.EmitPolylineDrawSetChangesForTesting(
+                MapRenderTrace.RenderSurface.PolylineForwardArc, prevArc, curArc, ut);
+
+            // -- ImguiLabeledMarker / AtmosphericMarker: Tier-B MarkerDecision via the REAL signature builder --
+            // EmitMarkerDecisionOnChange is keyed per recordingId, carried in the prefix pid= slot.
+            string flightSig = MapRenderTrace.BuildMarkerDecisionSignature(
+                recordingIndex: 0, vesselName: "TracerMatrixGhost",
+                directorTracedPathActive: false, polylineOwning: true, iconSuppressed: false,
+                shouldDrawNonProto: true, MapRenderTrace.MarkerOutcome.DrawnNonProto,
+                MapRenderTrace.MarkerRideReason.RodeLeg, legIndex: 1, posSource: "polyline");
+            MapRenderTrace.EmitMarkerDecisionOnChange(
+                MapRenderTrace.RenderSurface.ImguiLabeledMarker, recId, ut, flightSig);
+
+            string tsSig = MapRenderTrace.BuildMarkerDecisionSignature(
+                recordingIndex: 0, vesselName: "TracerMatrixGhost",
+                directorTracedPathActive: false, polylineOwning: true, iconSuppressed: false,
+                shouldDrawNonProto: true, MapRenderTrace.MarkerOutcome.DrawnNonProto,
+                MapRenderTrace.MarkerRideReason.RodeLeg, legIndex: 1, posSource: "polyline",
+                tsSkipReason: "in-atmosphere");
+            MapRenderTrace.EmitMarkerDecisionOnChange(
+                MapRenderTrace.RenderSurface.AtmosphericMarker, recId + "-ts", ut, tsSig);
+
+            // -- flight-scene mesh: MeshSpawned / MeshDestroyed (the GhostRenderTrace sibling) --
+            // important=true so it emits regardless of an open detailed window (matching EmitMeshLifecycleTrace).
+            GhostRenderTrace.EmitPhase(
+                recId, ghostIndex: 0, ut, ut, "MeshSpawned",
+                "vessel=TracerMatrixGhost reason=ghost-created", important: true);
+            GhostRenderTrace.EmitPhase(
+                recId, ghostIndex: 0, ut, ut, "MeshDestroyed",
+                "vessel=TracerMatrixGhost reason=retire", important: true);
+        }
+
+        // A minimal but REAL single-conic PhaseChain so the Phase-3 PhaseChainAssembled emit summarizes a
+        // genuine chain (phases / window / kinds / provenance / seams), not a hand-faked detail string.
+        private static PhaseChain BuildTracerMatrixChain(string recId, double ut)
+        {
+            var rec = new Recording
+            {
+                RecordingId = recId,
+                VesselName = "TracerMatrixGhost",
+                EndpointPhase = RecordingEndpointPhase.OrbitSegment,
+                EndpointBodyName = "Kerbin",
+                ExplicitStartUT = ut,
+                ExplicitEndUT = ut + 1000.0,
+                PlaybackEnabled = true,
+            };
+            rec.OrbitSegments.Add(new OrbitSegment
+            {
+                startUT = ut, endUT = ut + 1000.0, bodyName = "Kerbin",
+                semiMajorAxis = 700000.0, eccentricity = 0.01, epoch = ut,
+            });
+            rec.TrackSections.Add(new TrackSection
+            {
+                startUT = ut, endUT = ut + 1000.0, environment = SegmentEnvironment.ExoBallistic,
+            });
+            rec.MarkFilesDirty();
+
+            return PhaseFactory.BuildPhaseChain(
+                rec, committedIndex: 0, instanceKey: 0,
+                windowStartUT: ut, windowEndUT: ut + 1000.0);
+        }
+
+        // ---- Matrix assertion helpers (each names the gap precisely) ----
+
+        private static void AssertHasMapLine(
+            List<string> lines, string phaseToken, string surfaceToken, string message)
+        {
+            foreach (string l in lines)
+                if (l.Contains("[MapRenderTrace]")
+                    && l.Contains("phase=" + phaseToken)
+                    && l.Contains("surface=" + surfaceToken))
+                    return;
+            InGameAssert.Fail(message);
+        }
+
+        // GhostCreated / GhostDestroyed / FirstPosition / PhaseChainAssembled / DescentStitched are emitted
+        // through EmitStructural, so the phase token IS the event name (no separate reason=). Same matcher as
+        // AssertHasMapLine, kept distinct for readability of the matrix.
+        private static void AssertHasMapPhase(
+            List<string> lines, string phaseToken, string surfaceToken, string message)
+            => AssertHasMapLine(lines, phaseToken, surfaceToken, message);
+
+        // Anomalies + fail-closed-to-faithful are routed through EmitAnomaly / EmitStructural with the class in
+        // reason= (anomalies) or as the phase= (fail-closed). Match on the reason token OR the phase token so
+        // either routing is accepted.
+        private static void AssertHasReason(
+            List<string> lines, string reasonOrPhaseToken, string surfaceToken, string message)
+        {
+            foreach (string l in lines)
+                if (l.Contains("[MapRenderTrace]")
+                    && l.Contains("surface=" + surfaceToken)
+                    && (l.Contains("reason=" + reasonOrPhaseToken)
+                        || l.Contains("phase=" + reasonOrPhaseToken)))
+                    return;
+            InGameAssert.Fail(message);
+        }
+
+        private static void AssertHasMeshPhase(List<string> lines, string phaseToken, string message)
+        {
+            foreach (string l in lines)
+                if (l.Contains("[GhostRenderTrace]") && l.Contains("phase=" + phaseToken))
+                    return;
+            InGameAssert.Fail(message);
+        }
+
+        private static void AssertContainsAll(List<string> lines, string message, string[] needles)
+        {
+            foreach (string l in lines)
+            {
+                bool all = true;
+                foreach (string n in needles)
+                    if (!l.Contains(n)) { all = false; break; }
+                if (all)
+                    return;
+            }
+            InGameAssert.Fail(message + " (needles: " + string.Join(", ", needles) + ")");
+        }
+    }
+}

--- a/Source/Parsek/MapRender/GhostRenderReconciler.cs
+++ b/Source/Parsek/MapRender/GhostRenderReconciler.cs
@@ -17,6 +17,20 @@ namespace Parsek.MapRender
     /// divergence is the bug class the rewrite exists to surface: it means the new single-owner
     /// Director would have rendered something different from today's path.</para>
     ///
+    /// <para><b>Phase 8 (migration plan §10): the LIVE intent-vs-old-truth comparator is UNWIRED.</b>
+    /// Through Phases 0-7 the end-of-frame <see cref="MapRenderProbe"/> called
+    /// <see cref="CheckIntentAgainstOldTruth"/> to compare the new spine's intent against the OLD path's
+    /// rendered truth. Once the spine drives the render (Phases 3-7), that OLD truth IS the spine's own
+    /// consequence, so the comparison became CIRCULAR / self-confirming. The Phase-0 recorded-vs-rendered
+    /// <c>RenderParityOracle</c> (a DISTINCT axis that coexisted since Phase 0) is now the SOLE acceptance
+    /// oracle, so the probe call site was removed (a <c>scripts/grep-audit-render-reconciler-unwired.ps1</c>
+    /// gate enforces zero LIVE <see cref="CheckIntentAgainstOldTruth"/> call sites under <c>Source/Parsek/</c>).
+    /// This is an UNWIRING, not a rename/promote: the type, the pure predicates, and
+    /// <see cref="CheckIntentAgainstOldTruth"/> itself are KEPT and stay exercised by
+    /// <c>GhostRenderReconcilerTests</c>; only the production call site is gone.
+    /// <see cref="NoteIntent"/> (the shadow PRODUCER side) is UNAFFECTED - it feeds the spine, not this
+    /// retired comparator.</para>
+    ///
     /// <para>The compare predicates are PURE (primitive-only, Unity-ECall-free) so they are unit
     /// testable; only <see cref="NoteIntent"/> / <see cref="CheckIntentAgainstOldTruth"/> touch the
     /// gated <see cref="MapRenderTrace"/> store/sink. The three new anomaly classes (design §6.8):
@@ -190,8 +204,10 @@ namespace Parsek.MapRender
         }
 
         /// <summary>
-        /// Wiring (called by the end-of-frame <see cref="MapRenderProbe"/>): if a fresh new-pipeline
-        /// intent was recorded for <paramref name="pid"/> THIS frame (decision-only shadow producer),
+        /// <b>Phase 8: NO LONGER CALLED FROM PRODUCTION (the live probe call site was unwired - see the
+        /// type-level note). KEPT and exercised by <c>GhostRenderReconcilerTests</c>.</b>
+        /// Wiring (historically called by the end-of-frame <see cref="MapRenderProbe"/>): if a fresh
+        /// new-pipeline intent was recorded for <paramref name="pid"/> THIS frame (decision-only shadow producer),
         /// reconcile it against the old path's rendered truth and emit the matching anomaly. A
         /// visibility mismatch is the <c>gap-vs-retire</c> class; otherwise a treatment mismatch is
         /// the <c>decision-vs-old-truth</c> class. No fresh intent → no-op (nothing recorded the

--- a/Source/Parsek/MapRender/ShadowRenderDriver.cs
+++ b/Source/Parsek/MapRender/ShadowRenderDriver.cs
@@ -634,6 +634,15 @@ namespace Parsek.MapRender
                 MapRenderTrace.SegmentChangeWindowSeconds, details, phaseChain.RecordingId);
         }
 
+        /// <summary>Test seam: drive the Tier-A <c>PhaseChainAssembled</c> structural emit directly (the
+        /// production caller is the gated shadow hook inside <see cref="DriveShadow"/>, which needs a full live
+        /// frame). Used by the Phase-8 tracer-coverage matrix in-game test to prove the Phase-3 structural
+        /// wiring lights up end-to-end. No-op when tracing is off (the underlying emit early-returns).</summary>
+        internal static void EmitPhaseChainAssembledForTesting(uint pid, double currentUT, PhaseChain phaseChain)
+        {
+            EmitPhaseChainAssembled(pid, currentUT, phaseChain);
+        }
+
         private static string SummarizePhaseKinds(PhaseChain chain)
         {
             var sb = new System.Text.StringBuilder();

--- a/Source/Parsek/MapRenderProbe.cs
+++ b/Source/Parsek/MapRenderProbe.cs
@@ -176,8 +176,10 @@ namespace Parsek
             // Also flush MapRenderTrace's pid-keyed stores (detailed windows + line/render intents) so they
             // do not grow unbounded across the AppDomain lifetime; mirrors this probe's own per-pid reset.
             MapRenderTrace.Reset();
-            // Drop the reconciler's per-pid intent-reconcile rate-limit timestamps too, so a stale entry
-            // cannot suppress the first gap-vs-retire / decision-vs-old-truth divergence after re-entry.
+            // Drop the reconciler's per-pid intent-reconcile rate-limit timestamps too. NOTE (Phase 8): the
+            // intent-vs-old-truth comparator (CheckIntentAgainstOldTruth) was UNWIRED from this probe, so in
+            // production these dicts are never populated and this Clear is a harmless no-op; it is kept
+            // defensive (and the method stays referenced by GhostRenderReconcilerTests, which DO populate it).
             Parsek.MapRender.GhostRenderReconciler.ClearRateLimitState();
             // Phase 8e S0: drop any S0 coverage state straddling the scene switch (per-frame-cleared by its
             // producer, so this is belt-and-suspenders against a switch landing mid-frame). Diagnostic-only.
@@ -534,15 +536,23 @@ namespace Parsek
                         MapRenderTrace.FormatDouble(ecc, "F4"), bodyName, drawIcons, lineActive),
                     recId);
 
-            // --- Tier-C new-pipeline reconcile: intent (shadow) vs the OLD path's truth ---
-            // If the new render pipeline recorded a GhostRenderIntent for this pid THIS frame
-            // (decision-only shadow producer, wired in Phase 4), compare it against what the old
-            // scattered coordination actually drew. A divergence is the bug class the rewrite exists
-            // to surface (the new single-owner Director would have rendered something different).
-            // No fresh intent → no-op, so this is dormant until the Phase 4 shadow scene calls
-            // GhostRenderReconciler.NoteIntent. Reuses the same old-path truth read as above.
-            Parsek.MapRender.GhostRenderReconciler.CheckIntentAgainstOldTruth(
-                pid, pidKey, frame, currentUT, currentUT, lineActive, drawIcons, polylineOwns, realtime);
+            // --- Tier-C new-pipeline reconcile: UNWIRED (migration plan §10, Phase 8) ---
+            // The end-of-frame GhostRenderReconciler.CheckIntentAgainstOldTruth call (intent-vs-OLD-truth)
+            // was removed here. Through Phases 0-7 it compared the new spine's GhostRenderIntent against the
+            // OLD scattered coordination's rendered truth, to surface the swap/ownership divergence the
+            // rewrite existed to find. With the spine now driving (Phases 3-7) the OLD truth this probe reads
+            // (lineActive / drawIcons / polylineOwns) IS produced by that same spine, so the comparison
+            // became CIRCULAR (intent vs the intent's own consequence) and self-confirming - it can no longer
+            // detect a real divergence. The §0/§14 recorded-vs-rendered RenderParityOracle (TrySampleAndEmit-
+            // FaithfulOrbitParity above) is the DISTINCT axis that has coexisted since Phase 0 and is now the
+            // SOLE acceptance oracle. This is an UNWIRING, not a rename/promote of the old comparator; the
+            // GhostRenderReconciler type + its pure predicates stay (exercised by GhostRenderReconcilerTests)
+            // but have no LIVE production call site (a scripts/grep-audit-render-reconciler-unwired.ps1 gate
+            // enforces zero CheckIntentAgainstOldTruth call sites under Source/Parsek/). The shadow
+            // PRODUCER side (ShadowRenderDriver -> GhostRenderReconciler.NoteIntent) is unaffected - it feeds
+            // the spine, not this retired comparator. This whole probe is MapRenderTrace.IsEnabled-gated
+            // (tracing OFF by default), so removing the call is OBSERVABILITY-ONLY: flag-OFF / tracing-OFF
+            // normal play is byte-identical (the probe never ran).
 
             // --- Tier-C line-blink anomaly (line.active toggled within N frames) ---
             // A toggle is line.active != the previous sample's value. The blink

--- a/docs/dev/plans/map-ts-render-overhaul-migration.md
+++ b/docs/dev/plans/map-ts-render-overhaul-migration.md
@@ -428,6 +428,49 @@ appear/disappear + Tier-A/B/C lines. **Logging:** the full tracer matrix is now 
 — a `mapRenderTracing`-on run over the regression set emits the expected Tier-A/B/C lines for every new
 surface (a tracer-coverage assertion). **Parity gate:** oracle green. **Risk:** low (cleanup).
 
+**Status (implemented, observability-only / flag-OFF byte-identical):**
+- **Unwiring DONE.** The live `GhostRenderReconciler.CheckIntentAgainstOldTruth` call site was removed from
+  `Source/Parsek/MapRenderProbe.cs` (the end-of-frame "Tier-C new-pipeline reconcile" block in `Sample`,
+  replaced with a comment recording the unwiring rationale). Once the spine drives the render (Phases 3-7)
+  the OLD truth this probe reads (`lineActive` / `drawIcons` / `polylineOwns`) IS the spine's own
+  consequence, so the intent-vs-old-truth comparison became CIRCULAR / self-confirming; the Phase-0
+  recorded-vs-rendered `RenderParityOracle` (`TrySampleAndEmitFaithfulOrbitParity` -> `parity-drift`) is the
+  DISTINCT axis that has coexisted since Phase 0 and is now the SOLE acceptance oracle. The whole probe is
+  `MapRenderTrace.IsEnabled`-gated (tracing OFF by default), so the call only ever ran when tracing was on;
+  removing it is OBSERVABILITY-ONLY and flag-OFF / tracing-OFF normal play is byte-identical (the probe never
+  ran). The scene-switch `GhostRenderReconciler.ClearRateLimitState()` call is KEPT (now a harmless no-op in
+  production, still populated/cleared by the unit tests) with an updated comment.
+- **KEEP-not-remove decision (justified).** This is an UNWIRING, not a deletion of the type. The
+  `GhostRenderReconciler` type, its PURE predicates (`ReconcileVisibility` / `ReconcileTreatment` /
+  `IsPolylineOriginShiftJump`), and the `CheckIntentAgainstOldTruth` method itself are KEPT, exercised by
+  `Source/Parsek.Tests/MapRender/GhostRenderReconcilerTests.cs` (~14 references). Removing the method would
+  force deleting/rewriting those tests for no functional gain - not the minimal change the phase brief asks
+  for ("prefer removing only the LIVE call site unless removing the method is clearly clean"; it is not).
+  The shadow PRODUCER side (`ShadowRenderDriver` -> `GhostRenderReconciler.NoteIntent`) is UNAFFECTED: it
+  feeds the spine, not the retired comparator, so it stays live. Class + method doc-comments updated to
+  record the Phase-8 unwiring.
+- **Grep-audit gate.** `scripts/grep-audit-render-reconciler-unwired.ps1` asserts ZERO LIVE call sites of the
+  comparator under `Source/Parsek/`. The forbidden token is the CALL form (a leading dot + a trailing
+  open-paren) so the KEPT method DEFINITION (no leading dot) and the doc-comment crefs (no trailing paren)
+  are never flagged; the xUnit tests under `Source/Parsek.Tests/` are out of the audit's `Source/Parsek/`
+  scope. Its xUnit gate (mirroring `GrepAuditMapRenderDirectorDriveTests`, with a managed fallback for
+  non-Windows CI) lands in the Phase-8 test step.
+- **Tracer EVENT coverage: AUDITED COMPLETE, no production gap closed.** Every `RenderSurface` already has
+  appear/disappear + Tier-A/B/C coverage: ProtoOrbitLine / ProtoIcon via `GhostCreated` / `GhostDestroyed`
+  (A) + `LineVisibilityChange` / `body-orbit` / `icon-suppressed` / `drawIcons` / `line.active` (B) +
+  `icon-teleport` / `icon-off-orbit` / `line-blink` / `decision-vs-truth` / `polyline-orbit-overlap` /
+  `parity-drift` (C); Polyline + PolylineForwardArc via `PolylineLegChange appear|disappear` (A) +
+  `unaccounted-drawn-recording` (C); ImguiLabeledMarker + AtmosphericMarker via `MarkerDecision`
+  on-change (B, both scenes); the flight-scene mesh via `GhostRenderTrace` `MeshSpawned` / `MeshDestroyed`
+  (A). The NEW phase/seam/lifecycle events are covered: `PhaseChainAssembled` (Phase 3, A),
+  `DescentStitched` (Phase 6, A), `fail-closed-to-faithful` (Phase 7, A), `factory-parity` (Phase 2, C). The
+  only production-inert tokens (`rigid-seam-tangent-discontinuity` and the reserved
+  `retire-not-held` / `anchor-resolve-fail` / `clock-not-ready`) are deferred BY DESIGN: the tangent token's
+  production auto-raise lives at the descent DRAW site that Phase 5b reworks (Phase 5b is a separate parallel
+  branch, not part of this Phase-8 tree), and the other three are future-phase reserved constants documented
+  as wired-but-inert. No real Phase-8 gap exists; the build-core step adds no new EVENT emits. The remaining
+  Phase-8 work is the tracer-coverage in-game assertion + the grep-audit xUnit gate (test step).
+
 ---
 
 ## 11. Phase ordering & dependencies

--- a/scripts/grep-audit-render-reconciler-unwired.ps1
+++ b/scripts/grep-audit-render-reconciler-unwired.ps1
@@ -1,0 +1,82 @@
+# Phase 8 (map/TS render overhaul, migration plan section 10): lock the UNWIRING of the
+# now-circular intent-vs-old-truth comparator. The end-of-frame MapRenderProbe call to
+# GhostRenderReconciler.CheckIntentAgainstOldTruth was removed: once the spine drives the
+# render, the OLD truth the probe reads is the spine's own consequence, so the comparison
+# is circular / self-confirming. The Phase-0 recorded-vs-rendered RenderParityOracle (a
+# DISTINCT axis since Phase 0) is now the SOLE acceptance oracle.
+#
+# This is an UNWIRING, NOT a deletion of the type: GhostRenderReconciler, its pure
+# predicates, and the CheckIntentAgainstOldTruth METHOD are KEPT (exercised by the xUnit
+# GhostRenderReconcilerTests). What must stay gone is any LIVE production CALL SITE.
+#
+# Forbidden token: the CALL form `.CheckIntentAgainstOldTruth(` (a leading dot + a trailing
+# open-paren). That pattern matches an invocation
+# (e.g. `GhostRenderReconciler.CheckIntentAgainstOldTruth(`) but NOT:
+#   - the method DEFINITION (`internal static void CheckIntentAgainstOldTruth(` - no leading dot), nor
+#   - a doc-comment cref (`<see cref="CheckIntentAgainstOldTruth"/>` - no trailing paren).
+# So the kept method + its kept doc-comments are never flagged, while a resurrected live
+# call site is. The xUnit GhostRenderReconcilerTests under Source/Parsek.Tests/ DO call the
+# method, but this audit scans only Source/Parsek/ (production), so they are out of scope.
+#
+# Exit 0: zero `.CheckIntentAgainstOldTruth(` call sites under Source/Parsek/.
+# Exit 1: at least one match exists; offending sites are printed to stdout in
+#         "<file>:<line>: <match>" format.
+
+param(
+    [string]$RepoRoot
+)
+
+$ErrorActionPreference = "Stop"
+
+if ([string]::IsNullOrWhiteSpace($RepoRoot)) {
+    $RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+}
+
+$sourceRoot = Join-Path $RepoRoot "Source/Parsek"
+
+if (-not (Test-Path $sourceRoot)) {
+    Write-Error "grep-audit: source root not found: $sourceRoot"
+    exit 2
+}
+
+# The single forbidden token: the CALL form (leading dot + trailing open-paren). Plain
+# substring (case-sensitive). The method definition (no leading dot) and the doc-comment
+# crefs (no trailing paren) do NOT contain this literal and are therefore never flagged.
+$pattern = ".CheckIntentAgainstOldTruth("
+
+$violations = New-Object System.Collections.Generic.List[string]
+
+$repoRootFull = (Resolve-Path $RepoRoot).Path -replace '\\', '/'
+
+$files = Get-ChildItem -Path $sourceRoot -Recurse -Filter *.cs -File
+foreach ($file in $files) {
+    $fullPath = $file.FullName -replace '\\', '/'
+    $rel = $fullPath
+    if ($rel.StartsWith($repoRootFull, [System.StringComparison]::OrdinalIgnoreCase)) {
+        $rel = $rel.Substring($repoRootFull.Length).TrimStart('/')
+    }
+
+    # @(...) forces an array so a single-line file (Get-Content returns a bare string) is still iterated by
+    # LINE, not by character (the managed xUnit gate is already immune; this hardens the direct .ps1 run too).
+    $lines = @(Get-Content -LiteralPath $file.FullName)
+    for ($i = 0; $i -lt $lines.Length; $i++) {
+        $text = $lines[$i]
+        if ($text -clike "*$pattern*") {
+            $lineNum = $i + 1
+            $trimmed = $text.Trim()
+            $violations.Add("${rel}:${lineNum}: ${trimmed}")
+        }
+    }
+}
+
+if ($violations.Count -gt 0) {
+    $vcount = $violations.Count
+    Write-Host "grep-audit: $vcount resurrected '$pattern' call site(s) found under Source/Parsek/"
+    foreach ($v in $violations) {
+        Write-Host $v
+    }
+    exit 1
+}
+
+Write-Host "grep-audit: OK (zero '$pattern' call sites under Source/Parsek/)"
+exit 0


### PR DESCRIPTION
**Stacked on Phase 7 ([#1222](https://github.com/vl3c/Parsek/pull/1222)). Merge in order; this PR's diff is Phase 8 only.**

## What

Phase 8 of the map/TS render overhaul (migration plan §10): make the Phase-0 parity oracle the sole acceptance oracle, and close out observability. **Observability-only, low-risk cleanup.**

- **Unwire the circular comparator:** removes the live `GhostRenderReconciler.CheckIntentAgainstOldTruth` call in `MapRenderProbe.Sample`. Once the spine drives the render, the "old truth" the probe reads is the spine's own consequence — a self-confirming comparison. The Phase-0 recorded-vs-rendered `RenderParityOracle` (a distinct axis since Phase 0, still wired via `TrySampleAndEmitFaithfulOrbitParity` → `parity-drift`) now stands alone. This is an **unwiring, not a rename**.
- **Keep, not delete:** `GhostRenderReconciler` + `CheckIntentAgainstOldTruth` are kept (their unit tests exercise them directly); only the live call site is removed. A new grep-audit gate forbids the `.CheckIntentAgainstOldTruth(` call form under `Source/Parsek/`, and a companion test pins the method-present end-state.
- **Finalize the tracer matrix:** audited **complete** — every `RenderSurface` + new phase/seam/lifecycle event already has appear/disappear + Tier-A/B/C coverage (the only production-inert tokens are deferred by design: `rigid-seam-tangent-discontinuity` → Phase 5b draw site; `retire-not-held`/`anchor-resolve-fail`/`clock-not-ready` → future). Added **no new emits**, only a tracer-coverage matrix assertion.

## Safety

- **Flag-OFF / tracing-OFF byte-identical:** the removed call sat inside `MapRenderProbe.Sample`, reached only after the `if (!MapRenderTrace.IsEnabled) return;` gate; `mapRenderTracing` is off by default, so normal play never ran it. No spine file's behavior changed; `SwappedSpine_DoesNotConsumeDeorbitClock_SourceGate` + the Phase-7 fail-closed gate stay green.

## Tests

- New grep-audit gate (`GrepAuditRenderReconcilerUnwiredTests`) + method-kept pin; a tracer-coverage matrix test in-game (`MapRenderTracerCoverageInGameTest`, drives every surface through its real production emit) + headless (`MapRenderTracerCoverageTests`, surface→token completeness + per-tier schema). Two thin `*ForTesting` seams delegate to the existing private emits.
- `dotnet build` green; `dotnet test` **16588 passed, 0 failed**; the kept `GhostRenderReconcilerTests` + all source-gates green.

## Review

Two clean-context lenses (unwiring correctness/safety; tracer coverage/tests), verdict CLEAN, 0 blockers. Folded the one low item (the grep-audit `.ps1` now wraps `Get-Content` in `@(...)` for single-line-file robustness; the managed xUnit gate was already immune).

No `CHANGELOG` / `todo` change: observability-only behind the off-by-default `mapRenderTracing` instrument, no user-visible behavior change.