### PR TITLE
maprender Phase 10: cutover regression harness (flag-ON-vs-OFF differential + in-game scenarios + comparator widening)

### DIFF
--- a/Source/Parsek.Tests/MapRender/MultiMemberSpineParityTests.cs
+++ b/Source/Parsek.Tests/MapRender/MultiMemberSpineParityTests.cs
@@ -1,0 +1,265 @@
+using System.Collections.Generic;
+using Parsek;
+using Parsek.Display;
+using Parsek.MapRender;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    /// <summary>
+    /// Phase-10 A2 (headless half): the end-to-end flag-ON-vs-OFF differential the 5-lens audit found
+    /// missing. The existing parity suites cover SINGLE-member faithful CIRCULAR fixtures
+    /// (<c>PhaseFactoryTests</c> byte-parity per fixture; <c>PhaseSpineParityTests</c> intent sweeps over
+    /// the equatorial <c>FaithfulChain</c>); none runs a realistic MULTI-segment recording
+    /// (StockConic + TracedPath + an SOI crossing in ONE chain) through BOTH spines and asserts the full
+    /// differential.
+    ///
+    /// <para>This fixture is one recording whose assembled chain spans:
+    /// <list type="number">
+    ///   <item>Kerbin ASCENT (recorded points 0..8, not orbit-covered) -> TracedPath, body Kerbin;</item>
+    ///   <item>Kerbin PARKING (orbit 10..30, inclined+nonzero-LAN) -> StockConic, body Kerbin;</item>
+    ///   <item>Mun ARRIVAL ORBIT (orbit 40..60, different elements) -> StockConic, body Mun
+    ///     (the Kerbin->Mun body change is the SOI CROSSING: the assembler stamps a FlexibleSoi seam
+    ///     between the two conics);</item>
+    ///   <item>Mun DESCENT (recorded points 62..70, not orbit-covered) -> TracedPath, body Mun.</item>
+    /// </list>
+    /// So the chain carries BOTH treatments AND a real body-frame SOI crossing.</para>
+    ///
+    /// <para><b>What it asserts (the differential):</b>
+    /// <list type="bullet">
+    ///   <item>FULL geometry byte-parity: <c>PhaseFactory.BuildPhaseChain</c> projects byte-identically to
+    ///     <c>ChainAssembler.Build</c> (<see cref="GeometryParityComparator"/>) — every segment's
+    ///     treatment / UTs / frame body / full conic Kepler payload, the chain window, faithful-fallback,
+    ///     and the segment count.</item>
+    ///   <item>FULL intent parity for the faithful members across a continuous live-UT sweep: the typed
+    ///     spine (factory -> sampler -> director) and the legacy spine (assembler -> sampler -> director)
+    ///     emit byte-identical <c>GhostRenderIntent</c>s, threading the SAME prior intent as
+    ///     <c>ShadowRenderDriver.RunFrame</c> does, so a coverage flip / treatment swap / held-vs-retired
+    ///     gap (incl. the interior gaps on either side of each segment and across the SOI seam) on ANY
+    ///     frame fails here.</item>
+    /// </list></para>
+    ///
+    /// <para>Maps the §11.5 rows the audit flagged as headless-thin: "Single-level SOI transition", "Mixed
+    /// faithful + re-aimed members" (the faithful half), and the StockConic+TracedPath chain shape. The
+    /// re-aimed (synthesized) half stays in <see cref="PhaseSpineParityTests"/>'s re-aim sweeps; here the
+    /// whole chain is FAITHFUL (no override), which is the flag-ON==flag-OFF byte-identical contract.</para>
+    /// </summary>
+    public class MultiMemberSpineParityTests
+    {
+        private static TrajectoryPoint Pt(double ut, string body)
+            => new TrajectoryPoint { ut = ut, bodyName = body };
+
+        private static TrackSection Sec(double s, double e, SegmentEnvironment env)
+            => new TrackSection { startUT = s, endUT = e, environment = env };
+
+        private const double WindowStart = 0.0;
+        private const double WindowEnd = 80.0;
+
+        // The realistic multi-segment recording. Above-surface conics on TWO bodies (Kerbin then Mun) with
+        // recorded ascent points before the first conic and recorded descent points after the last conic, so
+        // the assembled chain is TracedPath -> StockConic -> StockConic(SOI crossing) -> TracedPath. Elements
+        // are inclined + nonzero-LAN so the full-Kepler intent parity is genuinely exercised (not 0==0).
+        private static MockTrajectory MultiMemberChain()
+            => new MockTrajectory
+            {
+                RecordingId = "rec-multi",
+                VesselName = "Mun Express",
+                Points = new List<TrajectoryPoint>
+                {
+                    // Kerbin ascent (before the parking orbit) -> TracedPath on Kerbin.
+                    Pt(0, "Kerbin"), Pt(2, "Kerbin"), Pt(4, "Kerbin"), Pt(6, "Kerbin"), Pt(8, "Kerbin"),
+                    // Mun descent (after the Mun arrival orbit) -> TracedPath on Mun.
+                    Pt(62, "Mun"), Pt(64, "Mun"), Pt(66, "Mun"), Pt(68, "Mun"), Pt(70, "Mun"),
+                },
+                OrbitSegments = new List<OrbitSegment>
+                {
+                    // Kerbin parking orbit (inclined, nonzero LAN/argPe/MnA/epoch).
+                    new OrbitSegment
+                    {
+                        startUT = 10, endUT = 30, bodyName = "Kerbin",
+                        semiMajorAxis = 900000, eccentricity = 0.12,
+                        inclination = 28.5, longitudeOfAscendingNode = 75.0,
+                        argumentOfPeriapsis = 40.0, meanAnomalyAtEpoch = 1.2, epoch = 12.5,
+                    },
+                    // Mun arrival orbit (different body -> SOI crossing; different elements).
+                    new OrbitSegment
+                    {
+                        startUT = 40, endUT = 60, bodyName = "Mun",
+                        semiMajorAxis = 250000, eccentricity = 0.30,
+                        inclination = 12.0, longitudeOfAscendingNode = 200.0,
+                        argumentOfPeriapsis = 110.0, meanAnomalyAtEpoch = 0.6, epoch = 41.0,
+                    },
+                },
+                // Env-class sections so the faithful leaf classification (ascent / parking / arrival /
+                // descent) resolves; these do not affect the byte-parity geometry but exercise the realistic
+                // classification path the factory runs.
+                TrackSections = new List<TrackSection>
+                {
+                    Sec(0, 8, SegmentEnvironment.Atmospheric),     // Kerbin ascent
+                    Sec(10, 30, SegmentEnvironment.ExoBallistic),  // Kerbin parking
+                    Sec(40, 60, SegmentEnvironment.ExoBallistic),  // Mun arrival orbit
+                    Sec(62, 70, SegmentEnvironment.Atmospheric),   // Mun descent
+                },
+            };
+
+        private static GhostPlaybackLogic.LoopUnitSet NonLooped => GhostPlaybackLogic.LoopUnitSet.Empty;
+
+        private static GhostRenderChain BuildAssembler(IPlaybackTrajectory traj)
+            => ChainAssembler.Build(
+                traj, committedIndex: 0, instanceKey: 0, WindowStart, WindowEnd,
+                faithfulFallback: false, surface: null);
+
+        private static PhaseChain BuildFactory(IPlaybackTrajectory traj)
+            => PhaseFactory.BuildPhaseChain(
+                traj, committedIndex: 0, instanceKey: 0, WindowStart, WindowEnd,
+                faithfulFallback: false, surface: null);
+
+        // The widened full-element intent parity (mirrors PhaseSpineParityTests.AssertIntentParity, kept
+        // self-contained here so the A2 differential is readable end-to-end in one file).
+        private static void AssertIntentParity(GhostRenderIntent assembler, GhostRenderIntent factory)
+        {
+            Assert.Equal(assembler.Visible, factory.Visible);
+            Assert.Equal(assembler.Treatment, factory.Treatment);
+            Assert.Equal(assembler.DriveUT, factory.DriveUT);
+            Assert.Equal(assembler.FrameBodyName, factory.FrameBodyName);
+            Assert.Equal(assembler.Payload.HasConic, factory.Payload.HasConic);
+            if (assembler.Payload.HasConic)
+            {
+                OrbitSegment a = assembler.Payload.Conic;
+                OrbitSegment f = factory.Payload.Conic;
+                Assert.Equal(a.startUT, f.startUT);
+                Assert.Equal(a.endUT, f.endUT);
+                Assert.Equal(a.semiMajorAxis, f.semiMajorAxis);
+                Assert.Equal(a.eccentricity, f.eccentricity);
+                Assert.Equal(a.inclination, f.inclination);
+                Assert.Equal(a.longitudeOfAscendingNode, f.longitudeOfAscendingNode);
+                Assert.Equal(a.argumentOfPeriapsis, f.argumentOfPeriapsis);
+                Assert.Equal(a.meanAnomalyAtEpoch, f.meanAnomalyAtEpoch);
+                Assert.Equal(a.epoch, f.epoch);
+                Assert.Equal(a.bodyName, f.bodyName);
+                Assert.Equal(a.isPredicted, f.isPredicted);
+            }
+        }
+
+        // ---- The fixture really is the multi-segment shape we claim (guard against a vacuous chain) ----
+
+        [Fact]
+        public void Fixture_AssemblesExpectedMultiSegmentChain_WithSoiCrossing()
+        {
+            GhostRenderChain assembler = BuildAssembler(MultiMemberChain());
+
+            // 2 TracedPath (Kerbin ascent, Mun descent) + 2 StockConic (Kerbin parking, Mun arrival).
+            int traced = 0, conic = 0;
+            for (int i = 0; i < assembler.SegmentCount; i++)
+            {
+                if (assembler.Segments[i].Treatment == Treatment.TracedPath) traced++;
+                if (assembler.Segments[i].Treatment == Treatment.StockConic) conic++;
+            }
+            Assert.Equal(2, traced);
+            Assert.Equal(2, conic);
+
+            // The SOI crossing: a body-frame change Kerbin -> Mun between two adjacent StockConic segments
+            // -> a FlexibleSoi seam (the assembler stamps it; the factory leaves it None, which is exactly
+            // why A4 keeps seams out of the byte-parity set). Prove the body change exists.
+            bool sawKerbinConic = false, sawMunConic = false;
+            for (int i = 0; i < assembler.SegmentCount; i++)
+            {
+                RenderSegment s = assembler.Segments[i];
+                if (s.Treatment != Treatment.StockConic) continue;
+                if (s.FrameBodyName == "Kerbin") sawKerbinConic = true;
+                if (s.FrameBodyName == "Mun") sawMunConic = true;
+            }
+            Assert.True(sawKerbinConic, "expected a Kerbin parking StockConic");
+            Assert.True(sawMunConic, "expected a Mun arrival StockConic (the SOI crossing target body)");
+        }
+
+        // ---- A2 part 1: FULL geometry byte-parity (factory projects == assembler) ----
+
+        [Fact]
+        public void MultiMemberChain_FactoryGeometry_ByteMatchesAssembler()
+        {
+            GhostRenderChain assembler = BuildAssembler(MultiMemberChain());
+            PhaseChain factory = BuildFactory(MultiMemberChain());
+
+            GeometryParityComparator.ParityResult result =
+                GeometryParityComparator.Compare(factory, assembler);
+
+            Assert.True(result.IsMatch, "multi-member geometry parity divergence: " + result);
+            Assert.False(result.CountMismatch);
+        }
+
+        // ---- A2 part 2: FULL intent parity across a continuous live-UT sweep (the flag-ON==flag-OFF run) ----
+
+        [Fact]
+        public void MultiMemberChain_FullSweep_TwoSpines_EmitIdenticalIntents_WithSharedPrior()
+        {
+            var traj = MultiMemberChain();
+            GhostRenderChain assembler = BuildAssembler(traj);
+            PhaseChain factory = BuildFactory(traj);
+
+            GhostRenderIntent aPrior = default(GhostRenderIntent);
+            GhostRenderIntent fPrior = default(GhostRenderIntent);
+            bool sawTraced = false, sawKerbinConic = false, sawMunConic = false;
+
+            // Step 0.5s across [-5, 85] so every segment + every interior gap (ascent->parking, parking->Mun
+            // SOI seam, Mun->descent) + the pre-launch / past-end tails is visited, threading the SAME prior
+            // through both spines exactly as RunFrame does.
+            for (double ut = -5.0; ut <= 85.0; ut += 0.5)
+            {
+                GhostRenderIntent aIntent = GhostRenderDirector.Decide(
+                    ChainSampler.Sample(assembler, ut, NonLooped), aPrior, traj.VesselName);
+                GhostRenderIntent fIntent = GhostRenderDirector.Decide(
+                    factory, ut, NonLooped, fPrior, traj.VesselName);
+
+                AssertIntentParity(aIntent, fIntent);
+
+                if (aIntent.Visible && aIntent.Treatment == Treatment.TracedPath)
+                    sawTraced = true;
+                if (aIntent.Visible && aIntent.Treatment == Treatment.StockConic
+                    && aIntent.FrameBodyName == "Kerbin")
+                    sawKerbinConic = true;
+                if (aIntent.Visible && aIntent.Treatment == Treatment.StockConic
+                    && aIntent.FrameBodyName == "Mun")
+                    sawMunConic = true;
+
+                aPrior = aIntent;
+                fPrior = fIntent;
+            }
+
+            // The sweep genuinely exercised both treatments AND both sides of the SOI crossing (else the
+            // parity assertions would be vacuous).
+            Assert.True(sawTraced, "the sweep must render a TracedPath leg (ascent/descent)");
+            Assert.True(sawKerbinConic, "the sweep must render the Kerbin parking StockConic");
+            Assert.True(sawMunConic, "the sweep must render the Mun arrival StockConic (post-SOI-crossing)");
+        }
+
+        // ---- Spot frames: one assertion per segment + the interior gaps, so a failure localizes ----
+
+        // NOTE: the treatment is passed as a string (not the internal Treatment enum) because a public
+        // [Theory] method cannot take an internal-typed parameter (CS0051). It is mapped to the enum inside.
+        [Theory]
+        [InlineData(4.0, true, "TracedPath", "Kerbin")]    // Kerbin ascent traced
+        [InlineData(20.0, true, "StockConic", "Kerbin")]   // Kerbin parking conic
+        [InlineData(50.0, true, "StockConic", "Mun")]      // Mun arrival conic (post-crossing)
+        [InlineData(66.0, true, "TracedPath", "Mun")]      // Mun descent traced
+        public void MultiMemberChain_SpotFrame_TwoSpines_Agree(
+            double liveUT, bool expectVisible, string expectTreatment, string expectBody)
+        {
+            var traj = MultiMemberChain();
+            GhostRenderChain assembler = BuildAssembler(traj);
+            PhaseChain factory = BuildFactory(traj);
+
+            GhostRenderIntent aIntent = GhostRenderDirector.Decide(
+                ChainSampler.Sample(assembler, liveUT, NonLooped), default(GhostRenderIntent), traj.VesselName);
+            GhostRenderIntent fIntent = GhostRenderDirector.Decide(
+                factory, liveUT, NonLooped, default(GhostRenderIntent), traj.VesselName);
+
+            // The two spines agree (the gate)...
+            AssertIntentParity(aIntent, fIntent);
+            // ...and the agreed intent is the one the fixture intends (so the parity is on the right thing).
+            Assert.Equal(expectVisible, aIntent.Visible);
+            Assert.Equal(expectTreatment, aIntent.Treatment.ToString());
+            Assert.Equal(expectBody, aIntent.FrameBodyName);
+        }
+    }
+}

--- a/Source/Parsek.Tests/MapRender/PhaseSpineParityTests.cs
+++ b/Source/Parsek.Tests/MapRender/PhaseSpineParityTests.cs
@@ -44,6 +44,33 @@ namespace Parsek.Tests
                 },
             };
 
+        // Phase-10 A5: an INCLINED, nonzero-LAN faithful chain. The earlier fixtures are all equatorial
+        // zero-LAN (inclination == 0, longitudeOfAscendingNode == 0), so a spine that dropped or mis-carried
+        // inclination / LAN / argPe / MnA / epoch would still read PARITY there (0 == 0). This conic carries
+        // a non-equatorial orientation (inc 28.5 deg, LAN 75 deg, argPe 40 deg, MnA 1.2 rad, epoch 12.5) so
+        // a non-equatorial intent divergence is CAUGHT by the widened AssertIntentParity. sma 900000 + ecc
+        // 0.15 keeps periapsis (~765000) well above Kerbin's 600000 surface so it stays a StockConic.
+        private static MockTrajectory InclinedChain()
+            => new MockTrajectory
+            {
+                RecordingId = "rec-inclined",
+                VesselName = "Polar Probe",
+                Points = new List<TrajectoryPoint>
+                {
+                    Pt(0, "Kerbin"), Pt(2, "Kerbin"), Pt(4, "Kerbin"), Pt(6, "Kerbin"), Pt(8, "Kerbin"),
+                },
+                OrbitSegments = new List<OrbitSegment>
+                {
+                    new OrbitSegment
+                    {
+                        startUT = 10, endUT = 30, bodyName = "Kerbin",
+                        semiMajorAxis = 900000, eccentricity = 0.15,
+                        inclination = 28.5, longitudeOfAscendingNode = 75.0,
+                        argumentOfPeriapsis = 40.0, meanAnomalyAtEpoch = 1.2, epoch = 12.5,
+                    },
+                },
+            };
+
         private static GhostPlaybackLogic.LoopUnitSet NonLooped => GhostPlaybackLogic.LoopUnitSet.Empty;
 
         private static GhostRenderChain BuildAssemblerChain(IPlaybackTrajectory traj, double wStart, double wEnd)
@@ -78,7 +105,18 @@ namespace Parsek.Tests
 
         // Assert the two spines' intents are byte-identical on the load-bearing fields (the only ones that
         // flow downstream into the side-channel stamps + draw): Visible, Treatment, DriveUT, FrameBodyName,
-        // and the conic payload (HasConic + the elements). Prior intent is shared so the gap-hold matches.
+        // and the FULL conic payload (HasConic + EVERY Kepler element). Prior intent is shared so the
+        // gap-hold matches.
+        //
+        // Phase-10 A5: the element set is the FULL OrbitSegment Kepler shape, not the sma/ecc/start/end/body
+        // subset the earlier version checked. The StockConic treatment seeds the live orbit from
+        // (inclination, eccentricity, semiMajorAxis, longitudeOfAscendingNode, argumentOfPeriapsis,
+        // meanAnomalyAtEpoch, epoch) — see StockConicTreatment.SeedAndDrive — so an inclination / LAN /
+        // argPe / MnA / epoch / isPredicted divergence between the two spines is a REAL render divergence
+        // (the icon + line would sit on a differently-oriented orbit) that the subset assertion would miss.
+        // This is exactly the gap an INCLINED, nonzero-LAN fixture exposes (see InclinedChain below): on an
+        // equatorial zero-LAN fixture inclination==0 and LAN==0 on BOTH spines, so a swap that dropped them
+        // could not be caught.
         private static void AssertIntentParity(GhostRenderIntent assembler, GhostRenderIntent factory)
         {
             Assert.Equal(assembler.Visible, factory.Visible);
@@ -88,11 +126,19 @@ namespace Parsek.Tests
             Assert.Equal(assembler.Payload.HasConic, factory.Payload.HasConic);
             if (assembler.Payload.HasConic)
             {
-                Assert.Equal(assembler.Payload.Conic.semiMajorAxis, factory.Payload.Conic.semiMajorAxis);
-                Assert.Equal(assembler.Payload.Conic.eccentricity, factory.Payload.Conic.eccentricity);
-                Assert.Equal(assembler.Payload.Conic.startUT, factory.Payload.Conic.startUT);
-                Assert.Equal(assembler.Payload.Conic.endUT, factory.Payload.Conic.endUT);
-                Assert.Equal(assembler.Payload.Conic.bodyName, factory.Payload.Conic.bodyName);
+                OrbitSegment a = assembler.Payload.Conic;
+                OrbitSegment f = factory.Payload.Conic;
+                Assert.Equal(a.startUT, f.startUT);
+                Assert.Equal(a.endUT, f.endUT);
+                Assert.Equal(a.semiMajorAxis, f.semiMajorAxis);
+                Assert.Equal(a.eccentricity, f.eccentricity);
+                Assert.Equal(a.inclination, f.inclination);
+                Assert.Equal(a.longitudeOfAscendingNode, f.longitudeOfAscendingNode);
+                Assert.Equal(a.argumentOfPeriapsis, f.argumentOfPeriapsis);
+                Assert.Equal(a.meanAnomalyAtEpoch, f.meanAnomalyAtEpoch);
+                Assert.Equal(a.epoch, f.epoch);
+                Assert.Equal(a.bodyName, f.bodyName);
+                Assert.Equal(a.isPredicted, f.isPredicted);
             }
         }
 
@@ -199,6 +245,79 @@ namespace Parsek.Tests
                 aPrior = aIntent;
                 fPrior = fIntent;
             }
+        }
+
+        // ---- Phase-10 A5: INCLINED, nonzero-LAN fixture (the non-equatorial intent-divergence gap) ----
+
+        [Theory]
+        [InlineData(4.0)]   // ascent traced run (Kerbin)
+        [InlineData(20.0)]  // on the inclined conic (the load-bearing leg: inc/LAN/argPe must carry)
+        [InlineData(50.0)]  // past window end -> hidden for both
+        public void InclinedChain_TwoSpines_EmitIdenticalIntents(double liveUT)
+        {
+            var traj = InclinedChain();
+            GhostRenderChain assembler = BuildAssemblerChain(traj, 0, 40);
+            PhaseChain factory = BuildFactoryChain(traj, 0, 40);
+
+            GhostRenderIntent aIntent = GhostRenderDirector.Decide(
+                ChainSampler.Sample(assembler, liveUT, NonLooped), default(GhostRenderIntent), traj.VesselName);
+            GhostRenderIntent fIntent = GhostRenderDirector.Decide(
+                factory, liveUT, NonLooped, default(GhostRenderIntent), traj.VesselName);
+
+            AssertIntentParity(aIntent, fIntent);
+        }
+
+        [Fact]
+        public void InclinedChain_OnConicLeg_CarriesNonEquatorialElements_OnBothSpines()
+        {
+            // GUARD against a vacuous fixture: prove the on-conic intent ACTUALLY carries non-equatorial
+            // orientation on BOTH spines (so the widened AssertIntentParity is exercising the inc/LAN/argPe
+            // path, not 0==0). If a future edit equatorialized the fixture this fails loudly rather than
+            // silently turning the A5 gap back off.
+            var traj = InclinedChain();
+            GhostRenderChain assembler = BuildAssemblerChain(traj, 0, 40);
+            PhaseChain factory = BuildFactoryChain(traj, 0, 40);
+
+            GhostRenderIntent aIntent = GhostRenderDirector.Decide(
+                ChainSampler.Sample(assembler, 20.0, NonLooped), default(GhostRenderIntent), traj.VesselName);
+            GhostRenderIntent fIntent = GhostRenderDirector.Decide(
+                factory, 20.0, NonLooped, default(GhostRenderIntent), traj.VesselName);
+
+            Assert.True(aIntent.Visible && aIntent.Payload.HasConic, "assembler must render the inclined conic at UT 20");
+            Assert.True(fIntent.Visible && fIntent.Payload.HasConic, "factory must render the inclined conic at UT 20");
+            Assert.Equal(28.5, aIntent.Payload.Conic.inclination);
+            Assert.NotEqual(0.0, aIntent.Payload.Conic.inclination);
+            Assert.NotEqual(0.0, aIntent.Payload.Conic.longitudeOfAscendingNode);
+            // and the two spines agree on the full element set (the widened gate)
+            AssertIntentParity(aIntent, fIntent);
+        }
+
+        [Fact]
+        public void InclinedChain_FullSweep_TwoSpines_EmitIdenticalIntents_WithSharedPrior()
+        {
+            // The continuous-run inclined proof: walk [-5, 45] at 0.5s threading the SAME prior through both
+            // spines (as RunFrame does). A divergence on ANY frame on the inclined conic (an inc/LAN/argPe
+            // swap, an epoch/MnA phase slip) fails the widened AssertIntentParity here.
+            var traj = InclinedChain();
+            GhostRenderChain assembler = BuildAssemblerChain(traj, 0, 40);
+            PhaseChain factory = BuildFactoryChain(traj, 0, 40);
+
+            GhostRenderIntent aPrior = default(GhostRenderIntent);
+            GhostRenderIntent fPrior = default(GhostRenderIntent);
+            bool sawConic = false;
+            for (double ut = -5.0; ut <= 45.0; ut += 0.5)
+            {
+                GhostRenderIntent aIntent = GhostRenderDirector.Decide(
+                    ChainSampler.Sample(assembler, ut, NonLooped), aPrior, traj.VesselName);
+                GhostRenderIntent fIntent = GhostRenderDirector.Decide(
+                    factory, ut, NonLooped, fPrior, traj.VesselName);
+
+                AssertIntentParity(aIntent, fIntent);
+                sawConic |= aIntent.Visible && aIntent.Payload.HasConic && aIntent.Payload.Conic.inclination != 0.0;
+                aPrior = aIntent;
+                fPrior = fIntent;
+            }
+            Assert.True(sawConic, "the inclined conic leg must render visible (non-equatorial) somewhere in the sweep");
         }
 
         // ---- Looped / overlap member: the shared span clock keeps the two spines glued (no per-instance) ----

--- a/Source/Parsek.Tests/MapRender/SeamFieldsDrawIrrelevantSourceGateTests.cs
+++ b/Source/Parsek.Tests/MapRender/SeamFieldsDrawIrrelevantSourceGateTests.cs
@@ -1,0 +1,128 @@
+using System;
+using System.IO;
+using System.Text;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    /// <summary>
+    /// Phase-10 A4 source gate (the "compare-vs-gate" decide for <see cref="Parsek.MapRender.RenderSegment"/>
+    /// seam / generated fields). <c>GeometryParityComparator.CompareSegment</c> DELIBERATELY does NOT
+    /// byte-compare <c>RenderSegment.LeadingSeam</c> / <c>TrailingSeam</c> / <c>IsGenerated</c>: the factory
+    /// builds null seams (-> <c>SeamKind.None</c>) while the assembler stamps Rigid/FlexibleSoi, so they
+    /// diverge by construction (seam re-derivation is a spine-side / Phase-5b concern), and they are
+    /// draw-irrelevant TODAY. This gate makes the "draw-irrelevant" claim a CHECKED invariant rather than a
+    /// silent assumption, so the comparator omission is guarded.
+    ///
+    /// <para><b>What it asserts.</b> The two LIVE PIXEL-DRAW paths read ZERO <c>RenderSegment</c> seam /
+    /// <c>IsGenerated</c> fields off a spine-emitted segment:
+    /// <list type="bullet">
+    ///   <item><c>Patches/GhostOrbitLinePatch.cs</c> — the StockConic proto-orbit-line draw.</item>
+    ///   <item><c>Display/GhostTrajectoryPolylineRenderer.cs</c> — the TracedPath owned-polyline draw.</item>
+    /// </list>
+    /// Both draw from <see cref="Recording"/> / <see cref="Orbit"/> / the <c>GhostRenderIntent</c>, which
+    /// carries treatment / payload / frame / drive-UT but NOT seams or <c>IsGenerated</c>
+    /// (<c>GhostRenderIntent.cs</c>). So the comparator cannot let a DRAW-affecting divergence pass by
+    /// skipping those fields.</para>
+    ///
+    /// <para><b>Why this is the right gate BEFORE Phase 5b.</b> Phase 5b deletes the legacy draw and makes
+    /// the descent orbit↔landing G1 seam load-bearing at the draw layer (the
+    /// <see cref="Parsek.MapRender.CrossMemberSeamStitcher"/> stamps it). The instant a draw path starts
+    /// reading a seam / <c>IsGenerated</c> field off a spine segment, this gate fails and forces the
+    /// comparator (and the factory's seam stamping) to be widened at exactly that point — instead of the
+    /// omission silently masking a regression.</para>
+    ///
+    /// <para>Mirrors the <c>FailClosedWiringSourceGateTests</c> source-text approach (strip line comments
+    /// + collapse whitespace, then a substring assertion). A substring gate (NOT a repo-wide forbidden
+    /// token) is correct here because these fields ARE legitimately read elsewhere: the assembler stamps
+    /// them, the <see cref="Parsek.MapRender.CrossMemberSeamStitcher"/> re-stamps the descent seam, the
+    /// tracer summarizes them, and the in-game <c>DescentReStitchInGameTest</c> asserts on a sampled seam.
+    /// Only the live DRAW files must stay clean.</para>
+    /// </summary>
+    public class SeamFieldsDrawIrrelevantSourceGateTests
+    {
+        // The exact member-access tokens a draw path would use to READ a seam / generated field off a
+        // RenderSegment / GhostSample.Segment (e.g. `seg.LeadingSeam`, `sample.Segment.IsGenerated`). The
+        // field name preceded by a '.' catches the read regardless of the local variable name; the
+        // declaring enum/struct names are not flagged (the gate is about READING the field, not the type).
+        private static readonly string[] ForbiddenSeamReads =
+        {
+            ".LeadingSeam",
+            ".TrailingSeam",
+            ".IsGenerated",
+        };
+
+        // The live pixel-draw files, relative to Source/Parsek/.
+        [Theory]
+        [InlineData("Patches/GhostOrbitLinePatch.cs")]
+        [InlineData("Display/GhostTrajectoryPolylineRenderer.cs")]
+        public void LiveDrawPath_ReadsNoRenderSegmentSeamOrGeneratedField(string relPath)
+        {
+            string src = CollapseWhitespace(StripLineComments(ReadParsekSource(relPath)));
+
+            foreach (string token in ForbiddenSeamReads)
+            {
+                Assert.False(
+                    src.Contains(token),
+                    string.Format(
+                        "Phase-10 A4 gate: live draw path '{0}' now reads a RenderSegment seam / generated " +
+                        "field ('{1}'). If Phase 5b (or any other change) has made these fields load-bearing " +
+                        "at the DRAW layer, the GeometryParityComparator MUST be widened to byte-compare " +
+                        "LeadingSeam/TrailingSeam/IsGenerated (and the factory must stamp seams to match) — " +
+                        "do not just delete this gate. See GeometryParityComparator's class header.",
+                        relPath, token));
+            }
+        }
+
+        // SANITY: the comparator's class header documents the deliberate omission + names this gate, so the
+        // decision is discoverable from the code (not only from this test). A wording drift that dropped the
+        // pointer would make the omission silent again.
+        [Fact]
+        public void Comparator_DocumentsSeamOmission_AndNamesThisGate()
+        {
+            string src = ReadParsekSource("MapRender/GeometryParityComparator.cs");
+            Assert.Contains("SeamFieldsDrawIrrelevantSourceGateTests", src);
+            Assert.Contains("Phase-10 A4", src);
+        }
+
+        // ---- helpers (mirrors FailClosedWiringSourceGateTests) ----
+
+        private static string ReadParsekSource(string relPath)
+        {
+            string root = Path.GetFullPath(Path.Combine(
+                AppDomain.CurrentDomain.BaseDirectory, "..", "..", "..", "..", ".."));
+            string path = Path.Combine(root, "Source", "Parsek", relPath.Replace('/', Path.DirectorySeparatorChar));
+            if (!File.Exists(path))
+                path = Path.Combine(root, "Parsek", relPath.Replace('/', Path.DirectorySeparatorChar));
+            Assert.True(File.Exists(path), "Source file not found at " + path);
+            return File.ReadAllText(path);
+        }
+
+        private static string StripLineComments(string source)
+        {
+            var sb = new StringBuilder(source.Length);
+            foreach (string line in source.Split('\n'))
+            {
+                int idx = line.IndexOf("//", StringComparison.Ordinal);
+                sb.Append(idx >= 0 ? line.Substring(0, idx) : line);
+                sb.Append('\n');
+            }
+            return sb.ToString();
+        }
+
+        private static string CollapseWhitespace(string source)
+        {
+            var sb = new StringBuilder(source.Length);
+            bool inWs = false;
+            foreach (char c in source)
+            {
+                if (char.IsWhiteSpace(c))
+                {
+                    if (!inWs) { sb.Append(' '); inWs = true; }
+                }
+                else { sb.Append(c); inWs = false; }
+            }
+            return sb.ToString();
+        }
+    }
+}

--- a/Source/Parsek/InGameTests/DescentEndToEndSpineInGameTest.cs
+++ b/Source/Parsek/InGameTests/DescentEndToEndSpineInGameTest.cs
@@ -1,0 +1,258 @@
+using System.Collections.Generic;
+using System.Globalization;
+using Parsek.MapRender;
+using UnityEngine;
+
+namespace Parsek.InGameTests
+{
+    // Phase 10 / B-row1 (cutover regression harness) - the DESCENT end-to-end SPINE test. It drives a looped
+    // landing flag-ON through the SAME sampler entry point ShadowRenderDriver.RunFrame inlines
+    // (ChainSampler.Sample(PhaseChain, liveUT, units) -> the span-clock remap + the CrossMemberSeamStitcher +
+    // the projection) at three live UTs and asserts the spine's DESCENT DECISION is correct:
+    //
+    //  - TRIGGERED (re-anchored head live, inside the descent clip): the spine resolves a VISIBLE TracedPath
+    //    DescentPhase at the swept-deorbit head (recordedDeorbitUT + (liveUT - triggerUT)), promoted to a
+    //    first-class DescentPhase over the cross-member Rigid orbit-landing seam.
+    //  - PAST-END (past the descent clip): the spine resolves OutsideWindow / Hidden (the stitcher returns no
+    //    held sample), so the descent member's intent retires - the spine's DECISION to not hold a sub-surface
+    //    ghost.
+    //
+    // WHY DRIVE ChainSampler.Sample DIRECTLY (not the per-pid RunFrame loop): RunFrame iterates the LIVE
+    // GhostMapPresence pid set + builds the chain via GetOrBuildChain off a re-aim resolver, which needs a
+    // full ReaimMissionPlan/Schedule to produce a descent-set member - a fragile fixture that frequently
+    // window-misses. ChainSampler.Sample(PhaseChain, ...) is the EXACT pure call RunFrame inlines for the
+    // spine (RunFrame: `sample = ChainSampler.Sample(phaseChain, currentUT, units)`), so driving it against a
+    // hand-built descent PhaseChain + descent-trigger unit exercises the production spine decision path the
+    // headless tests (CrossMemberSeamStitcherTests, pure-clock only) cannot reach: the live-PhaseChain
+    // span-clock remap -> stitcher -> projection -> the GhostSample the Director turns into an intent.
+    //
+    // ARCHITECTURAL TRUTH respected + the GATE FINDING surfaced (NOT a faked pixel change): the spine's
+    // DECISION (re-anchored head / promoted DescentPhase / Hidden-past-clip) is what flag-ON changes today.
+    // The legacy autonomous polyline Driver still OWNS the actual leg DRAW (the pixels), so the Phase-6
+    // sub-surface-retire FIX only LANDS at the draw layer when Phase 5b deletes the legacy draw. This test
+    // therefore asserts the spine's RETIRE DECISION (the sample retires past the clip) and DOCUMENTS - by
+    // asserting the CURRENT observable state - that the leg-draw ownership is still the legacy Driver
+    // (IsRenderingNonOrbitalLeg is NOT driven by this spine sample; the draw-layer retire lands at 5b). It
+    // does NOT assert a sub-surface pixel disappearing this phase.
+    //
+    // NOTE: in-game test (Ctrl+Shift+T / Settings > Diagnostics); cannot run headless (builds a live
+    // PhaseChain over a recording + resolves the destination body). FLIGHT only; career-independent.
+    public class DescentEndToEndSpineInGameTest
+    {
+        private const string DescentBodyName = "Kerbin";
+        private const int DescentMemberIdx = 0;
+        private const int TransferMemberIdx = 2;
+
+        private const double ClipSeconds = 100.0;
+        private const double CaptureShift = -150.0;
+        private const double Trot = 300.0;
+        private const double Tpark = 80.0;
+        private const double Cadence = 4000.0;
+
+        [InGameTest(Category = "MapRender", Scene = GameScenes.FLIGHT,
+            Description = "Phase 10 B-row1 descent end-to-end (spine): the spine's sampler (the RunFrame-"
+                + "inlined ChainSampler.Sample) resolves a VISIBLE re-anchored DescentPhase at a triggered "
+                + "live UT and RETIRES (Hidden, no held sample) past the descent clip; documents that the "
+                + "legacy Driver still owns the leg DRAW (sub-surface retire lands at 5b)")]
+        public void DescentSpine_FlagOn_PromotesReanchoredDescent_RetiresPastClip_LegDrawStillLegacy()
+        {
+            CelestialBody body = FlightGlobals.Bodies?.Find(b => b.bodyName == DescentBodyName);
+            if (body == null)
+            {
+                InGameAssert.Skip("destination body not found in FlightGlobals.Bodies (non-stock pack)");
+                return;
+            }
+
+            double now = Planetarium.GetUniversalTime();
+            double phaseAnchor = now;
+            double recordedDeorbitUT = now + 200.0;
+            double descentEndUT = recordedDeorbitUT + ClipSeconds;
+            double spanStart = now;
+            double spanEnd = now + 1000.0;
+
+            bool prevForceSpine = ShadowRenderDriver.ForceSpineDriveForTesting;
+            bool prevForceTrace = MapRenderTrace.ForceEnabledForTesting;
+
+            try
+            {
+                MapRenderTrace.ForceEnabledForTesting = true;
+                ShadowRenderDriver.ForceSpineDriveForTesting = true; // the spine drives (flag ON)
+
+                GhostPlaybackLogic.LoopUnitSet units = BuildDescentUnitSet(
+                    phaseAnchor, spanStart, spanEnd, recordedDeorbitUT, descentEndUT);
+                Recording rec = BuildDescentRecording(recordedDeorbitUT, descentEndUT);
+                PhaseChain chain = PhaseFactory.BuildPhaseChain(
+                    rec, DescentMemberIdx, instanceKey: 0,
+                    windowStartUT: recordedDeorbitUT - 50.0, windowEndUT: descentEndUT);
+
+                Parsek.Reaim.DescentTrigger.ComputeDescentTiming(
+                    0, phaseAnchor, Cadence, spanStart, recordedDeorbitUT, Trot, CaptureShift, null,
+                    out _, out double entryUT, out double triggerUT);
+
+                if (double.IsNaN(triggerUT))
+                {
+                    InGameAssert.Skip("descent trigger did not resolve for this fixture (degenerate timing)");
+                    return;
+                }
+
+                double triggeredLiveUT = triggerUT + 0.4 * ClipSeconds; // inside the clip
+                double pastEndLiveUT = triggerUT + 1.5 * ClipSeconds;   // past the clip => retire
+
+                // --- TRIGGERED frame: drive the SAME sampler RunFrame inlines for the spine path ---
+                GhostSample triggered = ChainSampler.Sample(chain, triggeredLiveUT, units);
+                // The Director turns that GhostSample into the intent the same way RunFrame does.
+                GhostRenderIntent triggeredIntent = GhostRenderDirector.Decide(
+                    triggered, GhostRenderIntent.Hidden(), rec.VesselName);
+
+                // --- PAST-END frame: same sampler, past the clip ---
+                GhostSample pastEnd = ChainSampler.Sample(chain, pastEndLiveUT, units);
+                GhostRenderIntent pastEndIntent = GhostRenderDirector.Decide(
+                    pastEnd, triggeredIntent /* prior was visible */, rec.VesselName);
+
+                ParsekLog.Info("TestRunner", string.Format(CultureInfo.InvariantCulture,
+                    "DescentSpine: deorbit={0:R} entry={1:R} trigger={2:R} | triggered cov={3} treat={4} "
+                    + "vis={5} driveUT={6:R} body={7} | pastEnd cov={8} vis={9}",
+                    recordedDeorbitUT, entryUT, triggerUT, triggered.Coverage, triggered.Treatment,
+                    triggeredIntent.Visible, triggered.DriveUT, triggered.FrameBodyName ?? "?",
+                    pastEnd.Coverage, pastEndIntent.Visible));
+
+                // (i) THE SPINE DECISION at the trigger: a VISIBLE re-anchored TracedPath descent.
+                InGameAssert.AreEqual(Coverage.InSegment, triggered.Coverage,
+                    "the spine must resolve the descent InSegment at the triggered live UT (re-anchored head "
+                    + "inside the clip)");
+                InGameAssert.AreEqual(Treatment.TracedPath, triggered.Treatment,
+                    "the promoted descent is a body-fixed TracedPath leg (polyline-owned)");
+                InGameAssert.IsTrue(triggeredIntent.Visible,
+                    "the spine's descent intent must be VISIBLE at the triggered head");
+                InGameAssert.AreEqual(DescentBodyName, triggered.FrameBodyName,
+                    "the promoted descent renders on the destination body");
+                InGameAssert.ApproxEqual(
+                    recordedDeorbitUT + (triggeredLiveUT - triggerUT), triggered.DriveUT, 1e-3,
+                    "the descent DriveUT is the swept deorbit head (recordedDeorbitUT + (liveUT - triggerUT))");
+                InGameAssert.AreEqual(SeamKind.Rigid, triggered.Segment.LeadingSeam,
+                    "the promoted descent carries the cross-member orbit-landing Rigid leading seam (the "
+                    + "stitcher owns it; the factory leaves it None) - the spine's seam decision");
+
+                // The promoted phase the spine located is a first-class DescentPhase (no longer hidden).
+                InGameAssert.IsTrue(
+                    chain.TryGetPhase(triggered.DriveUT, out TrajectoryPhase phase, out _),
+                    "the chain must locate a phase at the re-anchored head");
+                InGameAssert.IsTrue(phase is DescentPhase,
+                    "the spine promotes a first-class DescentPhase (visible, no longer hidden in transfer)");
+
+                // (ii) THE SPINE RETIRE DECISION past the clip: the sample is OutsideWindow and the intent
+                // retires to Hidden (no held sub-surface sample). This is the spine's decision; the actual
+                // sub-surface PIXEL only stops at 5b (see the gate finding below).
+                InGameAssert.AreEqual(Coverage.OutsideWindow, pastEnd.Coverage,
+                    "past the descent clip the spine must resolve OutsideWindow (the stitcher returns no held "
+                    + "sample - the spine's retire decision)");
+                InGameAssert.IsFalse(pastEndIntent.Visible,
+                    "the spine's descent intent must RETIRE (Hidden) past the clip, even though the prior "
+                    + "frame was visible - the spine does not hold a sub-surface ghost");
+
+                // (iii) THE GATE FINDING (documented, not faked): the ACTUAL leg DRAW is still owned by the
+                // legacy autonomous polyline Driver. The spine's intent above is the DECISION source; it does
+                // NOT itself drive the pixels. So the polyline ownership signal for this recording is NOT set
+                // by this spine sample (no live map render walk ran), confirming the Phase-6 sub-surface-retire
+                // FIX lands at the DRAW layer only when Phase 5b deletes the legacy draw. We assert the CURRENT
+                // observable state (ownership not driven by the spine sample) rather than a pixel change.
+                bool legDrawOwnedByPolyline =
+                    Parsek.Display.GhostTrajectoryPolylineRenderer.IsRenderingNonOrbitalLeg(rec.RecordingId);
+                InGameAssert.IsFalse(legDrawOwnedByPolyline,
+                    "GATE FINDING (documents the 5b-pending state): the spine's descent DECISION does not "
+                    + "itself own the leg DRAW - IsRenderingNonOrbitalLeg is false because no live polyline "
+                    + "walk drew this recording's leg (the legacy autonomous Driver owns the draw; the "
+                    + "sub-surface-retire fix lands at the DRAW layer at Phase 5b). This asserts the current "
+                    + "decision-source-swap contract, NOT a 5b-only pixel change.");
+
+                ParsekLog.Info("TestRunner",
+                    "DescentSpine GATE FINDING: spine descent DECISION is correct (visible re-anchored head + "
+                    + "retire past clip), but the leg DRAW ownership remains the legacy Driver - the "
+                    + "sub-surface-retire pixel change lands at Phase 5b (legacy-draw deletion).");
+            }
+            finally
+            {
+                ShadowRenderDriver.ForceSpineDriveForTesting = prevForceSpine;
+                ShadowRenderDriver.Reset();
+                MapRenderTrace.ForceEnabledForTesting = prevForceTrace;
+            }
+        }
+
+        // A descent-trigger LoopUnit + set whose descent set = {DescentMemberIdx}. Mirrors the working
+        // headless fixture (Supported plan + valid schedule => IsReaim; non-NaN periods + non-empty descent
+        // set => HasDescentTrigger).
+        private static GhostPlaybackLogic.LoopUnitSet BuildDescentUnitSet(
+            double phaseAnchor, double spanStart, double spanEnd,
+            double recordedDeorbitUT, double descentEndUT)
+        {
+            var plan = new Parsek.Reaim.ReaimMissionPlan { Supported = true };
+            var sched = new Parsek.Reaim.ReaimWindowPlanner.ReaimWindowSchedule { Valid = true };
+            var unit = new GhostPlaybackLogic.LoopUnit(
+                ownerIndex: TransferMemberIdx, memberIndices: new[] { DescentMemberIdx, TransferMemberIdx },
+                spanStartUT: spanStart, spanEndUT: spanEnd, cadenceSeconds: Cadence, phaseAnchorUT: phaseAnchor,
+                overlapCadenceSeconds: Cadence, memberWindows: null, relaunchSchedule: null,
+                reaimPlan: plan, reaimSchedule: sched,
+                loiterCuts: null, arrivalHoldSeconds: 0.0, arrivalHoldAtUT: double.NaN,
+                arrivalAlignPeriodSeconds: double.NaN, arrivalAmberReason: null,
+                launchBodyRotationPeriodSeconds: double.NaN, launchHoldEngaged: false,
+                recordedSoiExitUT: double.NaN,
+                descentMemberIndices: new[] { DescentMemberIdx }, recordedDeorbitUT: recordedDeorbitUT,
+                descentEndUT: descentEndUT, destinationBodyRotationPeriodSeconds: Trot,
+                loiterPeriodSeconds: Tpark, captureShiftSeconds: CaptureShift,
+                transferMemberIndex: TransferMemberIdx);
+            var ownerByIndex = new Dictionary<int, int>
+            {
+                { DescentMemberIdx, TransferMemberIdx }, { TransferMemberIdx, TransferMemberIdx },
+            };
+            return new GhostPlaybackLogic.LoopUnitSet(
+                new Dictionary<int, GhostPlaybackLogic.LoopUnit> { { TransferMemberIdx, unit } }, ownerByIndex);
+        }
+
+        // The descent member's recording: a parking conic [deorbit-50, deorbit] then a body-fixed atmospheric
+        // reentry/descent run [deorbit, descentEnd] so the factory classifies the traced run as a DescentPhase
+        // (a non-surface/non-approach traced run AFTER the first conic).
+        private static Recording BuildDescentRecording(double recordedDeorbitUT, double descentEndUT)
+        {
+            var rec = new Recording
+            {
+                RecordingId = "descent-spine-" + System.Guid.NewGuid().ToString("N"),
+                VesselName = "Parsek Descent Spine",
+                EndpointPhase = RecordingEndpointPhase.SurfacePosition,
+                EndpointBodyName = DescentBodyName,
+                ExplicitStartUT = recordedDeorbitUT - 50.0,
+                ExplicitEndUT = descentEndUT,
+                PlaybackEnabled = true,
+            };
+            rec.Points.Add(new TrajectoryPoint
+            {
+                ut = recordedDeorbitUT, latitude = 0.0, longitude = 0.0, altitude = 45000.0,
+                rotation = Quaternion.identity, velocity = new Vector3(0f, -200f, 0f), bodyName = DescentBodyName,
+            });
+            rec.Points.Add(new TrajectoryPoint
+            {
+                ut = 0.5 * (recordedDeorbitUT + descentEndUT), latitude = 0.1, longitude = 0.05, altitude = 20000.0,
+                rotation = Quaternion.identity, velocity = new Vector3(0f, -150f, 0f), bodyName = DescentBodyName,
+            });
+            rec.Points.Add(new TrajectoryPoint
+            {
+                ut = descentEndUT, latitude = 0.2, longitude = 0.1, altitude = 100.0,
+                rotation = Quaternion.identity, velocity = new Vector3(0f, -10f, 0f), bodyName = DescentBodyName,
+            });
+            rec.OrbitSegments.Add(new OrbitSegment
+            {
+                startUT = recordedDeorbitUT - 50.0, endUT = recordedDeorbitUT,
+                bodyName = DescentBodyName, semiMajorAxis = 700000.0, eccentricity = 0.01, epoch = recordedDeorbitUT - 50.0,
+            });
+            rec.TrackSections.Add(new TrackSection
+            {
+                startUT = recordedDeorbitUT - 50.0, endUT = recordedDeorbitUT, environment = SegmentEnvironment.ExoBallistic,
+            });
+            rec.TrackSections.Add(new TrackSection
+            {
+                startUT = recordedDeorbitUT, endUT = descentEndUT, environment = SegmentEnvironment.Atmospheric,
+            });
+            rec.MarkFilesDirty();
+            return rec;
+        }
+    }
+}

--- a/Source/Parsek/InGameTests/FlagOnParityBaselineInGameTest.cs
+++ b/Source/Parsek/InGameTests/FlagOnParityBaselineInGameTest.cs
@@ -1,0 +1,325 @@
+using System.Collections.Generic;
+using System.Globalization;
+using Parsek.MapRender;
+using UnityEngine;
+
+namespace Parsek.InGameTests
+{
+    // Phase 10 / A3 (cutover regression harness) - the FLAG-ON parity-BASELINE in-game test, the positive
+    // gate proving that with the typed PhaseChain spine DRIVING (ForceSpineDriveForTesting), a known-good
+    // faithful ghost rendered live reports ZERO parity-drift across ALL THREE Phase-9 oracle modes
+    // (faithful + synthesized + polyline).
+    //
+    // WHY THIS DID NOT EXIST: the existing RenderParityBaselineTest captures the zero-drift baseline with the
+    // spine flag OFF (the legacy assembler spine drives the orbit; the flag only swaps the DECISION source).
+    // PhaseSpineSwapInGameTest proves flag-ON and flag-OFF stamp the SAME seed and read zero FAITHFUL drift,
+    // but it exercises only the faithful oracle. This test closes the gap the 5-lens audit found: the
+    // KNOWN-GOOD baseline run with the spine ON, asserted through every oracle lens at once, so a flag-ON
+    // regression that diverged in ANY lens (faithful recorded-vs-rendered, synthesized rendered-vs-intended,
+    // or polyline rendered-leg-vs-recorded-track) lights up here.
+    //
+    // ARCHITECTURAL TRUTH respected: flag-ON only swaps the decision SOURCE - the legacy code still DRAWS the
+    // pixels (GhostOrbitLinePatch / the autonomous polyline Driver). So this asserts the CURRENT contract:
+    //  (i)  the spine's DECISION matches what flag-OFF would decide for a faithful member (the seed the icon-
+    //       drive reads is byte-identical across the flag), and
+    //  (ii) the live Phase-9 oracle stays GREEN (zero drift) on the correct draw, in all three modes.
+    // It does NOT assert any geometry change that only Phase 5b delivers.
+    //
+    // The three oracle modes:
+    //  - FAITHFUL  : MapRenderProbe.ComputeFaithfulOrbitParity on the live OrbitDriver.orbit vs the recorded
+    //                segment, PHASE-MATCHED. (the rendered-vs-recorded lens)
+    //  - SYNTHESIZED: MapRenderProbe.ComputeSynthesizedConicParity of the live orbit vs the Director's fresh
+    //                StockConic seed (ShadowRenderDriver.TryGetFreshStockConicSeed) - for a faithful StockConic
+    //                member the rendered orbit IS the seed, so it reads ~0. (the rendered-vs-intended lens)
+    //  - POLYLINE  : the leg-track lens (RenderParityOracle.ComputeDriftScaleDerived, ParityMode.Synthesized)
+    //                on a real body-framed recorded leg arc diffed against itself (rendered == recorded for a
+    //                non-anchored body-fixed leg). The live CaptureRenderedVsRecordedLegGeometry walk needs a
+    //                populated polylineCache from an actual map render, which a headless test harness cannot
+    //                produce; this mirrors FailClosedFaithfulInGameTest's established in-game polyline-lens
+    //                pattern (a real Unity-framed leg arc through the live body's world surface positions,
+    //                diffed against itself => the oracle's rendered==recorded zero-drift contract).
+    //
+    // NOTE: in-game test (Ctrl+Shift+T / Settings > Diagnostics); cannot run headless (builds a live ghost
+    // ProtoVessel, reads its OrbitDriver, drives RunFrame against a live MapViewScene, frames a leg arc
+    // through Kerbin's world surface positions). FLIGHT only; career-independent.
+    public class FlagOnParityBaselineInGameTest
+    {
+        private const string KerbinBodyName = "Kerbin";
+        private const double Sma = 850000.0;
+        private const double Ecc = 0.0;
+        private const double Inc = 0.0;
+        private const double KerbinRadiusFallback = 600000.0;
+
+        // A non-zero loop epoch shift (~18 min) for the loop-shifted arm, exercising the loop-shift epoch
+        // bake (the false-drift blocker path) end-to-end through the real seam under the SPINE-ON flag.
+        private const double LoopEpochShiftSeconds = 1100.0;
+
+        [InGameTest(Category = "MapRender", Scene = GameScenes.FLIGHT,
+            Description = "Phase 10 A3 flag-ON parity baseline: with the typed PhaseChain spine DRIVING, a "
+                + "known-good faithful ghost rendered live reports ZERO parity-drift across all THREE Phase-9 "
+                + "oracle modes (faithful + synthesized + polyline)")]
+        public void FlagOnBaseline_KnownGoodGhost_ZeroDrift_AllThreeOracleModes()
+        {
+            RunFlagOnAllModeBaseline(LoopEpochShiftSeconds: 0.0);
+        }
+
+        [InGameTest(Category = "MapRender", Scene = GameScenes.FLIGHT,
+            Description = "Phase 10 A3 flag-ON parity baseline (LOOP-SHIFTED): with the spine DRIVING, a "
+                + "ghost whose live orbit epoch is baked with a NON-ZERO loop shift reports ZERO parity-drift "
+                + "across all THREE oracle modes - the spine-ON proof the loop-shift epoch bake stays correct")]
+        public void FlagOnBaseline_LoopShiftedGhost_ZeroDrift_AllThreeOracleModes()
+        {
+            RunFlagOnAllModeBaseline(LoopEpochShiftSeconds);
+        }
+
+        private static void RunFlagOnAllModeBaseline(double LoopEpochShiftSeconds)
+        {
+            CelestialBody kerbin = FlightGlobals.Bodies?.Find(b => b.bodyName == KerbinBodyName);
+            if (kerbin == null)
+            {
+                InGameAssert.Skip("Kerbin not found in FlightGlobals.Bodies (non-stock pack)");
+                return;
+            }
+
+            double liveUT = Planetarium.GetUniversalTime();
+            // A loop-shifted ghost replays a PAST recorded segment whose effUT = liveUT - shift; author the
+            // segment around that effUT so the covering-segment lookup at the drive clock resolves.
+            double effUT = liveUT - LoopEpochShiftSeconds;
+            double startUT = effUT - 1800.0;
+            OrbitSegment seg = BuildSegment(startUT);
+
+            bool prevForceSpine = ShadowRenderDriver.ForceSpineDriveForTesting;
+            bool prevForceTrace = MapRenderTrace.ForceEnabledForTesting;
+            System.Func<double> prevUTNow = GhostMapPresence.CurrentUTNow;
+            var capturedLines = new List<string>();
+            System.Action<string> prevSink = ParsekLog.TestSinkForTesting;
+            bool prevSuppress = ParsekLog.SuppressLogging;
+            List<Recording> prevRecordings = RecordingStore.CommittedRecordings != null
+                ? new List<Recording>(RecordingStore.CommittedRecordings)
+                : new List<Recording>();
+            List<RecordingTree> prevTrees = RecordingStore.CommittedTrees != null
+                ? new List<RecordingTree>(RecordingStore.CommittedTrees)
+                : new List<RecordingTree>();
+
+            Recording rec = BuildRecording(startUT, seg);
+            RecordingStore.ClearCommittedInternal();
+            RecordingStore.ClearCommittedTreesInternal();
+            RecordingStore.AddCommittedInternal(rec);
+            int recordingIndex = RecordingStore.CommittedRecordings.Count - 1;
+            GhostMapPresence.CurrentUTNow = () => liveUT;
+            GhostMapPresence.RemoveAllGhostVessels("flagon-baseline-start");
+            ShadowRenderDriver.Reset();
+
+            uint pid = 0u;
+            try
+            {
+                MapRenderTrace.ForceEnabledForTesting = true;   // the parity sink + anomaly raises are live
+                ShadowRenderDriver.ForceSpineDriveForTesting = true; // THE SPINE DRIVES (flag ON)
+                ParsekLog.SuppressLogging = false;
+                ParsekLog.TestSinkForTesting = line => capturedLines.Add(line);
+
+                Vessel ghost = GhostMapPresence.CreateGhostVesselFromSource(
+                    recordingIndex, rec, GhostMapPresence.TrackingStationGhostSource.Segment,
+                    seg, default(TrajectoryPoint), startUT, loopEpochShiftSeconds: LoopEpochShiftSeconds);
+
+                if (ghost == null || ghost.orbitDriver == null || ghost.orbitDriver.orbit == null)
+                {
+                    InGameAssert.Skip("Faithful ghost did not create in this context (no proto)");
+                    return;
+                }
+                pid = ghost.persistentId;
+
+                var scene = new MapViewScene();
+                scene.SetFrameInputs(GhostPlaybackLogic.LoopUnitSet.Empty, liveUT);
+                if (!scene.IsActive)
+                {
+                    InGameAssert.Skip("MapViewScene not active (not in FLIGHT)");
+                    return;
+                }
+
+                // Drive the REAL wired RunFrame with the SPINE ON so the typed PhaseChain decides the intent
+                // and stamps the StockConic seed (the drive the icon-drive patch reads + the synthesized
+                // oracle diffs against). Reset before so the per-pid prior intent / chain cache is clean.
+                ShadowRenderDriver.Reset();
+                ShadowRenderDriver.RunFrame(scene);
+
+                Orbit renderedOrbit = ghost.orbitDriver.orbit;
+                Vector3d iconBodyRel = ghost.GetWorldPos3D() - kerbin.position;
+                if (iconBodyRel.magnitude < 1.0)
+                {
+                    InGameAssert.Skip("Ghost world position not resolved on the creation frame");
+                    return;
+                }
+
+                // The loop shift the live orbit was ACTUALLY baked with (read from the production map, not a
+                // local constant): the same value both oracle lenses thread into the phase-matched reference.
+                double loopShift = GhostMapPresence.GetGhostOrbitEpochShift(pid);
+                InGameAssert.ApproxEqual(LoopEpochShiftSeconds, loopShift, 1.0,
+                    "the spine-ON ghost must record the loop epoch shift the production probe reads back");
+
+                // --- ORACLE MODE 1: FAITHFUL (rendered orbit vs recorded segment, PHASE-MATCHED) ---
+                MapRenderProbe.FaithfulParitySample faithful = MapRenderProbe.ComputeFaithfulOrbitParity(
+                    renderedOrbit, kerbin, iconBodyRel, effUT, loopShift, liveUT, rec.RecordingId);
+                InGameAssert.IsTrue(faithful.Sampled,
+                    "FAITHFUL oracle must SAMPLE (not skip) the spine-ON faithful ghost; skipReason="
+                    + (faithful.SkipReason ?? "(none)"));
+                InGameAssert.IsTrue(faithful.Result.HasMeasurement,
+                    "FAITHFUL oracle must yield a measurement (else the lens is blind)");
+                InGameAssert.IsFalse(faithful.Result.OverTolerance,
+                    string.Format(CultureInfo.InvariantCulture,
+                        "FAITHFUL oracle must read ZERO drift on the spine-ON known-good ghost; maxDev={0:F1}m "
+                        + "tol={1:F1}m. The spine is driving a different orbit than the recorded segment.",
+                        faithful.Result.MaxDeviationMeters, faithful.Result.ToleranceMeters));
+
+                // --- ORACLE MODE 2: SYNTHESIZED (rendered orbit vs the Director's fresh StockConic seed) ---
+                // The spine stamped the seed in RunFrame above; the synthesized lens diffs the rendered orbit
+                // against it. For a faithful StockConic member the rendered orbit IS the seed, so ~0.
+                bool hasSeed = ShadowRenderDriver.TryGetFreshStockConicSeed(
+                    pid, Time.frameCount, out OrbitSegment seed, out string seedBody);
+                InGameAssert.IsTrue(hasSeed,
+                    "the spine-ON RunFrame must stamp a fresh StockConic seed for the synthesized oracle to "
+                    + "diff against (none stamped)");
+                MapRenderProbe.SynthesizedConicParitySample synth =
+                    MapRenderProbe.ComputeSynthesizedConicParity(
+                        renderedOrbit, kerbin, iconBodyRel, seed, seedBody, loopShift, liveUT);
+                InGameAssert.IsTrue(synth.Sampled,
+                    "SYNTHESIZED oracle must SAMPLE the rendered-vs-seed diff; skipReason="
+                    + (synth.SkipReason ?? "(none)"));
+                InGameAssert.IsTrue(synth.Result.HasMeasurement,
+                    "SYNTHESIZED oracle must yield a measurement");
+                InGameAssert.IsFalse(synth.Result.OverTolerance,
+                    string.Format(CultureInfo.InvariantCulture,
+                        "SYNTHESIZED oracle must read ZERO drift (the rendered orbit IS the spine's seed for a "
+                        + "faithful StockConic member); maxDev={0:F1}m tol={1:F1}m.",
+                        synth.Result.MaxDeviationMeters, synth.Result.ToleranceMeters));
+
+                // --- ORACLE MODE 3: POLYLINE (rendered leg track vs recorded leg track) ---
+                // A real Unity-framed body-fixed leg arc (Kerbin world surface positions) diffed against
+                // itself in the polyline lens (ParityMode.Synthesized, the same mode the live polyline-leg
+                // capture uses): a non-anchored body-fixed leg draws its points3 == the raw recorded track,
+                // so rendered == recorded => zero drift. This is the established in-game polyline-lens pattern
+                // (the live polylineCache walk needs an actual map render the harness cannot produce).
+                double[] recordedLegArc = BuildKerbinFramedLegArc(kerbin);
+                RenderParityOracle.ParityResult polyline = RenderParityOracle.ComputeDriftScaleDerived(
+                    RenderParityOracle.ParityMode.Synthesized, recordedLegArc, recordedLegArc);
+                InGameAssert.AreEqual(RenderParityOracle.ParityMode.Synthesized, polyline.Mode,
+                    "the polyline lens runs in Synthesized mode (rendered leg vs recorded leg track)");
+                InGameAssert.IsTrue(polyline.HasMeasurement,
+                    "POLYLINE oracle must yield a measurement (else the lens is blind)");
+                InGameAssert.IsFalse(polyline.OverTolerance,
+                    "POLYLINE oracle must read ZERO drift for a non-anchored body-fixed leg drawn verbatim "
+                    + "(rendered == recorded)");
+
+                ParsekLog.Info("TestRunner", string.Format(CultureInfo.InvariantCulture,
+                    "FlagOnBaseline_AllThreeModes: pid={0} loopShift={1:F1} | faithfulDev={2:F1}m "
+                    + "synthDev={3:F1}m polylineDev={4:F2}m | faithfulTol={5:F1}m synthTol={6:F1}m "
+                    + "polylineTol={7:F2}m",
+                    pid, loopShift, faithful.Result.MaxDeviationMeters, synth.Result.MaxDeviationMeters,
+                    polyline.MaxDeviationMeters, faithful.Result.ToleranceMeters,
+                    synth.Result.ToleranceMeters, polyline.ToleranceMeters));
+
+                // Mirror the production emit decision: a known-good spine-ON ghost emits NO parity-drift
+                // anomaly. The RunFrame pass above already ran with the trace sink live; assert no line fired.
+                foreach (string line in capturedLines)
+                    InGameAssert.IsFalse(
+                        line.Contains("[MapRenderTrace]")
+                        && line.Contains("reason=" + MapRenderTrace.AnomalyParityDrift),
+                        "the spine-ON known-good baseline must emit NO parity-drift anomaly; saw: " + line);
+            }
+            finally
+            {
+                ParsekLog.TestSinkForTesting = prevSink;
+                ParsekLog.SuppressLogging = prevSuppress;
+                if (pid != 0u)
+                    GhostMapPresence.RemoveAllGhostVessels("flagon-baseline-cleanup");
+                ShadowRenderDriver.ForceSpineDriveForTesting = prevForceSpine;
+                ShadowRenderDriver.Reset();
+                MapRenderTrace.ForceEnabledForTesting = prevForceTrace;
+                RecordingStore.ClearCommittedInternal();
+                RecordingStore.ClearCommittedTreesInternal();
+                for (int i = 0; i < prevRecordings.Count; i++)
+                    RecordingStore.AddCommittedInternal(prevRecordings[i]);
+                for (int i = 0; i < prevTrees.Count; i++)
+                    RecordingStore.AddCommittedTreeInternal(prevTrees[i]);
+                GhostMapPresence.CurrentUTNow = prevUTNow;
+            }
+        }
+
+        // A real Unity-framed body-fixed leg arc (Kerbin's own world surface positions, body-relative so the
+        // absolute frame cancels). The exact geometry is not load-bearing - it must be a finite multi-point
+        // arc the polyline lens can diff against itself (rendered == recorded => zero drift). Mirrors
+        // FailClosedFaithfulInGameTest.BuildJoolFramedArc.
+        private static double[] BuildKerbinFramedLegArc(CelestialBody kerbin)
+        {
+            const int n = 8;
+            var flat = new double[n * 3];
+            for (int i = 0; i < n; i++)
+            {
+                double lon = i * 9.0;        // a spread of longitudes
+                double alt = 40000.0;        // an atmospheric / descent-band altitude
+                Vector3d p = kerbin.GetWorldSurfacePosition(0.0, lon, alt) - kerbin.position;
+                flat[i * 3] = p.x;
+                flat[i * 3 + 1] = p.y;
+                flat[i * 3 + 2] = p.z;
+            }
+            return flat;
+        }
+
+        private static OrbitSegment BuildSegment(double startUT)
+        {
+            return new OrbitSegment
+            {
+                startUT = startUT,
+                endUT = startUT + 3600.0,
+                inclination = Inc,
+                eccentricity = Ecc,
+                semiMajorAxis = Sma,
+                longitudeOfAscendingNode = 0.0,
+                argumentOfPeriapsis = 0.0,
+                meanAnomalyAtEpoch = 0.0,
+                epoch = startUT,
+                bodyName = KerbinBodyName,
+                isPredicted = false,
+                orbitalFrameRotation = Quaternion.identity,
+                angularVelocity = Vector3.zero,
+            };
+        }
+
+        private static Recording BuildRecording(double startUT, OrbitSegment seg)
+        {
+            double endUT = startUT + 3600.0;
+            var rec = new Recording
+            {
+                RecordingId = "flagon-baseline-" + System.Guid.NewGuid().ToString("N"),
+                VesselName = "Parsek FlagOn Baseline",
+                TerminalStateValue = null,
+                EndpointPhase = RecordingEndpointPhase.OrbitSegment,
+                EndpointBodyName = KerbinBodyName,
+                TerminalOrbitBody = KerbinBodyName,
+                TerminalOrbitSemiMajorAxis = Sma,
+                TerminalOrbitEccentricity = Ecc,
+                TerminalOrbitInclination = Inc,
+                TerminalOrbitLAN = 0.0,
+                TerminalOrbitArgumentOfPeriapsis = 0.0,
+                TerminalOrbitMeanAnomalyAtEpoch = 0.0,
+                TerminalOrbitEpoch = startUT,
+                ExplicitStartUT = startUT,
+                ExplicitEndUT = endUT,
+                PlaybackEnabled = true,
+            };
+            rec.Points.Add(new TrajectoryPoint
+            {
+                ut = startUT, latitude = 0.0, longitude = 0.0, altitude = Sma - KerbinRadiusFallback,
+                rotation = Quaternion.identity, velocity = new Vector3(0f, 2200f, 0f), bodyName = KerbinBodyName,
+            });
+            rec.Points.Add(new TrajectoryPoint
+            {
+                ut = endUT, latitude = 0.0, longitude = 5.0, altitude = Sma - KerbinRadiusFallback,
+                rotation = Quaternion.identity, velocity = new Vector3(0f, 2200f, 0f), bodyName = KerbinBodyName,
+            });
+            rec.OrbitSegments.Add(seg);
+            rec.MarkFilesDirty();
+            return rec;
+        }
+    }
+}

--- a/Source/Parsek/InGameTests/ParentAnchoredChildSpineInGameTest.cs
+++ b/Source/Parsek/InGameTests/ParentAnchoredChildSpineInGameTest.cs
@@ -1,0 +1,256 @@
+using System.Collections.Generic;
+using System.Globalization;
+using Parsek.MapRender;
+using UnityEngine;
+
+namespace Parsek.InGameTests
+{
+    // Phase 10 / B-row4 (cutover regression harness) - the PARENT-ANCHORED controlled-child spine test. A
+    // controlled-decoupled child (a lander / probe / capsule off a parent through a decoupler:
+    // IsDebris=false, ParentAnchorRecordingId set) renders through its own body-relative arc while close to
+    // its parent. This test drives such a child flag-ON and asserts BOTH halves of the v1 contract:
+    //
+    //  (a) THE DUAL-SURFACE ROUTING DECISION (the AnchorFrameResolver.ResolveParentAnchoredChild decision):
+    //      against a LIVE-body-scaled UT range,
+    //        - >= 2 body-fixed samples AND the UT in-range  -> BodyFixedPrimary (render via bodyFixedFrames),
+    //        - the body-fixed primary unusable but an anchor-local frames surface covers the UT (loop-anchored
+    //          chain fallback)                               -> AnchorLocalSecondary,
+    //        - the UT out-of-range / too few samples         -> RETIRE (never clamp to a stale child offset -
+    //          the documented "stale ghost" bug it prevents).
+    //      The pure decision matrix is locked headlessly in AnchorFrameTests; here we exercise it against a
+    //      LIVE-body UT scale (the same body the rendered child arc is framed through) so the in-game
+    //      contract holds on real clock magnitudes, not just synthetic small numbers.
+    //
+    //  (b) THE ORACLE GREEN: a live parent-anchored child ghost on a body-relative orbit arc, driven through
+    //      the REAL wired RunFrame with the spine ON, reports ZERO faithful parity-drift (the rendered arc is
+    //      the recorded arc). A child whose dual-surface routing or body-relative framing drew it off its
+    //      recorded track would drift here.
+    //
+    // ARCHITECTURAL TRUTH respected: this asserts the spine's routing DECISION + the live oracle staying GREEN
+    // on the correct draw. It does NOT assert any geometry change that only Phase 5b delivers.
+    //
+    // NOTE: in-game test (Ctrl+Shift+T / Settings > Diagnostics); cannot run headless (builds a live child
+    // ghost ProtoVessel, reads its OrbitDriver, drives RunFrame, scales the dual-surface UT range off the live
+    // body). FLIGHT only; career-independent.
+    public class ParentAnchoredChildSpineInGameTest
+    {
+        private const string KerbinBodyName = "Kerbin";
+        private const double Sma = 750000.0;   // a body-relative parking arc around the parent's body
+        private const double Ecc = 0.0;
+        private const double Inc = 6.0;
+        private const double KerbinRadiusFallback = 600000.0;
+
+        [InGameTest(Category = "MapRender", Scene = GameScenes.FLIGHT,
+            Description = "Phase 10 B-row4 parent-anchored child (spine): the dual-surface routing decision is "
+                + "correct (>=2-sample in-range -> body-fixed primary; out-of-range -> RETIRE, never clamp) on "
+                + "a live-body UT scale, and a controlled-decoupled child ghost driven through RunFrame (spine "
+                + "ON) reports ZERO faithful parity-drift")]
+        public void ParentAnchoredChild_FlagOn_DualSurfaceRoutingCorrect_OracleGreen()
+        {
+            CelestialBody kerbin = FlightGlobals.Bodies?.Find(b => b.bodyName == KerbinBodyName);
+            if (kerbin == null)
+            {
+                InGameAssert.Skip("Kerbin not found in FlightGlobals.Bodies (non-stock pack)");
+                return;
+            }
+
+            double liveUT = Planetarium.GetUniversalTime();
+            double startUT = liveUT - 1800.0;
+            OrbitSegment seg = BuildSegment(startUT);
+
+            bool prevForceSpine = ShadowRenderDriver.ForceSpineDriveForTesting;
+            bool prevForceTrace = MapRenderTrace.ForceEnabledForTesting;
+            System.Func<double> prevUTNow = GhostMapPresence.CurrentUTNow;
+            List<Recording> prevRecordings = RecordingStore.CommittedRecordings != null
+                ? new List<Recording>(RecordingStore.CommittedRecordings)
+                : new List<Recording>();
+            List<RecordingTree> prevTrees = RecordingStore.CommittedTrees != null
+                ? new List<RecordingTree>(RecordingStore.CommittedTrees)
+                : new List<RecordingTree>();
+
+            Recording rec = BuildControlledChildRecording(startUT, seg);
+            RecordingStore.ClearCommittedInternal();
+            RecordingStore.ClearCommittedTreesInternal();
+            RecordingStore.AddCommittedInternal(rec);
+            int recordingIndex = RecordingStore.CommittedRecordings.Count - 1;
+            GhostMapPresence.CurrentUTNow = () => liveUT;
+            GhostMapPresence.RemoveAllGhostVessels("parent-child-start");
+            ShadowRenderDriver.Reset();
+
+            uint pid = 0u;
+            try
+            {
+                MapRenderTrace.ForceEnabledForTesting = true;
+                ShadowRenderDriver.ForceSpineDriveForTesting = true; // spine ON (flag-ON scenario)
+
+                // --- (a) THE DUAL-SURFACE ROUTING DECISION (the real resolver, live-body UT scale) ---
+                // Model a body-fixed window [winStart, winEnd] around the live drive clock. The body-fixed
+                // primary needs >=2 samples AND the UT inside the range. Use the live UT magnitudes so the
+                // decision holds on real clock scales, not just synthetic small numbers.
+                double winStart = liveUT - 300.0;
+                double winEnd = liveUT + 300.0;
+                double loopFramesStart = liveUT - 1000.0;   // a wider loop-anchored frames window
+                double loopFramesEnd = liveUT + 1000.0;
+
+                // IN-RANGE, >=2 samples -> BodyFixedPrimary.
+                AnchorFrameResolver.ParentChildSurface inRange =
+                    AnchorFrameResolver.ResolveParentAnchoredChild(
+                        liveUT, bodyFixedSampleCount: 3, bodyFixedStartUt: winStart, bodyFixedEndUt: winEnd,
+                        hasAnchorLocalFrames: true, anchorLocalStartUt: loopFramesStart,
+                        anchorLocalEndUt: loopFramesEnd);
+                InGameAssert.AreEqual(AnchorFrameResolver.ParentChildSurface.BodyFixedPrimary, inRange,
+                    "a parent-anchored child with >=2 body-fixed samples and the UT in-range must route to the "
+                    + "body-fixed PRIMARY surface (the ordinary controlled-child playback path)");
+
+                // OUT-OF-RANGE (past the body-fixed window) with NO loop-frames cover -> RETIRE (never clamp).
+                double pastEndUT = winEnd + 5000.0;
+                AnchorFrameResolver.ParentChildSurface outOfRange =
+                    AnchorFrameResolver.ResolveParentAnchoredChild(
+                        pastEndUT, bodyFixedSampleCount: 3, bodyFixedStartUt: winStart, bodyFixedEndUt: winEnd,
+                        hasAnchorLocalFrames: false, anchorLocalStartUt: double.NaN,
+                        anchorLocalEndUt: double.NaN);
+                InGameAssert.AreEqual(AnchorFrameResolver.ParentChildSurface.Retire, outOfRange,
+                    "a parent-anchored child whose UT is past the body-fixed window with no loop-frames cover "
+                    + "must RETIRE - never clamp to a stale child offset (the documented stale-ghost bug)");
+
+                // TOO FEW samples (1) but a loop-anchored frames surface covers the UT -> AnchorLocalSecondary.
+                AnchorFrameResolver.ParentChildSurface secondary =
+                    AnchorFrameResolver.ResolveParentAnchoredChild(
+                        liveUT, bodyFixedSampleCount: 1, bodyFixedStartUt: winStart, bodyFixedEndUt: winEnd,
+                        hasAnchorLocalFrames: true, anchorLocalStartUt: loopFramesStart,
+                        anchorLocalEndUt: loopFramesEnd);
+                InGameAssert.AreEqual(AnchorFrameResolver.ParentChildSurface.AnchorLocalSecondary, secondary,
+                    "a parent-anchored child with too few body-fixed samples but a covering loop-anchored "
+                    + "frames surface must fall back to the anchor-local SECONDARY surface");
+
+                // --- (b) THE ORACLE GREEN: a live child ghost on its body-relative arc, RunFrame spine ON ---
+                Vessel ghost = GhostMapPresence.CreateGhostVesselFromSource(
+                    recordingIndex, rec, GhostMapPresence.TrackingStationGhostSource.Segment,
+                    seg, default(TrajectoryPoint), startUT, loopEpochShiftSeconds: 0.0);
+
+                if (ghost == null || ghost.orbitDriver == null || ghost.orbitDriver.orbit == null)
+                {
+                    InGameAssert.Skip("Parent-anchored child ghost did not create in this context (no proto)");
+                    return;
+                }
+                pid = ghost.persistentId;
+
+                var scene = new MapViewScene();
+                scene.SetFrameInputs(GhostPlaybackLogic.LoopUnitSet.Empty, liveUT);
+                if (!scene.IsActive)
+                {
+                    InGameAssert.Skip("MapViewScene not active (not in FLIGHT)");
+                    return;
+                }
+
+                // Drive the REAL wired RunFrame with the spine ON over the live child ghost.
+                ShadowRenderDriver.Reset();
+                ShadowRenderDriver.RunFrame(scene);
+
+                Orbit renderedOrbit = ghost.orbitDriver.orbit;
+                Vector3d iconBodyRel = ghost.GetWorldPos3D() - kerbin.position;
+                if (iconBodyRel.magnitude < 1.0)
+                {
+                    InGameAssert.Skip("Child ghost world position not resolved on the creation frame");
+                    return;
+                }
+
+                MapRenderProbe.FaithfulParitySample faithful = MapRenderProbe.ComputeFaithfulOrbitParity(
+                    renderedOrbit, kerbin, iconBodyRel, liveUT, 0.0, liveUT, rec.RecordingId);
+                InGameAssert.IsTrue(faithful.Sampled,
+                    "the controlled-child faithful oracle must SAMPLE (not skip); skipReason="
+                    + (faithful.SkipReason ?? "(none)"));
+                InGameAssert.IsTrue(faithful.Result.HasMeasurement,
+                    "the controlled-child faithful oracle must yield a measurement");
+                InGameAssert.IsFalse(faithful.Result.OverTolerance,
+                    string.Format(CultureInfo.InvariantCulture,
+                        "a controlled-decoupled child driven spine-ON must report ZERO faithful drift (rendered "
+                        + "body-relative arc == recorded arc); maxDev={0:F1}m tol={1:F1}m",
+                        faithful.Result.MaxDeviationMeters, faithful.Result.ToleranceMeters));
+
+                ParsekLog.Info("TestRunner", string.Format(CultureInfo.InvariantCulture,
+                    "ParentAnchoredChild_Spine: pid={0} isDebris={1} parentAnchor={2} | routing inRange={3} "
+                    + "outOfRange={4} secondary={5} | faithfulDev={6:F1}m tol={7:F1}m",
+                    pid, rec.IsDebris, rec.ParentAnchorRecordingId ?? "(null)", inRange, outOfRange, secondary,
+                    faithful.Result.MaxDeviationMeters, faithful.Result.ToleranceMeters));
+            }
+            finally
+            {
+                if (pid != 0u)
+                    GhostMapPresence.RemoveAllGhostVessels("parent-child-cleanup");
+                ShadowRenderDriver.ForceSpineDriveForTesting = prevForceSpine;
+                ShadowRenderDriver.Reset();
+                MapRenderTrace.ForceEnabledForTesting = prevForceTrace;
+                RecordingStore.ClearCommittedInternal();
+                RecordingStore.ClearCommittedTreesInternal();
+                for (int i = 0; i < prevRecordings.Count; i++)
+                    RecordingStore.AddCommittedInternal(prevRecordings[i]);
+                for (int i = 0; i < prevTrees.Count; i++)
+                    RecordingStore.AddCommittedTreeInternal(prevTrees[i]);
+                GhostMapPresence.CurrentUTNow = prevUTNow;
+            }
+        }
+
+        private static OrbitSegment BuildSegment(double startUT)
+        {
+            return new OrbitSegment
+            {
+                startUT = startUT,
+                endUT = startUT + 3600.0,
+                inclination = Inc,
+                eccentricity = Ecc,
+                semiMajorAxis = Sma,
+                longitudeOfAscendingNode = 0.0,
+                argumentOfPeriapsis = 0.0,
+                meanAnomalyAtEpoch = 0.0,
+                epoch = startUT,
+                bodyName = KerbinBodyName,
+                isPredicted = false,
+                orbitalFrameRotation = Quaternion.identity,
+                angularVelocity = Vector3.zero,
+            };
+        }
+
+        // A CONTROLLED-DECOUPLED CHILD recording: IsDebris=false, ParentAnchorRecordingId set (a lander /
+        // probe off a parent through a decoupler). It records its own body-relative orbit arc; the rendered
+        // geometry under test is the OrbitSegment elements.
+        private static Recording BuildControlledChildRecording(double startUT, OrbitSegment seg)
+        {
+            double endUT = startUT + 3600.0;
+            var rec = new Recording
+            {
+                RecordingId = "parent-child-" + System.Guid.NewGuid().ToString("N"),
+                VesselName = "Parsek Controlled Child",
+                IsDebris = false,                                  // controlled-decoupled, NOT debris
+                ParentAnchorRecordingId = "parent-" + System.Guid.NewGuid().ToString("N"),
+                TerminalStateValue = null,
+                EndpointPhase = RecordingEndpointPhase.OrbitSegment,
+                EndpointBodyName = KerbinBodyName,
+                TerminalOrbitBody = KerbinBodyName,
+                TerminalOrbitSemiMajorAxis = Sma,
+                TerminalOrbitEccentricity = Ecc,
+                TerminalOrbitInclination = Inc,
+                TerminalOrbitLAN = 0.0,
+                TerminalOrbitArgumentOfPeriapsis = 0.0,
+                TerminalOrbitMeanAnomalyAtEpoch = 0.0,
+                TerminalOrbitEpoch = startUT,
+                ExplicitStartUT = startUT,
+                ExplicitEndUT = endUT,
+                PlaybackEnabled = true,
+            };
+            rec.Points.Add(new TrajectoryPoint
+            {
+                ut = startUT, latitude = 0.0, longitude = 0.0, altitude = Sma - KerbinRadiusFallback,
+                rotation = Quaternion.identity, velocity = new Vector3(0f, 2400f, 0f), bodyName = KerbinBodyName,
+            });
+            rec.Points.Add(new TrajectoryPoint
+            {
+                ut = endUT, latitude = 0.0, longitude = 5.0, altitude = Sma - KerbinRadiusFallback,
+                rotation = Quaternion.identity, velocity = new Vector3(0f, 2400f, 0f), bodyName = KerbinBodyName,
+            });
+            rec.OrbitSegments.Add(seg);
+            rec.MarkFilesDirty();
+            return rec;
+        }
+    }
+}

--- a/Source/Parsek/InGameTests/ReaimedLoopSynthesizedOracleInGameTest.cs
+++ b/Source/Parsek/InGameTests/ReaimedLoopSynthesizedOracleInGameTest.cs
@@ -1,0 +1,231 @@
+using System.Collections.Generic;
+using System.Globalization;
+using Parsek.MapRender;
+using UnityEngine;
+
+namespace Parsek.InGameTests
+{
+    // Phase 10 / B-row2 (cutover regression harness) - the RE-AIMED interplanetary-loop live proof: the
+    // payoff of the Phase-9 SYNTHESIZED lens. A re-aimed member's rendered conic is aimed at the target's
+    // CURRENT position, so it DIFFERS from the recorded segment - which means the FAITHFUL oracle (rendered
+    // vs RECORDED) cannot validate it (it flags drift / is skipped in production by ShouldSkipReaimSegment).
+    // The SYNTHESIZED oracle (rendered vs the PRODUCER'S INTENDED re-aimed seed) is the ONLY lens that can
+    // confirm a re-aimed draw is correct. This test gives that proof LIVE:
+    //
+    //  - The ghost's live OrbitDriver.orbit is driven from a RE-AIMED segment (a recorded shape rotated in
+    //    LAN, modelling "the target moved, so the transfer is re-aimed"). This is the rendered conic.
+    //  - The recording on disk still stores the RECORDED segment (the un-re-aimed original).
+    //  - SYNTHESIZED oracle (rendered re-aimed conic vs the re-aimed INTENDED seed): reads ~0 (the draw is
+    //    faithful to the intended re-aimed arc). THE PROOF.
+    //  - FAITHFUL oracle (rendered re-aimed conic vs the RECORDED segment): FLAGS drift. This is the negative
+    //    control that proves the faithful-only oracle could NOT have given the synthesized proof - the
+    //    re-aimed draw is correct yet the faithful lens reads it as drifted (which is exactly why production
+    //    skips faithful parity for re-aimed members and needs the synthesized lens).
+    //
+    // ARCHITECTURAL TRUTH respected: this asserts DRAW-fidelity (rendered == the intended re-aimed seed), NOT
+    // solve-correctness (whether the Lambert re-aim solver picked the physically right target position - the
+    // solver owns that). It exercises the live capture path (OrbitDriver.orbit, GetWorldPos3D) the headless
+    // synthesized regression scenarios cannot reach.
+    //
+    // NOTE: in-game test (Ctrl+Shift+T / Settings > Diagnostics); cannot run headless (builds a live ghost
+    // ProtoVessel from a re-aimed segment and reads its OrbitDriver). FLIGHT only; career-independent.
+    public class ReaimedLoopSynthesizedOracleInGameTest
+    {
+        private const string KerbinBodyName = "Kerbin";
+        private const double Sma = 1_200_000.0;   // a wider arc so the LAN rotation moves the conic clearly
+        private const double Ecc = 0.05;
+        private const double Inc = 12.0;
+        private const double RecordedLAN = 0.0;
+        private const double ReaimedLAN = 70.0;   // the target "moved": the transfer is re-aimed by 70 deg
+        private const double KerbinRadiusFallback = 600000.0;
+
+        [InGameTest(Category = "MapRender", Scene = GameScenes.FLIGHT,
+            Description = "Phase 10 B-row2 re-aimed loop (live): the SYNTHESIZED oracle reads ~0 on a re-aimed "
+                + "draw (rendered conic == intended re-aimed seed) while the FAITHFUL oracle FLAGS it (rendered "
+                + "!= recorded) - the live proof the faithful-only oracle could not give")]
+        public void ReaimedLoop_SynthesizedOracleReadsZero_FaithfulOracleFlagsIt()
+        {
+            CelestialBody kerbin = FlightGlobals.Bodies?.Find(b => b.bodyName == KerbinBodyName);
+            if (kerbin == null)
+            {
+                InGameAssert.Skip("Kerbin not found in FlightGlobals.Bodies (non-stock pack)");
+                return;
+            }
+
+            double liveUT = Planetarium.GetUniversalTime();
+            double startUT = liveUT - 1800.0;
+            // The RECORDED segment (what the recording stores) and the RE-AIMED segment (what the ghost is
+            // actually driven from - the producer's intended re-aimed arc). Same body + sma + ecc + inc, but
+            // a rotated LAN: the target moved, so the transfer is re-aimed.
+            OrbitSegment recordedSeg = BuildSegment(startUT, RecordedLAN);
+            OrbitSegment reaimedSeg = BuildSegment(startUT, ReaimedLAN);
+
+            bool prevForceSpine = ShadowRenderDriver.ForceSpineDriveForTesting;
+            bool prevForceTrace = MapRenderTrace.ForceEnabledForTesting;
+            System.Func<double> prevUTNow = GhostMapPresence.CurrentUTNow;
+            List<Recording> prevRecordings = RecordingStore.CommittedRecordings != null
+                ? new List<Recording>(RecordingStore.CommittedRecordings)
+                : new List<Recording>();
+            List<RecordingTree> prevTrees = RecordingStore.CommittedTrees != null
+                ? new List<RecordingTree>(RecordingStore.CommittedTrees)
+                : new List<RecordingTree>();
+
+            // The recording stores the RECORDED (un-re-aimed) segment - the faithful reference.
+            Recording rec = BuildRecording(startUT, recordedSeg);
+            RecordingStore.ClearCommittedInternal();
+            RecordingStore.ClearCommittedTreesInternal();
+            RecordingStore.AddCommittedInternal(rec);
+            int recordingIndex = RecordingStore.CommittedRecordings.Count - 1;
+            GhostMapPresence.CurrentUTNow = () => liveUT;
+            GhostMapPresence.RemoveAllGhostVessels("reaim-synth-start");
+            ShadowRenderDriver.Reset();
+
+            uint pid = 0u;
+            try
+            {
+                MapRenderTrace.ForceEnabledForTesting = true;
+                ShadowRenderDriver.ForceSpineDriveForTesting = true; // spine ON (flag-ON scenario)
+
+                // Drive the live ghost from the RE-AIMED segment: OrbitDriver.orbit is the re-aimed conic.
+                Vessel ghost = GhostMapPresence.CreateGhostVesselFromSource(
+                    recordingIndex, rec, GhostMapPresence.TrackingStationGhostSource.Segment,
+                    reaimedSeg, default(TrajectoryPoint), startUT, loopEpochShiftSeconds: 0.0);
+
+                if (ghost == null || ghost.orbitDriver == null || ghost.orbitDriver.orbit == null)
+                {
+                    InGameAssert.Skip("Re-aimed ghost did not create in this context (no proto)");
+                    return;
+                }
+                pid = ghost.persistentId;
+                Orbit renderedOrbit = ghost.orbitDriver.orbit;
+                Vector3d iconBodyRel = ghost.GetWorldPos3D() - kerbin.position;
+                if (iconBodyRel.magnitude < 1.0)
+                {
+                    InGameAssert.Skip("Ghost world position not resolved on the creation frame");
+                    return;
+                }
+
+                // --- THE PROOF: SYNTHESIZED oracle (rendered re-aimed conic vs the re-aimed INTENDED seed) ---
+                // The rendered orbit IS the re-aimed seed (the ghost was driven from it), so the synthesized
+                // lens reads ~0: the re-aimed draw is faithful to its intended arc. loopShift 0.0 (non-loop
+                // here; the loop-shift epoch bake is covered by the A3 loop-shifted arm + the existing
+                // SynthesizedParity_LoopShiftedGhost test).
+                MapRenderProbe.SynthesizedConicParitySample synth =
+                    MapRenderProbe.ComputeSynthesizedConicParity(
+                        renderedOrbit, kerbin, iconBodyRel, reaimedSeg, KerbinBodyName, 0.0, liveUT);
+                InGameAssert.IsTrue(synth.Sampled,
+                    "the synthesized oracle must SAMPLE the rendered-vs-re-aimed-seed diff; skipReason="
+                    + (synth.SkipReason ?? "(none)"));
+                InGameAssert.IsTrue(synth.Result.HasMeasurement,
+                    "the synthesized oracle must yield a measurement (else the proof is blind)");
+                InGameAssert.IsFalse(synth.Result.OverTolerance,
+                    string.Format(CultureInfo.InvariantCulture,
+                        "the SYNTHESIZED oracle must read ZERO drift on the re-aimed draw (rendered conic == "
+                        + "intended re-aimed seed); maxDev={0:F0}m tol={1:F0}m. A re-aim DRAW regression "
+                        + "(rendered conic diverging from the seed it was driven from) would flag here.",
+                        synth.Result.MaxDeviationMeters, synth.Result.ToleranceMeters));
+
+                // --- THE NEGATIVE CONTROL: FAITHFUL oracle (rendered re-aimed conic vs the RECORDED segment) ---
+                // The re-aimed orbit DIFFERS from the recorded segment (LAN rotated 70 deg), so the faithful
+                // lens FLAGS drift on this CORRECT re-aimed draw. This is precisely why the faithful-only
+                // oracle could not give the synthesized proof - it cannot tell a correct re-aim from a wrong
+                // one. (Production skips faithful parity for re-aimed members via ShouldSkipReaimSegment for
+                // exactly this reason; here we exercise it directly to prove the lens distinction is real.)
+                MapRenderProbe.FaithfulParitySample faithful = MapRenderProbe.ComputeFaithfulOrbitParity(
+                    renderedOrbit, kerbin, iconBodyRel, liveUT, 0.0, liveUT, rec.RecordingId);
+                InGameAssert.IsTrue(faithful.Sampled,
+                    "the faithful oracle must SAMPLE here (same body, covering recorded segment) so the "
+                    + "lens-distinction control is non-vacuous; skipReason=" + (faithful.SkipReason ?? "(none)"));
+                InGameAssert.IsTrue(faithful.Result.HasMeasurement,
+                    "the faithful control must yield a measurement");
+                InGameAssert.IsTrue(faithful.Result.OverTolerance,
+                    string.Format(CultureInfo.InvariantCulture,
+                        "the FAITHFUL oracle MUST flag the re-aimed draw as drifted (rendered LAN={0:F0} != "
+                        + "recorded LAN={1:F0}); maxDev={2:F0}m tol={3:F0}m. If this reads ~0 the LAN rotation "
+                        + "is not actually moving the conic (the proof would be tautological).",
+                        ReaimedLAN, RecordedLAN, faithful.Result.MaxDeviationMeters,
+                        faithful.Result.ToleranceMeters));
+
+                ParsekLog.Info("TestRunner", string.Format(CultureInfo.InvariantCulture,
+                    "ReaimedLoop_SynthOracle: pid={0} recordedLAN={1:F0} reaimedLAN={2:F0} | "
+                    + "synthDev={3:F0}m synthTol={4:F0}m (ZERO) | faithfulDev={5:F0}m faithfulTol={6:F0}m "
+                    + "(FLAGGED)",
+                    pid, RecordedLAN, ReaimedLAN, synth.Result.MaxDeviationMeters,
+                    synth.Result.ToleranceMeters, faithful.Result.MaxDeviationMeters,
+                    faithful.Result.ToleranceMeters));
+            }
+            finally
+            {
+                if (pid != 0u)
+                    GhostMapPresence.RemoveAllGhostVessels("reaim-synth-cleanup");
+                ShadowRenderDriver.ForceSpineDriveForTesting = prevForceSpine;
+                ShadowRenderDriver.Reset();
+                MapRenderTrace.ForceEnabledForTesting = prevForceTrace;
+                RecordingStore.ClearCommittedInternal();
+                RecordingStore.ClearCommittedTreesInternal();
+                for (int i = 0; i < prevRecordings.Count; i++)
+                    RecordingStore.AddCommittedInternal(prevRecordings[i]);
+                for (int i = 0; i < prevTrees.Count; i++)
+                    RecordingStore.AddCommittedTreeInternal(prevTrees[i]);
+                GhostMapPresence.CurrentUTNow = prevUTNow;
+            }
+        }
+
+        private static OrbitSegment BuildSegment(double startUT, double lan)
+        {
+            return new OrbitSegment
+            {
+                startUT = startUT,
+                endUT = startUT + 3600.0,
+                inclination = Inc,
+                eccentricity = Ecc,
+                semiMajorAxis = Sma,
+                longitudeOfAscendingNode = lan,
+                argumentOfPeriapsis = 0.0,
+                meanAnomalyAtEpoch = 0.0,
+                epoch = startUT,
+                bodyName = KerbinBodyName,
+                isPredicted = false,
+                orbitalFrameRotation = Quaternion.identity,
+                angularVelocity = Vector3.zero,
+            };
+        }
+
+        private static Recording BuildRecording(double startUT, OrbitSegment seg)
+        {
+            double endUT = startUT + 3600.0;
+            var rec = new Recording
+            {
+                RecordingId = "reaim-synth-" + System.Guid.NewGuid().ToString("N"),
+                VesselName = "Parsek Reaim Synth Loop",
+                TerminalStateValue = null,
+                EndpointPhase = RecordingEndpointPhase.OrbitSegment,
+                EndpointBodyName = KerbinBodyName,
+                TerminalOrbitBody = KerbinBodyName,
+                TerminalOrbitSemiMajorAxis = Sma,
+                TerminalOrbitEccentricity = Ecc,
+                TerminalOrbitInclination = Inc,
+                TerminalOrbitLAN = seg.longitudeOfAscendingNode,
+                TerminalOrbitArgumentOfPeriapsis = 0.0,
+                TerminalOrbitMeanAnomalyAtEpoch = 0.0,
+                TerminalOrbitEpoch = startUT,
+                ExplicitStartUT = startUT,
+                ExplicitEndUT = endUT,
+                PlaybackEnabled = true,
+            };
+            rec.Points.Add(new TrajectoryPoint
+            {
+                ut = startUT, latitude = 0.0, longitude = 0.0, altitude = Sma - KerbinRadiusFallback,
+                rotation = Quaternion.identity, velocity = new Vector3(0f, 2200f, 0f), bodyName = KerbinBodyName,
+            });
+            rec.Points.Add(new TrajectoryPoint
+            {
+                ut = endUT, latitude = 0.0, longitude = 5.0, altitude = Sma - KerbinRadiusFallback,
+                rotation = Quaternion.identity, velocity = new Vector3(0f, 2200f, 0f), bodyName = KerbinBodyName,
+            });
+            rec.OrbitSegments.Add(seg);
+            rec.MarkFilesDirty();
+            return rec;
+        }
+    }
+}

--- a/Source/Parsek/InGameTests/WarpThroughInteriorGapSpineInGameTest.cs
+++ b/Source/Parsek/InGameTests/WarpThroughInteriorGapSpineInGameTest.cs
@@ -1,0 +1,179 @@
+using System.Collections.Generic;
+using System.Globalization;
+using Parsek.MapRender;
+using UnityEngine;
+
+namespace Parsek.InGameTests
+{
+    // Phase 10 / B-row9 + B-row20 (cutover regression harness) - WARP-THROUGH-HOLDPHASE / interior-gap.
+    //
+    // THE HOLDPHASE DECISION (documented here with evidence): the §11.5 "warp through HoldPhase / loiter /
+    // descent re-anchor" row is VACUOUS-UNDER-FLAG-ON for the HoldPhase PRODUCER in v1, because the factory
+    // NEVER constructs a live HoldPhase. The only HoldPhase construction in the whole render pipeline is
+    // MovingTargetStationApproach.cs (the moving-target station case), which is FAIL-CLOSED / define-only in
+    // v1 (FailClosedClassifier routes it to FaithfulFallback - it never reaches a live spine-driven chain).
+    // PhaseFactory / ChainAssembler produce ZERO HoldPhases; interior chain gaps are COVERAGE-CLASSIFIED
+    // (PhaseChain.ClassifyCoverage -> Coverage.InInteriorGap), NOT modelled as a HoldPhase. Building a new
+    // HoldPhase producer to exercise the row would be NEW GEOMETRY (out of this test-only, additive scope).
+    // So per the task's allowed disposition, this test does NOT fabricate a HoldPhase; it asserts the
+    // OBSERVABLE EQUIVALENT the spine actually uses in v1 - the coverage-state interior-gap HOLD - and
+    // documents the HoldPhase vacuity with the factory evidence above.
+    //
+    // THE COVERAGE-STATE WARP-STEP ASSERTION (the live, valuable test): a single high-warp frame can advance
+    // liveUT across an entire interior gap in one step. The spine's contract (GhostRenderDirector.Decide:
+    // Coverage.InInteriorGap -> HOLD the prior intent) must mean a warp step that lands IN the gap keeps the
+    // prior (visible) intent - no blink, no retire, no icon disappearance - and a warp step that lands PAST
+    // the gap in the next phase resumes a visible intent. Critically, across the whole warp sequence the
+    // ghost is NEVER Hidden once it has become visible (the no-blink invariant). This drives the SAME pair
+    // ShadowRenderDriver.RunFrame inlines for the spine path - ChainSampler.Sample(PhaseChain, liveUT, units)
+    // then GhostRenderDirector.Decide(sample, prior, label) - at three live UTs (in phase 1 / IN the gap /
+    // past the gap in phase 2) with units=Empty so liveUT maps through unchanged and the gap is exercised
+    // deterministically.
+    //
+    // ARCHITECTURAL TRUTH respected: this asserts the spine's coverage DECISION + the director's gap-hold
+    // (the decision-source contract). It introduces no producer geometry and asserts no 5b-only pixel change.
+    //
+    // NOTE: in-game test (Ctrl+Shift+T / Settings > Diagnostics). It builds a PhaseChain + samples it; the
+    // chain build + the conic Orbit reference are KSP-coupled enough that it ships as an in-game test (it runs
+    // alongside the other spine in-game tests via Ctrl+Shift+T). FLIGHT only; career-independent.
+    public class WarpThroughInteriorGapSpineInGameTest
+    {
+        private const string KerbinBodyName = "Kerbin";
+
+        [InGameTest(Category = "MapRender", Scene = GameScenes.FLIGHT,
+            Description = "Phase 10 B-row9/20 warp-through interior-gap (spine): a single high-warp step that "
+                + "lands IN an interior gap HOLDS the prior visible intent (no blink/retire) and a step past "
+                + "the gap resumes visible - the ghost is never Hidden once visible. Documents HoldPhase as "
+                + "vacuous-under-flag-ON in v1 (the factory constructs none).")]
+        public void WarpStep_AcrossInteriorGap_HoldsPriorIntent_NoBlink()
+        {
+            CelestialBody kerbin = FlightGlobals.Bodies?.Find(b => b.bodyName == KerbinBodyName);
+            if (kerbin == null)
+            {
+                InGameAssert.Skip("Kerbin not found in FlightGlobals.Bodies (non-stock pack)");
+                return;
+            }
+
+            // --- THE HOLDPHASE VACUITY EVIDENCE (documented, asserted) ---
+            // A HoldPhase covers its WHOLE span (CoversUt the full [StartUt, EndUt)) BY DESIGN so a warp step
+            // never resolves to "no phase" mid-hold - that is the warp-safety contract IF a HoldPhase existed.
+            // We assert that warp-safety property directly on a constructed HoldPhase to lock the contract,
+            // while documenting that the v1 FACTORY constructs none (so the live row is the interior-gap hold
+            // below, not a HoldPhase). This proves we understand the contract without shipping a producer.
+            var holdId = new PhaseId("hold-doc", 0, 0);
+            var hold = new HoldPhase(holdId, new AnchorFrame.BodyAnchor(KerbinBodyName),
+                startUt: 1000.0, endUt: 2000.0);
+            // A warp step landing anywhere inside the hold span still resolves to the hold (never a gap),
+            // and the hold draws nothing of its own (Treatment.None -> the prior intent is held).
+            InGameAssert.IsTrue(hold.CoversUt(1500.0),
+                "a HoldPhase must cover its WHOLE span so a high-warp step landing mid-hold never resolves to "
+                + "no-phase (the warp-safety contract); documents the HoldPhase behavior even though the v1 "
+                + "factory constructs none");
+            InGameAssert.AreEqual(Treatment.None, hold.ResolveTreatment(),
+                "a HoldPhase draws nothing of its own (the prior intent is held)");
+
+            // --- THE LIVE COVERAGE-STATE WARP-STEP ASSERTION (the interior-gap hold the spine actually uses) ---
+            // Build a per-member PhaseChain with TWO StockConic phases separated by an interior GAP inside the
+            // window: [winStart .. p1End] phase 1, (p1End .. p2Start) GAP, [p2Start .. winEnd] phase 2. With
+            // units=Empty the sampler maps liveUT through unchanged, so we place liveUT in phase 1, then jump
+            // (one warp step) INTO the gap, then jump past it into phase 2 - and assert the gap holds.
+            double winStart = 100.0;
+            double p1End = 400.0;     // phase 1 ends here
+            double p2Start = 700.0;   // phase 2 starts here -> (400, 700) is the interior gap
+            double winEnd = 1000.0;
+
+            PhaseChain chain = BuildTwoPhaseChainWithGap(winStart, p1End, p2Start, winEnd);
+            // Sanity: the chain must actually classify a gap between the two phases (else the test is vacuous).
+            Coverage gapProbe = chain.ClassifyCoverage(550.0, out _, out _);
+            InGameAssert.AreEqual(Coverage.InInteriorGap, gapProbe,
+                "the fixture chain must classify a real interior gap between its two phases (else the warp-step "
+                + "hold assertion would be vacuous)");
+
+            GhostPlaybackLogic.LoopUnitSet units = GhostPlaybackLogic.LoopUnitSet.Empty;
+            const string label = "warp-gap-ghost";
+
+            // Frame A: liveUT inside phase 1 -> visible StockConic (the prior intent becomes visible).
+            GhostSample sampleA = ChainSampler.Sample(chain, 250.0, units);
+            GhostRenderIntent intentA = GhostRenderDirector.Decide(sampleA, GhostRenderIntent.Hidden(), label);
+            InGameAssert.AreEqual(Coverage.InSegment, sampleA.Coverage,
+                "frame A (in phase 1) must be InSegment");
+            InGameAssert.IsTrue(intentA.Visible, "frame A must be VISIBLE (phase 1 drawn)");
+
+            // Frame B: ONE high-warp step lands liveUT IN the gap -> the director must HOLD intent A (still
+            // visible, same treatment/body), NOT blink to Hidden / retire. This is the warp-step gap-hold.
+            GhostSample sampleB = ChainSampler.Sample(chain, 550.0, units);
+            GhostRenderIntent intentB = GhostRenderDirector.Decide(sampleB, intentA, label);
+            InGameAssert.AreEqual(Coverage.InInteriorGap, sampleB.Coverage,
+                "frame B (the warp step landing in the gap) must classify InInteriorGap");
+            InGameAssert.IsTrue(intentB.Visible,
+                "frame B must HOLD the prior visible intent across the gap (no blink/retire) - the warp-step "
+                + "gap-hold contract; a regression that dropped to Hidden in the gap would fail here");
+            InGameAssert.AreEqual(intentA.Treatment, intentB.Treatment,
+                "the held intent in the gap must keep the prior frame's treatment (no surface flip)");
+            InGameAssert.AreEqual(intentA.FrameBodyName, intentB.FrameBodyName,
+                "the held intent in the gap must keep the prior frame's body (no re-anchor blink)");
+
+            // Frame C: the next warp step lands liveUT PAST the gap in phase 2 -> visible again. Across A->B->C
+            // the ghost was NEVER Hidden once visible (the no-blink invariant a high-warp pass must preserve).
+            GhostSample sampleC = ChainSampler.Sample(chain, 850.0, units);
+            GhostRenderIntent intentC = GhostRenderDirector.Decide(sampleC, intentB, label);
+            InGameAssert.AreEqual(Coverage.InSegment, sampleC.Coverage,
+                "frame C (warp step past the gap into phase 2) must be InSegment again");
+            InGameAssert.IsTrue(intentC.Visible, "frame C must be VISIBLE (phase 2 drawn)");
+
+            // The no-blink invariant across the whole warp sequence: every frame after first-visible is visible.
+            bool everHiddenAfterVisible = !intentB.Visible || !intentC.Visible;
+            InGameAssert.IsFalse(everHiddenAfterVisible,
+                "across the high-warp A->gap->C sequence the ghost must NEVER blink Hidden once it has become "
+                + "visible - the warp-through-interior-gap no-blink invariant");
+
+            ParsekLog.Info("TestRunner", string.Format(CultureInfo.InvariantCulture,
+                "WarpStep_AcrossInteriorGap: holdCoversSpan={0} | A cov={1} vis={2} treat={3} | B(gap) cov={4} "
+                + "vis={5} treat={6} | C cov={7} vis={8} | HoldPhase-producer=VACUOUS-under-flag-ON (factory "
+                + "constructs none; only MovingTargetStationApproach, fail-closed)",
+                hold.CoversUt(1500.0), sampleA.Coverage, intentA.Visible, intentA.Treatment,
+                sampleB.Coverage, intentB.Visible, intentB.Treatment, sampleC.Coverage, intentC.Visible));
+        }
+
+        // A per-member PhaseChain with two StockConic phases and an interior gap between them. Both phases
+        // carry a simple Kerbin conic so the projected sample is a visible StockConic. The gap (p1End,p2Start)
+        // is inside [winStart, winEnd], so ClassifyCoverage returns InInteriorGap there.
+        private static PhaseChain BuildTwoPhaseChainWithGap(
+            double winStart, double p1End, double p2Start, double winEnd)
+        {
+            OrbitSegment conic1 = BuildConic(winStart, p1End, lan: 0.0);
+            OrbitSegment conic2 = BuildConic(p2Start, winEnd, lan: 0.0);
+            var phases = new List<TrajectoryPhase>
+            {
+                new DepartureLoiterPhase(
+                    new PhaseId("warp-gap", 0, 0), SegmentProvenance.Recorded,
+                    new AnchorFrame.BodyAnchor(KerbinBodyName), winStart, p1End, conic1),
+                new ArrivalLoiterPhase(
+                    new PhaseId("warp-gap", 0, 1), SegmentProvenance.Recorded,
+                    new AnchorFrame.BodyAnchor(KerbinBodyName), p2Start, winEnd, conic2),
+            };
+            return new PhaseChain(
+                "warp-gap-rec", committedIndex: 0, instanceKey: 0, phases, winStart, winEnd);
+        }
+
+        private static OrbitSegment BuildConic(double startUT, double endUT, double lan)
+        {
+            return new OrbitSegment
+            {
+                startUT = startUT,
+                endUT = endUT,
+                inclination = 0.0,
+                eccentricity = 0.0,
+                semiMajorAxis = 850000.0,
+                longitudeOfAscendingNode = lan,
+                argumentOfPeriapsis = 0.0,
+                meanAnomalyAtEpoch = 0.0,
+                epoch = startUT,
+                bodyName = KerbinBodyName,
+                isPredicted = false,
+                orbitalFrameRotation = Quaternion.identity,
+                angularVelocity = Vector3.zero,
+            };
+        }
+    }
+}

--- a/Source/Parsek/MapRender/GeometryParityComparator.cs
+++ b/Source/Parsek/MapRender/GeometryParityComparator.cs
@@ -13,9 +13,28 @@ namespace Parsek.MapRender
     /// (<c>HasConic</c> + the Kepler elements when present); chain-level it checks <c>WindowStartUt</c>,
     /// <c>WindowEndUt</c>, and <c>IsFaithfulFallback</c> (<c>GhostRenderChain.cs:24-27</c> — they drive
     /// coverage/clip and matter for the trimmed-window route case). <see cref="PhaseKind"/> /
-    /// <see cref="SegmentProvenance"/> (and the legacy cosmetic <c>SegmentKind</c> / <c>IsGenerated</c>)
-    /// are DELIBERATELY NOT in the parity set — they are validated by the Phase-1 unit tests, not this
-    /// gate (design §6 / plan §4).</para>
+    /// <see cref="SegmentProvenance"/> (and the legacy cosmetic <c>SegmentKind</c>) are DELIBERATELY NOT
+    /// in the parity set — they are validated by the Phase-1 unit tests, not this gate (design §6 / plan §4).</para>
+    ///
+    /// <para><b>Why seams (<c>LeadingSeam</c> / <c>TrailingSeam</c>) and <c>IsGenerated</c> are NOT compared
+    /// (Phase-10 A4 decide: GATE, not compare).</b> The factory deliberately builds every phase with NULL
+    /// seams (<c>PhaseFactory.ClassifySegment</c>: seam reproduction is a spine-side re-derivation concern,
+    /// landing at Phase 5b), so a factory segment projects <see cref="SeamKind.None"/> while the assembler
+    /// stamps Rigid/FlexibleSoi (<c>ChainAssembler.AssignSeams</c>) — they DIVERGE today by construction.
+    /// Comparing them would force the factory to stamp seams to match (a producer change this test layer is
+    /// forbidden to make) AND would false-fail every real factory-vs-assembler build (e.g.
+    /// <c>PhaseFactoryTests.FullChain_FactoryGeometry_ByteMatchesAssembler</c>). They are LEGITIMATELY
+    /// draw-irrelevant TODAY: the <see cref="GhostRenderDirector"/> reduces a sampled
+    /// <see cref="RenderSegment"/> to (<c>Treatment</c>, <c>Payload</c>, <c>FrameBodyName</c>, visibility)
+    /// in the <see cref="GhostRenderIntent"/> it emits, and the two LIVE PIXEL-DRAW paths
+    /// (<c>Patches/GhostOrbitLinePatch.cs</c> for StockConic, <c>Display/GhostTrajectoryPolylineRenderer.cs</c>
+    /// for TracedPath) read NEITHER seam fields NOR <c>IsGenerated</c> off a spine-emitted segment (they
+    /// draw from <see cref="Recording"/> / <see cref="Orbit"/> / the intent). So omitting them cannot let a
+    /// draw-affecting divergence pass. Rather than leave the omission SILENT, it is GUARDED: the
+    /// <c>SeamFieldsDrawIrrelevantSourceGateTests</c> source gate asserts those two draw files keep reading
+    /// zero <c>RenderSegment</c> seam / <c>IsGenerated</c> fields, so when Phase 5b makes the descent G1
+    /// seam load-bearing at the draw layer the gate fails and forces this comparator (and the factory's
+    /// seam stamping) to be revisited at exactly the right time.</para>
     ///
     /// <para>The factory's geometry is obtained by projecting each phase through
     /// <see cref="TrajectoryPhase.Emit"/> (a phase with no geometry — <see cref="HoldPhase"/> — yields
@@ -175,6 +194,13 @@ namespace Parsek.MapRender
                     return conic;
             }
 
+            // NOTE (Phase-10 A4): factory.LeadingSeam / factory.TrailingSeam / factory.IsGenerated are
+            // INTENTIONALLY NOT compared here. The factory builds null seams (-> SeamKind.None) while the
+            // assembler stamps Rigid/FlexibleSoi, so they diverge by construction (seam re-derivation is a
+            // spine-side / Phase-5b concern). They are also draw-irrelevant today (the director drops them
+            // when it forms the GhostRenderIntent, and neither live draw path reads them off a spine
+            // segment). The omission is GUARDED, not silent, by SeamFieldsDrawIrrelevantSourceGateTests.
+            // See the class-header "Why seams ... are NOT compared" section for the full justification.
             return ParityResult.Match;
         }
 

--- a/docs/dev/plans/map-ts-render-overhaul-migration.md
+++ b/docs/dev/plans/map-ts-render-overhaul-migration.md
@@ -573,6 +573,162 @@ off) normal play is BYTE-IDENTICAL to today.
 
 ---
 
+## 10c. Cutover regression harness (stacked on Phase 9)
+
+**Goal:** turn "flag-ON is byte-identical BY CONSTRUCTION" into "demonstrably regression-free ACROSS
+gameplay" by adding the tests the 5-lens cutover-readiness audit found missing, now that the Phase-9 parity
+oracle is trustworthy (faithful + synthesized + polyline lenses all live). TEST-FOCUSED + additive: NO
+producer geometry or draw path changed, so with the spine flag OFF
+(`MapRenderFlags.MapRenderPhaseSpineDrive` default false) AND tracing OFF (`mapRenderTracing` default off),
+normal play stays BYTE-IDENTICAL to today (all flag-OFF / tracing-OFF source gates green - see "Status" below).
+
+**Architectural truth these tests respect (do not write a test that assumes otherwise):** through this
+stack, flag-ON only swaps the DECISION SOURCE (the typed `PhaseChain` spine); the LEGACY code still DRAWS
+the pixels (`GhostOrbitLinePatch` for StockConic, the autonomous `GhostTrajectoryPolylineRenderer.Driver`
+for TracedPath, IMGUI markers). The geometry REPLACEMENT (e.g. the Phase-6 descent sub-surface-retire fix)
+only LANDS at the draw layer when Phase 5b deletes the legacy draw. So a flag-ON test asserts the CURRENT
+contract: (i) the spine's DECISION/intent is correct and matches what flag-OFF would decide for faithful
+members (byte-identical), (ii) the live oracle stays GREEN (zero parity-drift) on correct draws, and (iii)
+for the descent re-stitch it DOCUMENTS that the retire is not yet live at the draw layer (lands at 5b)
+rather than asserting a pixel change.
+
+**Status (implemented, test-only / flag-OFF + tracing-OFF byte-identical):**
+
+### Headless comparator + intent-parity widening (A2 / A4 / A5)
+
+- **A4 - the byte-parity comparator's seam / generated omission is now a CHECKED invariant, not a silent
+  gap.** `GeometryParityComparator.CompareSegment` deliberately does NOT byte-compare
+  `RenderSegment.LeadingSeam` / `TrailingSeam` / `IsGenerated`: `PhaseFactory.ClassifySegment` builds every
+  phase with NULL seams by design (seam re-derivation is a spine-side / Phase-5b concern), while
+  `ChainAssembler.AssignSeams` stamps `Rigid` / `FlexibleSoi`, so the two diverge BY CONSTRUCTION; comparing
+  them would force a forbidden producer change and false-fail every real factory-vs-assembler build. Instead
+  of GATE-by-comparison, A4 adds a SOURCE gate
+  (`Source/Parsek.Tests/MapRender/SeamFieldsDrawIrrelevantSourceGateTests.cs`) asserting the two LIVE
+  PIXEL-DRAW files (`Patches/GhostOrbitLinePatch.cs`, `Display/GhostTrajectoryPolylineRenderer.cs`) read
+  ZERO `RenderSegment` seam / `IsGenerated` fields (comments stripped, whitespace collapsed; mirrors
+  `FailClosedWiringSourceGateTests`), plus a sanity test that the comparator header documents the omission +
+  names the gate. The fields are provably draw-irrelevant today (`GhostRenderIntent` carries treatment /
+  payload / frame / drive-UT but NO seam / `IsGenerated`), so omitting them cannot let a draw-affecting
+  divergence pass. The gate is the pre-5b TRIPWIRE: the instant a draw path reads a seam / `IsGenerated` off
+  a spine segment (e.g. Phase 5b makes the descent G1 seam load-bearing), it FAILS and forces the comparator
+  to widen + the factory to stamp seams at exactly the right moment. Doc updates: comparator class header +
+  inline NOTE in `CompareSegment`. CLOSES the audit's "comparator surface omits seam / generated fields"
+  finding.
+
+- **A5 - intent parity widened from a SUBSET to the FULL conic Kepler set, plus an inclined / nonzero-LAN
+  fixture.** `PhaseSpineParityTests.AssertIntentParity` compared only `sma` / `ecc` / start / end / body;
+  A5 widens it to inclination / LAN / argPe / MnA / epoch / isPredicted, and adds an `InclinedChain()`
+  fixture (inc 28.5 deg, LAN 75 deg, argPe 40 deg, MnA 1.2, epoch 12.5) with a spot-frame theory, a
+  non-vacuity guard, and a full prior-threaded sweep. CLOSES the audit's "parity asserts only a subset of
+  conic elements, equatorial zero-LAN fixtures only" finding.
+
+- **A2 - the realistic MULTI-segment flag-ON-vs-OFF differential the audit found missing.**
+  `Source/Parsek.Tests/MapRender/MultiMemberSpineParityTests.cs` runs ONE faithful recording whose
+  assembled chain spans Kerbin ascent (TracedPath) -> Kerbin parking (StockConic) -> Kerbin->Mun SOI
+  crossing (FlexibleSoi seam) -> Mun arrival (StockConic) -> Mun descent (TracedPath), with inclined /
+  nonzero-LAN elements, through BOTH spines: full geometry byte-parity (`GeometryParityComparator`) + full
+  intent parity over a continuous `[-5, 85]` 0.5s sweep + per-segment spot frames + a fixture-shape guard.
+  CLOSES the audit's "single-member equatorial circular fixtures only; no realistic multi-segment / SOI
+  chain through both spines" finding.
+
+### Flag-ON live in-game scenario tests (A3 / B-rows)
+
+All five are `[InGameTest(Category="MapRender", Scene=GameScenes.FLIGHT)]`, auto-discovered by reflection,
+run via Ctrl+Shift+T. Each drives the REAL wired path (`ShadowRenderDriver.ForceSpineDriveForTesting` +
+`MapRenderTrace.ForceEnabledForTesting`) and asserts via the Phase-9 oracle, respecting the architectural
+truth above (assert the decision-source-swap contract; never a 5b-only geometry change).
+
+- **A3 - `FlagOnParityBaselineInGameTest.cs`** (known-good + loop-shifted): the FLAG-ON parity BASELINE the
+  audit found missing (the existing `RenderParityBaselineTest` is flag-OFF; `PhaseSpineSwapInGameTest`
+  exercises only the faithful lens). Drives the REAL `ShadowRenderDriver.RunFrame` SPINE-ON over a live
+  faithful ghost and asserts ZERO parity-drift across ALL THREE Phase-9 oracle modes at once (faithful,
+  synthesized, polyline), the spine's stamped loop-shift matches `GetGhostOrbitEpochShift`, and NO
+  `parity-drift` anomaly fired on the trace sink. Non-vacuous: each lens must `Sampled` + `HasMeasurement`
+  or it fails as blind; the loop-shifted arm bakes a 1100s shift end-to-end through the real seam. CLOSES
+  the section 11.5 "loop a single recording" / baseline-only-flag-OFF gap, flag-ON.
+
+- **B-row2 - `ReaimedLoopSynthesizedOracleInGameTest.cs`** (the Phase-9 SYNTHESIZED payoff): drives a live
+  ghost from a RE-AIMED segment (recorded shape rotated 70 deg in LAN) while the recording stores the
+  un-re-aimed segment. SYNTHESIZED oracle (rendered conic vs the re-aimed INTENDED seed) reads ~0 (the
+  proof); FAITHFUL oracle (rendered vs RECORDED) FLAGS drift (the negative control proving the faithful-only
+  oracle could not have validated a re-aimed draw, and that the LAN rotation actually moves the conic - a
+  tautology guard). CLOSES section 11.5 "re-aim with a large synodic target move" / "mixed faithful + re-aimed
+  members" at the LIVE synthesized-lens layer (headless only before).
+
+- **B-row1 - `DescentEndToEndSpineInGameTest.cs`** (descent end-to-end through the spine): drives the EXACT
+  RunFrame-inlined pair (`ChainSampler.Sample(PhaseChain, liveUT, units)` -> `GhostRenderDirector.Decide`)
+  over a descent-trigger unit + descent `PhaseChain` at a TRIGGERED live UT and a PAST-END UT. Asserts the
+  spine resolves a VISIBLE re-anchored first-class `DescentPhase` at the swept-deorbit head with the Rigid
+  orbit-landing seam, and RETIRES (OutsideWindow -> Hidden, no held sample) past the clip even though the
+  prior frame was visible. **GATE FINDING surfaced (not faked):** asserts `IsRenderingNonOrbitalLeg(recId)
+  == false` after a correct spine descent DECISION - documenting that the spine's descent decision does NOT
+  own the leg DRAW (the legacy autonomous Driver owns the pixels), so the Phase-6 sub-surface-retire fix
+  lands at the DRAW layer ONLY at Phase 5b. Asserts the current decision-source-swap contract, not a
+  5b-only pixel change. CLOSES section 11.5 "atmospheric descent to landing" / "reentry / destruction
+  mid-recording retire" at the spine-DECISION layer (the draw-layer retire stays expected-to-change until
+  5b).
+
+- **B-row4 - `ParentAnchoredChildSpineInGameTest.cs`** (parent-anchored controlled child): (a) drives the
+  REAL `AnchorFrameResolver.ResolveParentAnchoredChild` on LIVE-body UT magnitudes through all three
+  outcomes - >=2-sample in-range -> `BodyFixedPrimary`; out-of-range / no loop-frames -> `Retire` (never
+  clamp to a stale child offset, the documented "stale ghost" bug it prevents); too-few-samples + covering
+  loop frames -> `AnchorLocalSecondary`; (b) drives a live controlled-decoupled child ghost
+  (`IsDebris=false`, `ParentAnchorRecordingId` set) through RunFrame spine-ON and asserts ZERO faithful
+  drift. Non-vacuous: all three routing branches asserted distinctly; the oracle arm must `Sampled` +
+  `HasMeasurement`. CLOSES section 11.5 "controlled-decoupled child (lander off a stage)" dual-surface routing,
+  flag-ON.
+
+- **B-row9 / B-row20 - `WarpThroughInteriorGapSpineInGameTest.cs`** (the HoldPhase decision +
+  interior-gap warp-step hold). **HoldPhase decision: VACUOUS-UNDER-FLAG-ON in v1, with evidence.** The
+  factory constructs ZERO live HoldPhases - the only `new HoldPhase(...)` in the pipeline is in
+  `MovingTargetStationApproach.cs`, which `FailClosedClassifier` routes to FaithfulFallback (never reaches a
+  live spine-driven chain); interior chain gaps are coverage-classified
+  (`PhaseChain.ClassifyCoverage -> InInteriorGap`), NOT modelled as HoldPhases. Building a HoldPhase
+  producer would be new geometry (out of this test-only scope). The test documents this and asserts the
+  HoldPhase warp-safety contract on a CONSTRUCTED HoldPhase (`CoversUt` whole span, `Treatment.None`)
+  without shipping a producer. **Plus the live, valuable coverage-state warp-step assertion:** drives the
+  RunFrame-inlined `ChainSampler.Sample` + `GhostRenderDirector.Decide` pair across a 2-phase chain with a
+  real interior gap at 3 UTs (phase 1 / a single warp step landing IN the gap / a step past into phase 2);
+  asserts the gap HOLDS the prior visible intent (same treatment + body, no blink / retire) and the ghost is
+  NEVER Hidden once visible. Non-vacuous: a pre-assert confirms the fixture chain actually classifies
+  `InInteriorGap`. CLOSES section 11.5 "warp through HoldPhase / loiter / descent re-anchor" via the OBSERVABLE
+  EQUIVALENT the spine actually uses in v1 (the interior-gap hold), and DISPOSITIONS the HoldPhase producer
+  row as vacuous-for-v1 with factory evidence.
+
+### Gate findings surfaced (not faked)
+
+- **Descent retire is not yet live at the draw layer (lands at Phase 5b).** B-row1's
+  `IsRenderingNonOrbitalLeg == false` assertion (after a correct spine descent decision) turns the
+  architectural note into a passing TRIPWIRE: it documents that the spine's descent decision does not own
+  the leg DRAW, so the Phase-6 sub-surface-retire fix only reaches the pixels when 5b deletes the legacy
+  autonomous Driver. The G1 tangent-discontinuity PRODUCTION anomaly raise at the descent draw site is
+  likewise a Phase-5b item; the headless `CrossMemberSeamStitcher` predicate + this in-game test exercise it
+  only at the predicate / sample layer.
+- **HoldPhase has no live v1 producer.** B-row9/20 dispositions the row as vacuous-under-flag-ON with the
+  factory evidence above, rather than fabricating a producer (which would be out-of-scope new geometry).
+
+### Flag-OFF / tracing-OFF byte-identical
+
+No producer geometry or draw code was touched - only test files plus comparator doc-comments. Flag-OFF
+(`MapRenderPhaseSpineDrive` default false) and tracing-OFF (`mapRenderTracing` default off) normal play is
+byte-identical to today; every flag-OFF / tracing-OFF source gate stays green: the A4 seam-omission gate
+(`SeamFieldsDrawIrrelevantSourceGateTests`), `FailClosedWiringSourceGateTests` (incl. the SwappedSpine
+deorbit-clock + fail-closed-classifier discipline), and the repo-wide grep-audit gates
+(`grep-audit-render-reconciler-unwired`, `grep-audit-map-render-director-drive`,
+`grep-audit-active-leg-recordings`, `grep-audit-non-loop-live-pid`, `grep-audit-ers-els`). Because this is
+test-only / additive with no user-visible default-play change, there is NO CHANGELOG / todo entry.
+
+### Left for the runtime-only rows headless cannot reach
+
+The section 11.5 runtime-only rows that need a real KSP lifecycle / scene frame remain producer-phase /
+follow-up in-game work: quickload mid-gap, dock / undock member swaps, overlap gap-hold, in-bubble switch,
+Fly / Switch-To teardown, warp across a synodic boundary, and the scene-transition no-one-frame-blank settle.
+(Cold-load UT<=0 is already covered flag-ON by Phase 9's `ColdLoadClockGuardInGameTest` - the clock-readiness
+defer guard - so it is NOT in this list.) The headless gates + the five flag-ON scenario tests above lock the
+decision / geometry contract those runtime rows build on.
+
+---
+
 ## 11. Phase ordering & dependencies
 
 ```


### PR DESCRIPTION
**Stacked on Phase 9 ([#1224](https://github.com/vl3c/Parsek/pull/1224)). Merge in order; this PR's diff is Phase 10 only.**

Test-only + additive harness that turns "flag-ON is byte-identical by construction" into "demonstrably regression-free across gameplay", closing the parity/coverage gaps the cutover-readiness audit found. No producer geometry or draw code touched (the one non-test edit is comment-only); flag-OFF/tracing-OFF byte-identical.

## Headless widening

- **A2** — a realistic **multi-member** faithful recording (ascent TracedPath → parking StockConic → Kerbin→Mun SOI crossing → arrival StockConic → descent TracedPath, inclined/nonzero-LAN) through **both spines**, full geometry + intent byte-parity over a continuous sweep (was: single-member equatorial circular only).
- **A5** — widened `AssertIntentParity` to the **full conic Kepler set** + an inclined nonzero-LAN fixture. The efficacy reviewer mutation-proved it: a +5° LAN divergence injected into the factory spine fails the new tests while the old equatorial subset stayed green.
- **A4** — added `SeamFieldsDrawIrrelevantSourceGateTests`, a scoped tripwire that fails the instant a live draw path reads a spine seam/`IsGenerated` (verified none does today) — forcing the comparator widen + factory seam-stamp exactly when Phase 5b makes the descent G1 seam load-bearing.

## Flag-ON in-game scenario tests

Each forces the real spine + asserts via the Phase-9 oracle, asserts the **current decision-source-swap contract**, and **documents** rather than fakes the 5b-only geometry deltas:
- **A3** parity-baseline (zero drift across faithful + synthesized + polyline).
- **B-row2** re-aimed loop, synthesized-conic oracle reads ~0 (payoff of the Phase-9 synthesized lens) with a real negative control.
- **B-row1** descent end-to-end — asserts the spine decision (re-anchored DescentPhase + Rigid seam + retire-past-clip) and documents via `IsRenderingNonOrbitalLeg==false` that the legacy Driver still owns the draw, so the sub-surface retire lands at 5b.
- **B-row4** parent-anchored controlled child (dual-surface routing decision + oracle green).
- **B-row9/20** warp-through interior gap (HoldPhase dispositioned vacuous-under-flag-ON; covered by the observable interior-gap hold).

## Review

Two clean-context lenses (efficacy + correctness), verdict **CLEAN**, 0 blockers; efficacy ran a live mutation-injection proving the widened tests are non-tautological. Folded one LOW doc imprecision (cold-load UT=0 is already covered by Phase 9). `dotnet build` green; `dotnet test` **16644 passed, 0 failed**; all source-gates green.

Genuinely-uncovered runtime-only rows (quickload mid-gap, dock/undock swaps, in-bubble switch, synodic-boundary warp, scene-transition settle) are honestly deferred to their producing phases. No `CHANGELOG`/`todo` change (test-only).