### PR TITLE
maprender Phase 11: test automation + coverage (pad-runnable in-game hardening + new gameplay-case tests)

### DIFF
--- a/Source/Parsek.Tests/MapRender/AnchorFrameTests.cs
+++ b/Source/Parsek.Tests/MapRender/AnchorFrameTests.cs
@@ -205,5 +205,23 @@ namespace Parsek.Tests
                 hasAnchorLocalFrames: false, anchorLocalStartUt: 0, anchorLocalEndUt: 0);
             Assert.Equal(AnchorFrameResolver.ParentChildSurface.Retire, s);
         }
+
+        [Fact]
+        public void ParentChild_DegenerateSecondaryRange_FallsToRetire()
+        {
+            // The PRIMARY is unusable (1 body-fixed sample < the >=2 minimum) AND the SECONDARY's anchor-local
+            // range is DEGENERATE (start > end), with hasAnchorLocalFrames TRUE. A reversed range satisfies NO
+            // ut under the inclusive `ut >= start && ut <= end` check, so neither surface covers ut -> RETIRE,
+            // never a spurious AnchorLocalSecondary clamp to a stale child offset. This validates the
+            // primary-out + degenerate-secondary routing to Retire. (It does NOT separately prove the explicit
+            // `start > end` fast-reject is load-bearing: the inclusive range check already rejects every
+            // reversed range for any ut, so that guard is a redundant clarity guard, not observable through
+            // the public ResolveParentAnchoredChild.)
+            var s = AnchorFrameResolver.ResolveParentAnchoredChild(
+                ut: 150,
+                bodyFixedSampleCount: 1, bodyFixedStartUt: 150, bodyFixedEndUt: 150,  // 1 sample < 2 -> primary out
+                hasAnchorLocalFrames: true, anchorLocalStartUt: 200, anchorLocalEndUt: 100); // start > end -> degenerate
+            Assert.Equal(AnchorFrameResolver.ParentChildSurface.Retire, s);
+        }
     }
 }

--- a/Source/Parsek.Tests/MapRender/CrossMemberSeamStitcherTests.cs
+++ b/Source/Parsek.Tests/MapRender/CrossMemberSeamStitcherTests.cs
@@ -155,6 +155,56 @@ namespace Parsek.Tests
             Assert.Equal(Parsek.Reaim.DescentTrigger.DescentHeadPhase.Loiter, phase);
         }
 
+        [Theory]
+        [InlineData(-0.5, true)]  // triggerUT + clip - eps -> still inside the clip (head < descentEnd) -> Descent
+        [InlineData(0.0, true)]   // triggerUT + clip EXACTLY -> head == descentEnd -> INCLUSIVE -> still Descent
+        [InlineData(0.5, false)]  // triggerUT + clip + eps -> one tick past the clip (head > descentEnd) -> Done
+        public void DescentSeamHead_ExactlyAtDescentEnd_StillRenders_OneTickPastRetires(
+            double offsetFromClipEnd, bool expectRender)
+        {
+            // OFF-BY-ONE GUARD on the descent-clip end boundary. The offset=0.0 case lands the head EXACTLY
+            // on descentEnd, which is the ONLY input that distinguishes > from >= : with the correct
+            // `descentHead > descentEndUT` Done-condition it still renders (Descent); a mutation to >= would
+            // retire it one frame early (a visible clip truncation) and fail this case; a mutation to < would
+            // render one frame too long past +eps (a sub-surface ghost) and fail the 0.5 case. The descent head is
+            // recordedDeorbitUT + (currentUT - triggerUT); the clip duration is descentEnd - recordedDeorbit
+            // (= 300 - 200 = 100s here). At currentUT = triggerUT + clip the head == descentEnd EXACTLY: the
+            // boundary is INCLUSIVE (descentHead > descentEndUT is the Done condition, so head == end is still
+            // Descent). One tick PAST (head > descentEnd) retires (Done). A mutation that flipped the
+            // comparison to >= would retire one frame early (a visible clip truncation); one that used <
+            // would render one frame too long (a sub-surface ghost). This pins the exact > boundary.
+            var units = MakeDescentUnitSet();
+            Assert.True(units.TryGetUnitForMember(DescentMemberIdx, out GhostPlaybackLogic.LoopUnit unit));
+
+            Parsek.Reaim.DescentTrigger.ComputeDescentTiming(
+                0, PhaseAnchor, Cadence, SpanStart, RecDeorbit, TestTrot, CaptureShift, null,
+                out _, out _, out double triggerUT);
+
+            double clipSeconds = DescentEnd - RecDeorbit;               // 100s
+            double liveUT = triggerUT + clipSeconds + offsetFromClipEnd; // just inside / just past the clip end
+
+            bool ok = CrossMemberSeamStitcher.TryResolveDescentSeamHead(
+                unit, DescentMemberIdx, unitCycle: 0, currentUT: liveUT,
+                memberStartUT: 150, memberEndUT: 300,
+                out double head, out Parsek.Reaim.DescentTrigger.DescentHeadPhase phase);
+
+            Assert.Equal(expectRender, ok);
+            if (expectRender)
+            {
+                Assert.Equal(Parsek.Reaim.DescentTrigger.DescentHeadPhase.Descent, phase);
+                // head == recordedDeorbit + (liveUT - trigger), just under descentEnd (300).
+                Assert.Equal(RecDeorbit + (liveUT - triggerUT), head, 6);
+                Assert.True(head <= DescentEnd); // still inside the clip
+            }
+            else
+            {
+                // One tick past the clip end -> Done -> the stitcher hides the member (head NaN), so the
+                // sub-surface ghost retires rather than clamping to a stale below-surface sample.
+                Assert.Equal(Parsek.Reaim.DescentTrigger.DescentHeadPhase.Done, phase);
+                Assert.True(double.IsNaN(head));
+            }
+        }
+
         [Fact]
         public void DescentSeamHead_NonDescentMember_ReturnsFalse_ByteIdentical()
         {

--- a/Source/Parsek.Tests/MapRender/FailClosedClassifierTests.cs
+++ b/Source/Parsek.Tests/MapRender/FailClosedClassifierTests.cs
@@ -92,6 +92,26 @@ namespace Parsek.Tests
         }
 
         [Fact]
+        public void Classify_KerbinTwoMoonsTour_IsFailClosed_NestedSoi()
+        {
+            // Kerbin -> Mun -> Minmus: Mun and Minmus are SIBLINGS under Kerbin (a non-root ancestor: Kerbin
+            // itself orbits the Sun), so a two-moon hop under one planet is a nested-SOI tour -> fail closed
+            // to faithful, with RootBody == the shared parent "Kerbin" (NOT the Jool-only signature). This is
+            // the stock-system nested-SOI case (proves the classifier is not Jool-hardcoded): the moon-tour
+            // signature is "two visited bodies share a non-root parent", which Kerbin's moons satisfy.
+            var bodies = new List<string> { "Kerbin", "Mun", "Minmus" };
+            FailClosedClassifier.FailClosedDecision d = FailClosedClassifier.Classify(
+                bodies, hasLiveVesselArrivalAnchor: false, referenceBodyName: Parent);
+
+            Assert.True(d.IsFailClosed);
+            Assert.Equal(FailClosedClassifier.FailClosedReason.NestedSoi, d.Reason);
+            Assert.Equal(SegmentProvenance.FaithfulFallback, d.Provenance);
+            Assert.NotNull(d.NestedSubtree);
+            Assert.Equal("Kerbin", d.NestedSubtree.RootBody);
+            Assert.True(d.NestedSubtree.IsNested);
+        }
+
+        [Fact]
         public void Classify_StationArrivalAnchor_IsFailClosed_MovingTargetStation_HighestPrecedence()
         {
             // A live-vessel arrival anchor (a station) is the least-supported phase -> fail closed, and it

--- a/Source/Parsek.Tests/MapRender/PhaseFactoryTests.cs
+++ b/Source/Parsek.Tests/MapRender/PhaseFactoryTests.cs
@@ -458,5 +458,167 @@ namespace Parsek.Tests
             Assert.Empty(PhaseFactory.BuildOrderedRecordedBodies(
                 new MockTrajectory { RecordingId = "r", OrbitSegments = new List<OrbitSegment>() }));
         }
+
+        // ---- ClassifyTracedKind / ResolveEnvPhaseForWindow / IsArrivalConic internal helpers ----
+        // These exercise the branching faithful-leaf-identity helpers directly (PhaseFactory.cs ~330/350/389).
+        // They are NOT the byte-parity gate (kind/env are non-parity classification), so they assert the
+        // gameplay LABEL the helper resolves - the bug each catches is a wrong ascent/descent/surface/arrival
+        // split, which would mislabel a phase in the typed spine.
+
+        private static RenderSegment Traced(double s, double e, string body)
+            => new RenderSegment(SegmentKind.Surface, Treatment.TracedPath, s, e, body, SegmentPayload.Traced);
+
+        private static RenderSegment Conic(double s, double e, string body)
+            => new RenderSegment(
+                SegmentKind.Loiter, Treatment.StockConic, s, e, body,
+                SegmentPayload.ForConic(new OrbitSegment
+                {
+                    startUT = s, endUT = e, bodyName = body, semiMajorAxis = 700000, eccentricity = 0,
+                }));
+
+        [Fact]
+        public void ClassifyTracedKind_AscentBeforeFirstConic_DescentAfter()
+        {
+            // The recording has one above-surface conic at [10,30]. A traced run that STARTS before that
+            // first conic is an Ascent (the launch leg); one that starts at/after it is a Descent (the
+            // deorbit/landing leg). With no surface env on either run the split is purely positional. A
+            // mutation that dropped the FirstConicStartUT comparison (or flipped before/after) fails here.
+            var traj = new MockTrajectory
+            {
+                RecordingId = "rec-asc-desc",
+                Points = new List<TrajectoryPoint>
+                {
+                    Pt(0, "Kerbin"), Pt(4, "Kerbin"), Pt(35, "Kerbin"), Pt(40, "Kerbin"),
+                },
+                OrbitSegments = new List<OrbitSegment>
+                {
+                    new OrbitSegment { startUT = 10, endUT = 30, bodyName = "Kerbin", semiMajorAxis = 700000, eccentricity = 0 },
+                },
+                // No TrackSections: the env phase is null, so the kind is the positional ascent/descent split.
+            };
+
+            Assert.Equal(PhaseKind.Ascent,
+                PhaseFactory.ClassifyTracedKind(Traced(0, 4, "Kerbin"), traj));   // before the [10,30] conic
+            Assert.Equal(PhaseKind.Descent,
+                PhaseFactory.ClassifyTracedKind(Traced(35, 40, "Kerbin"), traj)); // after the conic
+        }
+
+        [Fact]
+        public void ClassifyTracedKind_SurfaceEnv_WinsOverAscentDescent()
+        {
+            // A traced run whose recorded env-class is SURFACE classifies Surface, EVEN when it starts AFTER
+            // the first conic (where the positional rule would otherwise say Descent). The surface env is the
+            // terminal landed state, which must win - a mutation that ran the ascent/descent split first
+            // (ignoring the surface env) would mislabel a landed run as Descent.
+            var traj = new MockTrajectory
+            {
+                RecordingId = "rec-surf-wins",
+                Points = new List<TrajectoryPoint> { Pt(35, "Kerbin"), Pt(40, "Kerbin") },
+                OrbitSegments = new List<OrbitSegment>
+                {
+                    new OrbitSegment { startUT = 10, endUT = 30, bodyName = "Kerbin", semiMajorAxis = 700000, eccentricity = 0 },
+                },
+                TrackSections = new List<TrackSection>
+                {
+                    // The traced run [35,40] overlaps a SurfaceStationary section -> "surface".
+                    Sec(34, 41, SegmentEnvironment.SurfaceStationary),
+                },
+            };
+
+            // Positionally this run is AFTER the conic (would be Descent), but the surface env wins.
+            Assert.Equal(PhaseKind.Surface,
+                PhaseFactory.ClassifyTracedKind(Traced(35, 40, "Kerbin"), traj));
+        }
+
+        [Fact]
+        public void ResolveEnvPhaseForWindow_MultiSection_UsesLastOverlapping()
+        {
+            // When several TrackSections overlap the window, the LAST overlapping section's environment is
+            // returned (a descent run ending in atmo/surface reads its TERMINAL class). A mutation that
+            // returned the FIRST overlap, or stopped at the first match, would read "exo" here instead of
+            // "surface".
+            var traj = new MockTrajectory
+            {
+                RecordingId = "rec-multi-env",
+                TrackSections = new List<TrackSection>
+                {
+                    Sec(0, 10, SegmentEnvironment.ExoBallistic),   // overlaps -> "exo"
+                    Sec(10, 20, SegmentEnvironment.Atmospheric),   // overlaps -> "atmo"
+                    Sec(20, 30, SegmentEnvironment.SurfaceStationary), // overlaps -> "surface" (LAST)
+                    Sec(40, 50, SegmentEnvironment.Approach),      // does NOT overlap [5,25]
+                },
+            };
+
+            // Window [5,25] overlaps the first three sections; the LAST overlapping (SurfaceStationary) wins.
+            Assert.Equal("surface", PhaseFactory.ResolveEnvPhaseForWindow(traj, 5, 25));
+            // A null/empty TrackSection list returns null (BG-on-rails tolerated, no assert).
+            Assert.Null(PhaseFactory.ResolveEnvPhaseForWindow(
+                new MockTrajectory { RecordingId = "r", TrackSections = null }, 0, 100));
+        }
+
+        [Theory]
+        [InlineData(true)]   // ApproachEnv: a traced/conic window with an "approach" env is an arrival
+        [InlineData(false)]  // no env, departure body conic: not an arrival
+        public void IsArrivalConic_ApproachEnv_True(bool approach)
+        {
+            // A recorded conic whose env-class is "approach" is an ARRIVAL loiter regardless of body. The
+            // approach env is the destination-arrival signal; a mutation that dropped the approach short-
+            // circuit would mislabel a destination approach as DepartureLoiter.
+            var traj = new MockTrajectory
+            {
+                RecordingId = "rec-approach",
+                OrbitSegments = new List<OrbitSegment>
+                {
+                    new OrbitSegment { startUT = 10, endUT = 30, bodyName = "Kerbin", semiMajorAxis = 700000 },
+                },
+                TrackSections = approach
+                    ? new List<TrackSection> { Sec(10, 30, SegmentEnvironment.Approach) }
+                    : new List<TrackSection> { Sec(10, 30, SegmentEnvironment.ExoBallistic) },
+            };
+
+            // The conic on the SAME (departure) body: approach env -> arrival; exo env -> not arrival.
+            Assert.Equal(approach,
+                PhaseFactory.IsArrivalConic(Conic(10, 30, "Kerbin"), ordinal: 0, traj));
+        }
+
+        [Fact]
+        public void IsArrivalConic_DifferentBodyLastInTime_True()
+        {
+            // The first conic's body is the DEPARTURE body. A later conic on a DIFFERENT body that is the
+            // LAST conic in time is the destination park -> arrival. A mutation that dropped the
+            // different-body OR the last-in-time gate would mislabel the destination park.
+            var traj = new MockTrajectory
+            {
+                RecordingId = "rec-arrival",
+                OrbitSegments = new List<OrbitSegment>
+                {
+                    new OrbitSegment { startUT = 10, endUT = 30, bodyName = "Kerbin", semiMajorAxis = 700000 }, // departure (first)
+                    new OrbitSegment { startUT = 100, endUT = 130, bodyName = "Duna", semiMajorAxis = 400000 }, // arrival (last)
+                },
+            };
+
+            // The Duna conic at [100,130] is on a different body AND last in time -> arrival.
+            Assert.True(PhaseFactory.IsArrivalConic(Conic(100, 130, "Duna"), ordinal: 1, traj));
+        }
+
+        [Fact]
+        public void IsArrivalConic_DepartureBodyConic_False()
+        {
+            // The departure-body conic (the FIRST conic's body, not last in time) is a DEPARTURE loiter, not
+            // arrival - even when a later different-body conic exists. The different-body gate must reject a
+            // conic that is ON the first (departure) body.
+            var traj = new MockTrajectory
+            {
+                RecordingId = "rec-departure",
+                OrbitSegments = new List<OrbitSegment>
+                {
+                    new OrbitSegment { startUT = 10, endUT = 30, bodyName = "Kerbin", semiMajorAxis = 700000 }, // departure (first)
+                    new OrbitSegment { startUT = 100, endUT = 130, bodyName = "Duna", semiMajorAxis = 400000 }, // a later arrival
+                },
+            };
+
+            // The Kerbin departure conic at [10,30]: same body as the first conic -> NOT arrival.
+            Assert.False(PhaseFactory.IsArrivalConic(Conic(10, 30, "Kerbin"), ordinal: 0, traj));
+        }
     }
 }

--- a/Source/Parsek.Tests/RenderParityOracleTests.cs
+++ b/Source/Parsek.Tests/RenderParityOracleTests.cs
@@ -96,6 +96,34 @@ namespace Parsek.Tests
             Assert.True(r.MaxDeviationMeters <= 5.0 + 1e-6);
         }
 
+        // ---- ComputeDrift: point-to-POLYLINE (not point-to-vertex) - the "green but blind" guard ----
+
+        [Fact]
+        public void ComputeDrift_ReferencePointNearSegmentInterior_NotVertices_MeasuresSmall()
+        {
+            // THE point-to-polyline guard (catches a "green but blind" rewrite to point-to-VERTEX): the
+            // rendered polyline has vertices ONLY at (0,0,0) and (1000,0,0) - a single 1000 m segment with
+            // no vertex in its interior. The reference point sits at (250,0,0), ON that segment but FAR from
+            // either vertex (250 m from the nearest vertex). A correct point-to-segment (polyline) diff
+            // projects onto the segment interior and measures ~0 m -> within a 10 m tolerance, OverTolerance
+            // false. A point-to-VERTEX rewrite would measure 250 m (the nearest-vertex distance) and FALSE-
+            // FIRE drift - so this test would go RED on that regression. The whole acceptance axis is "did
+            // the rendered ARC match the reference ARC", and an arc is the polyline, not its sample vertices.
+            double[] reference = new double[] { 250.0, 0.0, 0.0 }; // on the segment interior, 250 m from both vertices
+            double[] rendered = new double[]
+            {
+                0.0, 0.0, 0.0,
+                1000.0, 0.0, 0.0, // a single 1000 m segment; NO vertex near (250,0,0)
+            };
+
+            var r = RenderParityOracle.ComputeDrift(
+                RenderParityOracle.ParityMode.Faithful, reference, rendered, toleranceMeters: 10.0);
+
+            Assert.True(r.HasMeasurement);
+            Assert.False(r.OverTolerance);                       // ~0 m to the segment interior, not 250 m to a vertex
+            Assert.Equal(0.0, r.MaxDeviationMeters, 6);          // projects exactly onto the segment
+        }
+
         // ---- ComputeDrift: over tolerance (drift) ----
 
         [Fact]

--- a/Source/Parsek/InGameTests/BgOnRailsAllOrbitalSpineInGameTest.cs
+++ b/Source/Parsek/InGameTests/BgOnRailsAllOrbitalSpineInGameTest.cs
@@ -1,0 +1,214 @@
+using System.Collections.Generic;
+using System.Globalization;
+using Parsek.MapRender;
+using UnityEngine;
+
+namespace Parsek.InGameTests
+{
+    // Phase 11 / N5 (test-automation coverage follow-up) - the BG-ON-RAILS ALL-ORBITAL spine test. A
+    // background / on-rails member emits NO env-classified per-frame TrackSections and no atmospheric Points; it
+    // is orbit-bridge-only (see the on-rails BG invariant in CLAUDE.md). The render pipeline must build an
+    // all-orbital chain for such a member - Loiter/Transfer conics with NO Descent/Surface phase - and never
+    // assert on the absent SegmentPhase data (PhaseFactory design §11.3).
+    //
+    // It combines the two proven patterns:
+    //   - P2-pure: build an all-OrbitSegment recording (NO atmospheric Points), run the REAL
+    //     PhaseFactory.BuildPhaseChain over it, and assert the chain has ZERO DescentPhase / SurfacePhase /
+    //     AscentPhase (only conic phases) and at least one conic phase. A regression that synthesized a
+    //     traced Descent/Surface phase for an orbit-only member (e.g. by reading absent track sections as
+    //     surface) would fail here.
+    //   - P1-ghost: create the live faithful ghost on the same orbit and assert
+    //     MapRenderProbe.ComputeFaithfulOrbitParity reports ZERO drift (the rendered conic == the recorded
+    //     conic).
+    //
+    // ARCHITECTURAL TRUTH respected + honest caveat: this asserts the factory's all-orbital CLASSIFICATION (no
+    // traced phases for an orbit-only member) + the live faithful parity, NOT any 5b pixel. The factory
+    // classification is unit-tested headlessly; this runs the SAME PhaseFactory.BuildPhaseChain over a real
+    // orbit-only recording and pairs it with a live ghost.
+    //
+    // NOTE: in-game test (Ctrl+Shift+T / Settings > Diagnostics); the parity half builds a live ghost
+    // ProtoVessel so it cannot run headless. FLIGHT only; career-independent; self-contained.
+    public class BgOnRailsAllOrbitalSpineInGameTest
+    {
+        private const string KerbinBodyName = "Kerbin";
+        private const double Sma = 900000.0;   // well above Kerbin's 600km surface (a high circular park)
+        private const double Ecc = 0.0;
+        private const double Inc = 0.0;
+
+        [InGameTest(Category = "MapRender", Scene = GameScenes.FLIGHT,
+            Description = "Phase 11 N5 BG-on-rails all-orbital (spine): PhaseFactory.BuildPhaseChain over an "
+                + "all-OrbitSegment recording (no atmospheric Points / track sections) yields ONLY conic phases "
+                + "(zero Descent/Surface/Ascent) and the live faithful ghost on that orbit reports ZERO parity-"
+                + "drift. Asserts the factory all-orbital classification + live parity, not any 5b pixel.")]
+        public void AllOrbitalRecording_FactoryYieldsConicOnly_AndLiveGhostZeroDrift()
+        {
+            CelestialBody kerbin = FlightGlobals.Bodies?.Find(b => b.bodyName == KerbinBodyName);
+            if (kerbin == null)
+            {
+                InGameAssert.Skip("Kerbin not found in FlightGlobals.Bodies (non-stock pack)");
+                return;
+            }
+
+            double liveUT = Planetarium.GetUniversalTime();
+            double startUT = liveUT - 1800.0;
+            double endUT = startUT + 3600.0;
+            OrbitSegment seg = BuildSegment(startUT);
+
+            // An ALL-ORBITAL recording: ONE above-surface OrbitSegment, NO atmospheric Points, NO TrackSections
+            // (the on-rails BG shape). The factory must build a conic-only chain.
+            Recording rec = BuildAllOrbitalRecording(startUT, endUT, seg);
+
+            // --- (P2-pure) THE FACTORY ALL-ORBITAL CLASSIFICATION: conic phases only, no traced phases. ---
+            // surface=null (the default): IsOrbitSegmentBelowSurface returns false for a null provider, so the
+            // above-surface orbit stays a StockConic (it is genuinely above Kerbin's radius anyway). With no
+            // Points, the assembler produces no TracedPath runs, so the factory classifies ONLY conic phases.
+            PhaseChain chain = PhaseFactory.BuildPhaseChain(
+                rec, committedIndex: 0, instanceKey: 0, windowStartUT: startUT, windowEndUT: endUT);
+
+            int conicPhases = 0;
+            int descentPhases = 0;
+            int surfacePhases = 0;
+            int ascentPhases = 0;
+            for (int i = 0; i < chain.Phases.Count; i++)
+            {
+                TrajectoryPhase p = chain.Phases[i];
+                if (p is DescentPhase) descentPhases++;
+                else if (p is SurfacePhase) surfacePhases++;
+                else if (p is AscentPhase) ascentPhases++;
+                else if (p is ConicPhase || p is DualTreatmentConicPhase) conicPhases++;
+            }
+
+            ParsekLog.Info("TestRunner", string.Format(CultureInfo.InvariantCulture,
+                "BgOnRailsAllOrbital: phases={0} conic={1} descent={2} surface={3} ascent={4} "
+                + "window=[{5:F1},{6:F1}]",
+                chain.Phases.Count, conicPhases, descentPhases, surfacePhases, ascentPhases, startUT, endUT));
+
+            InGameAssert.AreEqual(0, descentPhases,
+                "an all-orbital (orbit-bridge-only) recording must produce NO DescentPhase - the factory must "
+                + "not synthesize a traced descent for an orbit-only member (design §11.3)");
+            InGameAssert.AreEqual(0, surfacePhases,
+                "an all-orbital recording must produce NO SurfacePhase (no recorded surface/atmospheric run)");
+            InGameAssert.AreEqual(0, ascentPhases,
+                "an all-orbital recording must produce NO AscentPhase (no recorded ascent/atmospheric run)");
+            InGameAssert.IsTrue(conicPhases >= 1,
+                string.Format(CultureInfo.InvariantCulture,
+                    "an all-orbital recording must produce at least one CONIC phase (saw {0}); a conic-free "
+                    + "chain here would mean the above-surface orbit was wrongly dropped", conicPhases));
+
+            // --- (P1-ghost) THE LIVE FAITHFUL PARITY: the ghost on this orbit reports zero drift. ---
+            System.Func<double> prevUTNow = GhostMapPresence.CurrentUTNow;
+            List<Recording> prevRecordings = RecordingStore.CommittedRecordings != null
+                ? new List<Recording>(RecordingStore.CommittedRecordings)
+                : new List<Recording>();
+            List<RecordingTree> prevTrees = RecordingStore.CommittedTrees != null
+                ? new List<RecordingTree>(RecordingStore.CommittedTrees)
+                : new List<RecordingTree>();
+
+            RecordingStore.ClearCommittedInternal();
+            RecordingStore.ClearCommittedTreesInternal();
+            RecordingStore.AddCommittedInternal(rec);
+            int recordingIndex = 0;
+            GhostMapPresence.CurrentUTNow = () => liveUT;
+            GhostMapPresence.RemoveAllGhostVessels("bgonrails-start");
+
+            uint pid = 0u;
+            try
+            {
+                Vessel ghost = GhostMapPresence.CreateGhostVesselFromSource(
+                    recordingIndex, rec, GhostMapPresence.TrackingStationGhostSource.Segment,
+                    seg, default(TrajectoryPoint), startUT);
+
+                if (ghost == null || ghost.orbitDriver == null || ghost.orbitDriver.orbit == null)
+                {
+                    InGameAssert.Skip("all-orbital faithful ghost did not create in this context (no proto)");
+                    return;
+                }
+                pid = ghost.persistentId;
+
+                Orbit renderedOrbit = ghost.orbitDriver.orbit;
+                Vector3d iconBodyRel = ghost.GetWorldPos3D() - kerbin.position;
+
+                MapRenderProbe.FaithfulParitySample sample = MapRenderProbe.ComputeFaithfulOrbitParity(
+                    renderedOrbit, kerbin, iconBodyRel, liveUT, 0.0, liveUT, rec.RecordingId);
+                Parsek.MapRender.RenderParityOracle.ParityResult result = sample.Result;
+
+                ParsekLog.Info("TestRunner", string.Format(CultureInfo.InvariantCulture,
+                    "BgOnRailsAllOrbital parity: pid={0} sampled={1} skip={2} hasMeas={3} maxDev={4:F1}m "
+                    + "tol={5:F1}m over={6}",
+                    pid, sample.Sampled, sample.SkipReason ?? "(none)", result.HasMeasurement,
+                    result.MaxDeviationMeters, result.ToleranceMeters, result.OverTolerance));
+
+                InGameAssert.IsTrue(sample.Sampled,
+                    "the all-orbital faithful ghost must SAMPLE its parity (not skip); skipReason="
+                    + (sample.SkipReason ?? "(none)"));
+                InGameAssert.IsTrue(result.HasMeasurement,
+                    "the all-orbital faithful ghost must yield a parity measurement (else the gate is blind)");
+                InGameAssert.IsFalse(result.OverTolerance,
+                    string.Format(CultureInfo.InvariantCulture,
+                        "the all-orbital faithful ghost must report ZERO drift; maxDev={0:F1}m exceeded "
+                        + "tol={1:F1}m", result.MaxDeviationMeters, result.ToleranceMeters));
+            }
+            finally
+            {
+                if (pid != 0u)
+                    GhostMapPresence.RemoveAllGhostVessels("bgonrails-cleanup");
+                RecordingStore.ClearCommittedInternal();
+                RecordingStore.ClearCommittedTreesInternal();
+                for (int i = 0; i < prevRecordings.Count; i++)
+                    RecordingStore.AddCommittedInternal(prevRecordings[i]);
+                for (int i = 0; i < prevTrees.Count; i++)
+                    RecordingStore.AddCommittedTreeInternal(prevTrees[i]);
+                GhostMapPresence.CurrentUTNow = prevUTNow;
+            }
+        }
+
+        private static OrbitSegment BuildSegment(double startUT)
+        {
+            return new OrbitSegment
+            {
+                startUT = startUT,
+                endUT = startUT + 3600.0,
+                inclination = Inc,
+                eccentricity = Ecc,
+                semiMajorAxis = Sma,
+                longitudeOfAscendingNode = 0.0,
+                argumentOfPeriapsis = 0.0,
+                meanAnomalyAtEpoch = 0.0,
+                epoch = startUT,
+                bodyName = KerbinBodyName,
+                isPredicted = false,
+                orbitalFrameRotation = Quaternion.identity,
+                angularVelocity = Vector3.zero,
+            };
+        }
+
+        // An ALL-ORBITAL recording (the on-rails BG shape): ONE above-surface OrbitSegment, NO atmospheric
+        // Points, NO TrackSections. The assembler produces no traced runs (no Points), so the factory classifies
+        // only conic phases.
+        private static Recording BuildAllOrbitalRecording(double startUT, double endUT, OrbitSegment seg)
+        {
+            var rec = new Recording
+            {
+                RecordingId = "bgonrails-allorbital-" + System.Guid.NewGuid().ToString("N"),
+                VesselName = "Parsek BG OnRails AllOrbital",
+                EndpointPhase = RecordingEndpointPhase.OrbitSegment,
+                EndpointBodyName = KerbinBodyName,
+                TerminalOrbitBody = KerbinBodyName,
+                TerminalOrbitSemiMajorAxis = Sma,
+                TerminalOrbitEccentricity = Ecc,
+                TerminalOrbitInclination = Inc,
+                TerminalOrbitLAN = 0.0,
+                TerminalOrbitArgumentOfPeriapsis = 0.0,
+                TerminalOrbitMeanAnomalyAtEpoch = 0.0,
+                TerminalOrbitEpoch = startUT,
+                ExplicitStartUT = startUT,
+                ExplicitEndUT = endUT,
+                PlaybackEnabled = true,
+            };
+            // NO Points, NO TrackSections (orbit-bridge-only). One above-surface conic.
+            rec.OrbitSegments.Add(seg);
+            rec.MarkFilesDirty();
+            return rec;
+        }
+    }
+}

--- a/Source/Parsek/InGameTests/DockUndockMemberWindowSpineInGameTest.cs
+++ b/Source/Parsek/InGameTests/DockUndockMemberWindowSpineInGameTest.cs
@@ -1,0 +1,153 @@
+using System.Collections.Generic;
+using System.Globalization;
+using Parsek.MapRender;
+using UnityEngine;
+
+namespace Parsek.InGameTests
+{
+    // Phase 11 / N2 (test-automation coverage follow-up) - the DOCK/UNDOCK MEMBER-WINDOW spine test. It closes
+    // the dock/undock case at the DECISION layer with the proven P2-pure pattern (synthetic PhaseChain +
+    // LoopUnitSet, sampled via ChainSampler.Sample + GhostRenderDirector.Decide - no ghost / scene).
+    //
+    // THE MODEL: a docking absorbs one member's identity into another at dockUT (the absorbed craft stops
+    // existing as a distinct ghost when it docks), and an undock SPLITS off a child member at splitUT (the new
+    // craft begins to exist as a distinct ghost when it undocks). At the render-decision layer these are
+    // member-window TRIMS on the shared mission span clock: a LoopUnit whose memberWindows dict trims
+    //   - the ABSORBED member to END at dockUT (its window is [spanStart, dockUT]); and
+    //   - the SPLIT child member to BEGIN at splitUT (its window is [splitUT, spanEnd]).
+    //
+    // THE CONTRACT (the live assertions): sampling at the boundary -/+ eps, the spine must
+    //   - flip the absorbed member Visible -> Hidden EXACTLY at dockUT (no clamp past its window - a regression
+    //     that clamped a docked ghost past dockUT, the "stale ghost after dock" bug, would keep it Visible); and
+    //   - flip the split child Hidden -> Visible EXACTLY at splitUT (it does not exist before it undocks).
+    //
+    // To make the boundary deterministic, the unit runs ONE span instance (CadenceSeconds == span,
+    // phaseAnchorUT == spanStart), so the shared span-clock loopUT tracks liveUT linearly inside the span and the
+    // member-window trim is the SOLE governing factor (IsLoopUTInMemberWindow is epsilon-tolerant at 1e-6; the
+    // -/+ 1.0s probes are far outside that, so the flips are unambiguous).
+    //
+    // ARCHITECTURAL TRUTH respected + honest caveat: this asserts the spine's member-window DECISION (the
+    // Visible/Hidden flip at the dock/undock boundary), NOT the live ProtoVessel lifecycle (no ghost is created
+    // or destroyed here) nor any 5b pixel. The member-window trim math is exercised headlessly via the span
+    // clock; this drives it through the SAME ChainSampler.Sample entry the production spine inlines.
+    //
+    // NOTE: in-game test (Ctrl+Shift+T / Settings > Diagnostics) so it runs on a cold launch pad. Fast (void, no
+    // ghost / scene / save). FLIGHT only; career-independent; self-contained.
+    public class DockUndockMemberWindowSpineInGameTest
+    {
+        private const string KerbinBodyName = "Kerbin";
+
+        private const int AbsorbedIdx = 0;   // the member that docks (its identity is absorbed at dockUT)
+        private const int SplitIdx = 1;      // the child that undocks (begins at splitUT)
+        private const double SpanStart = 1000.0;
+        private const double SpanEnd = 2000.0;
+        private const double DockUT = 1400.0;    // absorbed member trimmed to END here
+        private const double SplitUT = 1600.0;   // split child trimmed to BEGIN here
+        private const double Eps = 1.0;          // boundary probe (>> BoundaryEpsilon 1e-6)
+
+        [InGameTest(Category = "MapRender", Scene = GameScenes.FLIGHT,
+            Description = "Phase 11 N2 dock/undock member-window (spine): the absorbed member flips Visible->"
+                + "Hidden EXACTLY at dockUT (no clamp past its window - the stale-ghost-after-dock guard) and "
+                + "the split child flips Hidden->Visible EXACTLY at splitUT (it does not exist before undock). "
+                + "Asserts the spine member-window DECISION, not the ProtoVessel lifecycle.")]
+        public void MemberWindow_DockUndock_FlipsVisibilityExactlyAtBoundaries()
+        {
+            CelestialBody kerbin = FlightGlobals.Bodies?.Find(b => b.bodyName == KerbinBodyName);
+            if (kerbin == null)
+            {
+                InGameAssert.Skip("Kerbin not found in FlightGlobals.Bodies (non-stock pack)");
+                return;
+            }
+
+            GhostPlaybackLogic.LoopUnitSet units = BuildDockUndockUnit();
+            PhaseChain absorbedChain = BuildMemberChain(AbsorbedIdx, "rec-absorbed");
+            PhaseChain splitChain = BuildMemberChain(SplitIdx, "rec-split");
+
+            // --- ABSORBED member: Visible just BEFORE dockUT, Hidden just AFTER (no clamp past its window) ---
+            bool absorbedBeforeDock = SampleVisible(absorbedChain, AbsorbedIdx, DockUT - Eps, units, "absorbed");
+            bool absorbedAfterDock = SampleVisible(absorbedChain, AbsorbedIdx, DockUT + Eps, units, "absorbed");
+
+            InGameAssert.IsTrue(absorbedBeforeDock,
+                "the absorbed member must be VISIBLE just before dockUT (it still exists as a distinct ghost "
+                + "until it docks)");
+            InGameAssert.IsFalse(absorbedAfterDock,
+                "the absorbed member must flip to HIDDEN just after dockUT - never clamp past its trimmed "
+                + "window (the stale-ghost-after-dock bug: a docked craft's ghost must stop, not freeze)");
+
+            // --- SPLIT child member: Hidden just BEFORE splitUT, Visible just AFTER (begins at undock) ---
+            bool splitBeforeSplit = SampleVisible(splitChain, SplitIdx, SplitUT - Eps, units, "split");
+            bool splitAfterSplit = SampleVisible(splitChain, SplitIdx, SplitUT + Eps, units, "split");
+
+            InGameAssert.IsFalse(splitBeforeSplit,
+                "the split child must be HIDDEN just before splitUT - it does not exist as a distinct ghost "
+                + "before it undocks (no premature appearance)");
+            InGameAssert.IsTrue(splitAfterSplit,
+                "the split child must flip to VISIBLE just after splitUT (it begins to exist at undock)");
+
+            ParsekLog.Info("TestRunner", string.Format(CultureInfo.InvariantCulture,
+                "DockUndockMemberWindow: dockUT={0:F1} absorbed[before={1} after={2}] | splitUT={3:F1} "
+                + "split[before={4} after={5}]",
+                DockUT, absorbedBeforeDock, absorbedAfterDock, SplitUT, splitBeforeSplit, splitAfterSplit));
+        }
+
+        // Sample one member's chain at liveUT and return whether the director's intent is visible. The chain's
+        // full window is [SpanStart, SpanEnd]; the member-window trim (in the unit) is the governing factor.
+        private static bool SampleVisible(
+            PhaseChain chain, int memberIdx, double liveUT, GhostPlaybackLogic.LoopUnitSet units, string label)
+        {
+            GhostSample sample = ChainSampler.Sample(chain, liveUT, units);
+            GhostRenderIntent intent = GhostRenderDirector.Decide(sample, GhostRenderIntent.Hidden(), label);
+            ParsekLog.Info("TestRunner", string.Format(CultureInfo.InvariantCulture,
+                "DockUndockMemberWindow.sample: member={0} liveUT={1:F1} cov={2} vis={3} driveUT={4:F3}",
+                memberIdx, liveUT, sample.Coverage, intent.Visible, sample.DriveUT));
+            return intent.Visible;
+        }
+
+        // One LoopUnit running ONE span instance (cadence == span, anchor == spanStart -> loopUT tracks liveUT
+        // linearly in [SpanStart, SpanEnd]) with a memberWindows dict trimming the absorbed member to end at
+        // dockUT and the split child to begin at splitUT. The MemberWindow ctor is at SpanClock.cs:61.
+        private static GhostPlaybackLogic.LoopUnitSet BuildDockUndockUnit()
+        {
+            var memberWindows = new Dictionary<int, GhostPlaybackLogic.LoopUnit.MemberWindow>
+            {
+                { AbsorbedIdx, new GhostPlaybackLogic.LoopUnit.MemberWindow(SpanStart, DockUT) },
+                { SplitIdx, new GhostPlaybackLogic.LoopUnit.MemberWindow(SplitUT, SpanEnd) },
+            };
+            // The 7-arg + memberWindows LoopUnit ctor (SpanClock.cs:61). overlapCadence == cadence keeps it a
+            // single non-overlap instance (the boundary flip is the subject, not overlap).
+            var unit = new GhostPlaybackLogic.LoopUnit(
+                ownerIndex: AbsorbedIdx,
+                memberIndices: new[] { AbsorbedIdx, SplitIdx },
+                spanStartUT: SpanStart,
+                spanEndUT: SpanEnd,
+                cadenceSeconds: SpanEnd - SpanStart,        // == span -> one instance, loopUT tracks liveUT
+                phaseAnchorUT: SpanStart,
+                overlapCadenceSeconds: SpanEnd - SpanStart, // == cadence -> no overlap
+                memberWindows: memberWindows);
+            var unitsByOwner = new Dictionary<int, GhostPlaybackLogic.LoopUnit> { { AbsorbedIdx, unit } };
+            var ownerByIndex = new Dictionary<int, int>
+            {
+                { AbsorbedIdx, AbsorbedIdx }, { SplitIdx, AbsorbedIdx },
+            };
+            return new GhostPlaybackLogic.LoopUnitSet(unitsByOwner, ownerByIndex);
+        }
+
+        // A one-conic chain covering the WHOLE span [SpanStart, SpanEnd] for a member, so the ONLY thing that
+        // governs Visible/Hidden at the dock/undock boundary is the member-window trim (the chain itself never
+        // gates these UTs out).
+        private static PhaseChain BuildMemberChain(int memberIdx, string recId)
+        {
+            var anchor = new AnchorFrame.BodyAnchor(KerbinBodyName);
+            var phase = new DepartureLoiterPhase(
+                new PhaseId(recId, 0, 0), SegmentProvenance.Recorded, anchor, SpanStart, SpanEnd,
+                new OrbitSegment
+                {
+                    startUT = SpanStart, endUT = SpanEnd, bodyName = KerbinBodyName,
+                    semiMajorAxis = 850000.0, eccentricity = 0.0, epoch = SpanStart,
+                });
+            return new PhaseChain(
+                recId, committedIndex: memberIdx, instanceKey: 0,
+                phases: new List<TrajectoryPhase> { phase }, windowStartUt: SpanStart, windowEndUt: SpanEnd);
+        }
+    }
+}

--- a/Source/Parsek/InGameTests/MultiBodyConcurrentGhostsParityInGameTest.cs
+++ b/Source/Parsek/InGameTests/MultiBodyConcurrentGhostsParityInGameTest.cs
@@ -1,0 +1,230 @@
+using System.Collections.Generic;
+using System.Globalization;
+using UnityEngine;
+
+namespace Parsek.InGameTests
+{
+    // Phase 11 / N3 (test-automation coverage follow-up) - the MULTI-BODY CONCURRENT GHOSTS parity test. It
+    // closes the "two faithful ghosts on different bodies render concurrently without cross-frame leakage" case
+    // with the proven P1-ghost pattern (live faithful ghosts via GhostMapPresence.CreateGhostVesselFromSource +
+    // MapRenderProbe.ComputeFaithfulOrbitParity, modelled on RenderParityBaselineTest.cs:134-141).
+    //
+    // THE CONTRACT (the live assertions): TWO live faithful ghosts created in ONE RecordingStore swap - one on a
+    // Kerbin orbit, one on a Mun orbit - must each:
+    //   - report ZERO faithful parity-drift through the REAL wired probe seam (each rendered orbit == its own
+    //     recorded arc);
+    //   - have DISTINCT persistent ids (two separate ProtoVessels, not one reused); and
+    //   - resolve parity in its OWN body frame (the probe's covering-segment body equals the ghost's rendered
+    //     body). A regression that framed the Mun ghost in Kerbin's frame (cross-frame leak) would either
+    //     parity-skip with body-mismatch or drift hugely - either way this fails.
+    //
+    // WHY IT IS NON-VACUOUS: the probe (ComputeFaithfulOrbitParity) skips with "body-mismatch" if the rendered
+    // body differs from the recorded covering body, so the test asserts BOTH ghosts SAMPLED (not skipped) AND
+    // measured within tolerance AND that the covering body each parity used is the ghost's own body - catching a
+    // cross-frame leak rather than passing it through as a silent skip.
+    //
+    // ARCHITECTURAL TRUTH respected + honest caveat: this asserts the live faithful parity (the rendered orbit
+    // equals the recorded orbit, per body), NOT any 5b pixel. It DOES exercise the live ProtoVessel lifecycle
+    // (two concurrent ghosts), which is the point of the multi-body case.
+    //
+    // NOTE: in-game test (Ctrl+Shift+T / Settings > Diagnostics); cannot run headless (builds two live ghost
+    // ProtoVessels + reads their OrbitDrivers). Skips cleanly if Mun is absent (mirrors the FailClosedFaithful
+    // Jool guard). FLIGHT only; career-independent; self-contained (its own two recordings, cleaned up).
+    public class MultiBodyConcurrentGhostsParityInGameTest
+    {
+        private const string KerbinBodyName = "Kerbin";
+        private const string MunBodyName = "Mun";
+
+        // A clean above-atmosphere circular equatorial orbit per body (stock radii: Kerbin 600km, Mun 200km).
+        private const double KerbinSma = 850000.0;
+        private const double MunSma = 400000.0;
+        private const double Ecc = 0.0;
+        private const double Inc = 0.0;
+
+        [InGameTest(Category = "MapRender", Scene = GameScenes.FLIGHT,
+            Description = "Phase 11 N3 multi-body concurrent ghosts (parity): two live faithful ghosts (one "
+                + "Kerbin orbit, one Mun orbit) created in one RecordingStore swap each report ZERO faithful "
+                + "drift through the real probe seam, have DISTINCT pids, and resolve parity in their OWN body "
+                + "frame (no cross-frame leak). Skips if Mun absent.")]
+        public void MultiBodyConcurrentGhosts_KerbinAndMun_BothZeroDrift_DistinctPids_NoCrossFrameLeak()
+        {
+            CelestialBody kerbin = FlightGlobals.Bodies?.Find(b => b.bodyName == KerbinBodyName);
+            CelestialBody mun = FlightGlobals.Bodies?.Find(b => b.bodyName == MunBodyName);
+            if (kerbin == null)
+            {
+                InGameAssert.Skip("Kerbin not found in FlightGlobals.Bodies (non-stock pack)");
+                return;
+            }
+            if (mun == null)
+            {
+                InGameAssert.Skip("Mun not present (non-stock pack) - cannot exercise the multi-body case");
+                return;
+            }
+
+            double liveUT = Planetarium.GetUniversalTime();
+            double startUT = liveUT - 1800.0;
+
+            OrbitSegment kerbinSeg = BuildSegment(startUT, KerbinBodyName, KerbinSma);
+            OrbitSegment munSeg = BuildSegment(startUT, MunBodyName, MunSma);
+
+            System.Func<double> prevUTNow = GhostMapPresence.CurrentUTNow;
+            List<Recording> prevRecordings = RecordingStore.CommittedRecordings != null
+                ? new List<Recording>(RecordingStore.CommittedRecordings)
+                : new List<Recording>();
+            List<RecordingTree> prevTrees = RecordingStore.CommittedTrees != null
+                ? new List<RecordingTree>(RecordingStore.CommittedTrees)
+                : new List<RecordingTree>();
+
+            Recording kerbinRec = BuildRecording(startUT, kerbinSeg, KerbinBodyName, KerbinSma);
+            Recording munRec = BuildRecording(startUT, munSeg, MunBodyName, MunSma);
+
+            RecordingStore.ClearCommittedInternal();
+            RecordingStore.ClearCommittedTreesInternal();
+            RecordingStore.AddCommittedInternal(kerbinRec);
+            RecordingStore.AddCommittedInternal(munRec);
+            int kerbinIdx = 0;
+            int munIdx = 1;
+            GhostMapPresence.CurrentUTNow = () => liveUT;
+            GhostMapPresence.RemoveAllGhostVessels("multibody-start");
+
+            uint kerbinPid = 0u;
+            uint munPid = 0u;
+            try
+            {
+                Vessel kerbinGhost = GhostMapPresence.CreateGhostVesselFromSource(
+                    kerbinIdx, kerbinRec, GhostMapPresence.TrackingStationGhostSource.Segment,
+                    kerbinSeg, default(TrajectoryPoint), startUT);
+                Vessel munGhost = GhostMapPresence.CreateGhostVesselFromSource(
+                    munIdx, munRec, GhostMapPresence.TrackingStationGhostSource.Segment,
+                    munSeg, default(TrajectoryPoint), startUT);
+
+                if (kerbinGhost == null || kerbinGhost.orbitDriver == null || kerbinGhost.orbitDriver.orbit == null
+                    || munGhost == null || munGhost.orbitDriver == null || munGhost.orbitDriver.orbit == null)
+                {
+                    InGameAssert.Skip("one or both faithful ghosts did not create in this context (no proto)");
+                    return;
+                }
+                kerbinPid = kerbinGhost.persistentId;
+                munPid = munGhost.persistentId;
+
+                // DISTINCT pids: two separate ProtoVessels, not one reused (a reuse would alias the two ghosts).
+                InGameAssert.IsTrue(kerbinPid != munPid,
+                    string.Format(CultureInfo.InvariantCulture,
+                        "the two concurrent ghosts must have DISTINCT persistent ids (kerbinPid={0} munPid={1}) - "
+                        + "a shared pid would alias the two recordings' map presence", kerbinPid, munPid));
+
+                // Each ghost's parity, in its OWN body frame, must be sampled + zero drift.
+                AssertGhostFaithfulInOwnFrame(
+                    "Kerbin", kerbinGhost, kerbin, kerbinRec, liveUT);
+                AssertGhostFaithfulInOwnFrame(
+                    "Mun", munGhost, mun, munRec, liveUT);
+            }
+            finally
+            {
+                if (kerbinPid != 0u || munPid != 0u)
+                    GhostMapPresence.RemoveAllGhostVessels("multibody-cleanup");
+                RecordingStore.ClearCommittedInternal();
+                RecordingStore.ClearCommittedTreesInternal();
+                for (int i = 0; i < prevRecordings.Count; i++)
+                    RecordingStore.AddCommittedInternal(prevRecordings[i]);
+                for (int i = 0; i < prevTrees.Count; i++)
+                    RecordingStore.AddCommittedTreeInternal(prevTrees[i]);
+                GhostMapPresence.CurrentUTNow = prevUTNow;
+            }
+        }
+
+        // Drive the REAL probe seam for one ghost against its OWN body and assert: sampled (not skipped), a
+        // measurement, zero drift, AND the parity's covering segment is on this ghost's own body (the no-cross-
+        // frame-leak proof: ComputeFaithfulOrbitParity skips with body-mismatch if the rendered body differs
+        // from the recorded covering body, so a leak surfaces as either a skip or drift - both fail here).
+        private static void AssertGhostFaithfulInOwnFrame(
+            string label, Vessel ghost, CelestialBody body, Recording rec, double liveUT)
+        {
+            Orbit renderedOrbit = ghost.orbitDriver.orbit;
+            Vector3d iconBodyRel = ghost.GetWorldPos3D() - body.position;
+
+            MapRenderProbe.FaithfulParitySample sample = MapRenderProbe.ComputeFaithfulOrbitParity(
+                renderedOrbit, body, iconBodyRel, liveUT, 0.0, liveUT, rec.RecordingId);
+            Parsek.MapRender.RenderParityOracle.ParityResult result = sample.Result;
+
+            ParsekLog.Info("TestRunner", string.Format(CultureInfo.InvariantCulture,
+                "MultiBodyConcurrent {0}: pid={1} body={2} sampled={3} skip={4} hasMeas={5} maxDev={6:F1}m "
+                + "tol={7:F1}m over={8}",
+                label, ghost.persistentId, body.bodyName, sample.Sampled, sample.SkipReason ?? "(none)",
+                result.HasMeasurement, result.MaxDeviationMeters, result.ToleranceMeters, result.OverTolerance));
+
+            InGameAssert.IsTrue(sample.Sampled,
+                string.Format(CultureInfo.InvariantCulture,
+                    "the {0} faithful ghost must SAMPLE its OWN-body parity (not skip); a body-mismatch skip here "
+                    + "is a cross-frame leak (the ghost was framed in another body). skipReason={1}",
+                    label, sample.SkipReason ?? "(none)"));
+            InGameAssert.IsTrue(result.HasMeasurement,
+                string.Format(CultureInfo.InvariantCulture,
+                    "the {0} faithful ghost must yield a parity measurement (else the gate is blind)", label));
+            InGameAssert.IsFalse(result.OverTolerance,
+                string.Format(CultureInfo.InvariantCulture,
+                    "the {0} faithful ghost must report ZERO drift in its own body frame; maxDev={1:F1}m exceeded "
+                    + "tol={2:F1}m - a cross-frame leak (e.g. the Mun ghost framed in Kerbin) would drift here",
+                    label, result.MaxDeviationMeters, result.ToleranceMeters));
+        }
+
+        private static OrbitSegment BuildSegment(double startUT, string bodyName, double sma)
+        {
+            return new OrbitSegment
+            {
+                startUT = startUT,
+                endUT = startUT + 3600.0,
+                inclination = Inc,
+                eccentricity = Ecc,
+                semiMajorAxis = sma,
+                longitudeOfAscendingNode = 0.0,
+                argumentOfPeriapsis = 0.0,
+                meanAnomalyAtEpoch = 0.0,
+                epoch = startUT,
+                bodyName = bodyName,
+                isPredicted = false,
+                orbitalFrameRotation = Quaternion.identity,
+                angularVelocity = Vector3.zero,
+            };
+        }
+
+        private static Recording BuildRecording(double startUT, OrbitSegment seg, string bodyName, double sma)
+        {
+            double endUT = startUT + 3600.0;
+            var rec = new Recording
+            {
+                RecordingId = "multibody-" + bodyName + "-" + System.Guid.NewGuid().ToString("N"),
+                VesselName = "Parsek MultiBody " + bodyName,
+                EndpointPhase = RecordingEndpointPhase.OrbitSegment,
+                EndpointBodyName = bodyName,
+                TerminalOrbitBody = bodyName,
+                TerminalOrbitSemiMajorAxis = sma,
+                TerminalOrbitEccentricity = Ecc,
+                TerminalOrbitInclination = Inc,
+                TerminalOrbitLAN = 0.0,
+                TerminalOrbitArgumentOfPeriapsis = 0.0,
+                TerminalOrbitMeanAnomalyAtEpoch = 0.0,
+                TerminalOrbitEpoch = startUT,
+                ExplicitStartUT = startUT,
+                ExplicitEndUT = endUT,
+                PlaybackEnabled = true,
+            };
+            // Two above-surface points; the geometry under test is the OrbitSegment elements. Altitude is an
+            // approximate above-surface value (not load-bearing - the orbit drives the parity).
+            double approxAlt = sma * 0.25;
+            rec.Points.Add(new TrajectoryPoint
+            {
+                ut = startUT, latitude = 0.0, longitude = 0.0, altitude = approxAlt,
+                rotation = Quaternion.identity, velocity = new Vector3(0f, 1500f, 0f), bodyName = bodyName,
+            });
+            rec.Points.Add(new TrajectoryPoint
+            {
+                ut = endUT, latitude = 0.0, longitude = 5.0, altitude = approxAlt,
+                rotation = Quaternion.identity, velocity = new Vector3(0f, 1500f, 0f), bodyName = bodyName,
+            });
+            rec.OrbitSegments.Add(seg);
+            rec.MarkFilesDirty();
+            return rec;
+        }
+    }
+}

--- a/Source/Parsek/InGameTests/OverlapNInstanceSpineInGameTest.cs
+++ b/Source/Parsek/InGameTests/OverlapNInstanceSpineInGameTest.cs
@@ -1,0 +1,191 @@
+using System.Collections.Generic;
+using System.Globalization;
+using Parsek.MapRender;
+using UnityEngine;
+
+namespace Parsek.InGameTests
+{
+    // Phase 11 / N1 (test-automation coverage follow-up) - the OVERLAP N-INSTANCE spine test. It closes the
+    // overlap matrix gap at the DECISION layer with the proven P2-pure pattern (a synthetic PhaseChain +
+    // LoopUnitSet, sampled via ChainSampler.Sample + GhostRenderDirector.Decide - no ghost / scene), copying
+    // the OverlapUnit fixture verbatim from Source/Parsek.Tests/MapRender/ChainSamplerTests.cs:72.
+    //
+    // THE CONTRACT (the live, valuable assertions): a self-overlap member (OverlapCadenceSeconds < span, so
+    // UnitMemberOverlaps is true) replays ONE span instance per overlap cycle. The map shows ONE ghost on the
+    // span-clock head-UT (the selected cycle), never enumerating N instances. Sampling across a span of liveUTs
+    // that crosses >= 2 overlap cycles, the spine must:
+    //   - resolve a DISTINCT selected-cycle head-UT for each cycle (the head advances as the cycle advances -
+    //     a regression that froze the head on one cycle, or enumerated all N at once, would fail here);
+    //   - stay InSegment (visible) at every liveUT across the span head (the one-segment chain covers the whole
+    //     member window, so any in-window selected head lands InSegment); and
+    //   - NEVER spuriously Hidden mid-cycle (the no-blink invariant for the looped overlap ghost).
+    //
+    // DRIVE-UT ANCHOR (weak by construction - the real value of this test is the distinct-heads + no-spurious-
+    // hide assertions below): each sampled DriveUT equals GhostPlaybackLogic.ResolveTrackingStationSampleUT for
+    // the same member at the same liveUT. ChainSampler.Sample calls that same span clock internally, so this is
+    // largely the same computation twice - it confirms the sampler did NOT take the renderHidden / stitcher
+    // branch and returned the span-clock head, but it is NOT an independent legacy-vs-spine parity oracle.
+    //
+    // ARCHITECTURAL TRUTH respected + honest caveat: this asserts the spine's overlap DECISION / parity (which
+    // selected-cycle head the sampler resolves, and that it stays visible across cycles), NOT the live
+    // ProtoVessel lifecycle or any 5b pixel. The pure span-clock math is locked headlessly in ChainSamplerTests;
+    // this drives the SAME ChainSampler.Sample entry the production spine inlines over a real overlap unit.
+    //
+    // NOTE: in-game test (Ctrl+Shift+T / Settings > Diagnostics) so it runs alongside the other spine in-game
+    // tests on a cold launch pad. It builds a PhaseChain + LoopUnitSet and samples them; fast (void, no ghost /
+    // scene / save). FLIGHT only; career-independent; self-contained (no live mission / active-vessel data).
+    public class OverlapNInstanceSpineInGameTest
+    {
+        private const string KerbinBodyName = "Kerbin";
+
+        // Fixture mirrors ChainSamplerTests.cs:72 (OverlapUnit) - a single-member SELF-OVERLAP unit: span
+        // [100,200], CadenceSeconds == span (one span instance) but OverlapCadenceSeconds < span (so it IS
+        // classified overlap). The member window is the full span. This is exactly what a Kerbin launch-to-orbit
+        // mission looped shorter than its length produces on the map.
+        private const int MemberIdx = 0;
+        private const double SpanStart = 100.0;
+        private const double SpanEnd = 200.0;
+        private const double Cadence = 100.0;        // == span -> one span instance
+        private const double OverlapCadence = 25.0;  // < span -> overlap classified
+        private const double Anchor = 100.0;
+
+        [InGameTest(Category = "MapRender", Scene = GameScenes.FLIGHT,
+            Description = "Phase 11 N1 overlap N-instance (spine): a self-overlap member sampled across >=2 "
+                + "overlap cycles resolves a DISTINCT selected-cycle head-UT per cycle, stays InSegment across "
+                + "the span head, and is never spuriously Hidden mid-cycle (ONE ghost on the span head, never N "
+                + "instances). Asserts the spine DECISION + legacy-head parity, not the ProtoVessel lifecycle.")]
+        public void OverlapMember_AcrossCycles_DistinctHeads_AlwaysVisible_NeverBlink()
+        {
+            CelestialBody kerbin = FlightGlobals.Bodies?.Find(b => b.bodyName == KerbinBodyName);
+            if (kerbin == null)
+            {
+                InGameAssert.Skip("Kerbin not found in FlightGlobals.Bodies (non-stock pack)");
+                return;
+            }
+
+            GhostPlaybackLogic.LoopUnitSet units = BuildOverlapUnit();
+            PhaseChain chain = BuildOverlapMemberChain();
+
+            // liveUTs spanning >= 2 overlap cycles (overlap cadence 25, so cycles tick every 25s). Across
+            // elapsed 10..280 the unit cycle advances 0 -> 2 on the span-raised CadenceSeconds (100), with
+            // phaseInCycle landing the selected-cycle head at distinct loopUTs in [100,200]. These mirror the
+            // ChainSamplerTests cross-cycle cases (110/225/380) plus extra in-cycle samples to prove no blink.
+            double[] liveUTs = { 110.0, 150.0, 190.0, 225.0, 260.0, 290.0, 380.0, 420.0 };
+
+            var headsByCycleSlot = new HashSet<long>();   // distinct selected-cycle head buckets observed
+            var distinctHeads = new HashSet<double>();
+            GhostRenderIntent prior = GhostRenderIntent.Hidden();
+            bool everHiddenAfterVisible = false;
+            bool everVisible = false;
+            int sampleCount = 0;
+            int distinctCycleCount = 0;
+
+            for (int k = 0; k < liveUTs.Length; k++)
+            {
+                double liveUT = liveUTs[k];
+
+                // PARITY ANCHOR: the legacy single-head UT the sampler must glue to.
+                double expectedHead = GhostPlaybackLogic.ResolveTrackingStationSampleUT(
+                    MemberIdx, SpanStart, SpanEnd, liveUT, units, out bool legacyHidden);
+
+                GhostSample sample = ChainSampler.Sample(chain, liveUT, units);
+                GhostRenderIntent intent = GhostRenderDirector.Decide(sample, prior, "overlap-ghost");
+
+                // The selected cycle index on the span-raised cadence (NOT the overlap cadence): identifies
+                // which span instance the head rides. Distinct cycle slots prove the head advances.
+                long cycleSlot = (long)System.Math.Floor((liveUT - Anchor) / Cadence);
+                if (headsByCycleSlot.Add(cycleSlot))
+                    distinctCycleCount++;
+
+                ParsekLog.Info("TestRunner", string.Format(CultureInfo.InvariantCulture,
+                    "OverlapNInstance: liveUT={0:F1} cycleSlot={1} cov={2} vis={3} driveUT={4:F3} "
+                    + "expectedHead={5:F3} legacyHidden={6}",
+                    liveUT, cycleSlot, sample.Coverage, intent.Visible, sample.DriveUT, expectedHead,
+                    legacyHidden));
+
+                // The selected cycle is always inside the member window in this fixture -> never legacy-hidden.
+                InGameAssert.IsFalse(legacyHidden,
+                    string.Format(CultureInfo.InvariantCulture,
+                        "the overlap member's selected cycle must be inside its window at liveUT={0:F1} (else "
+                        + "the fixture is mis-built and the visibility assertions are vacuous)", liveUT));
+
+                // Spine-vs-legacy parity: the sampler lands on the SAME selected-cycle head the legacy single
+                // head uses (one ghost on the map, not N enumerated instances).
+                InGameAssert.AreEqual(Coverage.InSegment, sample.Coverage,
+                    string.Format(CultureInfo.InvariantCulture,
+                        "the overlap member must classify InSegment at liveUT={0:F1} (the one-segment chain "
+                        + "covers the whole member window, so any in-window selected head is InSegment)", liveUT));
+                InGameAssert.ApproxEqual(expectedHead, sample.DriveUT, 1e-3,
+                    string.Format(CultureInfo.InvariantCulture,
+                        "the spine's DriveUT must equal the legacy single-head UT at liveUT={0:F1} (ResolveTrackin"
+                        + "gStationSampleUT) - the map ghost rides ONE span instance, never enumerating N", liveUT));
+
+                // Visibility / no-blink: once visible, never spuriously Hidden mid-cycle.
+                InGameAssert.IsTrue(intent.Visible,
+                    string.Format(CultureInfo.InvariantCulture,
+                        "the overlap ghost must be VISIBLE at every in-window liveUT={0:F1} (never blink Hidden "
+                        + "mid-cycle - the looped overlap no-blink invariant)", liveUT));
+                if (everVisible && !intent.Visible)
+                    everHiddenAfterVisible = true;
+                if (intent.Visible)
+                    everVisible = true;
+
+                distinctHeads.Add(System.Math.Round(sample.DriveUT, 3));
+                prior = intent;
+                sampleCount++;
+            }
+
+            // The selected-cycle head must be DISTINCT across cycles: the fixture spans >= 2 span-cadence
+            // cycles, and the head advances as the cycle advances (a frozen head, or N-at-once enumeration,
+            // would collapse these).
+            InGameAssert.IsTrue(distinctCycleCount >= 2,
+                string.Format(CultureInfo.InvariantCulture,
+                    "the sampled span must cross >= 2 overlap cycles (saw {0}) so the distinct-head assertion is "
+                    + "non-vacuous", distinctCycleCount));
+            InGameAssert.IsTrue(distinctHeads.Count >= 2,
+                string.Format(CultureInfo.InvariantCulture,
+                    "the spine must resolve >= 2 DISTINCT selected-cycle head-UTs across the span (saw {0}); a "
+                    + "regression that froze the head on one cycle would collapse these to 1", distinctHeads.Count));
+            InGameAssert.IsFalse(everHiddenAfterVisible,
+                "across the overlap span the ghost must NEVER blink Hidden once it has become visible - the "
+                + "looped overlap no-blink invariant");
+
+            ParsekLog.Info("TestRunner", string.Format(CultureInfo.InvariantCulture,
+                "OverlapNInstance SUMMARY: samples={0} distinctCycles={1} distinctHeads={2} everHiddenAfterVis={3}",
+                sampleCount, distinctCycleCount, distinctHeads.Count, everHiddenAfterVisible));
+        }
+
+        // Copied verbatim from ChainSamplerTests.cs:72 (OverlapUnit) minus the xUnit Assert (replaced by an
+        // in-game guard): a single-member SELF-OVERLAP unit. The two-arg overlap LoopUnit ctor takes the
+        // overlapCadenceSeconds positionally; UnitMemberOverlaps must be true (else the test is moot).
+        private static GhostPlaybackLogic.LoopUnitSet BuildOverlapUnit()
+        {
+            var unit = new GhostPlaybackLogic.LoopUnit(
+                MemberIdx, new[] { MemberIdx }, SpanStart, SpanEnd, cadenceSeconds: Cadence,
+                phaseAnchorUT: Anchor, overlapCadenceSeconds: OverlapCadence);
+            InGameAssert.IsTrue(GhostPlaybackLogic.UnitMemberOverlaps(unit),
+                "the N1 fixture unit MUST be an overlap unit (OverlapCadenceSeconds < span) or the overlap "
+                + "matrix it covers is not exercised");
+            var unitsByOwner = new Dictionary<int, GhostPlaybackLogic.LoopUnit> { { MemberIdx, unit } };
+            var ownerByIndex = new Dictionary<int, int> { { MemberIdx, MemberIdx } };
+            return new GhostPlaybackLogic.LoopUnitSet(unitsByOwner, ownerByIndex);
+        }
+
+        // One StockConic phase spanning the whole member window so any in-window selected-cycle head-UT lands
+        // InSegment and its DriveUT is observable (mirrors ChainSamplerTests.OverlapMemberChain).
+        private static PhaseChain BuildOverlapMemberChain()
+        {
+            var anchor = new AnchorFrame.BodyAnchor(KerbinBodyName);
+            var phase = new DepartureLoiterPhase(
+                new PhaseId("rec-overlap", 0, 0), SegmentProvenance.Recorded, anchor, SpanStart, SpanEnd,
+                new OrbitSegment
+                {
+                    startUT = SpanStart, endUT = SpanEnd, bodyName = KerbinBodyName,
+                    semiMajorAxis = 850000.0, eccentricity = 0.0, epoch = SpanStart,
+                });
+            return new PhaseChain(
+                "rec-overlap", committedIndex: MemberIdx, instanceKey: 0,
+                phases: new List<TrajectoryPhase> { phase }, windowStartUt: SpanStart, windowEndUt: SpanEnd);
+        }
+    }
+}

--- a/Source/Parsek/InGameTests/SuppressedMarkerOwnedDrawInGameTest.cs
+++ b/Source/Parsek/InGameTests/SuppressedMarkerOwnedDrawInGameTest.cs
@@ -50,8 +50,11 @@ namespace Parsek.InGameTests
             RunMarkerOwnership(forceSpineOn: false);
         }
 
-        // Build a live below-atmosphere (non-orbital) ghost, drive RunFrame with the spine forced the
-        // requested way, and assert the marker-draw contract. Shared invariants in BOTH flag states:
+        // Build a live below-atmosphere (non-orbital) ghost (SELF-CREATED via
+        // GhostMapPresence.CreateGhostVesselFromSource - the RenderParityBaselineTest pattern - so the test
+        // needs ZERO live mission / pre-existing ghost and ASSERTS instead of passing-as-skip on a cold pad
+        // launch), drive RunFrame with the spine forced the requested way, and assert the marker-draw
+        // contract. Shared invariants in BOTH flag states:
         //  (1) the marker decision (ShouldDrawNonProtoMarkerForGhost) draws our marker - never a blank icon;
         //  (2) the marker's TracedPath disjunct source (IsTracedPathOwnedThisFrame) equals the proto-line
         //      consumer signal (IsDirectorTracedPathActive) - exactly one painter, no double, no gap.
@@ -67,6 +70,8 @@ namespace Parsek.InGameTests
             }
 
             double liveUT = Planetarium.GetUniversalTime();
+            // Author the below-atmosphere TracedPath leg AROUND liveUT so the leg deterministically covers
+            // liveUT and the chain's active segment at liveUT classifies TracedPath + in-coverage.
             double startUT = liveUT - 60.0;
             double endUT = liveUT + 60.0;
 
@@ -94,13 +99,28 @@ namespace Parsek.InGameTests
             {
                 MapRenderTrace.ForceEnabledForTesting = true; // so the spine + intent path are live
 
-                uint resolvedPid = GhostMapPresence.GetGhostVesselPidForRecording(recordingIndex);
-                Vessel ghost = null;
-                if (resolvedPid != 0u)
-                    FlightGlobals.FindVessel(resolvedPid, out ghost);
+                // SELF-CREATE the ghost from the recording's own first body-relative state vector (the
+                // RenderParityBaselineTest.cs:134-141 pattern). A below-atmosphere / no-bounds leg has no
+                // conic to seed, so create through the StateVector source (a flat low-altitude
+                // TrajectoryPoint), which registers the pid in GhostMapPresence.ghostMapVesselPids + the
+                // pid->recording maps the MapViewScene + the marker decision resolve through. SELF-CONTAINED
+                // (no live mission / pre-existing ghost) + DETERMINISTIC (the leg classifies TracedPath +
+                // in-coverage at liveUT), so the marker-draw + ownership ASSERT rather than skip on a cold
+                // pad launch.
+                Vessel ghost = GhostMapPresence.CreateGhostVesselFromSource(
+                    recordingIndex,
+                    rec,
+                    GhostMapPresence.TrackingStationGhostSource.StateVector,
+                    default(OrbitSegment),
+                    rec.Points[0],
+                    liveUT);
                 if (ghost == null)
                 {
-                    InGameAssert.Skip("non-orbital recording produced no ghost proto in this context");
+                    // A ghost-create miss here is environmental (the state-vector create resolves the body
+                    // by name and needs a live PartLoader/Vessel context). Keep this a Skip - the body-
+                    // not-found guard's sibling - rather than a false assert. It is NOT a pass-as-skip on
+                    // the marker decision: it means no ghost could be created AT ALL in this context.
+                    InGameAssert.Skip("ghost ProtoVessel did not create in this context (no proto)");
                     return;
                 }
                 pid = ghost.persistentId;
@@ -133,6 +153,14 @@ namespace Parsek.InGameTests
                     forceSpineOn, pid, legacyActive, intentActive, ownedRouting, shouldDraw,
                     decDirectorTraced, decPolylineOwning, decIconSuppressed));
 
+                // DETERMINISTIC TracedPath: the self-created ghost's recording is a flat below-atmosphere
+                // leg (no OrbitSegment) covering liveUT, so RunFrame's chain classifies its active segment
+                // at liveUT as TracedPath and stamps the legacy side-channel. ASSERT it (no pass-as-skip on
+                // a cold pad launch - the self-created in-coverage leg makes this deterministic).
+                InGameAssert.IsTrue(legacyActive,
+                    "the self-created below-atmosphere ghost's leg must classify TracedPath in-coverage at "
+                    + "liveUT (the legacy side-channel must be active)");
+
                 // The marker site's TracedPath disjunct (decDirectorTraced) IS the flag-aware selector
                 // output - the Phase-4b re-home. Assert that wiring directly.
                 InGameAssert.AreEqual(ownedRouting, decDirectorTraced,
@@ -158,18 +186,15 @@ namespace Parsek.InGameTests
 
                 if (forceSpineOn)
                 {
-                    // FLAG ON: the marker's TracedPath disjunct is SOURCED FROM THE INTENT. When the spine
-                    // decided TracedPath this frame (legacyActive), the intent stamp is present and the
-                    // disjunct equals it.
-                    if (legacyActive)
-                    {
-                        InGameAssert.IsTrue(intentActive,
-                            "FLAG ON: the intent-sourced stamp must be present (RunFrame stamps it from the "
-                            + "same intent as the legacy side-channel)");
-                        InGameAssert.AreEqual(intentActive, decDirectorTraced,
-                            "FLAG ON: the marker TracedPath disjunct must equal the intent-sourced signal "
-                            + "(re-homed)");
-                    }
+                    // FLAG ON: the marker's TracedPath disjunct is SOURCED FROM THE INTENT. The leg is
+                    // deterministically TracedPath this frame (legacyActive asserted above), so the
+                    // intent-sourced stamp is present and the disjunct equals it - assert unconditionally.
+                    InGameAssert.IsTrue(intentActive,
+                        "FLAG ON: the intent-sourced stamp must be present (RunFrame stamps it from the "
+                        + "same intent as the legacy side-channel)");
+                    InGameAssert.AreEqual(intentActive, decDirectorTraced,
+                        "FLAG ON: the marker TracedPath disjunct must equal the intent-sourced signal "
+                        + "(re-homed)");
                 }
                 else
                 {

--- a/Source/Parsek/InGameTests/TerminalRetireDecisionInGameTest.cs
+++ b/Source/Parsek/InGameTests/TerminalRetireDecisionInGameTest.cs
@@ -1,0 +1,110 @@
+using System.Collections.Generic;
+using System.Globalization;
+using Parsek.MapRender;
+using UnityEngine;
+
+namespace Parsek.InGameTests
+{
+    // Phase 11 / N4 (test-automation coverage follow-up) - the TERMINAL RETIRE decision test. It closes the
+    // terminal / crash retire case at the DECISION layer with the proven P2-pure pattern (synthetic PhaseChain,
+    // sampled via ChainSampler.Sample + GhostRenderDirector.Decide - no ghost / scene).
+    //
+    // THE CONTRACT (design §11.1, GhostRenderDirector.cs:43-44): a recording that ends at a TERMINAL UT (a crash
+    // / impact / surface end-of-data) produces a phase chain whose phases end at the recorded end-of-data, so
+    // the chain window ENDS at the terminal UT. The producer does NOT model post-terminal time as an interior
+    // gap; it leaves the post-terminal UT OUTSIDE the window. The spine must therefore:
+    //   - sample INSIDE the window (before the terminal end) as InSegment -> Visible; and
+    //   - sample PAST the terminal end as Coverage.OutsideWindow -> the Director returns Hidden EVEN WITH a
+    //     visible prior intent (the crash retire: the ghost does not linger at the crash site). A regression
+    //     that held the prior intent past the terminal end (treating it as an interior gap) would keep it
+    //     Visible here and fail.
+    //
+    // ARCHITECTURAL TRUTH respected + honest caveat: this asserts the spine's terminal RETIRE DECISION
+    // (OutsideWindow -> Hidden past the recorded terminal end), NOT the live ProtoVessel lifecycle (no ghost is
+    // created/destroyed) nor any 5b pixel. PhaseChain.ClassifyCoverage / GhostRenderDirector.Decide are unit-
+    // tested headlessly; this drives the SAME ChainSampler.Sample entry the production spine inlines over a
+    // terminal-ended chain, alongside the other spine in-game tests on a cold pad.
+    //
+    // NOTE: in-game test (Ctrl+Shift+T / Settings > Diagnostics). Fast (void, no ghost / scene / save). FLIGHT
+    // only; career-independent; self-contained.
+    public class TerminalRetireDecisionInGameTest
+    {
+        private const string KerbinBodyName = "Kerbin";
+
+        [InGameTest(Category = "MapRender", Scene = GameScenes.FLIGHT,
+            Description = "Phase 11 N4 terminal retire (spine): a one-phase chain ending at a terminal (crash) "
+                + "UT samples Visible inside the window and RETIRES (Hidden) past the terminal end even with a "
+                + "visible prior intent (Coverage.OutsideWindow -> Decide returns Hidden). Asserts the spine "
+                + "retire DECISION, not the ProtoVessel lifecycle.")]
+        public void TerminalChain_PastEnd_RetiresHidden_EvenWithVisiblePriorIntent()
+        {
+            CelestialBody kerbin = FlightGlobals.Bodies?.Find(b => b.bodyName == KerbinBodyName);
+            if (kerbin == null)
+            {
+                InGameAssert.Skip("Kerbin not found in FlightGlobals.Bodies (non-stock pack)");
+                return;
+            }
+
+            // A short ballistic/surface leg ending at a TERMINAL (crash) UT. The chain window ENDS at crashUT
+            // (the recorded end-of-data); there is no post-terminal phase / interior gap.
+            const double startUT = 1000.0;
+            const double crashUT = 1100.0;
+            PhaseChain chain = BuildTerminalChain(startUT, crashUT);
+
+            // Sanity: the recording's EndpointPhase models a terminal (surface impact) end so the fixture
+            // represents the crash-retire case, not an orbital one that would never retire.
+            // (Documented on the recording shape in BuildTerminalChain.)
+
+            GhostPlaybackLogic.LoopUnitSet units = GhostPlaybackLogic.LoopUnitSet.Empty;
+
+            // --- INSIDE the window: Visible. ---
+            double insideUT = 0.5 * (startUT + crashUT);
+            GhostSample inside = ChainSampler.Sample(chain, insideUT, units);
+            GhostRenderIntent insideIntent = GhostRenderDirector.Decide(inside, GhostRenderIntent.Hidden(), "term");
+
+            InGameAssert.AreEqual(Coverage.InSegment, inside.Coverage,
+                "inside the terminal window the spine must classify InSegment (the recorded leg before the crash "
+                + "is drawn)");
+            InGameAssert.IsTrue(insideIntent.Visible,
+                "inside the terminal window the spine's intent must be VISIBLE");
+
+            // --- PAST the terminal end: OutsideWindow -> Hidden, EVEN with the visible prior intent. ---
+            double pastEndUT = crashUT + 200.0;
+            GhostSample pastEnd = ChainSampler.Sample(chain, pastEndUT, units);
+            // Feed the VISIBLE prior intent: the director must STILL retire (OutsideWindow -> Hidden), proving it
+            // does not hold a prior visible intent past the terminal end (the crash-linger guard).
+            GhostRenderIntent pastEndIntent = GhostRenderDirector.Decide(pastEnd, insideIntent, "term");
+
+            ParsekLog.Info("TestRunner", string.Format(CultureInfo.InvariantCulture,
+                "TerminalRetire: start={0:F1} crash={1:F1} | inside UT={2:F1} cov={3} vis={4} | pastEnd UT={5:F1} "
+                + "cov={6} vis={7} (priorWasVisible={8})",
+                startUT, crashUT, insideUT, inside.Coverage, insideIntent.Visible, pastEndUT, pastEnd.Coverage,
+                pastEndIntent.Visible, insideIntent.Visible));
+
+            InGameAssert.AreEqual(Coverage.OutsideWindow, pastEnd.Coverage,
+                "past the terminal end the spine must classify OutsideWindow (the chain window ends at the "
+                + "recorded terminal UT - the post-terminal UT is NOT an interior gap, design §11.1)");
+            InGameAssert.IsFalse(pastEndIntent.Visible,
+                "past the terminal end the spine must RETIRE (Hidden) even though the prior intent was VISIBLE - "
+                + "a crashed/impacted ghost does not linger at the crash site (GhostRenderDirector.cs:43-44); a "
+                + "regression that held the prior intent (treating post-terminal as an interior gap) would keep "
+                + "it Visible here");
+        }
+
+        // A one-phase chain ending at a terminal (crash) UT. The single traced leg covers [startUT, crashUT] and
+        // the chain window ENDS at crashUT - the producer leaves post-terminal time OUTSIDE the window (design
+        // §11.1: a terminal end is not modelled as an interior gap). EndpointPhase=SurfacePosition documents the
+        // terminal (impact) endpoint the recording would carry.
+        private static PhaseChain BuildTerminalChain(double startUT, double crashUT)
+        {
+            var anchor = new AnchorFrame.BodyAnchor(KerbinBodyName);
+            // A traced surface/ballistic leg (TracedPath) ending at the crash; one phase, window ends at crashUT.
+            var phase = new DescentPhase(
+                new PhaseId("rec-terminal", 0, 0), SegmentProvenance.Recorded, anchor, startUT, crashUT,
+                KerbinBodyName);
+            return new PhaseChain(
+                "rec-terminal", committedIndex: 0, instanceKey: 0,
+                phases: new List<TrajectoryPhase> { phase }, windowStartUt: startUT, windowEndUt: crashUT);
+        }
+    }
+}

--- a/Source/Parsek/InGameTests/TracedPathOwnedDrawInGameTest.cs
+++ b/Source/Parsek/InGameTests/TracedPathOwnedDrawInGameTest.cs
@@ -51,12 +51,14 @@ namespace Parsek.InGameTests
             RunTracedPathOwnership(forceSpineOn: false);
         }
 
-        // Build a live non-orbital ghost, drive RunFrame with the spine forced the requested way, and assert
-        // the flag-aware owned-draw signal contract. The shared invariant in BOTH flag states: the owned-
-        // draw routing (IsTracedPathOwnedThisFrame) equals the proto/marker consumer signal
-        // (IsDirectorTracedPathActive) for the ghost pid, so exactly one painter owns the leg (no double,
-        // no gap). Additionally: flag-OFF must read the legacy side-channel (intent stamp absent off the
-        // flag); flag-ON must read the intent source.
+        // Build a live non-orbital ghost (SELF-CREATED via GhostMapPresence.CreateGhostVesselFromSource -
+        // the RenderParityBaselineTest pattern - so the test needs ZERO live mission / pre-existing ghost
+        // and ASSERTS instead of passing-as-skip on a cold pad launch), drive RunFrame with the spine
+        // forced the requested way, and assert the flag-aware owned-draw signal contract. The shared
+        // invariant in BOTH flag states: the owned-draw routing (IsTracedPathOwnedThisFrame) equals the
+        // proto/marker consumer signal (IsDirectorTracedPathActive) for the ghost pid, so exactly one
+        // painter owns the leg (no double, no gap). Additionally: flag-OFF must read the legacy
+        // side-channel (intent stamp absent off the flag); flag-ON must read the intent source.
         private static void RunTracedPathOwnership(bool forceSpineOn)
         {
             CelestialBody kerbin = FlightGlobals.Bodies?.Find(b => b.bodyName == KerbinBodyName);
@@ -67,6 +69,9 @@ namespace Parsek.InGameTests
             }
 
             double liveUT = Planetarium.GetUniversalTime();
+            // Author the non-orbital TracedPath leg AROUND liveUT so the leg deterministically covers liveUT
+            // and the chain's active segment at liveUT classifies TracedPath + in-coverage - the leg ASSERTS
+            // instead of skipping.
             double startUT = liveUT - 60.0;
             double endUT = liveUT + 60.0;
 
@@ -94,15 +99,27 @@ namespace Parsek.InGameTests
             {
                 MapRenderTrace.ForceEnabledForTesting = true; // so the spine + intent path are live
 
-                // A non-orbital recording's ghost has no faithful orbit drive; it may still create a proto
-                // for the marker. Resolve the recording's ghost pid; skip gracefully if none materialized.
-                uint resolvedPid = GhostMapPresence.GetGhostVesselPidForRecording(recordingIndex);
-                Vessel ghost = null;
-                if (resolvedPid != 0u)
-                    FlightGlobals.FindVessel(resolvedPid, out ghost);
+                // SELF-CREATE the ghost from the recording's own first body-relative state vector (the
+                // RenderParityBaselineTest.cs:134-141 pattern). A non-orbital leg has no conic to seed, so
+                // create through the StateVector source (a flat low-altitude TrajectoryPoint), which
+                // registers the pid in GhostMapPresence.ghostMapVesselPids + the pid->recording maps the
+                // MapViewScene resolves through. This makes the test SELF-CONTAINED (no live mission /
+                // pre-existing ghost) and DETERMINISTIC (the leg classifies TracedPath + in-coverage at
+                // liveUT), so it ASSERTS rather than skipping on a cold pad launch.
+                Vessel ghost = GhostMapPresence.CreateGhostVesselFromSource(
+                    recordingIndex,
+                    rec,
+                    GhostMapPresence.TrackingStationGhostSource.StateVector,
+                    default(OrbitSegment),
+                    rec.Points[0],
+                    liveUT);
                 if (ghost == null)
                 {
-                    InGameAssert.Skip("non-orbital recording produced no ghost proto in this context");
+                    // A ghost-create miss here is environmental (the state-vector create resolves the body
+                    // by name and needs a live PartLoader/Vessel context). Keep this a Skip - the body-
+                    // not-found guard's sibling - rather than a false assert. It is NOT a pass-as-skip on
+                    // the TracedPath decision: it means no ghost could be created AT ALL in this context.
+                    InGameAssert.Skip("ghost ProtoVessel did not create in this context (no proto)");
                     return;
                 }
                 pid = ghost.persistentId;
@@ -129,15 +146,15 @@ namespace Parsek.InGameTests
                     + "ownedRouting={4}",
                     forceSpineOn, pid, legacyActive, intentActive, ownedRouting));
 
-                if (!legacyActive)
-                {
-                    // The spine did not decide TracedPath for this ghost this frame (e.g. coverage gap or the
-                    // ghost is orbital here). Nothing to assert about owned routing; skip rather than false-
-                    // pass.
-                    InGameAssert.Skip("spine did not decide TracedPath for the ghost this frame "
-                        + "(legacy side-channel not active)");
-                    return;
-                }
+                // DETERMINISTIC TracedPath: the self-created ghost's recording is a flat non-orbital leg
+                // (no OrbitSegment) covering liveUT, so RunFrame's chain classifies its active segment at
+                // liveUT as TracedPath, sets a visible-InSegment intent, and stamps the legacy side-channel.
+                // ASSERT it decided TracedPath (the prior Skip("spine did not decide TracedPath") was a
+                // pass-as-skip on a cold pad launch; the self-created in-coverage leg removes that path).
+                InGameAssert.IsTrue(legacyActive,
+                    "the self-created non-orbital ghost's leg must classify TracedPath in-coverage at liveUT "
+                    + "(the legacy side-channel must be active) - if not, the chain mis-classified a flat "
+                    + "non-orbital leg covering liveUT");
 
                 // EXACTLY-ONE-PAINTER: the owned-draw routing must AGREE with the proto/marker consumers
                 // (which read IsDirectorTracedPathActive). If they disagreed, either the owned treatment AND

--- a/docs/dev/plans/map-ts-render-overhaul-migration.md
+++ b/docs/dev/plans/map-ts-render-overhaul-migration.md
@@ -729,6 +729,122 @@ decision / geometry contract those runtime rows build on.
 
 ---
 
+## 10d. Phase 11 - test automation + coverage (stacked on Phase 10)
+
+**Goal:** make every MapRender in-game test RUN and ASSERT (not skip) from a fresh launch-pad FLIGHT
+scene with zero manual setup and FAST, and add self-contained gameplay-case coverage the prior phases
+left to the manual runbook. TEST-ONLY + additive: NO production geometry / draw / spine code changed,
+so with the spine flag OFF (`MapRenderFlags.MapRenderPhaseSpineDrive` default false) AND tracing OFF
+(`mapRenderTracing` default off) normal play stays BYTE-IDENTICAL to today (all flag-OFF / tracing-OFF
+source gates stay green).
+
+**Status (implemented, test-only / flag-OFF + tracing-OFF byte-identical):**
+
+### P1 portability hardening (the two prior in-game tests no longer pass-as-skip on a cold pad)
+
+`Source/Parsek/InGameTests/TracedPathOwnedDrawInGameTest.cs` and
+`Source/Parsek/InGameTests/SuppressedMarkerOwnedDrawInGameTest.cs` previously resolved a PRE-EXISTING
+ghost (via `GetGhostVesselPidForRecording` + `FindVessel`) and, when none was present on a cold pad,
+Skipped - so they passed as skips with no assertion. Both now SELF-CREATE their ghost via
+`GhostMapPresence.CreateGhostVesselFromSource(... TrackingStationGhostSource.StateVector ...)` (the
+`RenderParityBaselineTest.cs` create pattern) from the recording's first flat low-altitude
+`TrajectoryPoint` (a non-orbital leg has no conic to seed), which registers the pid in
+`ghostMapVesselPids` + the pid->recording maps the spine resolves through. The two pass-as-skip Skips
+were removed: the spine-decided-TracedPath early-return is now a firm `InGameAssert.IsTrue(legacyActive,
+...)`, and the FLAG-ON intent-stamp assertion is unconditional. The ONLY Skips kept are legitimate
+environmental guards - `Kerbin not found` (non-stock pack), `MapViewScene not active` (not in FLIGHT),
+and a new `ghost ProtoVessel did not create` (a true no-proto-at-all context, NOT a pass-as-skip on the
+TracedPath / marker render decision).
+
+### Five new SELF-CONTAINED pad-runnable in-game tests
+
+All are `[InGameTest(Category="MapRender", Scene=GameScenes.FLIGHT)]`, VOID (not IEnumerator - fast),
+self-contained (build their own synthetic Recording / ghost / PhaseChain - no live mission / active
+vessel / loaded save), and CLEAN UP in `finally` (remove synthetic ghosts via `GhostMapPresence`,
+restore `ForceSpineDriveForTesting` / `ForceEnabledForTesting` / `CurrentUTNow` / `RecordingStore`,
+`ShadowRenderDriver.Reset()`). Each carries the honest caveat that it asserts the spine
+DECISION / parity, not the live ProtoVessel lifecycle / 5b pixel. Files under
+`Source/Parsek/InGameTests/`:
+
+- **N1 `OverlapNInstanceSpineInGameTest.cs`** (P2-pure) - copies `OverlapUnit` verbatim from
+  `ChainSamplerTests.cs:72` (two-arg overlap LoopUnit ctor + `UnitMemberOverlaps`); samples 8 liveUTs
+  across 4 span-cadence cycles through `ChainSampler.Sample` + `GhostRenderDirector.Decide`. Asserts
+  >=2 DISTINCT selected-cycle head-UTs, every sample InSegment + Visible, `DriveUT ==
+  ResolveTrackingStationSampleUT` (legacy single-head parity = ONE ghost not N), never Hidden-after-
+  visible. A frozen-head / N-at-once regression collapses the distinct-head count to 1 and fails.
+- **N2 `DockUndockMemberWindowSpineInGameTest.cs`** (P2-pure) - a `LoopUnit` with `memberWindows`
+  (`MemberWindow` ctor at `GhostPlaybackLogic.SpanClock.cs:61`): absorbed member trimmed to dockUT,
+  split child beginning at splitUT, cadence==span + anchor==spanStart so `spanLoopUT` tracks liveUT
+  linearly. Samples at boundary -/+ 1.0s. Asserts the absorbed member flips Visible->Hidden EXACTLY at
+  dockUT (no clamp past its window = the stale-ghost-after-dock guard) and the split child
+  Hidden->Visible exactly at splitUT.
+- **N3 `MultiBodyConcurrentGhostsParityInGameTest.cs`** (P1-ghost) - TWO live faithful ghosts in one
+  `RecordingStore` swap (Kerbin orbit idx 0, Mun orbit idx 1) via `CreateGhostVesselFromSource(...
+  Segment ...)`; runs `ComputeFaithfulOrbitParity` for each vs its OWN body. Asserts both Sampled (not
+  body-mismatch-skipped) + zero drift, DISTINCT pids, own-body framing (a cross-frame leak surfaces as
+  body-mismatch skip or large drift). Skips cleanly if Mun absent (mirrors the fail-closed Jool guard);
+  cleans up BOTH ghosts + restores RecordingStore / CurrentUTNow in `finally`.
+- **N4 `TerminalRetireDecisionInGameTest.cs`** (P2-pure) - a one-phase `DescentPhase` PhaseChain whose
+  window ENDS at a terminal crashUT (recording `EndpointPhase=SurfacePosition`). Samples inside
+  (Visible) and past the terminal end WITH a visible prior intent fed in; asserts
+  `Coverage.OutsideWindow` past end -> `Decide` returns Hidden even with the visible prior (the
+  crash-no-linger retire). A regression that held the prior (treating post-terminal as an interior gap)
+  keeps it Visible and fails.
+- **N5 `BgOnRailsAllOrbitalSpineInGameTest.cs`** (P1+P2) - an all-`OrbitSegment` recording (NO
+  atmospheric Points, NO TrackSections = the on-rails BG shape). Runs the REAL
+  `PhaseFactory.BuildPhaseChain` and asserts zero Descent / Surface / Ascent phases + >=1 conic phase,
+  then creates the live ghost and asserts `ComputeFaithfulOrbitParity` zero drift.
+
+The P2-pure tests (N1 / N2 / N4 + N5's factory half) do pure builder / count-seam work, so they run
+instantly from a cold pad. The P1-ghost tests (N3, N5's parity half) author their own Recording(s), swap
+`RecordingStore`, create the ghost via `CreateGhostVesselFromSource`, and restore in `finally`.
+
+### New headless unit tests
+
+- `PhaseFactoryTests.cs`: ascent/descent positional split around the first conic; surface env wins over
+  the after-conic Descent default; `ResolveEnvPhaseForWindow` last-overlapping-section + null-list
+  tolerance; `IsArrivalConic` approach-env short-circuit (Theory, 2 cases) / destination-park /
+  departure-body-conic rejected.
+- `RenderParityOracleTests.cs`: `ComputeDrift` with the reference point at a segment INTERIOR (not a
+  vertex) measures ~0 (point-to-POLYLINE), catching a point-to-VERTEX rewrite that would false-fire
+  ("green but blind").
+- `FailClosedClassifierTests.cs`: Kerbin->Mun->Minmus siblings -> `NestedSoi`, `RootBody=="Kerbin"`,
+  `FaithfulFallback` (stock-system nested-SOI, proves not Jool-hardcoded).
+- `CrossMemberSeamStitcherTests.cs`: descent seam head EXACTLY at descentEnd still renders, one tick
+  past retires (Theory, 2 cases) - the off-by-one boundary guard.
+- `AnchorFrameTests.cs`: 1-sample primary + degenerate (start>end) secondary -> `Retire`, not a
+  spurious `AnchorLocalSecondary` match.
+
+### Gameplay case dispositioned NOT self-containable (with evidence)
+
+The HoldPhase warp-through PRODUCER stays vacuous-under-flag-ON: the factory constructs no live
+HoldPhase (only `MovingTargetStationApproach`, which is fail-closed / define-only); fabricating a
+producer would be new geometry, out of test-only scope. The existing
+`WarpThroughInteriorGapSpineInGameTest` already documents this with factory evidence and asserts the
+observable interior-gap-hold equivalent, so no new HoldPhase test was fabricated. Anything needing a
+real re-fly merge / live re-aim mission plan / actual ProtoVessel lifecycle transition belongs in the
+manual Ctrl+Shift+T runbook.
+
+### P2 runbook note - the one intentional cold-pad skip
+
+A full launch-pad Ctrl+Shift+T MapRender sweep now runs and asserts every method EXCEPT exactly ONE:
+`RenderParityBaselineTest.ParityBaseline_KnownGoodFaithfulGhost_ZeroDrift_TrackingStation`
+(Category `GhostMap`, `Scene=GameScenes.TRACKSTATION`), which is intentional per design 11.5 - it
+exercises the TRACKSTATION variant of the parity baseline and therefore cannot run from a FLIGHT-scene
+sweep. It MUST be signed off separately from the Tracking Station view (Ctrl+Shift+T in TRACKSTATION).
+No in-repo cutover sign-off runbook file exists; this one-line TS-view caveat is recorded here in the
+migration plan (the in-game playtest sign-off home, see sections 0 and 12) and should be carried into
+the umbrella cutover sign-off doc when one is written.
+
+### Flag-OFF / tracing-OFF byte-identical
+
+No producer geometry or draw code was touched - only test files. Flag-OFF
+(`MapRenderPhaseSpineDrive` default false) and tracing-OFF (`mapRenderTracing` default off) normal play
+is byte-identical to today; every source gate stays green. Because this is test-only / additive with no
+user-visible default-play change, there is NO CHANGELOG / todo entry.
+
+---
+
 ## 11. Phase ordering & dependencies
 
 ```


### PR DESCRIPTION
**Stacked on Phase 10 ([#1225](https://github.com/vl3c/Parsek/pull/1225)). Merge in order; this PR's diff is Phase 11 only.**

Test-only + additive, from a 4-lens test-automation audit. Goal: every MapRender in-game test runs + **asserts** (not skips) one-click from a fresh **launch-pad FLIGHT** scene with zero manual setup, fast — plus more self-contained gameplay-case coverage. The audit confirmed the suite was already in good shape (all in-game tests void/fast/`Scene=FLIGHT`/self-contained); this closes the last reliability gap + adds coverage. No production geometry/draw/spine code touched; flag-off/tracing-off byte-identical.

## Portability hardening (the one real gap)
`TracedPathOwnedDrawInGameTest` + `SuppressedMarkerOwnedDrawInGameTest` were the only two that could pass-as-**Skip** (green-but-blind) on a cold pad launch — they waited on the autonomous Driver to materialize a ghost. They now **self-create** the ghost via `CreateGhostVesselFromSource(StateVector)`, so they deterministically **assert** (`IsTrue(legacyActive)` + unconditional flag-on intent-stamp). Only legitimate environmental Skips remain.

## New self-contained pad-runnable in-game tests
`OverlapNInstance` (distinct cycle heads, no spurious hide) · `DockUndockMemberWindow` (member-window flip at dock/undock UT) · `MultiBodyConcurrentGhostsParity` (two ghosts at different bodies, no cross-frame) · `TerminalRetireDecision` (retire past terminal end) · `BgOnRailsAllOrbital` (no descent/surface phase + zero drift). All void, `Scene=FLIGHT`, finally-cleanup, non-vacuous, decision-vs-5b-pixel caveat documented.

## New unit tests (mutation-checked)
3 untested `PhaseFactory` classifier helpers; a **point-to-polyline-interior** oracle test (catches a point-to-vertex rewrite — the "green but blind" class); a Kerbin→Mun→Minmus nested-SOI case; a descent-clip **exact-boundary** off-by-one guard; a degenerate reversed-secondary-range anchor case.

## Review
Two clean-context lenses. **Automation = CLEAN.** **Efficacy = ship-with-fixes, both folded** (reviewer caught two new tests whose *documented* mutation was unreachable, mutation-proven): the descent-end `[Theory]` now includes the exact `head==descentEnd` boundary so it genuinely catches the `>=` off-by-one (it previously only probed ±0.5s); the anchor + overlap comments corrected to not overstate. `dotnet build` green; `dotnet test` **16657 passed, 0 failed**; all source-gates green.

## Honest caveat
A full pad `Ctrl+Shift+T` MapRender sweep skips exactly **one** method — `RenderParityBaselineTest..._TrackingStation` (`Scene=TRACKSTATION`, intentional flight↔TS parity) — signed off from the TS view; its FLIGHT siblings cover the same probe from the pad. Genuinely runtime-only rows (quickload, in-bubble switch, re-fly, scene-settle, synodic warp, live dock/undock) stay manual in the runbook.

No `CHANGELOG`/`todo` change (test-only).