### PR TITLE
chore: bump version to 0.10.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to Parsek are documented here.
 
 ---
 
+## 0.10.3
+
 ## 0.10.2
 
 ### Fixes

--- a/GameData/Parsek/Parsek.version
+++ b/GameData/Parsek/Parsek.version
@@ -1,7 +1,7 @@
 {
     "NAME": "Parsek",
     "URL": "https://raw.githubusercontent.com/vl3c/Parsek/main/GameData/Parsek/Parsek.version",
-    "VERSION": { "MAJOR": 0, "MINOR": 10, "PATCH": 2 },
+    "VERSION": { "MAJOR": 0, "MINOR": 10, "PATCH": 3 },
     "KSP_VERSION": { "MAJOR": 1, "MINOR": 12, "PATCH": 5 },
     "KSP_VERSION_MIN": { "MAJOR": 1, "MINOR": 12, "PATCH": 0 },
     "KSP_VERSION_MAX": { "MAJOR": 1, "MINOR": 12, "PATCH": 99 }

--- a/Source/Parsek/Properties/AssemblyInfo.cs
+++ b/Source/Parsek/Properties/AssemblyInfo.cs
@@ -17,7 +17,7 @@ using System.Runtime.InteropServices;
 
 [assembly: Guid("a1b2c3d4-e5f6-7890-abcd-ef1234567890")]
 
-[assembly: AssemblyVersion("0.10.2.0")]
-[assembly: AssemblyFileVersion("0.10.2.0")]
+[assembly: AssemblyVersion("0.10.3.0")]
+[assembly: AssemblyFileVersion("0.10.3.0")]
 
 [assembly: KSPAssembly("Parsek", 0, 10)]


### PR DESCRIPTION
Opens the 0.10.3 development cycle now that v0.10.2 (Refaktor V) is released.

- `AssemblyInfo.cs`: `AssemblyVersion` / `AssemblyFileVersion` 0.10.2.0 -> 0.10.3.0
- `GameData/Parsek/Parsek.version`: PATCH 2 -> 3
- `CHANGELOG.md`: new `## 0.10.3` section header above 0.10.2

Mirrors the prior `chore: bump version to 0.10.2` (29ffe753f). `release.py`'s version-match check stays satisfied (both version sources are 0.10.3).