### PR TITLE
log: rate-limit ghost polyline-build VERBOSE lines per recording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to Parsek are documented here.
 - Code-health refactor pass over the systems added since the last structural cleanup, with no behavior change: several large methods were split into well-named same-file helpers (the supply-route builder, the mission loop-unit builder, the map render-session rebuild, mission scheduling and structure building, route source revalidation and harvest analysis, the relative-anchor resolver, terminal-orbit spawn safety, and the pannotations / FX sidecar codecs). Pure restructuring, verified byte-for-byte behavior-neutral by the existing test suites; no gameplay, save-format, or log change.
 - De-duplicated repeated blocks across the route and settings code (settings persistence, switch-segment refusal logging, route-codec field loaders, and recovered-credit sums) into single shared helpers. No behavior change.
 - Introduced two shared owners to remove copy-pasted code: a route-id log-shortening helper used across the logistics route files, and a shared ConfigNode codec for route endpoints and connection kinds used by both the route and route-proof serializers (the on-disk byte and field order is unchanged). No behavior or save-format change.
+- Log hygiene: the ghost map-polyline build and below-surface-exclusion diagnostic lines are now rate-limited per recording, so an active descent no longer repeats them at frame rate in the log.
 
 ## 0.10.1
 

--- a/Source/Parsek.Tests/GhostTrajectoryPolylineBuildTests.cs
+++ b/Source/Parsek.Tests/GhostTrajectoryPolylineBuildTests.cs
@@ -347,14 +347,15 @@ namespace Parsek.Tests
             rec.Points.Add(MakePoint(200.0, 0.0, 0.0, 100.0));
 
             GhostTrajectoryPolylineRenderer.RefreshForRecording(rec);
-            int buildsBefore =
-                logLines.Count(l => l.Contains("[GhostMap]") && l.Contains("Polyline build:"));
+            // The build log is now rate-limited per recording, so a same-recording
+            // rebuild within the interval is suppressed. Assert the rebuild via the
+            // build-invocation counter instead of the (throttled) log line.
+            int buildsBefore = GhostTrajectoryPolylineRenderer.BuildInvocationCountForTesting;
 
             // Mutate -- append a new point. The hash flips.
             rec.Points.Add(MakePoint(300.0, 0.0, 0.0, 150.0));
             GhostTrajectoryPolylineRenderer.RefreshForRecording(rec);
-            int buildsAfter =
-                logLines.Count(l => l.Contains("[GhostMap]") && l.Contains("Polyline build:"));
+            int buildsAfter = GhostTrajectoryPolylineRenderer.BuildInvocationCountForTesting;
 
             Assert.True(buildsAfter > buildsBefore, "expected a fresh polyline build after mutation");
         }

--- a/Source/Parsek/Display/GhostTrajectoryPolylineRenderer.cs
+++ b/Source/Parsek/Display/GhostTrajectoryPolylineRenderer.cs
@@ -603,6 +603,13 @@ namespace Parsek.Display
         internal static int CacheCountForTesting => polylineCache.Count;
 
         /// <summary>
+        /// Test-only counter of actual polyline (re)builds that reach the build
+        /// log site. Lets a cache-invalidation test assert a rebuild happened
+        /// without depending on the now rate-limited build log line.
+        /// </summary>
+        internal static int BuildInvocationCountForTesting;
+
+        /// <summary>
         /// OBSERVABILITY (descent render-window tracing): emit one line per RENDERED polyline object - every
         /// cached leg AND forward-arc whose Vectrosity <c>VectorLine</c> is live this frame (active, or drawn
         /// this frame). These VectorLines are NOT in <see cref="GhostMapPresence.ghostMapVesselPids"/>, so the
@@ -1216,6 +1223,8 @@ namespace Parsek.Display
         /// </summary>
         internal static void Clear()
         {
+            // Test-only rebuild counter shares the cross-save / test-reset lifecycle of the caches below.
+            BuildInvocationCountForTesting = 0;
             // Drop the per-frame ownership publish set first (before the empty-cache early-return), so a
             // cross-save flush / test reset never leaves a stale ownership behind. It is re-cleared
             // every LateUpdate, so this is belt-and-suspenders in normal play and the reset hook in tests.
@@ -2701,8 +2710,13 @@ namespace Parsek.Display
             }
             FlushPolylineRun(run, runBody, legs);
 
-            ParsekLog.Verbose(Tag,
-                string.Format(System.Globalization.CultureInfo.InvariantCulture,
+            BuildInvocationCountForTesting++;
+            // Per-recording rate limit: a descent rebuilds the polyline (cache
+            // miss) every frame, so an unthrottled Verbose here bursts at frame
+            // rate. verboseLogging ships ON, so this reaches a default install.
+            ParsekLog.VerboseRateLimited(Tag,
+                "polyline-build:" + rec.RecordingId,
+                () => string.Format(System.Globalization.CultureInfo.InvariantCulture,
                     "Polyline build: rec={0} legs={1} (sectionPts={2} flatPts={3} skippedRelNoBodyFixed={4} excludedBelowSurfaceSegs={5} gapFilled={6})",
                     rec.RecordingId,
                     legs.Count, sectionPointCount, flatPointCount,
@@ -2715,8 +2729,9 @@ namespace Parsek.Display
             if (excludedBelowSurfaceSegments > 0 && legs.Count > 0)
             {
                 var descentLeg = legs[legs.Count - 1];
-                ParsekLog.Verbose(Tag,
-                    string.Format(System.Globalization.CultureInfo.InvariantCulture,
+                ParsekLog.VerboseRateLimited(Tag,
+                    "polyline-excluded-belowsurf:" + rec.RecordingId,
+                    () => string.Format(System.Globalization.CultureInfo.InvariantCulture,
                         "excluded {0} below-surface orbit segments from cover rec={1} -> descent leg [{2:F1},{3:F1}]",
                         excludedBelowSurfaceSegments, rec.RecordingId,
                         descentLeg.startUT, descentLeg.endUT));


### PR DESCRIPTION
## What

The `[GhostMap]` "Polyline build" and "excluded N below-surface orbit segments" diagnostics in `GhostTrajectoryPolylineRenderer` were plain `ParsekLog.Verbose`, emitted once per polyline (re)build. A descent render rebuilds the polyline (cache miss) every frame, and `verboseLogging` ships **on** by default, so a default install bursts these at frame rate during a descent (measured ~118/sec in a pre-release playtest log). This is the exact per-frame-VERBOSE pattern the logging convention says to route through `VerboseRateLimited`.

## Fix

- Route both lines through `VerboseRateLimited` (deferred message factory, so the `string.Format` is skipped on suppressed frames), keyed per recording. A descent burst collapses to one line per recording per interval while the diagnostic stays present in default logs.
- The `RefreshForRecording_RecordingMutates_CacheInvalidates` test used the build log line as its "did it rebuild" signal, which the rate limiter now suppresses. Added `BuildInvocationCountForTesting` (reset in `Clear()`) and repointed that test to the counter.

## Scope / risk

Log-hygiene only, single subsystem. No render behavior change. Pre-existing (not a 0.10.2 regression). The "excluded" and cache-hit tests are unaffected (single build each).

## Validation

Full xUnit suite green: **16753 passed, 0 failed, 0 skipped**.