### PR TITLE
maprender Phase 9: cutover-hardening instruments (synthesized+polyline parity oracle, cold-load guard, anomaly raises)

### DIFF
--- a/Source/Parsek.Tests/GhostTrajectoryPolylineBuildTests.cs
+++ b/Source/Parsek.Tests/GhostTrajectoryPolylineBuildTests.cs
@@ -3000,5 +3000,37 @@ namespace Parsek.Tests
                 GhostTrajectoryPolylineRenderer.UndrawnLegFallback.UseFreshBodyFixedHead,
                 GhostTrajectoryPolylineRenderer.ResolveUndrawnLegFallback(legWasConicAnchored: false));
         }
+
+        // --- A1 polyline-leg parity lens: ShouldCaptureLegForParity (pure capture-skip decision, BLOCKER 2)
+        // The rendered-vs-recorded leg-geometry parity lens diffs the leg's rendered points3 against its RAW
+        // recorded surface track. A CONIC-ANCHORED leg draws its points ~96 deg off that raw track ON PURPOSE
+        // (TryAnchorLegToConicSeam), so including it would report ~body-radius drift on a CORRECT anchor (a
+        // false positive) while a leg that FAILED to anchor reads ~0 - exactly backwards. So anchored legs are
+        // SKIPPED and only non-anchored body-fixed legs (descent / atmospheric / surface) are validated, where
+        // rendered == recorded by construction. The Unity capture (points3 / ScaledSpace / GetWorldSurface
+        // Position) is in-game-only; this pure decision is the xUnit-covered seam.
+
+        [Fact]
+        public void AnchoredLeg_IsSkippedFromParityCapture()
+        {
+            // A conic-anchored leg's rendered points are intentionally rotated off the raw recorded track, so
+            // the lens must NOT capture it (it would false-fire on a correct anchor).
+            Assert.False(
+                GhostTrajectoryPolylineRenderer.ShouldCaptureLegForParity(legWasConicAnchored: true),
+                "A conic-anchored leg must be excluded from the rendered-vs-recorded parity capture (its "
+                + "rendered points are intentionally far from the raw recorded surface track).");
+        }
+
+        [Fact]
+        public void NonAnchoredBodyFixedLeg_IsCapturedForParity()
+        {
+            // The descent / atmospheric / surface re-stitch the audit cares about: a non-anchored body-fixed
+            // leg draws the raw body-fixed points, so rendered == recorded by construction and a genuine
+            // mis-draw drifts. The lens MUST capture it.
+            Assert.True(
+                GhostTrajectoryPolylineRenderer.ShouldCaptureLegForParity(legWasConicAnchored: false),
+                "A non-anchored body-fixed leg (descent / atmospheric / surface) must be captured for parity; "
+                + "its rendered points ARE the raw recorded track, so a real mis-draw shows drift.");
+        }
     }
 }

--- a/Source/Parsek.Tests/MapRender/CutoverHardeningTests.cs
+++ b/Source/Parsek.Tests/MapRender/CutoverHardeningTests.cs
@@ -1,0 +1,480 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Parsek;
+using Parsek.MapRender;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    /// <summary>
+    /// Cutover-hardening instrument layer (a stacked PR on Phase 8): the cold-load clock-readiness guard
+    /// (B4/D2, design §11.2) and the three previously-unraised Tier-C cutover anomalies (C1:
+    /// clock-not-ready / retire-not-held / anchor-resolve-fail). This is the HEADLESS half:
+    ///
+    ///  - the PURE predicates (<see cref="ShadowRenderDriver.IsLiveClockReady"/>,
+    ///    <see cref="MapRenderTrace.IsRetireNotHeld"/>, <see cref="AnchorFrameResolver.OutcomeToken"/>);
+    ///  - the once-per-event dedup gate (<see cref="MapRenderTrace.ShouldEmitCutoverAnomalyOnChange"/>);
+    ///  - the three emit helpers land the right <c>reason=</c> token through the real
+    ///    <see cref="MapRenderTrace"/> sink (pure-builder + global-sink, the robust pattern);
+    ///  - source gates proving the RunFrame wiring (the flag-ON-only cold-load defer + the C4
+    ///    flag-ON-assembler-fallback warn) exists and is flag-gated, so the flag-OFF path stays
+    ///    byte-identical.
+    ///
+    /// The live Unity orchestration (RunFrame actually deferring at UT&lt;=0, the C4 one-shot firing) is an
+    /// in-game test (RunFrame reads Time.frameCount + a live scene); these gates lock the decision logic +
+    /// the schema it feeds. Touches the shared <see cref="MapRenderTrace"/> registry + the
+    /// <see cref="ParsekLog"/> sink + the <see cref="MapRenderTrace.FrameCounterOverrideForTesting"/> seam,
+    /// so it runs Sequential (mirroring MapRenderTraceTests / MapRenderTracerCoverageTests).
+    /// </summary>
+    [Collection("Sequential")]
+    public class CutoverHardeningTests : IDisposable
+    {
+        private readonly List<string> logLines = new List<string>();
+
+        public CutoverHardeningTests()
+        {
+            MapRenderTrace.Reset();
+            MapRenderTrace.FrameCounterOverrideForTesting = () => 42;
+            MapRenderTrace.ForceEnabledForTesting = true;
+            ParsekSettings.CurrentOverrideForTesting = null;
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.ResetRateLimitsForTesting();
+            ParsekLog.SuppressLogging = false;
+            ParsekLog.VerboseOverrideForTesting = true;
+            ParsekLog.TestSinkForTesting = line => logLines.Add(line);
+        }
+
+        public void Dispose()
+        {
+            MapRenderTrace.Reset();
+            MapRenderTrace.ForceEnabledForTesting = false;
+            MapRenderTrace.FrameCounterOverrideForTesting = null;
+            ParsekSettings.CurrentOverrideForTesting = null;
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.ResetRateLimitsForTesting();
+            ParsekLog.SuppressLogging = true;
+        }
+
+        // ---- B4/D2 cold-load clock-readiness predicate ----
+
+        [Theory]
+        [InlineData(0.0, false)]      // the Planetarium UT=0 cold-load trap
+        [InlineData(-1.0, false)]     // pre-time-init negative
+        [InlineData(double.NaN, false)]
+        [InlineData(double.PositiveInfinity, false)]
+        [InlineData(double.NegativeInfinity, false)]
+        [InlineData(1.0, true)]       // any positive finite UT is ready
+        [InlineData(2.5e9, true)]     // a Duna-region looped UT is ready
+        public void IsLiveClockReady_OnlyPositiveFiniteUt(double liveUT, bool expected)
+        {
+            // Mirrors LedgerOrchestrator.IsCurrentUtReadyForCutoff (ut > 0), extended with a finite guard
+            // since the render path multiplies UT into geometry. A regression that let UT=0 through would
+            // reintroduce the degenerate cold-load TS ghost the guard exists to prevent.
+            Assert.Equal(expected, ShadowRenderDriver.IsLiveClockReady(liveUT));
+        }
+
+        [Fact]
+        public void IsLiveClockReady_MatchesLedgerCutoffReadiness_ForPositiveUt()
+        {
+            // The two readiness gates must agree on the positive-UT contract (the guard is documented as
+            // "mirroring LedgerOrchestrator.IsCurrentUtReadyForCutoff"). The render guard is STRICTER only
+            // on non-finite UT (which the ledger never sees), so for finite UT they are identical.
+            foreach (double ut in new[] { 0.0, 0.0001, 1.0, 1e6, 2.5e9 })
+            {
+                Assert.Equal(
+                    LedgerOrchestrator.IsCurrentUtReadyForCutoff(ut),
+                    ShadowRenderDriver.IsLiveClockReady(ut));
+            }
+        }
+
+        // ---- C1 retire-not-held pure predicate ----
+
+        [Fact]
+        public void IsRetireNotHeld_OutsideWindowAndStillVisible_IsTrue()
+        {
+            // The defect: a sample resolved OUTSIDE its window (should retire) yet the member is still
+            // visible because the prior intent was visible and was held.
+            Assert.True(MapRenderTrace.IsRetireNotHeld(
+                sampleOutsideWindow: true, priorVisible: true, resolvedVisible: true));
+        }
+
+        [Theory]
+        [InlineData(false, true, true)]   // in-window (interior gap / in-segment): a hold is legitimate
+        [InlineData(true, false, true)]   // nothing was held (no prior) -> a fresh visible is not a held-not-retire
+        [InlineData(true, true, false)]   // correctly retired (resolved hidden) -> no defect
+        [InlineData(false, false, false)] // nothing anywhere
+        public void IsRetireNotHeld_OtherCombinations_AreFalse(
+            bool outside, bool priorVisible, bool resolvedVisible)
+        {
+            Assert.False(MapRenderTrace.IsRetireNotHeld(outside, priorVisible, resolvedVisible));
+        }
+
+        // ---- AnchorFrameResolver outcome tokens (carried on the anchor-resolve-fail line) ----
+
+        // BodyResolveOutcome is internal, so a public xUnit theory cannot take it directly; pass the
+        // underlying byte and cast inside (mirroring MapRenderTracerCoverageTests' RenderSurface pattern).
+        [Theory]
+        [InlineData((byte)AnchorFrameResolver.BodyResolveOutcome.Resolved, "resolved")]
+        [InlineData((byte)AnchorFrameResolver.BodyResolveOutcome.FailClosedMissingName, "fail-closed-missing-name")]
+        [InlineData((byte)AnchorFrameResolver.BodyResolveOutcome.FailClosedUnknownBody, "fail-closed-unknown-body")]
+        public void AnchorFrameResolver_OutcomeToken_IsGrepStable(byte outcomeByte, string expected)
+        {
+            var outcome = (AnchorFrameResolver.BodyResolveOutcome)outcomeByte;
+            Assert.Equal(expected, AnchorFrameResolver.OutcomeToken(outcome));
+        }
+
+        [Fact]
+        public void AnchorFrameResolver_OutcomeToken_OutOfRangeValue_IsUnknown()
+        {
+            // A defensive default so a future enum addition that forgets a token still emits a grep-stable
+            // (non-empty, non-null) outcome rather than a blank slot on the anomaly line.
+            var bogus = (AnchorFrameResolver.BodyResolveOutcome)200;
+            Assert.Equal("unknown", AnchorFrameResolver.OutcomeToken(bogus));
+        }
+
+        [Fact]
+        public void ResolveBodyAndRaise_FailClosedMissingName_EmitsAnchorResolveFailWithNoneBody()
+        {
+            // A null / empty frame body name fails closed as MISSING-NAME (distinct from unknown-body) and
+            // still raises the anomaly; the empty body renders as the grep-stable <none> token so the line
+            // is never a blank body= slot.
+            var outcome = AnchorFrameResolver.ResolveBodyAndRaise(
+                pid: 100037u, recordingId: "rec-anchor", currentUT: 9.0,
+                bodyName: "", bodyExists: _ => true);
+
+            Assert.Equal(AnchorFrameResolver.BodyResolveOutcome.FailClosedMissingName, outcome);
+            Assert.Contains(logLines, l =>
+                l.Contains("[MapRenderTrace]")
+                && l.Contains("reason=" + MapRenderTrace.AnomalyAnchorResolveFail)
+                && l.Contains("outcome=fail-closed-missing-name")
+                && l.Contains("body=<none>")
+                && l.Contains("recId=rec-anchor"));
+        }
+
+        [Fact]
+        public void ResolveBodyAndRaise_NoOpWhenTracingDisabled()
+        {
+            // Tracing OFF (the default in normal play): the resolve still returns the fail-closed outcome
+            // (the caller branches on it) but pays NO emit cost - the flag-OFF / tracing-OFF path is free.
+            MapRenderTrace.ForceEnabledForTesting = false;
+            var outcome = AnchorFrameResolver.ResolveBodyAndRaise(
+                pid: 100037u, recordingId: "rec-anchor", currentUT: 9.0,
+                bodyName: "Gone", bodyExists: _ => false);
+
+            Assert.Equal(AnchorFrameResolver.BodyResolveOutcome.FailClosedUnknownBody, outcome);
+            Assert.DoesNotContain(logLines, l =>
+                l.Contains("reason=" + MapRenderTrace.AnomalyAnchorResolveFail));
+        }
+
+        [Fact]
+        public void ResolveBodyAndRaise_DedupesSamePidBodyOutcome_ReEmitsOnChangedBody()
+        {
+            // Steady-state: a body anchor that fails the same way every frame emits ONE line, not one per
+            // frame (once-per-event via ShouldEmitCutoverAnomalyOnChange keyed on pid+reason, signature on
+            // outcome+body). A DIFFERENT failing body on the same pid re-emits (the event changed).
+            AnchorFrameResolver.ResolveBodyAndRaise(100037u, "rec", 1.0, "Gone", _ => false);
+            int afterFirst = CountAnomaly(MapRenderTrace.AnomalyAnchorResolveFail);
+            AnchorFrameResolver.ResolveBodyAndRaise(100037u, "rec", 2.0, "Gone", _ => false);
+            AnchorFrameResolver.ResolveBodyAndRaise(100037u, "rec", 3.0, "Gone", _ => false);
+            int afterRepeat = CountAnomaly(MapRenderTrace.AnomalyAnchorResolveFail);
+            AnchorFrameResolver.ResolveBodyAndRaise(100037u, "rec", 4.0, "AlsoGone", _ => false);
+            int afterChanged = CountAnomaly(MapRenderTrace.AnomalyAnchorResolveFail);
+
+            Assert.Equal(1, afterFirst);
+            Assert.Equal(1, afterRepeat); // repeated identical event deduped
+            Assert.Equal(2, afterChanged); // changed body re-emits
+        }
+
+        [Fact]
+        public void ResolveBodyAndRaise_FailClosedUnknownBody_EmitsAnchorResolveFail()
+        {
+            // A non-empty name the probe rejects (renamed / removed modded body) fails closed AND raises the
+            // anchor-resolve-fail anomaly naming the outcome. The render result is the fail-closed (hide)
+            // the caller already takes; this only makes it observable.
+            var outcome = AnchorFrameResolver.ResolveBodyAndRaise(
+                pid: 100037u, recordingId: "rec-anchor", currentUT: 1234.0,
+                bodyName: "PlanetThatVanished", bodyExists: _ => false);
+
+            Assert.Equal(AnchorFrameResolver.BodyResolveOutcome.FailClosedUnknownBody, outcome);
+            Assert.Contains(logLines, l =>
+                l.Contains("[MapRenderTrace]")
+                && l.Contains("reason=" + MapRenderTrace.AnomalyAnchorResolveFail)
+                && l.Contains("surface=ProtoOrbitLine")
+                && l.Contains("body=PlanetThatVanished")
+                && l.Contains("outcome=fail-closed-unknown-body")
+                && l.Contains("recId=rec-anchor"));
+        }
+
+        [Fact]
+        public void ResolveBodyAndRaise_Resolved_EmitsNothing()
+        {
+            var outcome = AnchorFrameResolver.ResolveBodyAndRaise(
+                pid: 100037u, recordingId: "rec-anchor", currentUT: 1234.0,
+                bodyName: "Kerbin", bodyExists: _ => true);
+
+            Assert.Equal(AnchorFrameResolver.BodyResolveOutcome.Resolved, outcome);
+            Assert.DoesNotContain(logLines, l =>
+                l.Contains("reason=" + MapRenderTrace.AnomalyAnchorResolveFail));
+        }
+
+        // ---- The three emit helpers land the right reason token ----
+
+        [Fact]
+        public void EmitClockNotReady_LandsClockNotReadyReason_OnDefer()
+        {
+            MapRenderTrace.EmitClockNotReady(liveUT: 0.0, ghostCount: 3);
+            Assert.Contains(logLines, l =>
+                l.Contains("[MapRenderTrace]")
+                && l.Contains("phase=Anomaly")
+                && l.Contains("reason=" + MapRenderTrace.AnomalyClockNotReady)
+                && l.Contains("action=defer-render")
+                && l.Contains("ghosts=3"));
+        }
+
+        [Fact]
+        public void EmitRetireNotHeld_LandsRetireNotHeldReason()
+        {
+            MapRenderTrace.EmitRetireNotHeld(
+                pid: 100037u, recId: "rec-retire", currentUT: 50.0, effUT: 50.0, treatmentToken: "StockConic");
+            Assert.Contains(logLines, l =>
+                l.Contains("[MapRenderTrace]")
+                && l.Contains("reason=" + MapRenderTrace.AnomalyRetireNotHeld)
+                && l.Contains("heldTreatment=StockConic")
+                && l.Contains("action=should-retire")
+                && l.Contains("recId=rec-retire"));
+        }
+
+        [Fact]
+        public void EmitAnchorResolveFail_LandsAnchorResolveFailReason_Directly()
+        {
+            // The raise helper exercised directly (not via ResolveBodyAndRaise): the reason + body + outcome
+            // tokens land on a ProtoOrbitLine anomaly line.
+            MapRenderTrace.EmitAnchorResolveFail(
+                pid: 100037u, recId: "rec-direct", currentUT: 7.0,
+                bodyName: "Gone", outcomeToken: "fail-closed-unknown-body");
+            Assert.Contains(logLines, l =>
+                l.Contains("[MapRenderTrace]")
+                && l.Contains("reason=" + MapRenderTrace.AnomalyAnchorResolveFail)
+                && l.Contains("surface=ProtoOrbitLine")
+                && l.Contains("body=Gone")
+                && l.Contains("outcome=fail-closed-unknown-body")
+                && l.Contains("action=fail-closed")
+                && l.Contains("recId=rec-direct"));
+        }
+
+        [Fact]
+        public void EmitRetireNotHeld_ReEmitsWhenHeldTreatmentChanges_OnSamePid()
+        {
+            // The signature includes the held treatment so a member that flips from one held treatment to a
+            // different one re-emits (the defect changed character), while a steady identical hold dedups.
+            MapRenderTrace.EmitRetireNotHeld(100037u, "rec", 1.0, 1.0, "StockConic");
+            int afterFirst = CountAnomaly(MapRenderTrace.AnomalyRetireNotHeld);
+            MapRenderTrace.EmitRetireNotHeld(100037u, "rec", 2.0, 2.0, "StockConic");
+            int afterRepeat = CountAnomaly(MapRenderTrace.AnomalyRetireNotHeld);
+            MapRenderTrace.EmitRetireNotHeld(100037u, "rec", 3.0, 3.0, "TracedPath");
+            int afterChanged = CountAnomaly(MapRenderTrace.AnomalyRetireNotHeld);
+
+            Assert.Equal(1, afterFirst);
+            Assert.Equal(1, afterRepeat); // identical hold deduped
+            Assert.Equal(2, afterChanged); // changed held treatment re-emits
+        }
+
+        [Fact]
+        public void EmitHelpers_AreNoOpWhenTracingDisabled()
+        {
+            // All three raises short-circuit on IsEnabled BEFORE any formatting work, so the flag-OFF /
+            // tracing-OFF default-play path is byte-identical (no log line, no dict mutation).
+            MapRenderTrace.ForceEnabledForTesting = false;
+            MapRenderTrace.EmitClockNotReady(0.0, 3);
+            MapRenderTrace.EmitRetireNotHeld(100037u, "rec", 1.0, 1.0, "StockConic");
+            MapRenderTrace.EmitAnchorResolveFail(100037u, "rec", 1.0, "Gone", "fail-closed-unknown-body");
+
+            Assert.DoesNotContain(logLines, l => l.Contains("[MapRenderTrace]"));
+            Assert.Equal(0, MapRenderTrace.CutoverAnomalySignatureCountForTesting);
+        }
+
+        // ---- ShouldEmitCutoverAnomalyOnChange once-per-event dedup ----
+
+        [Fact]
+        public void ShouldEmitCutoverAnomaly_EmitsOncePerSignatureThenSuppresses()
+        {
+            const string key = "100037:retire-not-held";
+            const string sig = "retire-not-held:StockConic";
+            Assert.True(MapRenderTrace.ShouldEmitCutoverAnomalyOnChange(key, sig)); // first -> emit
+            Assert.False(MapRenderTrace.ShouldEmitCutoverAnomalyOnChange(key, sig)); // unchanged -> suppress
+            Assert.False(MapRenderTrace.ShouldEmitCutoverAnomalyOnChange(key, sig)); // still suppressed
+            // A changed signature for the same key re-emits (e.g. the held treatment changed).
+            Assert.True(MapRenderTrace.ShouldEmitCutoverAnomalyOnChange(key, "retire-not-held:TracedPath"));
+        }
+
+        [Fact]
+        public void ShouldEmitCutoverAnomaly_NoOpWhenDisabled()
+        {
+            MapRenderTrace.ForceEnabledForTesting = false;
+            Assert.False(MapRenderTrace.ShouldEmitCutoverAnomalyOnChange("k", "s"));
+        }
+
+        [Fact]
+        public void ShouldEmitCutoverAnomaly_EmptyKey_AllowedThrough()
+        {
+            // A headless / no-resolvable-ghost path passes an empty key; the gate lets it through (the caller
+            // still bound the emit + the IsEnabled gate already fired), mirroring the sibling gates.
+            Assert.True(MapRenderTrace.ShouldEmitCutoverAnomalyOnChange("", "anything"));
+            Assert.True(MapRenderTrace.ShouldEmitCutoverAnomalyOnChange(null, "anything"));
+        }
+
+        [Fact]
+        public void EmitClockNotReady_IsDedupedOncePerEvent_NotPerFrame()
+        {
+            // The cold-load defer runs every frame the clock is not ready; the anomaly must fire ONCE per
+            // event, not per frame (the VerboseRateLimited convention the sibling structural events use).
+            MapRenderTrace.EmitClockNotReady(0.0, 2);
+            int afterFirst = CountAnomaly(MapRenderTrace.AnomalyClockNotReady);
+            MapRenderTrace.EmitClockNotReady(0.0, 2);
+            MapRenderTrace.EmitClockNotReady(0.0, 2);
+            int afterThird = CountAnomaly(MapRenderTrace.AnomalyClockNotReady);
+
+            Assert.Equal(1, afterFirst);
+            Assert.Equal(1, afterThird); // still one: the repeat frames are deduped
+        }
+
+        [Fact]
+        public void ShouldEmitCutoverAnomaly_WarpCapBoundsTheDict()
+        {
+            // At high time warp a fresh per-cycle key could be minted without bound within a scene
+            // (Reset only fires on scene switch). The dict is capped (clearing is correctness-neutral:
+            // each active site simply re-emits its current signature on its next change). Mint well past
+            // the cap and assert it never grows unbounded.
+            for (int i = 0; i < 5000; i++)
+                MapRenderTrace.ShouldEmitCutoverAnomalyOnChange(
+                    "key" + i.ToString(System.Globalization.CultureInfo.InvariantCulture), "sig");
+            Assert.True(MapRenderTrace.CutoverAnomalySignatureCountForTesting <= 4096,
+                "the cutover-anomaly dict must be warp-capped, was "
+                    + MapRenderTrace.CutoverAnomalySignatureCountForTesting);
+        }
+
+        private int CountAnomaly(string reason)
+        {
+            int n = 0;
+            foreach (string l in logLines)
+                if (l.Contains("[MapRenderTrace]") && l.Contains("reason=" + reason))
+                    n++;
+            return n;
+        }
+
+        // ---- Source gates: the RunFrame wiring is flag-gated (flag-OFF byte-identical) ----
+
+        [Fact]
+        public void RunFrame_ColdLoadGuard_IsFlagGated_AndDefers_SourceGate()
+        {
+            // The cold-load defer must be gated on PhaseSpineDriveActive (flag-ON only) so the flag-OFF
+            // legacy spine path is byte-identical to today, and it must RETURN (defer the whole frame) when
+            // the clock is not ready. A regression that dropped the flag guard (changing flag-OFF behavior)
+            // or sampled anyway at UT<=0 is caught here.
+            string src = CollapseWhitespace(StripLineComments(ReadMapRenderSource("ShadowRenderDriver.cs")));
+            Assert.Contains("if (PhaseSpineDriveActive && !IsLiveClockReady(currentUT))", src);
+            Assert.Contains("MapRenderTrace.EmitClockNotReady(currentUT, pids?.Count ?? 0);", src);
+        }
+
+        [Fact]
+        public void RunFrame_C4_FlagOnAssemblerFallbackWarn_IsFlagGated_SourceGate()
+        {
+            // The C4 silent flag-ON -> assembler fallback warn fires only inside the flag-ON else-branch
+            // (PhaseSpineDriveActive true but phaseChain null), so a correctly-driven flag-ON run (or any
+            // flag-OFF run) never warns. A regression that warned unconditionally (flooding flag-OFF) is
+            // caught here.
+            string src = CollapseWhitespace(StripLineComments(ReadMapRenderSource("ShadowRenderDriver.cs")));
+            Assert.Contains("if (PhaseSpineDriveActive) WarnSpineFlagOnAssemblerFallback(pid, traj.RecordingId, currentUT);", src);
+        }
+
+        [Fact]
+        public void RunFrame_RetireNotHeld_IsTracingGated_SourceGate()
+        {
+            // The retire-not-held raise must be behind MapRenderTrace.IsEnabled (tracing-gated) so it is
+            // free in normal play, and it reads the pure IsRetireNotHeld predicate on the resolved sample.
+            string src = CollapseWhitespace(StripLineComments(ReadMapRenderSource("ShadowRenderDriver.cs")));
+            Assert.Contains("MapRenderTrace.IsEnabled && MapRenderTrace.IsRetireNotHeld(", src);
+            Assert.Contains("sample.Coverage == Coverage.OutsideWindow, prior.Visible, intent.Visible", src);
+        }
+
+        [Fact]
+        public void RunFrame_AnchorResolveFail_IsTracingGated_SourceGate()
+        {
+            // The anchor-resolve-fail raise must be behind MapRenderTrace.IsEnabled and route through the
+            // pure AnchorFrameResolver.ResolveBodyAndRaise decision (not a bespoke inline body check).
+            string src = CollapseWhitespace(StripLineComments(ReadMapRenderSource("ShadowRenderDriver.cs")));
+            Assert.Contains("AnchorFrameResolver.ResolveBodyAndRaise(", src);
+        }
+
+        // ---- C4 one-shot warn seam: the per-pid fallback-warned set is scene-switch cleared ----
+
+        [Fact]
+        public void SpineFallbackWarnedPidSet_IsClearedOnReset()
+        {
+            // The C4 silent-fallback warn is one-shot PER PID, guarded by a HashSet cleared in Reset()
+            // (scene switch) + PruneStaleState (ghost retire) so a re-entered scene re-warns the operator
+            // on a still-stale flag toggle. The warn site itself is private (driven only from the Unity
+            // RunFrame), so the live one-shot firing is the in-game test's job; here we lock the seam +
+            // the scene-switch clear (a regression that forgot to clear the set would silence the warn
+            // forever after the first scene). The count is 0 in a fresh fixture and stays 0 after Reset.
+            Parsek.MapRender.ShadowRenderDriver.Reset();
+            Assert.Equal(0, Parsek.MapRender.ShadowRenderDriver.SpineFallbackWarnedPidCountForTesting);
+        }
+
+        [Fact]
+        public void RunFrame_ColdLoadGuard_DoesNotPruneStaleState_SourceGate()
+        {
+            // The cold-load defer is a HOLD, not a teardown: it must NOT call PruneStaleState (which would
+            // drop the cached chains / prior intents the next ready frame resumes from). A regression that
+            // pruned on a transient UT=0 frame would lose the resume state. The documented intent marker
+            // (a comment, read from the RAW source) is the contract.
+            string rawSrc = ReadMapRenderSource("ShadowRenderDriver.cs");
+            Assert.Contains("PruneStaleState is intentionally NOT called", rawSrc);
+            // The defer block ends in a bare `return;` (no PruneStaleState before it): with comments stripped
+            // the rate-limit log's close `5.0);` is immediately followed by the defer `return;` and the block
+            // close `}`.
+            string collapsed = CollapseWhitespace(StripLineComments(rawSrc));
+            Assert.Contains("5.0); return; }", collapsed);
+        }
+
+        // Mirrors ShadowRenderDriverTests.ReadMapRenderSource (root resolve + Parsek/-rooted fallback).
+        private static string ReadMapRenderSource(string fileName)
+        {
+            string root = Path.GetFullPath(Path.Combine(
+                AppDomain.CurrentDomain.BaseDirectory, "..", "..", "..", "..", ".."));
+            string path = Path.Combine(root, "Source", "Parsek", "MapRender", fileName);
+            if (!File.Exists(path))
+                path = Path.Combine(root, "Parsek", "MapRender", fileName);
+            Assert.True(File.Exists(path), $"Source file not found at {path}");
+            return File.ReadAllText(path);
+        }
+
+        private static string StripLineComments(string source)
+        {
+            var sb = new System.Text.StringBuilder(source.Length);
+            foreach (string line in source.Split('\n'))
+            {
+                int idx = line.IndexOf("//", StringComparison.Ordinal);
+                sb.Append(idx >= 0 ? line.Substring(0, idx) : line);
+                sb.Append('\n');
+            }
+            return sb.ToString();
+        }
+
+        private static string CollapseWhitespace(string source)
+        {
+            var sb = new System.Text.StringBuilder(source.Length);
+            bool inWs = false;
+            foreach (char c in source)
+            {
+                if (char.IsWhiteSpace(c))
+                {
+                    if (!inWs) { sb.Append(' '); inWs = true; }
+                }
+                else { sb.Append(c); inWs = false; }
+            }
+            return sb.ToString();
+        }
+    }
+}

--- a/Source/Parsek.Tests/RenderParityRegressionScenarioTests.cs
+++ b/Source/Parsek.Tests/RenderParityRegressionScenarioTests.cs
@@ -450,6 +450,49 @@ namespace Parsek.Tests
             Assert.False(r.OverTolerance);
         }
 
+        [Fact]
+        public void Synthesized_LoopShiftedReaimedSeed_PhaseMatched_ZeroDrift()
+        {
+            // BLOCKER row: a LOOPED re-aimed (synthesized) member. The producer DRIVES the rendered conic at
+            // epoch = seg.epoch + loopShift (StockConicTreatment.SeedAndDriveLive) and propagates it at the
+            // LIVE clock, so the synthesized reference (the producer's intended seed) MUST be built with the
+            // SAME loop-shift epoch bake (MapRenderProbe.BuildPhaseMatchedReferenceOrbit, the BLOCKER fix) and
+            // sampled at the SAME live-clock UTs - otherwise it traces a different mean-anomaly half-arc and
+            // false-fires on a CORRECT draw. This is the headless analogue of the production probe's phase-
+            // matched synthesized reference (the in-game SynthesizedParity_LoopShiftedGhost_PhaseMatched_
+            // ZeroDrift drives the real seam). It ACTUALLY applies the shift (both sides baked +shift, sampled
+            // at the live UTs), so a correct "shift the clock, not the shape" pipeline reads zero drift.
+            const double omega = 2.0 * Math.PI / 5400.0; // ~1.5 h circular period
+            const double epoch = 100_000.0;
+            const double shift = 1300.0;                  // a sizeable fraction of the period
+            const double liveCenterUT = epoch + 4.0 * 5400.0; // four loops later
+
+            double[] renderedUTs = RenderGeometrySampler.BuildSampleUTs(
+                liveCenterUT, 5400.0 * 0.25, SampleCount);
+            // BOTH the rendered orbit AND the intended-seed reference are baked with epoch + shift and sampled
+            // at the SAME live-clock UTs (the synthesized path samples both at currentUT, unlike the faithful
+            // path which can remap the recorded UTs): a faithful loop draw of the intended seed reads ~0.
+            double[] rendered = CircleAtUTs(LkoRadius, omega, epoch + shift, renderedUTs);
+            double[] intendedPhaseMatched = CircleAtUTs(LkoRadius, omega, epoch + shift, renderedUTs);
+
+            var r = RenderParityOracle.ComputeDriftScaleDerived(
+                RenderParityOracle.ParityMode.Synthesized, intendedPhaseMatched, rendered);
+
+            Assert.True(r.HasMeasurement);
+            Assert.False(r.OverTolerance);
+
+            // LOAD-BEARING negative control: drop the phase-match (build the intended seed at the RAW epoch -
+            // the pre-fix BuildOrbitFromSegment behavior) and sample it at the SAME live UTs. The loop phase
+            // no longer cancels, so the reference and the rendered conic trace different arcs and the oracle
+            // MUST flag drift. This is exactly the BLOCKER the production probe's phase-matched epoch fixes;
+            // it proves the row is a real shift, not a tautological circle-vs-itself.
+            double[] intendedRawEpoch = CircleAtUTs(LkoRadius, omega, epoch, renderedUTs);
+            var rBug = RenderParityOracle.ComputeDriftScaleDerived(
+                RenderParityOracle.ParityMode.Synthesized, intendedRawEpoch, rendered);
+            Assert.True(rBug.HasMeasurement);
+            Assert.True(rBug.OverTolerance);
+        }
+
         // ===================================================================================
         //  SYNTHESIZED drifted rows -> drift flagged (rendered != the producer's intended arc)
         // ===================================================================================

--- a/Source/Parsek/Display/GhostTrajectoryPolylineRenderer.cs
+++ b/Source/Parsek/Display/GhostTrajectoryPolylineRenderer.cs
@@ -668,6 +668,132 @@ namespace Parsek.Display
         }
 
         /// <summary>
+        /// A1 cutover-instrument (design §14, ParityMode.Synthesized polyline leg): for every cached leg
+        /// whose Vectrosity <c>VectorLine</c> is RENDERED this frame, hand the caller two flat
+        /// <c>[x0,y0,z0, x1,...]</c> XYZ-triple arrays in ONE consistent BODY-RELATIVE WORLD metres frame:
+        /// the RENDERED polyline geometry (the leg's live <c>VectorLine.points3</c>, each scaled-space
+        /// point converted back to world via <c>ScaledSpace.ScaledToLocalSpace</c> then made body-relative
+        /// = <c>world - body.position</c>) and the RECORDED reference geometry (the leg's own recorded
+        /// <c>lats/lons/alts</c> via <c>body.GetWorldSurfacePosition</c>, made body-relative against the
+        /// SAME live body position). Both sides therefore share the floating-origin- and body-world-motion-
+        /// free frame the icon/orbit parity already uses, so the diff is pure geometry.
+        ///
+        /// <para>CONIC-ANCHORED legs are SKIPPED (a known, stated limitation). A leg the draw rotated ~96 deg
+        /// onto the bracketing conic seam (<see cref="TryAnchorLegToConicSeam"/> returned true, recorded in
+        /// <see cref="LegPolyline.wasAnchored"/>) draws its <c>points3</c> INTENTIONALLY far from its raw
+        /// recorded surface track, so diffing rendered-<c>points3</c> against the raw <c>lats/lons/alts</c>
+        /// would report ~body-radius drift on EVERY correctly-anchored leg (a false positive) while a leg
+        /// that FAILED to anchor would read ~0 - exactly backwards. The anchor transform is a per-point Slerp
+        /// of two live-computed <c>FromToRotation</c> quaternions, not a cheaply recoverable single transform
+        /// to rebuild the reference in, so this lens deliberately covers ONLY non-anchored body-fixed legs
+        /// (descent / atmospheric / surface - the descent re-stitch the audit cares about). For those the
+        /// rendered <c>points3</c> ARE the raw body-fixed points, so rendered == recorded by construction and
+        /// any genuine mis-draw drifts. The two arrays use the SAME index set (the first
+        /// <c>min(points3.Count, leg.PointCount)</c> samples), so the diff is a like-for-like recorded-vs-
+        /// rendered comparison even though the oracle itself is count-independent.</para>
+        ///
+        /// <para>Unity-coupled (reads <c>VectorLine.points3</c>, <c>ScaledSpace</c>, <c>body.position</c>,
+        /// <c>GetWorldSurfacePosition</c>), so it is driven ONLY from the live <see cref="MapRenderProbe"/>
+        /// (never xUnit) and only while tracing is on. NaN/Inf-safe: a non-finite scaled point or surface
+        /// position is written through unchanged (the oracle filters non-finite points and never raises a
+        /// false anomaly). A leg with no rendered line, no recorded surface samples, or an unresolved body is
+        /// skipped silently. Each drawn leg is handed to <paramref name="onLeg"/> as
+        /// <c>(recordingId, legIndex, legCount, bodyName, renderedBodyRelFlat, recordedBodyRelFlat)</c>; the
+        /// caller owns the oracle diff + emit so the decision math stays pure/unit-testable.</para>
+        /// </summary>
+        internal static void CaptureRenderedVsRecordedLegGeometry(
+            int currentFrame,
+            System.Action<string, int, int, string, double[], double[]> onLeg)
+        {
+            if (onLeg == null) return;
+
+            foreach (var kv in polylineCache)
+            {
+                LegPolyline[] legs = kv.Value.legs;
+                if (legs == null) continue;
+                for (int l = 0; l < legs.Length; l++)
+                {
+                    LegPolyline leg = legs[l];
+                    VectorLine line = leg.vectorLine;
+                    if (line == null) continue;
+                    bool active = line.active;
+                    bool drawnRecently = leg.lastDrawnFrame >= currentFrame - 1;
+                    if (!active && !drawnRecently) continue; // not rendered recently
+
+                    // SKIP conic-anchored legs: a leg the last draw rotated onto the bracketing conic seam
+                    // (TryAnchorLegToConicSeam returned true, stamped here) draws its points3 ~96 deg off the
+                    // RAW recorded surface track on PURPOSE, so diffing rendered-points3 against leg.lats/lons/
+                    // alts would report ~body-radius drift on EVERY correctly-anchored leg (false positive) -
+                    // and a leg that FAILED to anchor (the real regression) reads ~0 (exactly backwards). The
+                    // anchor rotation is a per-point Slerp of two live-computed FromToRotation quaternions, not
+                    // a cheaply recoverable single transform, so this lens does NOT cover anchored vacuum-
+                    // maneuver legs - a STATED limitation. It validates ONLY non-anchored body-fixed legs
+                    // (descent / atmospheric / surface - the descent re-stitch the audit cares about), where
+                    // the rendered points3 ARE the raw body-fixed points so rendered == recorded by
+                    // construction and any real mis-draw (incl. a leg that should have stayed body-fixed but
+                    // drew wrong) drifts. See LegPolyline.wasAnchored / TryAnchorLegToConicSeam. The skip
+                    // decision is the pure ShouldCaptureLegForParity (xUnit-covered).
+                    if (!ShouldCaptureLegForParity(leg.wasAnchored)) continue;
+
+                    var points3 = line.points3;
+                    if (points3 == null || points3.Count == 0) continue;
+                    if (leg.lats == null || leg.lons == null || leg.alts == null) continue;
+
+                    CelestialBody body = ParityResolveBodyByName(leg.bodyName);
+                    if (body == null) continue;
+
+                    // Like-for-like index set: the leg's points3 hold this leg's drawn samples 1:1 with its
+                    // recorded lats/lons/alts (CopyLegIntoVectorLine writes exactly leg.PointCount of them at
+                    // offset 0). Diff over the common prefix so a transiently-resized line never misaligns.
+                    int m = leg.PointCount;
+                    if (m > points3.Count) m = points3.Count;
+                    if (m <= 0) continue;
+
+                    Vector3d bodyPos = body.position;
+                    var renderedFlat = new double[m * 3];
+                    var recordedFlat = new double[m * 3];
+                    for (int i = 0; i < m; i++)
+                    {
+                        // RENDERED: live scaled-space vertex -> world metres -> body-relative.
+                        Vector3d renderedWorld = ScaledSpace.ScaledToLocalSpace(points3[i]);
+                        Vector3d renderedRel = renderedWorld - bodyPos;
+                        renderedFlat[i * 3] = renderedRel.x;
+                        renderedFlat[i * 3 + 1] = renderedRel.y;
+                        renderedFlat[i * 3 + 2] = renderedRel.z;
+
+                        // RECORDED reference: the leg's own body-fixed surface track, body-relative.
+                        Vector3d recordedWorld = body.GetWorldSurfacePosition(
+                            leg.lats[i], leg.lons[i], leg.alts[i]);
+                        Vector3d recordedRel = recordedWorld - bodyPos;
+                        recordedFlat[i * 3] = recordedRel.x;
+                        recordedFlat[i * 3 + 1] = recordedRel.y;
+                        recordedFlat[i * 3 + 2] = recordedRel.z;
+                    }
+
+                    onLeg(kv.Key, l, legs.Length, leg.bodyName ?? "(null)", renderedFlat, recordedFlat);
+                }
+            }
+        }
+
+        // Minimal name->CelestialBody resolve for the tracing-only leg-parity capture. A small
+        // FlightGlobals.Bodies scan (the Driver's own per-frame cache is a private instance member; this
+        // static capture path is gated behind MapRenderTrace.IsEnabled, so the scan cost is paid only while
+        // tracing is on). Returns null on an empty / unknown name (caller skips the leg).
+        private static CelestialBody ParityResolveBodyByName(string bodyName)
+        {
+            if (string.IsNullOrEmpty(bodyName)) return null;
+            var bodies = FlightGlobals.Bodies;
+            if (bodies == null) return null;
+            for (int i = 0; i < bodies.Count; i++)
+            {
+                CelestialBody b = bodies[i];
+                if (b != null && string.Equals(b.bodyName, bodyName, System.StringComparison.Ordinal))
+                    return b;
+            }
+            return null;
+        }
+
+        /// <summary>
         /// One body-coherent contiguous polyline leg covering a non-orbital
         /// phase of the recording. Built ONCE at cache-build time from
         /// either a TrackSection's per-frame sample list (Absolute /
@@ -2104,6 +2230,21 @@ namespace Parsek.Display
             => legWasConicAnchored
                 ? UndrawnLegFallback.HoldLastGoodOnLine
                 : UndrawnLegFallback.UseFreshBodyFixedHead;
+
+        /// <summary>
+        /// PURE decision (A1 polyline-leg parity lens): should this leg be included in the rendered-vs-
+        /// recorded leg-geometry parity capture (<see cref="CaptureRenderedVsRecordedLegGeometry"/>)? A
+        /// CONIC-ANCHORED leg (<see cref="LegPolyline.wasAnchored"/>: the draw rotated its points ~96 deg onto
+        /// the bracketing conic seam) is EXCLUDED - its rendered points3 are INTENTIONALLY far from the raw
+        /// recorded surface track, so a rendered-vs-raw-recorded diff would false-fire on a CORRECT anchor
+        /// (and read ~0 on a leg that FAILED to anchor - exactly backwards). A NON-anchored body-fixed leg
+        /// (descent / atmospheric / surface) draws the raw body-fixed points, so rendered == recorded by
+        /// construction and a genuine mis-draw drifts -> INCLUDED. The anchor's per-point Slerp is not cheaply
+        /// recoverable to rebuild the reference in, so anchored vacuum-maneuver legs are a STATED, documented
+        /// lens limitation. xUnit-testable without Unity.
+        /// </summary>
+        internal static bool ShouldCaptureLegForParity(bool legWasConicAnchored)
+            => !legWasConicAnchored;
 
         /// <summary>
         /// Rides the polyline with a labeled marker (icon + label): returns the world position ON the

--- a/Source/Parsek/InGameTests/ColdLoadClockGuardInGameTest.cs
+++ b/Source/Parsek/InGameTests/ColdLoadClockGuardInGameTest.cs
@@ -1,0 +1,211 @@
+using System.Collections.Generic;
+using System.Globalization;
+using Parsek.MapRender;
+using UnityEngine;
+
+namespace Parsek.InGameTests
+{
+    // Cutover-hardening (B4/D2, design §11.2) - the in-game gate that drives the REAL wired
+    // ShadowRenderDriver.RunFrame with the typed-spine flag ON over a live faithful ghost and proves the
+    // cold-load clock-readiness guard:
+    //
+    //  - liveUT <= 0 (the Planetarium UT=0 cold-load trap): RunFrame DEFERS the whole spine frame (renders
+    //    nothing), so NO StockConic seed is stamped, and the once-per-event clock-not-ready anomaly fires.
+    //  - liveUT > 0: the SAME ghost + scene stamps the seed normally (the guard only defers at UT<=0; a
+    //    ready clock samples as before). This is the "the guard does not over-defer" arm.
+    //
+    // This is the Unity-coupled half of the cold-load guard (the pure predicate IsLiveClockReady + the
+    // dedup + emit helpers are unit-tested headless in CutoverHardeningTests). RunFrame reads Time.frameCount
+    // and drives a live MapViewScene, so it cannot run headless.
+    //
+    // NOTE: in-game test (Ctrl+Shift+T / Settings > Diagnostics); FLIGHT only; career-independent. The guard
+    // is flag-ON only (flag-OFF is byte-identical to today), so the test forces the spine ON via
+    // ShadowRenderDriver.ForceSpineDriveForTesting and restores it in finally.
+    public class ColdLoadClockGuardInGameTest
+    {
+        private const string KerbinBodyName = "Kerbin";
+        private const double Sma = 850000.0;
+        private const double Ecc = 0.0;
+        private const double Inc = 0.0;
+        private const double KerbinRadiusFallback = 600000.0;
+
+        [InGameTest(Category = "MapRender", Scene = GameScenes.FLIGHT,
+            Description = "Cold-load clock guard: RunFrame (spine flag ON) DEFERS at liveUT<=0 (no seed "
+                + "stamped, clock-not-ready anomaly fired) and samples normally at liveUT>0 (the guard does "
+                + "not over-defer a ready clock)")]
+        public void ColdLoadGuard_DefersAtUtZero_SamplesWhenReady()
+        {
+            CelestialBody kerbin = FlightGlobals.Bodies?.Find(b => b.bodyName == KerbinBodyName);
+            if (kerbin == null)
+            {
+                InGameAssert.Skip("Kerbin not found in FlightGlobals.Bodies (non-stock pack)");
+                return;
+            }
+
+            double liveUT = Planetarium.GetUniversalTime();
+            double startUT = liveUT - 1800.0;
+            OrbitSegment seg = BuildSegment(startUT);
+
+            bool prevForceSpine = ShadowRenderDriver.ForceSpineDriveForTesting;
+            bool prevForceTrace = MapRenderTrace.ForceEnabledForTesting;
+            System.Func<double> prevUTNow = GhostMapPresence.CurrentUTNow;
+            List<Recording> prevRecordings = RecordingStore.CommittedRecordings != null
+                ? new List<Recording>(RecordingStore.CommittedRecordings)
+                : new List<Recording>();
+            List<RecordingTree> prevTrees = RecordingStore.CommittedTrees != null
+                ? new List<RecordingTree>(RecordingStore.CommittedTrees)
+                : new List<RecordingTree>();
+
+            Recording rec = BuildRecording(startUT, seg);
+            RecordingStore.ClearCommittedInternal();
+            RecordingStore.ClearCommittedTreesInternal();
+            RecordingStore.AddCommittedInternal(rec);
+            int recordingIndex = RecordingStore.CommittedRecordings.Count - 1;
+            GhostMapPresence.CurrentUTNow = () => liveUT;
+            GhostMapPresence.RemoveAllGhostVessels("coldload-guard-start");
+            ShadowRenderDriver.Reset();
+
+            // Capture the trace sink so we can assert the clock-not-ready anomaly fired on the defer frame
+            // WITHOUT depending on global log scraping (a robust in-game capture).
+            var traceLines = new List<string>();
+            System.Action<string> prevSink = ParsekLog.TestSinkForTesting;
+
+            uint pid = 0u;
+            try
+            {
+                MapRenderTrace.ForceEnabledForTesting = true; // so the anomaly raise is live
+                ShadowRenderDriver.ForceSpineDriveForTesting = true; // the guard is flag-ON only
+
+                Vessel ghost = GhostMapPresence.CreateGhostVesselFromSource(
+                    recordingIndex, rec, GhostMapPresence.TrackingStationGhostSource.Segment,
+                    seg, default(TrajectoryPoint), startUT, loopEpochShiftSeconds: 0.0);
+
+                if (ghost == null || ghost.orbitDriver == null || ghost.orbitDriver.orbit == null)
+                {
+                    InGameAssert.Skip("Faithful ghost did not create in this context (no proto)");
+                    return;
+                }
+                pid = ghost.persistentId;
+
+                var scene = new MapViewScene();
+                if (!scene.IsActive)
+                {
+                    InGameAssert.Skip("MapViewScene not active (not in FLIGHT)");
+                    return;
+                }
+
+                // --- Arm 1: liveUT = 0 (cold-load trap) -> the spine must DEFER. ---
+                ParsekLog.TestSinkForTesting = line => traceLines.Add(line);
+                scene.SetFrameInputs(GhostPlaybackLogic.LoopUnitSet.Empty, 0.0);
+                ShadowRenderDriver.Reset();
+                ShadowRenderDriver.RunFrame(scene);
+                bool stampedAtZero = ShadowRenderDriver.TryGetFreshStockConicSeed(
+                    pid, Time.frameCount, out OrbitSegment _, out string _);
+                ParsekLog.TestSinkForTesting = prevSink;
+
+                bool clockNotReadyFired = false;
+                foreach (string l in traceLines)
+                    if (l.Contains("[MapRenderTrace]")
+                        && l.Contains("reason=" + MapRenderTrace.AnomalyClockNotReady))
+                        clockNotReadyFired = true;
+
+                InGameAssert.IsFalse(stampedAtZero,
+                    "the cold-load guard must DEFER at liveUT=0: no StockConic seed may be stamped (a "
+                    + "degenerate UT=0 ghost would otherwise place on the first cold-load frames)");
+                InGameAssert.IsTrue(clockNotReadyFired,
+                    "the cold-load defer must raise the clock-not-ready anomaly (reason="
+                    + MapRenderTrace.AnomalyClockNotReady + ") so the defer is observable");
+
+                // --- Arm 2: liveUT > 0 (ready clock) -> the SAME ghost/scene samples normally. ---
+                scene.SetFrameInputs(GhostPlaybackLogic.LoopUnitSet.Empty, liveUT);
+                ShadowRenderDriver.Reset();
+                ShadowRenderDriver.RunFrame(scene);
+                bool stampedWhenReady = ShadowRenderDriver.TryGetFreshStockConicSeed(
+                    pid, Time.frameCount, out OrbitSegment readySeed, out string readyBody);
+
+                ParsekLog.Info("TestRunner", string.Format(CultureInfo.InvariantCulture,
+                    "ColdLoadGuard: stampedAtZero={0} clockNotReadyFired={1} stampedWhenReady={2} "
+                    + "readyBody={3} readySma={4:F0}",
+                    stampedAtZero, clockNotReadyFired, stampedWhenReady, readyBody ?? "?",
+                    readySeed.semiMajorAxis));
+
+                InGameAssert.IsTrue(stampedWhenReady,
+                    "the guard must NOT over-defer: at a ready (positive) liveUT the SAME ghost must stamp "
+                    + "its StockConic seed normally");
+            }
+            finally
+            {
+                ParsekLog.TestSinkForTesting = prevSink;
+                if (pid != 0u)
+                    GhostMapPresence.RemoveAllGhostVessels("coldload-guard-cleanup");
+                ShadowRenderDriver.ForceSpineDriveForTesting = prevForceSpine;
+                ShadowRenderDriver.Reset();
+                MapRenderTrace.ForceEnabledForTesting = prevForceTrace;
+                RecordingStore.ClearCommittedInternal();
+                RecordingStore.ClearCommittedTreesInternal();
+                for (int i = 0; i < prevRecordings.Count; i++)
+                    RecordingStore.AddCommittedInternal(prevRecordings[i]);
+                for (int i = 0; i < prevTrees.Count; i++)
+                    RecordingStore.AddCommittedTreeInternal(prevTrees[i]);
+                GhostMapPresence.CurrentUTNow = prevUTNow;
+            }
+        }
+
+        private static OrbitSegment BuildSegment(double startUT)
+        {
+            return new OrbitSegment
+            {
+                startUT = startUT,
+                endUT = startUT + 3600.0,
+                inclination = Inc,
+                eccentricity = Ecc,
+                semiMajorAxis = Sma,
+                longitudeOfAscendingNode = 0.0,
+                argumentOfPeriapsis = 0.0,
+                meanAnomalyAtEpoch = 0.0,
+                epoch = startUT,
+                bodyName = KerbinBodyName,
+                isPredicted = false,
+                orbitalFrameRotation = Quaternion.identity,
+                angularVelocity = Vector3.zero,
+            };
+        }
+
+        private static Recording BuildRecording(double startUT, OrbitSegment seg)
+        {
+            double endUT = startUT + 3600.0;
+            var rec = new Recording
+            {
+                RecordingId = "coldload-guard-" + System.Guid.NewGuid().ToString("N"),
+                VesselName = "Parsek Cold-Load Guard",
+                TerminalStateValue = null,
+                EndpointPhase = RecordingEndpointPhase.OrbitSegment,
+                EndpointBodyName = KerbinBodyName,
+                TerminalOrbitBody = KerbinBodyName,
+                TerminalOrbitSemiMajorAxis = Sma,
+                TerminalOrbitEccentricity = Ecc,
+                TerminalOrbitInclination = Inc,
+                TerminalOrbitLAN = 0.0,
+                TerminalOrbitArgumentOfPeriapsis = 0.0,
+                TerminalOrbitMeanAnomalyAtEpoch = 0.0,
+                TerminalOrbitEpoch = startUT,
+                ExplicitStartUT = startUT,
+                ExplicitEndUT = endUT,
+                PlaybackEnabled = true,
+            };
+            rec.Points.Add(new TrajectoryPoint
+            {
+                ut = startUT, latitude = 0.0, longitude = 0.0, altitude = Sma - KerbinRadiusFallback,
+                rotation = Quaternion.identity, velocity = new Vector3(0f, 2200f, 0f), bodyName = KerbinBodyName,
+            });
+            rec.Points.Add(new TrajectoryPoint
+            {
+                ut = endUT, latitude = 0.0, longitude = 5.0, altitude = Sma - KerbinRadiusFallback,
+                rotation = Quaternion.identity, velocity = new Vector3(0f, 2200f, 0f), bodyName = KerbinBodyName,
+            });
+            rec.OrbitSegments.Add(seg);
+            rec.MarkFilesDirty();
+            return rec;
+        }
+    }
+}

--- a/Source/Parsek/InGameTests/RenderParitySamplerFixtureTest.cs
+++ b/Source/Parsek/InGameTests/RenderParitySamplerFixtureTest.cs
@@ -174,6 +174,292 @@ namespace Parsek.InGameTests
             }
         }
 
+        // A1 cutover-instrument: the SYNTHESIZED-mode conic parity capture-harness, the sibling guard to
+        // ParitySampler_CapturesHandComputedOrbitGeometry above. Exercises the REAL production orchestration
+        // (MapRenderProbe.ComputeSynthesizedConicParity: BuildOrbitFromSegment of the producer's intended
+        // seed, OrbitRelativePositionYup sampling of BOTH the rendered orbit and the intended reference, the
+        // scale-derived tolerance, the oracle diff in ParityMode.Synthesized) against a live ghost. Two
+        // arms: (1) intended seed == the rendered orbit's own elements -> the synthesized diff reads ~0
+        // (rendered IS the intended arc, no anomaly); (2) intended seed with the SAME shape ROTATED in LAN
+        // (a re-aim DRAW regression: the rendered orbit drew a different orientation than the seed it was
+        // driven from) -> the diff flags OverTolerance. This proves the synthesized capture path is not
+        // "green but blind". Career-independent; FLIGHT on a stock Kerbin pack.
+        [InGameTest(Category = "GhostMap", Scene = GameScenes.FLIGHT,
+            Description = "A1 synthesized-mode parity capture-harness: ComputeSynthesizedConicParity diffs a "
+                + "live ghost's rendered conic against the producer's intended seed (~0 when seed==rendered, "
+                + "flags drift when the seed is rotated off the rendered orbit)")]
+        public void SynthesizedParity_CapturesRenderedVsIntendedConic()
+        {
+            CelestialBody kerbin = FlightGlobals.Bodies?.Find(b => b.bodyName == KerbinBodyName);
+            if (kerbin == null)
+            {
+                InGameAssert.Skip("Kerbin not found in FlightGlobals.Bodies (non-stock pack)");
+                return;
+            }
+
+            double liveUT = Planetarium.GetUniversalTime();
+            double startUT = liveUT;
+            OrbitSegment seg = BuildSegment(startUT);
+
+            System.Func<double> prevUTNow = GhostMapPresence.CurrentUTNow;
+            List<Recording> prevRecordings = RecordingStore.CommittedRecordings != null
+                ? new List<Recording>(RecordingStore.CommittedRecordings)
+                : new List<Recording>();
+            List<RecordingTree> prevTrees = RecordingStore.CommittedTrees != null
+                ? new List<RecordingTree>(RecordingStore.CommittedTrees)
+                : new List<RecordingTree>();
+
+            Recording rec = BuildRecording(startUT, seg);
+            RecordingStore.ClearCommittedInternal();
+            RecordingStore.ClearCommittedTreesInternal();
+            RecordingStore.AddCommittedInternal(rec);
+            int recordingIndex = RecordingStore.CommittedRecordings.Count - 1;
+            GhostMapPresence.CurrentUTNow = () => liveUT;
+            GhostMapPresence.RemoveAllGhostVessels("synth-parity-fixture-start");
+
+            uint pid = 0u;
+            try
+            {
+                Vessel ghost = GhostMapPresence.CreateGhostVesselFromSource(
+                    recordingIndex,
+                    rec,
+                    GhostMapPresence.TrackingStationGhostSource.Segment,
+                    seg,
+                    default(TrajectoryPoint),
+                    startUT,
+                    loopEpochShiftSeconds: 0.0);
+
+                if (ghost == null || ghost.orbitDriver == null || ghost.orbitDriver.orbit == null)
+                {
+                    InGameAssert.Skip("Ghost did not create in this context (no proto)");
+                    return;
+                }
+                pid = ghost.persistentId;
+                Orbit renderedOrbit = ghost.orbitDriver.orbit;
+                Vector3d iconBodyRel = ghost.GetWorldPos3D() - kerbin.position;
+                if (iconBodyRel.magnitude < 1.0)
+                {
+                    InGameAssert.Skip("Ghost world position not resolved on the creation frame");
+                    return;
+                }
+
+                // Arm 1: intended seed == the rendered orbit's own elements (a faithful StockConic draw:
+                // rendered IS the intended arc). The synthesized diff must measure and report ZERO drift.
+                // loopShift 0.0: this non-loop ghost was created with loopEpochShiftSeconds 0.0, so the
+                // phase-matched reference equals the raw-epoch reference (BuildOrbitFromSegment verbatim).
+                MapRenderProbe.SynthesizedConicParitySample matched =
+                    MapRenderProbe.ComputeSynthesizedConicParity(
+                        renderedOrbit, kerbin, iconBodyRel, seg, KerbinBodyName, 0.0, liveUT);
+                InGameAssert.IsTrue(matched.Sampled,
+                    "A matching intended seed must yield a synthesized parity measurement (skipReason="
+                    + (matched.SkipReason ?? "(none)") + ")");
+                InGameAssert.IsTrue(matched.Result.HasMeasurement,
+                    "The synthesized faithful arm must produce a usable measurement");
+                InGameAssert.IsFalse(matched.Result.OverTolerance,
+                    string.Format(System.Globalization.CultureInfo.InvariantCulture,
+                        "rendered == intended seed must read ~0 synthesized drift; maxDev={0:F0} m tol={1:F0} m",
+                        matched.Result.MaxDeviationMeters, matched.Result.ToleranceMeters));
+
+                // Arm 2: intended seed ROTATED 90 deg in LAN (same shape, drawn at a different orientation).
+                // This is the re-aim DRAW regression the synthesized lens exists to catch: the rendered orbit
+                // (LAN=0) diverges from the intended seed (LAN=90). The diff must flag OverTolerance.
+                OrbitSegment rotatedSeed = seg;
+                rotatedSeed.longitudeOfAscendingNode = 90.0;
+                MapRenderProbe.SynthesizedConicParitySample rotated =
+                    MapRenderProbe.ComputeSynthesizedConicParity(
+                        renderedOrbit, kerbin, iconBodyRel, rotatedSeed, KerbinBodyName, 0.0, liveUT);
+                InGameAssert.IsTrue(rotated.Sampled,
+                    "A rotated (still-on-Kerbin) intended seed must still yield a measurement, not skip");
+                InGameAssert.IsTrue(rotated.Result.HasMeasurement,
+                    "The synthesized rotated-seed arm must produce a usable measurement");
+                InGameAssert.IsTrue(rotated.Result.OverTolerance,
+                    string.Format(System.Globalization.CultureInfo.InvariantCulture,
+                        "A rendered orbit drawn 90 deg off its intended seed LAN must flag synthesized "
+                        + "parity drift; maxDev={0:F0} m tol={1:F0} m",
+                        rotated.Result.MaxDeviationMeters, rotated.Result.ToleranceMeters));
+
+                // Body-mismatch arm: a seed naming a different frame body is a stale-seed / SOI race and must
+                // SKIP cleanly (no false anomaly).
+                MapRenderProbe.SynthesizedConicParitySample wrongBody =
+                    MapRenderProbe.ComputeSynthesizedConicParity(
+                        renderedOrbit, kerbin, iconBodyRel, seg, "Mun", 0.0, liveUT);
+                InGameAssert.IsFalse(wrongBody.Sampled,
+                    "A seed on a different frame body must skip cleanly (no synthesized diff)");
+
+                ParsekLog.Info("TestRunner",
+                    string.Format(System.Globalization.CultureInfo.InvariantCulture,
+                        "SynthesizedParity_CapturesRenderedVsIntendedConic: pid={0} matchedDev={1:F0}m "
+                        + "rotatedDev={2:F0}m tol={3:F0}m wrongBodySkip={4}",
+                        pid, matched.Result.MaxDeviationMeters, rotated.Result.MaxDeviationMeters,
+                        matched.Result.ToleranceMeters, wrongBody.SkipReason ?? "(none)"));
+            }
+            finally
+            {
+                if (pid != 0u)
+                    GhostMapPresence.RemoveAllGhostVessels("synth-parity-fixture-cleanup");
+                RecordingStore.ClearCommittedInternal();
+                RecordingStore.ClearCommittedTreesInternal();
+                for (int i = 0; i < prevRecordings.Count; i++)
+                    RecordingStore.AddCommittedInternal(prevRecordings[i]);
+                for (int i = 0; i < prevTrees.Count; i++)
+                    RecordingStore.AddCommittedTreeInternal(prevTrees[i]);
+                GhostMapPresence.CurrentUTNow = prevUTNow;
+            }
+        }
+
+        // A1 cutover-instrument (BLOCKER fix): the LOOPED synthesized-mode parity arm. The non-loop fixture
+        // above (loopEpochShiftSeconds 0.0) never exercises the loop-shift epoch bake, so it was BLIND to the
+        // false-drift blocker (the synthesized reference was built at the RAW intendedSeg.epoch while the
+        // rendered conic is driven at seg.epoch + loopShift, so every LOOPED member traced a different mean-
+        // anomaly half-arc and false-fired on a CORRECT draw). This arm drives a ghost whose live orbit epoch
+        // IS baked with a NON-ZERO loop shift (read back from the production map via GetGhostOrbitEpochShift)
+        // and asserts: (1) the PHASE-MATCHED synthesized diff (loopShift threaded in -> the reference epoch is
+        // baked with the SAME shift) reads ~0 for a faithful loop draw (rendered == intended seed); and (2)
+        // the fix is LOAD-BEARING - a deliberately phase-MISMATCHED reference (loopShift 0.0, the raw epoch,
+        // i.e. the pre-fix behavior) WOULD flag drift on the SAME correct draw. Mirrors the faithful path's
+        // loop-shifted in-game arm (RenderParityBaselineTest.ParityBaseline_LoopShiftedFaithfulGhost_*).
+        [InGameTest(Category = "GhostMap", Scene = GameScenes.FLIGHT,
+            Description = "A1 synthesized-mode parity (LOOP-SHIFTED): a ghost whose live orbit epoch is baked "
+                + "with a NON-ZERO loop shift reads ~0 synthesized drift when the intended reference is phase-"
+                + "matched (loopShift threaded in), and the raw-epoch (phase-MISMATCHED) reference WOULD drift "
+                + "- the proof the false-drift blocker fix is load-bearing")]
+        public void SynthesizedParity_LoopShiftedGhost_PhaseMatched_ZeroDrift()
+        {
+            CelestialBody kerbin = FlightGlobals.Bodies?.Find(b => b.bodyName == KerbinBodyName);
+            if (kerbin == null)
+            {
+                InGameAssert.Skip("Kerbin not found in FlightGlobals.Bodies (non-stock pack)");
+                return;
+            }
+
+            double liveUT = Planetarium.GetUniversalTime();
+            // The looped ghost replays a PAST recorded segment whose effUT = liveUT - shift. Author the
+            // segment around that effUT so the seed is a real recorded arc, mirroring a real loop replay.
+            double effUT = liveUT - LoopEpochShiftSeconds;
+            double startUT = effUT - 1800.0;
+            OrbitSegment seg = BuildSegment(startUT);
+
+            System.Func<double> prevUTNow = GhostMapPresence.CurrentUTNow;
+            List<Recording> prevRecordings = RecordingStore.CommittedRecordings != null
+                ? new List<Recording>(RecordingStore.CommittedRecordings)
+                : new List<Recording>();
+            List<RecordingTree> prevTrees = RecordingStore.CommittedTrees != null
+                ? new List<RecordingTree>(RecordingStore.CommittedTrees)
+                : new List<RecordingTree>();
+
+            Recording rec = BuildRecording(startUT, seg);
+            RecordingStore.ClearCommittedInternal();
+            RecordingStore.ClearCommittedTreesInternal();
+            RecordingStore.AddCommittedInternal(rec);
+            int recordingIndex = RecordingStore.CommittedRecordings.Count - 1;
+            GhostMapPresence.CurrentUTNow = () => liveUT;
+            GhostMapPresence.RemoveAllGhostVessels("synth-parity-loop-fixture-start");
+
+            uint pid = 0u;
+            try
+            {
+                // Create the live ghost with the NON-ZERO loop epoch shift baked in: this seeds the rendered
+                // OrbitDriver.orbit epoch to seg.epoch + shift (StockConicTreatment.SeedAndDriveLive) and
+                // records the shift via GetGhostOrbitEpochShift(pid) - the EXACT orchestration the probe reads.
+                Vessel ghost = GhostMapPresence.CreateGhostVesselFromSource(
+                    recordingIndex,
+                    rec,
+                    GhostMapPresence.TrackingStationGhostSource.Segment,
+                    seg,
+                    default(TrajectoryPoint),
+                    startUT,
+                    loopEpochShiftSeconds: LoopEpochShiftSeconds);
+
+                if (ghost == null || ghost.orbitDriver == null || ghost.orbitDriver.orbit == null)
+                {
+                    InGameAssert.Skip("Loop ghost did not create in this context (no proto)");
+                    return;
+                }
+                pid = ghost.persistentId;
+                Orbit renderedOrbit = ghost.orbitDriver.orbit;
+                Vector3d iconBodyRel = ghost.GetWorldPos3D() - kerbin.position;
+                if (iconBodyRel.magnitude < 1.0)
+                {
+                    InGameAssert.Skip("Ghost world position not resolved on the creation frame");
+                    return;
+                }
+
+                // Read the loop shift the live orbit was ACTUALLY baked with from the production map (NOT a
+                // local constant): proves the create path stored it and the probe reads back the same value
+                // the rendered orbit was driven with.
+                double loopShift = GhostMapPresence.GetGhostOrbitEpochShift(pid);
+                InGameAssert.ApproxEqual(LoopEpochShiftSeconds, loopShift, 1.0,
+                    "Loop ghost must record the loop epoch shift the production probe threads into the "
+                    + "synthesized reference");
+
+                // PHASE-MATCHED arm: intended seed == the rendered orbit's elements, reference built with the
+                // SAME loopShift the rendered conic was driven with. A faithful loop draw must read ~0 drift.
+                MapRenderProbe.SynthesizedConicParitySample phaseMatched =
+                    MapRenderProbe.ComputeSynthesizedConicParity(
+                        renderedOrbit, kerbin, iconBodyRel, seg, KerbinBodyName, loopShift, liveUT);
+                InGameAssert.IsTrue(phaseMatched.Sampled,
+                    "The phase-matched loop arm must yield a synthesized parity measurement (skipReason="
+                    + (phaseMatched.SkipReason ?? "(none)") + ")");
+                InGameAssert.IsTrue(phaseMatched.Result.HasMeasurement,
+                    "The phase-matched loop arm must produce a usable measurement");
+                InGameAssert.IsFalse(phaseMatched.Result.OverTolerance,
+                    string.Format(System.Globalization.CultureInfo.InvariantCulture,
+                        "A loop-shifted ghost drawing its intended seed must read ~0 synthesized drift when "
+                        + "the reference is PHASE-MATCHED (loopShift={0:F1}); maxDev={1:F0} m tol={2:F0} m. A "
+                        + "drift here is the false-drift blocker re-appearing.",
+                        loopShift, phaseMatched.Result.MaxDeviationMeters,
+                        phaseMatched.Result.ToleranceMeters));
+
+                // LOAD-BEARING negative control: build the reference with loopShift 0.0 (the raw epoch, the
+                // PRE-FIX behavior) against the SAME correct rendered loop draw. The phase no longer cancels,
+                // so the two orbits trace different mean-anomaly arcs and the diff MUST flag OverTolerance.
+                // Without this the phase-match could be a no-op (e.g. a tautological circle-vs-itself) and the
+                // arm would pass green-but-blind.
+                MapRenderProbe.SynthesizedConicParitySample phaseMismatched =
+                    MapRenderProbe.ComputeSynthesizedConicParity(
+                        renderedOrbit, kerbin, iconBodyRel, seg, KerbinBodyName, 0.0, liveUT);
+                InGameAssert.IsTrue(phaseMismatched.Sampled,
+                    "The phase-mismatched control arm must still SAMPLE (it is a real diff, not a skip)");
+                InGameAssert.IsTrue(phaseMismatched.Result.HasMeasurement,
+                    "The phase-mismatched control arm must produce a usable measurement");
+                InGameAssert.IsTrue(phaseMismatched.Result.OverTolerance,
+                    string.Format(System.Globalization.CultureInfo.InvariantCulture,
+                        "A raw-epoch (phase-MISMATCHED, loopShift=0) reference against a loop-shifted rendered "
+                        + "draw MUST flag synthesized drift - proving the phase-match is load-bearing; "
+                        + "maxDev={0:F0} m tol={1:F0} m. If this reads ~0 the loopShift is not actually moving "
+                        + "the reference phase (the test is tautological).",
+                        phaseMismatched.Result.MaxDeviationMeters,
+                        phaseMismatched.Result.ToleranceMeters));
+
+                ParsekLog.Info("TestRunner",
+                    string.Format(System.Globalization.CultureInfo.InvariantCulture,
+                        "SynthesizedParity_LoopShiftedGhost_PhaseMatched_ZeroDrift: pid={0} loopShift={1:F1} "
+                        + "matchedDev={2:F0}m mismatchedDev={3:F0}m tol={4:F0}m",
+                        pid, loopShift, phaseMatched.Result.MaxDeviationMeters,
+                        phaseMismatched.Result.MaxDeviationMeters,
+                        phaseMatched.Result.ToleranceMeters));
+            }
+            finally
+            {
+                if (pid != 0u)
+                    GhostMapPresence.RemoveAllGhostVessels("synth-parity-loop-fixture-cleanup");
+                RecordingStore.ClearCommittedInternal();
+                RecordingStore.ClearCommittedTreesInternal();
+                for (int i = 0; i < prevRecordings.Count; i++)
+                    RecordingStore.AddCommittedInternal(prevRecordings[i]);
+                for (int i = 0; i < prevTrees.Count; i++)
+                    RecordingStore.AddCommittedTreeInternal(prevTrees[i]);
+                GhostMapPresence.CurrentUTNow = prevUTNow;
+            }
+        }
+
+        // A deliberately non-zero loop epoch shift (seconds) for the LOOP-SHIFTED synthesized arm: ~18 min, a
+        // sizeable fraction of the orbit period at Sma, so the rendered conic sits well around the orbit from
+        // the raw recorded phase. With the BLOCKER bug present (raw-epoch reference) the phase-matched and
+        // raw-epoch references diverge by ~orbit-diameter at this shift; the fix collapses the phase-matched
+        // case to ~0 while the raw-epoch control still drifts.
+        private const double LoopEpochShiftSeconds = 1100.0;
+
         private static OrbitSegment BuildSegment(double startUT)
         {
             return new OrbitSegment

--- a/Source/Parsek/MapRender/AnchorFrameResolver.cs
+++ b/Source/Parsek/MapRender/AnchorFrameResolver.cs
@@ -54,6 +54,42 @@ namespace Parsek.MapRender
         internal static bool TryResolveBody(string bodyName, Func<string, bool> bodyExists)
             => ResolveBody(bodyName, bodyExists) == BodyResolveOutcome.Resolved;
 
+        /// <summary>Grep-stable lowercase token for a <see cref="BodyResolveOutcome"/> (carried on the
+        /// Tier-C <c>anchor-resolve-fail</c> anomaly detail line so a grep names WHY the anchor failed).</summary>
+        internal static string OutcomeToken(BodyResolveOutcome outcome)
+        {
+            switch (outcome)
+            {
+                case BodyResolveOutcome.Resolved: return "resolved";
+                case BodyResolveOutcome.FailClosedMissingName: return "fail-closed-missing-name";
+                case BodyResolveOutcome.FailClosedUnknownBody: return "fail-closed-unknown-body";
+                default: return "unknown";
+            }
+        }
+
+        /// <summary>
+        /// C1 anchor-resolve-fail RAISE wiring: resolve a <see cref="AnchorFrame.BodyAnchor"/> and, when it
+        /// fails closed (missing / unknown body), emit the Tier-C <c>anchor-resolve-fail</c> anomaly naming
+        /// the outcome - so a body-anchor that fails closed (rather than NRE) is observable. The DECISION is
+        /// the pure <see cref="ResolveBody"/> above; this is its once-per-event observability raise. The
+        /// trace emit is gated on <see cref="MapRenderTrace.IsEnabled"/> (free in normal play), so the
+        /// flag-OFF / tracing-OFF path pays nothing. Returns the resolve outcome so the caller can branch
+        /// (fail-closed -> hide) on the SAME decision it traced. Pure with respect to Unity (the body probe
+        /// is the injected delegate); the only side effect is the gated trace line.
+        /// </summary>
+        internal static BodyResolveOutcome ResolveBodyAndRaise(
+            uint pid, string recordingId, double currentUT,
+            string bodyName, Func<string, bool> bodyExists)
+        {
+            BodyResolveOutcome outcome = ResolveBody(bodyName, bodyExists);
+            if (outcome != BodyResolveOutcome.Resolved && MapRenderTrace.IsEnabled)
+            {
+                MapRenderTrace.EmitAnchorResolveFail(
+                    pid, recordingId, currentUT, bodyName, OutcomeToken(outcome));
+            }
+            return outcome;
+        }
+
         /// <summary>
         /// The outcome of a <see cref="AnchorFrame.ParentAnchoredChild"/> dual-surface resolution at a
         /// playback UT (design §5.2 / CLAUDE.md parent-anchored invariant).

--- a/Source/Parsek/MapRender/ShadowRenderDriver.cs
+++ b/Source/Parsek/MapRender/ShadowRenderDriver.cs
@@ -124,6 +124,7 @@ namespace Parsek.MapRender
             seedByPid.Clear();
             tracedPathByPid.Clear();
             tracedPathIntentByPid.Clear();
+            spineFallbackWarnedPids.Clear();
         }
 
         /// <summary>The shadow always runs: the Director pipeline is unconditional (8e S4 dropped the
@@ -359,6 +360,31 @@ namespace Parsek.MapRender
             double currentUT = scene.CurrentUT;
             var surface = scene.BodySurface;
 
+            // B4/D2 COLD-LOAD CLOCK-READINESS GUARD (design §11.2): a cold OnLoad / pre-time-init frame
+            // reports Planetarium UT=0 (or a non-finite UT) before the clock is established. Sampling the
+            // span clock at UT<=0 would place a degenerate TS/map ghost on the first cold-load frames (TS
+            // presence is stock-automatic the moment a ProtoVessel exists). DEFER the whole spine frame
+            // (render nothing / hold) and raise the once-per-event clock-not-ready anomaly. Mirrors
+            // LedgerOrchestrator.IsCurrentUtReadyForCutoff (ut > 0).
+            //
+            // FLAG-GATED so the flag-OFF path is BYTE-IDENTICAL to today: with the spine flag off the legacy
+            // assembler-driven branch below already runs unchanged, and this overhaul's defer must not alter
+            // any currently-supported producer's geometry. The clock-not-ready RAISE is additionally
+            // tracing-gated inside EmitClockNotReady (free in normal play). The legacy spine continues to
+            // sample as before when the flag is off (no behavior change there).
+            if (PhaseSpineDriveActive && !IsLiveClockReady(currentUT))
+            {
+                MapRenderTrace.EmitClockNotReady(currentUT, pids?.Count ?? 0);
+                ParsekLog.VerboseRateLimited("MapRender", "spine-clock-not-ready",
+                    string.Format(CultureInfo.InvariantCulture,
+                        "spine deferred: live clock not ready (liveUT={0:R} <= 0 / non-finite); rendering nothing this frame",
+                        currentUT),
+                    5.0);
+                // PruneStaleState is intentionally NOT called: a transient UT=0 frame must not drop the
+                // cached chains / prior intents the next ready frame resumes from. The defer is a hold.
+                return;
+            }
+
             int shadowed = 0, skipReaim = 0, overlapShadowed = 0, unresolved = 0;
             if (pids != null)
             {
@@ -404,10 +430,36 @@ namespace Parsek.MapRender
                     }
                     else
                     {
+                        // C4 SILENT-FALLBACK VISIBILITY: BuildChainSignature deliberately OMITS the spine
+                        // flag from the cache key, so a chain cached while the flag was off carries a null
+                        // PhaseChain; after an A/B toggle / hot-reload of the flag (without a Reset) the
+                        // flag-ON branch above would silently fall through HERE to the assembler chain
+                        // (phaseChain == null). Without a log this is invisible - a flag-ON run that is
+                        // actually rendering off the LEGACY spine. Warn ONCE per pid+condition so the
+                        // toggle is observable (the in-game test seam Resets on every flip, so this never
+                        // fires in a correctly-driven flag-ON run). Pure observability; the render result
+                        // (assembler chain) is unchanged. Note: NOT tracing-gated - this is a correctness
+                        // signal for the cutover operator, but it is rate-limited so it cannot flood.
+                        if (PhaseSpineDriveActive)
+                            WarnSpineFlagOnAssemblerFallback(pid, traj.RecordingId, currentUT);
                         sample = ChainSampler.Sample(chain, currentUT, units);
                         intent = GhostRenderDirector.Decide(sample, prior, traj.VesselName);
                     }
                     priorIntentByPid[pid] = intent;
+
+                    // C1 RETIRE-NOT-HELD raise (design §6.4 / §10.7): a member whose sample resolved
+                    // OUTSIDE its window (it should RETIRE this frame) yet was kept VISIBLE because the
+                    // prior intent was visible and the director held it - the inverse of the held-across-gap
+                    // contract. The Director's OutsideWindow case returns Hidden, so in the normal pipeline
+                    // this never fires; it is the guard that proves it stays that way (a future regression
+                    // that held an out-of-window member would light it). Tracing-gated, once-per-event.
+                    if (MapRenderTrace.IsEnabled
+                        && MapRenderTrace.IsRetireNotHeld(
+                            sample.Coverage == Coverage.OutsideWindow, prior.Visible, intent.Visible))
+                    {
+                        MapRenderTrace.EmitRetireNotHeld(
+                            pid, traj.RecordingId, currentUT, intent.DriveUT, intent.Treatment.ToString());
+                    }
 
                     // Per-ACTIVE-SEGMENT re-aim skip (design §4, refined from per-member): only the
                     // heliocentric (Sun-relative) LEG of a re-aim owner is replaced. Now COVERAGE-AWARE:
@@ -431,6 +483,21 @@ namespace Parsek.MapRender
                     {
                         skipReaim++;
                         continue;
+                    }
+
+                    // C1 ANCHOR-RESOLVE-FAIL raise (design §5.2 / §11.4): a visible intent carries a
+                    // BodyAnchor (FrameBodyName); resolve it through the PURE AnchorFrameResolver decision
+                    // against the scene's live body-existence probe and, when it fails closed (missing /
+                    // unknown body), emit the once-per-event anchor-resolve-fail anomaly. This is the
+                    // fail-closed (hide) outcome the downstream draw already takes (StockConicTreatment.Apply
+                    // returns on a null body) - here we make it OBSERVABLE rather than a silent drop. Pure
+                    // decision + tracing-gated emit (free in normal play); the render result is unchanged.
+                    if (MapRenderTrace.IsEnabled && intent.Visible
+                        && !string.IsNullOrEmpty(intent.FrameBodyName))
+                    {
+                        AnchorFrameResolver.ResolveBodyAndRaise(
+                            pid, traj.RecordingId, currentUT, intent.FrameBodyName,
+                            name => scene.ResolveBody(name) != null);
                     }
 
                     // Record the Director's StockConic seed this frame so the Phase-8a gated patch can
@@ -503,6 +570,16 @@ namespace Parsek.MapRender
         {
             return intentVisible && frameBodyIsStar && memberIsReaimOwner
                 && !(chainHasReaimedSegments && sampleInSegment);
+        }
+
+        // PURE clock-readiness predicate (B4/D2, design §11.2): the live UT must be strictly positive AND
+        // finite for the span clock to be sampled. A cold OnLoad / pre-time-init frame reports UT=0 (the
+        // Planetarium UT=0 trap); a pathological frame could report NaN/Inf. Mirrors
+        // LedgerOrchestrator.IsCurrentUtReadyForCutoff (ut > 0), extended with the finite guard since the
+        // render path multiplies UT into geometry. Unity-free / unit-testable.
+        internal static bool IsLiveClockReady(double liveUT)
+        {
+            return !double.IsNaN(liveUT) && !double.IsInfinity(liveUT) && liveUT > 0.0;
         }
 
         // Resolve a member's window (trimmed if it belongs to a unit) and classify its overlap scope
@@ -755,8 +832,37 @@ namespace Parsek.MapRender
                 seedByPid.Remove(stalePidScratch[i]);
                 tracedPathByPid.Remove(stalePidScratch[i]);
                 tracedPathIntentByPid.Remove(stalePidScratch[i]);
+                spineFallbackWarnedPids.Remove(stalePidScratch[i]);
             }
         }
+
+        // C4: per-pid one-shot guard for the silent flag-ON -> assembler-chain fallback warn. A flag
+        // toggle / hot-reload without a Reset leaves a stale cache entry with a null PhaseChain, so the
+        // flag-ON branch falls through to the assembler chain; warn ONCE per pid so an A/B toggle is
+        // visible without flooding (the condition is per-pid steady until the next signature rebuild
+        // re-populates PhaseChain). Cleared in Reset() (scene switch) + PruneStaleState (ghost retire).
+        private static readonly HashSet<uint> spineFallbackWarnedPids = new HashSet<uint>();
+
+        // C4 (the silent flag-ON -> assembler fallback, since BuildChainSignature omits the flag): warn
+        // ONE Info line per pid when the spine flag is ON yet the cached chain carries a null PhaseChain
+        // (so the spine-select fell through to the legacy assembler chain). NOT tracing-gated - this is a
+        // cutover-correctness signal for an A/B toggle / hot-reload, but one-shot per pid so it cannot
+        // flood. The render result is unchanged (the assembler chain renders); this only surfaces that the
+        // flag-ON run is actually driving the LEGACY spine for this ghost.
+        private static void WarnSpineFlagOnAssemblerFallback(uint pid, string recordingId, double currentUT)
+        {
+            if (!spineFallbackWarnedPids.Add(pid))
+                return;
+            ParsekLog.Warn("MapRender", string.Format(CultureInfo.InvariantCulture,
+                "spine flag ON but PhaseChain null for pid={0} rec={1} at UT={2:R}: falling back to the "
+                + "legacy assembler chain (stale chain cache after a flag toggle? call ShadowRenderDriver.Reset "
+                + "on every flag flip). Rendering off the LEGACY spine for this ghost.",
+                pid, recordingId ?? "?", currentUT));
+        }
+
+        /// <summary>Test-only: count of pids that have logged the C4 flag-ON assembler-fallback warn (so a
+        /// test can assert the one-shot guard fires once per pid). Cleared by <see cref="Reset"/>.</summary>
+        internal static int SpineFallbackWarnedPidCountForTesting => spineFallbackWarnedPids.Count;
 
         // Isolated Unity-native read (Time.frameCount): only ever JIT-compiled in-game, since the unit
         // tests exercise DecideForGhost / ClassifyScope directly and never call RunFrame.

--- a/Source/Parsek/MapRenderProbe.cs
+++ b/Source/Parsek/MapRenderProbe.cs
@@ -131,6 +131,19 @@ namespace Parsek
         // Soft rate-limit timestamps for the per-pid Phase-0 recorded-vs-rendered parity-drift anomaly (a
         // PERSISTENT condition, like icon-off-orbit, so it must not fire every frame).
         private readonly Dictionary<uint, double> lastParityDriftEmitRealtime = new Dictionary<uint, double>();
+        // A1 cutover-instrument: soft rate-limit timestamps for the per-pid SYNTHESIZED-mode (rendered conic
+        // vs the Director's intended re-aimed seed) parity-drift anomaly. SEPARATE from the faithful dict so
+        // a faithful drift and a synthesized drift on the same pid do not suppress each other. PERSISTENT
+        // condition (a re-aim draw bug diverges every frame), so throttled like the faithful one.
+        private readonly Dictionary<uint, double> lastSynthParityDriftEmitRealtime =
+            new Dictionary<uint, double>();
+        // A1 cutover-instrument: soft rate-limit timestamps for the per-RECORDING polyline-leg parity-drift
+        // anomaly (rendered VectorLine points vs the recorded leg surface track). Keyed by RecordingId (legs
+        // are per-recording, NOT per-pid - they are not in ghostMapVesselPids). PERSISTENT (a mis-anchored
+        // leg diverges every frame it draws), so throttled to one line per recording per second.
+        private const double PolylineParityDriftAnomalyMinIntervalSeconds = 1.0;
+        private readonly Dictionary<string, double> lastPolylineParityDriftEmitRealtime =
+            new Dictionary<string, double>(System.StringComparer.Ordinal);
         // Soft rate-limit timestamps for the per-pid polyline-orbit-overlap anomaly (a PERSISTENT
         // condition through a whole burn, so it must not fire every frame).
         private readonly Dictionary<uint, double> lastPolylineOverlapEmitRealtime = new Dictionary<uint, double>();
@@ -208,6 +221,8 @@ namespace Parsek
             lastSnapshotEmitRealtime.Clear();
             lastOffOrbitEmitRealtime.Clear();
             lastParityDriftEmitRealtime.Clear();
+            lastSynthParityDriftEmitRealtime.Clear();
+            lastPolylineParityDriftEmitRealtime.Clear();
             lastPolylineOverlapEmitRealtime.Clear();
             firstPositionEmittedPids.Clear();
             lastUnaccountedEmitRealtime.Clear();
@@ -280,6 +295,18 @@ namespace Parsek
             if (MapRenderTrace.TryGetDescentRenderWindow(
                     frame, out string descentPhase, out string descentRecId))
                 EmitMapSceneSnapshot(frame, currentUT, descentPhase, descentRecId);
+
+            // --- A1 cutover-instrument / design §14: SYNTHESIZED-mode POLYLINE leg parity ---
+            // Once per frame (NOT inside the per-pid loop above: the TracedPath polyline legs are per-
+            // RECORDING and are NOT in ghostMapVesselPids, so the loop never sees them). For every leg the
+            // polyline renderer actually drew this frame, diff the RENDERED VectorLine geometry (its live
+            // points3, scaled->world body-relative) against the RECORDED leg surface track (its own
+            // lats/lons/alts, body-relative) via the pure RenderParityOracle. A leg rotated onto a wrong
+            // conic seam, mis-anchored, or otherwise drawn off its recorded path shows drift here - the
+            // TracedPath-polyline regression class the faithful orbit oracle (orbit-only) cannot see. The
+            // whole LateUpdate is IsEnabled-gated; the per-recording rate-limit below keeps a persistent
+            // mis-drawn leg from flooding the log.
+            CapturePolylineLegParity(frame, currentUT, realtime);
         }
 
         // Per-frame full snapshot of every RENDERED map object, gated to the descent render window by the
@@ -813,6 +840,30 @@ namespace Parsek
                     TrySampleAndEmitFaithfulOrbitParity(
                         offOrbit, body, bodyRelPos, offEffUT, offShift, parityLoopShift, currentUT,
                         pid, pidKey, recId, lineActive, bodyName, realtime);
+
+                    // --- A1 cutover-instrument / design §14: SYNTHESIZED-mode conic parity ---
+                    // Where the FAITHFUL path above asks "did the rendered orbit match the RECORDED segment?"
+                    // (and SKIPS re-aimed / synthesized members because no recorded segment covers their
+                    // drive clock), this asks the COMPLEMENTARY question for exactly those members: "did the
+                    // rendered StockConic match the PRODUCER'S INTENDED arc - the re-aimed OrbitSegment the
+                    // spine actually fed the drive this frame?" The intended arc is the Director's fresh
+                    // StockConic seed (ShadowRenderDriver.TryGetFreshStockConicSeed = intent.Payload.Conic).
+                    // A re-aim DRAW regression (rendered conic != the seed it was driven from) shows drift;
+                    // a faithful StockConic member reads ~0 (rendered IS the seed) and never emits. Validates
+                    // DRAW-fidelity (rendered == intended), NOT solve-correctness (the re-aim solver owns
+                    // whether the intended arc is physically right). Same body-relative Y-up frame.
+                    //
+                    // PHASE-MATCH (same fix as the faithful path above): the rendered conic is driven at
+                    // epoch = seg.epoch + loopShift (StockConicTreatment.SeedAndDriveLive, GhostOrbitLine
+                    // Patch.cs:410 with shift = GetGhostOrbitEpochShift(pid)), so the intended reference MUST
+                    // be built with the SAME loop-shift epoch bake (BuildPhaseMatchedReferenceOrbit) and
+                    // sampled at the SAME live-clock UTs, or a LOOPED member samples a different mean-anomaly
+                    // half-arc and reads a FALSE drift on a CORRECT draw. parityLoopShift is the SAME value
+                    // the live orbit was baked with (GetGhostOrbitEpochShift(pid), computed above for the
+                    // faithful path); a non-loop member's shift is ~0 so this is identical to the raw epoch.
+                    TrySampleAndEmitSynthesizedConicParity(
+                        offOrbit, body, bodyRelPos, currentUT, parityLoopShift, pid, pidKey, recId,
+                        lineActive, bodyName, realtime);
                 }
 
                 // Record this frame's body-relative position + body so the next
@@ -972,6 +1023,28 @@ namespace Parsek
                 && realtime - last < ParityDriftAnomalyMinIntervalSeconds)
                 return false;
             lastParityDriftEmitRealtime[pid] = realtime;
+            return true;
+        }
+
+        private bool PassesSynthParityDriftRateLimit(uint pid, double realtime)
+        {
+            double last;
+            if (lastSynthParityDriftEmitRealtime.TryGetValue(pid, out last)
+                && realtime - last < ParityDriftAnomalyMinIntervalSeconds)
+                return false;
+            lastSynthParityDriftEmitRealtime[pid] = realtime;
+            return true;
+        }
+
+        private bool PassesPolylineParityDriftRateLimit(string recId, double realtime)
+        {
+            if (string.IsNullOrEmpty(recId))
+                return false;
+            double last;
+            if (lastPolylineParityDriftEmitRealtime.TryGetValue(recId, out last)
+                && realtime - last < PolylineParityDriftAnomalyMinIntervalSeconds)
+                return false;
+            lastPolylineParityDriftEmitRealtime[recId] = realtime;
             return true;
         }
 
@@ -1182,6 +1255,222 @@ namespace Parsek
             return new FaithfulParitySample(
                 true, null, result, scale,
                 covering.semiMajorAxis, covering.eccentricity, covering.bodyName);
+        }
+
+        // --- A1 cutover-instrument / design §14: SYNTHESIZED-mode conic parity (Unity capture) ---
+        //
+        // Samples the RENDERED orbit geometry (the live OrbitDriver.orbit) and the PRODUCER'S INTENDED arc
+        // (the Director's fresh StockConic seed = intent.Payload.Conic, the re-aimed OrbitSegment the spine
+        // fed the drive THIS frame), both in the SAME Y-up body-relative metres frame, hands them to the
+        // pure RenderParityOracle in ParityMode.Synthesized, and emits a parity-drift anomaly on
+        // OverTolerance. Validates DRAW-fidelity (rendered == intended), NOT solve-correctness. The intended
+        // reference is built PHASE-MATCHED to the live rendered orbit (its epoch baked with the SAME loop
+        // shift StockConicTreatment.SeedAndDriveLive drove the rendered conic with) and BOTH orbits are
+        // sampled at the SAME live-clock UTs, so a LOOPED re-aim member lands on the same arc as its rendered
+        // orbit and reads ~0 when the draw is faithful to the seed (the false-drift BLOCKER fix - the raw-
+        // epoch reference traced a different mean-anomaly half-arc and false-fired on every looped member).
+        // When there is no fresh seed (a TracedPath / faithful-fallback / hidden member) it skips cleanly. A
+        // faithful StockConic member's rendered orbit IS the seed (loop or not), so the diff reads ~0 and
+        // never emits - the synthesized lens only LIGHTS UP on a re-aim DRAW regression (rendered conic
+        // diverging from the re-aimed seed it was driven from), which the faithful lens (orbit-vs-recorded-
+        // segment) skips for exactly those re-aimed members. Additive observability: no draw change. Gated by
+        // the caller's IsEnabled check.
+        private void TrySampleAndEmitSynthesizedConicParity(
+            Orbit renderedOrbit, CelestialBody renderedBody, Vector3d iconBodyRel,
+            double currentUT, double loopShift, uint pid, string pidKey, string recId, string lineActive,
+            string bodyName, double realtime)
+        {
+            int frame = Time.frameCount;
+            // The intended arc: the Director's fresh StockConic seed for this pid. No fresh seed (TracedPath /
+            // faithful-fallback / hidden / no shadow run) -> nothing to diff against, skip (no anomaly).
+            if (!Parsek.MapRender.ShadowRenderDriver.TryGetFreshStockConicSeed(
+                    pid, frame, out OrbitSegment intendedSeg, out string seedBody))
+                return;
+
+            SynthesizedConicParitySample sample = ComputeSynthesizedConicParity(
+                renderedOrbit, renderedBody, iconBodyRel, intendedSeg, seedBody, loopShift, currentUT);
+            if (!sample.Sampled)
+                return;
+            Parsek.MapRender.RenderParityOracle.ParityResult result = sample.Result;
+            if (!result.HasMeasurement || !result.OverTolerance)
+                return;
+            if (!PassesSynthParityDriftRateLimit(pid, realtime))
+                return;
+
+            MapRenderTrace.EmitAnomaly(
+                MapRenderTrace.RenderSurface.ProtoOrbitLine, pidKey, currentUT, currentUT,
+                MapRenderTrace.AnomalyParityDrift,
+                string.Format(ic,
+                    "mode=synthesized maxDev={0}m tol={1}m scale={2}m refCount={3} rendCount={4} "
+                    + "countMismatch={5} | intendedSeg=[sma={6} ecc={7} body={8}] "
+                    + "rendOrbit=[sma={9} ecc={10} body={11}] iconR={12} lineActive={13}",
+                    MapRenderTrace.FormatDouble(result.MaxDeviationMeters, "F0"),
+                    MapRenderTrace.FormatDouble(result.ToleranceMeters, "F0"),
+                    MapRenderTrace.FormatDouble(sample.Scale, "F0"),
+                    result.ReferenceCount, result.RenderedCount, result.CountMismatch,
+                    MapRenderTrace.FormatDouble(intendedSeg.semiMajorAxis, "F0"),
+                    MapRenderTrace.FormatDouble(intendedSeg.eccentricity, "F4"),
+                    intendedSeg.bodyName ?? "(null)",
+                    MapRenderTrace.FormatDouble(renderedOrbit.semiMajorAxis, "F0"),
+                    MapRenderTrace.FormatDouble(renderedOrbit.eccentricity, "F4"),
+                    bodyName,
+                    MapRenderTrace.FormatDouble(iconBodyRel.magnitude, "F0"),
+                    lineActive),
+                recId);
+        }
+
+        /// <summary>
+        /// Outcome of one SYNTHESIZED-mode rendered-conic-vs-intended-arc parity sample. <see cref="Sampled"/>
+        /// is false (with <see cref="SkipReason"/>) when the sampler cleanly bailed before a diff (no rendered
+        /// orbit / different intended body / degenerate intended elements / reference build or sample fault):
+        /// the caller MUST treat a non-sampled outcome as "no anomaly". internal so an in-game baseline test
+        /// can exercise the REAL orchestration.
+        /// </summary>
+        internal readonly struct SynthesizedConicParitySample
+        {
+            internal bool Sampled { get; }
+            internal string SkipReason { get; }
+            internal Parsek.MapRender.RenderParityOracle.ParityResult Result { get; }
+            internal double Scale { get; }
+
+            internal SynthesizedConicParitySample(
+                bool sampled, string skipReason,
+                Parsek.MapRender.RenderParityOracle.ParityResult result, double scale)
+            {
+                Sampled = sampled;
+                SkipReason = skipReason;
+                Result = result;
+                Scale = scale;
+            }
+
+            internal static SynthesizedConicParitySample Skip(string reason)
+            {
+                return new SynthesizedConicParitySample(
+                    false, reason,
+                    default(Parsek.MapRender.RenderParityOracle.ParityResult), 0.0);
+            }
+        }
+
+        // The pure-orchestration CORE of the synthesized conic parity sample: build the intended re-aimed
+        // reference orbit from the Director's seed segment PHASE-MATCHED to the live rendered orbit (the SAME
+        // BuildPhaseMatchedReferenceOrbit loop-shift epoch bake the faithful path uses, NOT the raw-epoch
+        // BuildOrbitFromSegment - that was the false-drift BLOCKER on LOOPED members), sample BOTH the
+        // rendered orbit and the intended reference at the SAME live-clock UTs in the SAME Y-up body-relative
+        // frame, and run the oracle diff in ParityMode.Synthesized. No emit, no rate-limit, no per-pid state.
+        // internal for an in-game baseline test.
+        internal static SynthesizedConicParitySample ComputeSynthesizedConicParity(
+            Orbit renderedOrbit, CelestialBody renderedBody, Vector3d iconBodyRel,
+            OrbitSegment intendedSeg, string seedBody, double loopShift, double currentUT)
+        {
+            if (renderedOrbit == null || renderedBody == null)
+                return SynthesizedConicParitySample.Skip("no-rendered-orbit");
+            // The seed's frame body must match the rendered orbit's body: the body-relative inertial
+            // positions are comparable ONLY about the same body. A mismatch is a stale-seed / SOI-leg race
+            // (the icon is on the next body's orbit while the seed still names the prior body) -> skip.
+            string intendedBodyName = !string.IsNullOrEmpty(seedBody) ? seedBody : intendedSeg.bodyName;
+            if (!string.Equals(intendedBodyName, renderedBody.bodyName, System.StringComparison.Ordinal))
+                return SynthesizedConicParitySample.Skip("body-mismatch");
+            if (!TrajectoryMath.HasUsableOrbitSegmentElements(intendedSeg))
+                return SynthesizedConicParitySample.Skip("degenerate-elements");
+
+            // The intended reference orbit, built from the seed's Kepler elements PHASE-MATCHED to the live
+            // rendered orbit via the SAME BuildPhaseMatchedReferenceOrbit helper the faithful path uses. The
+            // producer DRIVES the rendered conic at epoch = seg.epoch + loopShift (StockConicTreatment
+            // .SeedAndDriveLive, GhostOrbitLinePatch.cs:410 with shift = GetGhostOrbitEpochShift(pid)) and
+            // propagates it at the LIVE clock, so the reference MUST use the SAME loop-shift epoch bake and be
+            // sampled at the SAME live-clock UTs - otherwise a LOOPED member samples a different mean-anomaly
+            // half-arc and reads a FALSE drift on a CORRECT draw (the BLOCKER this fix corrects). When the
+            // draw is faithful to the seed, both orbits land on the same phase at the same UT and read ~0.
+            // A non-loop member's loopShift is ~0, so this is BuildOrbitFromSegment verbatim.
+            Orbit intendedOrbit = BuildPhaseMatchedReferenceOrbit(intendedSeg, renderedBody, loopShift);
+            if (intendedOrbit == null)
+                return SynthesizedConicParitySample.Skip("intended-orbit-build-failed");
+
+            double halfSpan = ResolveOrbitSampleHalfSpanSeconds(renderedOrbit);
+            double[] sampleUTs = Parsek.MapRender.RenderGeometrySampler.BuildSampleUTs(
+                currentUT, halfSpan, ParityOrbitSampleCount);
+            if (sampleUTs.Length == 0)
+                return SynthesizedConicParitySample.Skip("no-sample-uts");
+
+            var renderedPts = new Vector3d[sampleUTs.Length + 1];
+            var referencePts = new Vector3d[sampleUTs.Length];
+            try
+            {
+                for (int i = 0; i < sampleUTs.Length; i++)
+                {
+                    renderedPts[i] = OrbitRelativePositionYup(renderedOrbit, sampleUTs[i]);
+                    referencePts[i] = OrbitRelativePositionYup(intendedOrbit, sampleUTs[i]);
+                }
+                // Anchor the rendered set with the live icon point so the diff also catches an icon parked
+                // off the intended arc (mirrors the faithful path).
+                renderedPts[sampleUTs.Length] = iconBodyRel;
+            }
+            catch (System.Exception)
+            {
+                return SynthesizedConicParitySample.Skip("sample-threw");
+            }
+
+            double[] referenceFlat = Parsek.MapRender.RenderGeometrySampler.Flatten(
+                referencePts, referencePts.Length);
+            double[] renderedFlat = Parsek.MapRender.RenderGeometrySampler.Flatten(
+                renderedPts, renderedPts.Length);
+
+            double scale = Parsek.MapRender.RenderParityOracle.EstimateScaleFromPoints(referenceFlat);
+            double tol = Parsek.MapRender.RenderParityOracle.ToleranceForScale(scale);
+            Parsek.MapRender.RenderParityOracle.ParityResult result =
+                Parsek.MapRender.RenderParityOracle.ComputeDrift(
+                    Parsek.MapRender.RenderParityOracle.ParityMode.Synthesized,
+                    referenceFlat, renderedFlat, tol);
+
+            return new SynthesizedConicParitySample(true, null, result, scale);
+        }
+
+        // --- A1 cutover-instrument / design §14: SYNTHESIZED-mode POLYLINE leg parity (Unity capture) ---
+        //
+        // Once per frame: for every NON-ANCHORED body-fixed TracedPath polyline leg the renderer drew this
+        // frame, the renderer hands back the rendered VectorLine geometry and the recorded leg surface track
+        // BOTH in body-relative world metres (CaptureRenderedVsRecordedLegGeometry isolates all the Unity
+        // reads AND skips conic-anchored legs), and this method runs the pure RenderParityOracle diff + emits
+        // a parity-drift anomaly on OverTolerance. CONIC-ANCHORED vacuum-maneuver legs are NOT covered (the
+        // draw intentionally rotates them ~96 deg off the raw recorded surface track, so a rendered-vs-raw-
+        // recorded diff would false-fire on a CORRECT anchor; the anchor's per-point Slerp is not cheaply
+        // recoverable to build the reference in - a stated limitation). The lens therefore validates the
+        // descent / atmospheric / surface re-stitch the audit cares about, where rendered == recorded. Per-
+        // RECORDING rate-limited (legs are per-recording, not per-pid). The geometry math (the oracle) is pure
+        // / unit-tested; only the Unity sampling (points3 / ScaledSpace / GetWorldSurfacePosition) lives in
+        // the renderer accessor, in-game-only.
+        private void CapturePolylineLegParity(int frame, double currentUT, double realtime)
+        {
+            Parsek.Display.GhostTrajectoryPolylineRenderer.CaptureRenderedVsRecordedLegGeometry(
+                frame,
+                (recId, legIndex, legCount, legBody, renderedFlat, recordedFlat) =>
+                {
+                    // Reference = the recorded leg track; rendered = what the VectorLine actually drew.
+                    Parsek.MapRender.RenderParityOracle.ParityResult result =
+                        Parsek.MapRender.RenderParityOracle.ComputeDriftScaleDerived(
+                            Parsek.MapRender.RenderParityOracle.ParityMode.Synthesized,
+                            recordedFlat, renderedFlat);
+                    if (!result.HasMeasurement || !result.OverTolerance)
+                        return;
+                    if (!PassesPolylineParityDriftRateLimit(recId, realtime))
+                        return;
+
+                    double scale = Parsek.MapRender.RenderParityOracle.EstimateScaleFromPoints(recordedFlat);
+                    // recId carried in the marker-surface pid= slot (the same convention the unaccounted-
+                    // drawn-recording anomaly uses for proto-less, recording-keyed events).
+                    MapRenderTrace.EmitAnomaly(
+                        MapRenderTrace.RenderSurface.Polyline, recId, currentUT, currentUT,
+                        MapRenderTrace.AnomalyParityDrift,
+                        string.Format(ic,
+                            "mode=polyline maxDev={0}m tol={1}m scale={2}m refCount={3} rendCount={4} "
+                            + "countMismatch={5} leg={6}/{7} body={8} recId={9}",
+                            MapRenderTrace.FormatDouble(result.MaxDeviationMeters, "F0"),
+                            MapRenderTrace.FormatDouble(result.ToleranceMeters, "F0"),
+                            MapRenderTrace.FormatDouble(scale, "F0"),
+                            result.ReferenceCount, result.RenderedCount, result.CountMismatch,
+                            legIndex, legCount, legBody, recId),
+                        recId);
+                });
         }
 
         // Half-window (seconds) the parity samples span on either side of the drive clock. A full closed

--- a/Source/Parsek/MapRenderTrace.cs
+++ b/Source/Parsek/MapRenderTrace.cs
@@ -498,6 +498,48 @@ namespace Parsek
                 currentUT, currentUT, details, recId);
         }
 
+        // ---- Cutover-hardening: Tier-C cutover-anomaly once-per-event dedup ----
+        // The cold-load clock-not-ready guard, the retire-not-held inverse-hold check, and the
+        // anchor-resolve-fail fail-closed check are all evaluated every frame at their decision site (the
+        // MAP spine), but each Tier-C anomaly is a per-EVENT signal, not a per-frame one (EmitAnomaly
+        // routes to Info + opens a detail window). This per-(pid+reason+detail-key) signature gate emits
+        // ONE line per distinct event onset, honoring the VerboseRateLimited convention - matching the
+        // ShouldEmit*OnChange pattern already used for the descent-stitch / fail-closed structural events.
+        // Same warp-cap + Reset() (scene-switch) clearing as the sibling signature dicts.
+        private static readonly Dictionary<string, string> lastCutoverAnomalySignatureByKey =
+            new Dictionary<string, string>(StringComparer.Ordinal);
+
+        /// <summary>Test-only: current size of the cutover-anomaly change-detection dict (warp-cap assert).</summary>
+        internal static int CutoverAnomalySignatureCountForTesting => lastCutoverAnomalySignatureByKey.Count;
+
+        /// <summary>
+        /// Once-per-event gate for a Tier-C cutover anomaly (clock-not-ready / retire-not-held /
+        /// anchor-resolve-fail): returns true only when <paramref name="signature"/> changed for this
+        /// <paramref name="eventKey"/> (typically <c>pid + ":" + reason</c>) since its last emit, so a
+        /// steadily-true decision site emits ONE anomaly line rather than one per frame. No-op (false) when
+        /// disabled. An empty key (a headless / no-resolvable-ghost path) is allowed through (the
+        /// <see cref="IsEnabled"/> gate + the caller still bound the emit). Warp-capped + cleared in
+        /// <see cref="Reset"/> (scene switch), like the sibling signature dicts.
+        /// </summary>
+        internal static bool ShouldEmitCutoverAnomalyOnChange(string eventKey, string signature)
+        {
+            if (!IsEnabled)
+                return false;
+            if (string.IsNullOrEmpty(eventKey))
+                return true;
+
+            if (lastCutoverAnomalySignatureByKey.TryGetValue(eventKey, out string last)
+                && string.Equals(last, signature, StringComparison.Ordinal))
+                return false; // unchanged anomaly onset for this key -> suppress
+
+            if (!lastCutoverAnomalySignatureByKey.ContainsKey(eventKey)
+                && lastCutoverAnomalySignatureByKey.Count >= MaxTrackedMarkerDecisionKeys)
+                lastCutoverAnomalySignatureByKey.Clear();
+
+            lastCutoverAnomalySignatureByKey[eventKey] = signature;
+            return true;
+        }
+
         // ---- Phase 6: descent-stitch structural-event once-per-event dedup ----
         // The CrossMemberSeamStitcher's TryStitchDescentSeam runs every frame the re-aim looped descent is
         // live + re-anchored, but the Tier-A DescentStitched structural event is a per-(re)stitch ONSET
@@ -608,6 +650,7 @@ namespace Parsek
             lastLineVisibilitySignatureByPid.Clear();
             lastDescentStitchSignatureByPid.Clear();
             lastFailClosedSignatureByPid.Clear();
+            lastCutoverAnomalySignatureByKey.Clear();
             descentRenderWindowFrame = -1;
             descentRenderWindowPhase = null;
             descentRenderWindowRecId = null;
@@ -1158,6 +1201,104 @@ namespace Parsek
             string combined = "reason=" + Token(reason)
                 + (string.IsNullOrEmpty(details) ? string.Empty : " " + details);
             EmitRaw(true, "Anomaly", surface, pidKey, currentUT, effUT, combined, recId);
+        }
+
+        // ---- Cutover-hardening Tier-C anomaly raises (clock-not-ready / retire-not-held /
+        //      anchor-resolve-fail) ----
+        //
+        // Each is a thin, tracing-gated, once-per-event wrapper over EmitAnomaly so the call site at the
+        // real decision point passes only values already in scope and never pays a formatting cost in
+        // normal play (the IsEnabled guard short-circuits before any work). They reuse the existing
+        // AnomalyClockNotReady / AnomalyRetireNotHeld / AnomalyAnchorResolveFail reason tokens, so one grep
+        // (reason=clock-not-ready | retire-not-held | anchor-resolve-fail) lights up each lens.
+
+        /// <summary>
+        /// PURE <c>retire-not-held</c> predicate (Tier C): true when a member's resolved sample is
+        /// OUTSIDE its window (it should RETIRE this frame) yet the prior intent was VISIBLE and the
+        /// director HELD it (kept it visible) instead — the inverse of the held-across-gap contract
+        /// (design §6.4 / §10.7). An interior-gap hold is legitimate (brief off-camera flexible-SOI seam),
+        /// so this is scoped to the OutsideWindow case only: a terminal / past-end / pre-launch member that
+        /// is still being shown. Pure (no Unity / no global state) so it is directly unit-testable.
+        /// </summary>
+        internal static bool IsRetireNotHeld(
+            bool sampleOutsideWindow, bool priorVisible, bool resolvedVisible)
+        {
+            return sampleOutsideWindow && priorVisible && resolvedVisible;
+        }
+
+        /// <summary>
+        /// Raise the Tier-C <c>clock-not-ready</c> anomaly: the MAP render spine was reached at a
+        /// non-positive live UT (cold-load Planetarium UT=0 / pre-time-init — design §11.2), so the spine
+        /// DEFERS (renders nothing) rather than sampling the span clock at UT&lt;=0 and placing a degenerate
+        /// ghost. Gated by <see cref="IsEnabled"/> (free in normal play) and deduped once-per-event via
+        /// <see cref="ShouldEmitCutoverAnomalyOnChange"/> (keyed on the whole-frame defer, not per ghost,
+        /// so one cold-load defer burst emits one line). Surface = ProtoOrbitLine (the spine ultimately
+        /// drives the proto icon/line). This is OBSERVABILITY for the flag-ON defer; it never changes the
+        /// flag-OFF path.
+        /// </summary>
+        internal static void EmitClockNotReady(double liveUT, int ghostCount)
+        {
+            if (!IsEnabled)
+                return;
+            // Frame-scoped event key: the defer is whole-frame (not per ghost). Re-emit only when the
+            // not-ready condition (re)appears, not every cold-load frame.
+            const string eventKey = "spine:clock-not-ready";
+            if (!ShouldEmitCutoverAnomalyOnChange(eventKey, AnomalyClockNotReady))
+                return;
+            string details = "liveUT=" + FormatDouble(liveUT, "F3")
+                + " ghosts=" + ghostCount.ToString(CultureInfo.InvariantCulture)
+                + " action=defer-render";
+            EmitAnomaly(RenderSurface.ProtoOrbitLine, "<none>", liveUT, liveUT,
+                AnomalyClockNotReady, details, recId: null);
+        }
+
+        /// <summary>
+        /// Raise the Tier-C <c>retire-not-held</c> anomaly for <paramref name="pid"/>: a member whose
+        /// sample resolved OUTSIDE its window (should retire) was nonetheless kept visible (held) this
+        /// frame — the inverse-hold defect (design §6.4 / §10.7). Caller pre-checks
+        /// <see cref="IsRetireNotHeld"/>. Gated by <see cref="IsEnabled"/> and deduped once-per-event
+        /// (pid + reason) via <see cref="ShouldEmitCutoverAnomalyOnChange"/>. Surface = ProtoOrbitLine.
+        /// </summary>
+        internal static void EmitRetireNotHeld(
+            uint pid, string recId, double currentUT, double effUT, string treatmentToken)
+        {
+            if (!IsEnabled)
+                return;
+            string pidKey = pid.ToString(CultureInfo.InvariantCulture);
+            string eventKey = pidKey + ":" + AnomalyRetireNotHeld;
+            // Signature includes the treatment so a held-then-different-held transition re-emits.
+            if (!ShouldEmitCutoverAnomalyOnChange(eventKey, AnomalyRetireNotHeld + ":" + (treatmentToken ?? "?")))
+                return;
+            string details = "heldTreatment=" + Token(treatmentToken)
+                + " action=should-retire";
+            EmitAnomaly(RenderSurface.ProtoOrbitLine, pidKey, currentUT, effUT,
+                AnomalyRetireNotHeld, details, recId);
+        }
+
+        /// <summary>
+        /// Raise the Tier-C <c>anchor-resolve-fail</c> anomaly for <paramref name="pid"/>: a
+        /// <c>BodyAnchor</c> / parent-anchor resolution failed (missing / unknown body, or an
+        /// out-of-range parent-anchored surface) so the phase failed CLOSED (hide / suppress) rather than
+        /// NRE (design §5.2 / §11.4). The pure decision is <see cref="MapRender.AnchorFrameResolver"/>;
+        /// this is its observability raise. Gated by <see cref="IsEnabled"/> and deduped once-per-event
+        /// (pid + reason + outcome) via <see cref="ShouldEmitCutoverAnomalyOnChange"/>. Surface =
+        /// ProtoOrbitLine.
+        /// </summary>
+        internal static void EmitAnchorResolveFail(
+            uint pid, string recId, double currentUT, string bodyName, string outcomeToken)
+        {
+            if (!IsEnabled)
+                return;
+            string pidKey = pid.ToString(CultureInfo.InvariantCulture);
+            string eventKey = pidKey + ":" + AnomalyAnchorResolveFail;
+            if (!ShouldEmitCutoverAnomalyOnChange(
+                    eventKey, AnomalyAnchorResolveFail + ":" + (outcomeToken ?? "?") + ":" + (bodyName ?? "?")))
+                return;
+            string details = "body=" + Token(bodyName)
+                + " outcome=" + Token(outcomeToken)
+                + " action=fail-closed";
+            EmitAnomaly(RenderSurface.ProtoOrbitLine, pidKey, currentUT, currentUT,
+                AnomalyAnchorResolveFail, details, recId);
         }
 
         /// <summary>

--- a/docs/dev/plans/map-ts-render-overhaul-migration.md
+++ b/docs/dev/plans/map-ts-render-overhaul-migration.md
@@ -473,6 +473,106 @@ surface (a tracer-coverage assertion). **Parity gate:** oracle green. **Risk:** 
 
 ---
 
+## 10b. Cutover-hardening instruments (stacked on Phase 8)
+
+**Goal:** build the observability + guard instruments that make the eventual flag-ON flip (the spine drives
+the render) and the 5a/5b legacy-draw deletes provably regression-free, BEFORE any of those irreversible
+steps. A 5-lens cutover-readiness audit found gaps in the live oracle and four previously-unraised
+guard/anomaly sites; this stacked PR closes them. Every item is ADDITIVE and reversible: with the spine flag
+OFF (`MapRenderFlags.MapRenderPhaseSpineDrive` default false) AND tracing OFF (`mapRenderTracing` default
+off) normal play is BYTE-IDENTICAL to today.
+
+**Status (implemented, observability-only / flag-OFF + tracing-OFF byte-identical):**
+
+- **A1 - the live parity oracle gains the SYNTHESIZED lens (rendered-vs-intended) it was missing.** Before
+  this PR the only LIVE oracle caller (`MapRenderProbe.ComputeFaithfulOrbitParity`) ran the oracle in
+  `ParityMode.Faithful` ONLY and SKIPPED every re-aimed / synthesized member (no-covering-segment /
+  body-mismatch), so a re-aim / descent / TracedPath DRAW regression produced no anomaly at all. The pure
+  Synthesized diff (`RenderParityOracle.ComputeDrift` / `ComputeDriftScaleDerived` in `ParityMode.Synthesized`,
+  count-independent nearest-point projection) and `NearestDistanceToPolyline` already existed and were
+  unit-tested but had NO live caller. A1 wires two live Synthesized lenses, both inside the
+  `MapRenderTrace.IsEnabled`-gated probe (tracing OFF = the probe never runs = zero new work):
+  - SYNTHESIZED conic parity: rendered StockConic vs the Director's intended re-aimed seed
+    (`ShadowRenderDriver.TryGetFreshStockConicSeed` = `intent.Payload.Conic`, stamped in BOTH flag states).
+    The intended reference is built PHASE-MATCHED to the live rendered orbit (its epoch baked with the SAME
+    loop shift `StockConicTreatment.SeedAndDriveLive` drove the rendered conic with,
+    `GetGhostOrbitEpochShift(pid)`, via the shared `BuildPhaseMatchedReferenceOrbit` helper - the SAME helper
+    the faithful lens uses) and BOTH orbits are sampled at the SAME live-clock UTs. So a faithful member reads
+    ~0 whether or not it is looped (a non-loop member's shift is ~0; a LOOPED member's reference now lands on
+    the same arc as its rendered orbit instead of a different mean-anomaly half-arc). Without this the raw-
+    epoch reference false-fired `parity-drift` on every CORRECT looped synthesized draw. The lens lights up
+    only on a re-aim DRAW divergence - the exact complement of the faithful lens's skip. Emits
+    `parity-drift mode=synthesized`.
+  - SYNTHESIZED polyline-leg parity: the live `VectorLine.points3` (scaled->world body-relative) vs the leg's
+    own recorded surface track, diffed per drawn leg. CONIC-ANCHORED legs are SKIPPED (a known, stated
+    limitation): the draw intentionally rotates an anchored leg ~96 deg onto the bracketing conic seam, so a
+    rendered-vs-raw-recorded diff would false-fire on a CORRECT anchor (and read ~0 on a leg that FAILED to
+    anchor - exactly backwards), and the anchor's per-point Slerp is not cheaply recoverable to rebuild the
+    reference in. The lens therefore validates only NON-anchored body-fixed legs (descent / atmospheric /
+    surface - the descent re-stitch the audit cares about), where the rendered points ARE the raw body-fixed
+    points so rendered == recorded by construction and a genuine mis-draw drifts. Emits
+    `parity-drift mode=polyline`.
+  - The pure diff math (`ComputeDrift*` / `EstimateScaleFromPoints` / `ToleranceForScale`) is xUnit-green
+    (the RenderParity regression set, including a Synthesized rotated-arc and a dense-vs-sparse count-mismatch
+    case). The Unity capture orchestration (`ComputeSynthesizedConicParity`,
+    `CaptureRenderedVsRecordedLegGeometry` - Orbit construction / `points3` / `ScaledSpace` /
+    `GetWorldSurfacePosition`) and the per-pid / per-recording rate-limit guards are Unity-bound and validated
+    by the FOLLOW-UP in-game harness (see below).
+
+- **B4/D2 - cold-load clock-readiness guard (design 11.2).** `ShadowRenderDriver.RunFrame` reached the MAP
+  spine at the cold-load Planetarium UT=0 (or a non-finite UT) before the clock was established, with no
+  `liveUT <= 0` check (`ChainSampler.Sample` passed `liveUT` straight through). Sampling the span clock at
+  UT<=0 would place a degenerate TS/map ghost on the first cold-load frames. B4 adds the pure predicate
+  `ShadowRenderDriver.IsLiveClockReady(double)` (strictly positive AND finite, mirroring
+  `LedgerOrchestrator.IsCurrentUtReadyForCutoff(ut > 0)`, extended with a finite guard) and, gated on
+  `PhaseSpineDriveActive` (flag-ON ONLY), DEFERS the whole spine frame (renders nothing / holds) when the
+  clock is not ready, raising the once-per-event `clock-not-ready` anomaly. The defer is a HOLD: it does NOT
+  call `PruneStaleState`, so the cached chains / prior intents the next ready frame resumes from survive. This
+  guard lives in the MAP spine, NOT flight gameplay, and only affects the flag-ON path; flag-OFF is unchanged.
+
+- **C1 - three previously-unraised Tier-C cutover anomalies now have production raises.**
+  `clock-not-ready` / `retire-not-held` / `anchor-resolve-fail` were defined-but-inert constants (Phase 8
+  status above). C1 wires their raises, each tracing-gated and deduped once-per-event:
+  - `clock-not-ready`: the B4 defer above.
+  - `retire-not-held` (pure `MapRenderTrace.IsRetireNotHeld`): a member whose sample resolved OUTSIDE its
+    window (should retire) yet was kept visible (held) - the inverse-hold defect. The Director's
+    OutsideWindow case returns Hidden, so this never fires in the normal pipeline; it is the guard that proves
+    it stays that way.
+  - `anchor-resolve-fail` (pure `AnchorFrameResolver.ResolveBodyAndRaise` over the existing `ResolveBody`
+    decision): a visible BodyAnchor whose body fails closed (missing / unknown body) - the fail-closed (hide)
+    outcome the draw already takes, now made observable rather than a silent drop.
+  - Shared once-per-event dedup `MapRenderTrace.ShouldEmitCutoverAnomalyOnChange` (warp-capped + scene-switch
+    cleared, mirroring the sibling `ShouldEmit*OnChange` gates).
+
+- **C4 - the silent flag-ON -> assembler-chain fallback is now observable.** `BuildChainSignature` omits the
+  spine flag from the cache key, so after an A/B toggle / hot-reload (without a `Reset`) a chain cached while
+  the flag was off carries a null PhaseChain and the flag-ON branch silently falls through to the LEGACY
+  assembler chain. C4 warns ONCE per pid (`WarnSpineFlagOnAssemblerFallback`, one-shot HashSet cleared in
+  `Reset()` + `PruneStaleState`) inside the flag-ON `else` branch so the toggle is visible without flooding.
+  The render result is unchanged (the assembler chain still renders); this only surfaces that the flag-ON run
+  is driving the legacy spine for that ghost.
+
+- **Flag-OFF / tracing-OFF byte-identical.** A1 / C1's `retire-not-held` + `anchor-resolve-fail` are behind
+  `MapRenderTrace.IsEnabled` (tracing OFF short-circuits before any work). B4's defer + C4's warn are behind
+  `PhaseSpineDriveActive` (the false const folds out; flag-OFF never enters either block). No
+  currently-supported producer's geometry changed; the renderer accessor only READS `points3`. No flight-scene
+  gameplay touched. No new user-visible default-play behavior, so NO CHANGELOG / todo entry (the cold-load
+  defer is a flag-ON-only guard; everything else is observability gated on `mapRenderTracing`).
+
+- **Tests.** Headless: `Source/Parsek.Tests/MapRender/CutoverHardeningTests.cs` (the pure predicates
+  `IsLiveClockReady` / `IsRetireNotHeld` / `AnchorFrameResolver.OutcomeToken` + `ResolveBodyAndRaise`, the
+  once-per-event dedup + warp-cap, the three emit helpers' reason tokens + IsEnabled short-circuits, and
+  source gates proving the RunFrame wiring is flag-/tracing-gated). The Synthesized diff MATH is covered by the
+  RenderParity regression set. **FOLLOW-UP (next PR) = the LIVE in-game validation harness:** the A1
+  Unity-capture orchestration (synthesized conic + polyline-leg capture), the B4 cold-load defer firing at
+  UT=0 (`Source/Parsek/InGameTests/ColdLoadClockGuardInGameTest.cs`), the C4 one-shot warn on a live flag
+  toggle, and the descent / re-aim regression scenarios are all Unity-bound (RunFrame reads
+  `Time.frameCount` + a live scene; Orbit / Vectrosity / ScaledSpace are Unity-bound) and must run via
+  Ctrl+Shift+T in FLIGHT to actually exercise the live capture. The headless gates lock the decision logic +
+  the schema those instruments feed.
+
+---
+
 ## 11. Phase ordering & dependencies
 
 ```


### PR DESCRIPTION
**Stacked on Phase 8 ([#1223](https://github.com/vl3c/Parsek/pull/1223)). Merge in order; this PR's diff is Phase 9 only.**

Additive, **flag-OFF + tracing-OFF byte-identical** cutover-hardening layer built from a 5-lens cutover-readiness audit. It makes the eventual flag-ON flip + 5a/5b legacy-draw deletes provably regression-free by closing the audit's observability + guard gaps. Nothing changes default play (oracle/anomaly behind `MapRenderTrace.IsEnabled` off-by-default; cold-load guard behind `MapRenderPhaseSpineDrive` off-by-default).

## A1 — live synthesized-mode + polyline parity oracle

The live oracle was **faithful-StockConic-only** (blind to re-aim, descent, and traced-polyline geometry). Added beside it:
- **Synthesized conic parity:** diffs the rendered StockConic vs the producer's **intended** arc (the Director's seed), phase-matched with the same `BuildPhaseMatchedReferenceOrbit(seg, body, loopShift)` the faithful path uses — a correctly-drawn looped ghost reads ~0, only a real re-aim *draw* regression drifts.
- **Polyline-leg parity:** diffs rendered traced-leg points (`VectorLine.points3`, scaled→world) vs the recorded body-fixed track. Validates non-anchored body-fixed legs (descent/atmospheric/surface); conic-anchored vacuum legs are skipped (the anchor is a per-point Slerp, not cheaply re-derivable) — a documented limitation, not a false-fire.

## B4 — cold-load UT≤0 defer guard

Design §11.2 mandates deferring render at cold-load Planetarium UT≤0; it was absent. Added `IsLiveClockReady` (>0 && finite); flag-ON + not-ready → `RunFrame` defers (holds, no teardown) + raises `clock-not-ready`. Flag-OFF untouched.

## C1 / C4 — wire the unraised anomalies + fallback signal

`clock-not-ready`, `retire-not-held`, `anchor-resolve-fail` now raise at their real decision sites (tracing-gated, once-per-event). `rigid-seam-tangent-discontinuity` stays deferred to 5b (needs the draw-site world tangents 5b reworks; in-game descent test is the interim gate). C4: a one-shot Warn on the silent `PhaseSpineDriveActive && phaseChain==null` fallback.

## Review

Two clean-context lenses caught **two real A1 false-positive blockers** — the synthesized lens wasn't loop-shift phase-matched (false-fired on every looped ghost), and the polyline lens diffed vs the raw recorded track ignoring `leg.wasAnchored` (false-fired on every correctly conic-anchored leg, blind to the real mis-anchor). Both fixed and a focused re-review verdict **CLEAN**, with load-bearing negative-control test arms (phase-matched reads ~0 *and* phase-mismatched drifts). B4/C1/C4 confirmed correct first pass.

## Tests

Pure predicates + diff math (`CutoverHardeningTests`, `RenderParityRegressionScenarioTests` incl. the looped-shift negative control, `GhostTrajectoryPolylineBuildTests` anchored-leg skip); in-game `ColdLoadClockGuardInGameTest` (real RunFrame defer at UT=0) + `RenderParitySamplerFixtureTest` (live synthesized capture + looped-shift phase-match arm). `dotnet build` green; `dotnet test` **16629 passed, 0 failed**; all source-gates green.

Live in-game validation of the oracle + cold-load defer + descent/re-aim scenarios is the follow-up regression harness (next PR). No `CHANGELOG`/`todo` change (observability + a flag-ON-only guard).