### PR TITLE
fix(logistics): surface inventory-only shortfalls in per-cycle flow lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ All notable changes to Parsek are documented here.
 - Supply run candidates can now be dismissed: each candidate and near-miss row in the Logistics window gets a Dismiss button that hides trees you never intend to run as routes, and a collapsed "Dismissed (N)" list at the bottom of the Candidates section lets you restore any of them later.
 - A supply route held because another route reserved a shared depot's cargo for its own in-flight cycle now says so in the Logistics window, naming the reserving route, instead of wrongly claiming the depot is out of that resource.
 
+### Fixes
+
+- The route detail panel's recent-cycles lines now surface stored-part inventory shortfalls: a cycle short only on inventory items gets the shortfall highlight and a "(source was short)" note, and a fully blocked inventory pickup reads "picked up 0 of N inventory item(s)" instead of "picked up nothing" with no explanation.
+
 ### Internals & Tests
 
 - Loop-unit API hardening on the Missions-to-Logistics seam, with no behavior change: supply routes now cache their built loop unit (rebuilt only when an input actually changes, instead of re-running the full builder pipeline every orchestrator tick and countdown call), the fire-once dock-crossing detection is centralized in one shared emitter, and the loop cycle index carries an explicit flat-vs-scheduled type so consumers cannot misread one as the other. Route firing, replay keys, escrow, and ledger rows are unchanged.

--- a/Source/Parsek.Tests/Logistics/LogisticsFlowPresentationTests.cs
+++ b/Source/Parsek.Tests/Logistics/LogisticsFlowPresentationTests.cs
@@ -288,6 +288,121 @@ namespace Parsek.Tests.Logistics
         }
 
         [Fact]
+        public void FormatPerCycleFlow_InventoryOnlyPickupShortfall_FlagsAndAnnotates()
+        {
+            // Inventory-only pickup that came up short: 1 of 3 requested
+            // stored-part payloads moved, no resources involved. The cycle line
+            // must carry the shortfall tint flag and the "(source was short)"
+            // annotation, mirroring the resource shortfall path.
+            var rows = new List<LogisticsFlowPresentation.FlowRow>
+            {
+                FlowRow(LogisticsFlowPresentation.FlowRowKind.PickedUp, "cyc-1", 0, 1000.0, 2,
+                    null, null, 42u, 0f, 1, 3),
+            };
+            var names = new Dictionary<uint, string> { [42u] = "Parts Depot" };
+
+            List<LogisticsFlowPresentation.CycleFlowLine> lines =
+                LogisticsFlowPresentation.FormatPerCycleFlow(
+                    rows, names, null, null, 1000.0, 5);
+
+            Assert.Single(lines);
+            Assert.True(lines[0].Shortfall);
+            Assert.Contains("picked up 1 of 3 inventory item(s) from Parts Depot", lines[0].Text);
+            Assert.Contains("(source was short)", lines[0].Text);
+        }
+
+        [Fact]
+        public void FormatPerCycleFlow_FullyBlockedInventoryPickup_RendersZeroOfN()
+        {
+            // Fully blocked inventory pickup: nothing moved but 2 payloads were
+            // requested. Must NOT read "picked up nothing" with no explanation.
+            var rows = new List<LogisticsFlowPresentation.FlowRow>
+            {
+                FlowRow(LogisticsFlowPresentation.FlowRowKind.PickedUp, "cyc-1", 0, 1000.0, 2,
+                    null, null, 42u, 0f, 0, 2),
+            };
+            var names = new Dictionary<uint, string> { [42u] = "Parts Depot" };
+
+            List<LogisticsFlowPresentation.CycleFlowLine> lines =
+                LogisticsFlowPresentation.FormatPerCycleFlow(
+                    rows, names, null, null, 1000.0, 5);
+
+            Assert.Single(lines);
+            Assert.True(lines[0].Shortfall);
+            Assert.Contains("picked up 0 of 2 inventory item(s) from Parts Depot", lines[0].Text);
+            Assert.Contains("(source was short)", lines[0].Text);
+            Assert.DoesNotContain("nothing", lines[0].Text);
+        }
+
+        [Fact]
+        public void FormatPerCycleFlow_InventoryDebitShortfall_MarksOriginShort()
+        {
+            var rows = new List<LogisticsFlowPresentation.FlowRow>
+            {
+                FlowRow(LogisticsFlowPresentation.FlowRowKind.Debited, "cyc-1", 0, 1000.0, 1,
+                    null, null, 7u, 0f, 1, 2),
+            };
+            var names = new Dictionary<uint, string> { [7u] = "Minmus Depot" };
+
+            List<LogisticsFlowPresentation.CycleFlowLine> lines =
+                LogisticsFlowPresentation.FormatPerCycleFlow(
+                    rows, names, null, null, 1000.0, 5);
+
+            Assert.Single(lines);
+            Assert.True(lines[0].Shortfall);
+            Assert.Contains("took 1 of 2 inventory item(s) from Minmus Depot", lines[0].Text);
+            Assert.Contains("(origin was short)", lines[0].Text);
+        }
+
+        [Fact]
+        public void FormatPerCycleFlow_QuantityLevelInventoryShortfall_EqualCounts_StillFlags()
+        {
+            // A quantity-level shortfall within ONE identity: the requested
+            // manifest (populated only on shortfall) has the same ENTRY count
+            // as the actual, so no "K of N" rendering, but the presence of the
+            // requested manifest alone must still flag + annotate the line.
+            var rows = new List<LogisticsFlowPresentation.FlowRow>
+            {
+                FlowRow(LogisticsFlowPresentation.FlowRowKind.PickedUp, "cyc-1", 0, 1000.0, 2,
+                    null, null, 42u, 0f, 1, 1),
+            };
+            var names = new Dictionary<uint, string> { [42u] = "Parts Depot" };
+
+            List<LogisticsFlowPresentation.CycleFlowLine> lines =
+                LogisticsFlowPresentation.FormatPerCycleFlow(
+                    rows, names, null, null, 1000.0, 5);
+
+            Assert.Single(lines);
+            Assert.True(lines[0].Shortfall);
+            Assert.Contains("picked up 1 inventory item(s) from Parts Depot", lines[0].Text);
+            Assert.DoesNotContain(" of ", lines[0].Text);
+            Assert.Contains("(source was short)", lines[0].Text);
+        }
+
+        [Fact]
+        public void CollectRows_CarriesRequestedInventoryCount()
+        {
+            var pickedUp = MakePickedUpAction(RouteId, "cyc-1", 0, 100.0, 2, null, null, 42u);
+            pickedUp.RouteInventoryManifest = new List<InventoryPayloadItem>
+            {
+                new InventoryPayloadItem { IdentityHash = "ore-container", Quantity = 1 },
+            };
+            pickedUp.RouteRequestedInventoryManifest = new List<InventoryPayloadItem>
+            {
+                new InventoryPayloadItem { IdentityHash = "ore-container", Quantity = 2 },
+                new InventoryPayloadItem { IdentityHash = "science-box", Quantity = 1 },
+            };
+            var els = new List<GameAction> { pickedUp };
+
+            var flowRows = new List<LogisticsFlowPresentation.FlowRow>();
+            LogisticsFlowPresentation.CollectRows(els, RouteId, null, flowRows);
+
+            Assert.Single(flowRows);
+            Assert.Equal(1, flowRows[0].InventoryCount);
+            Assert.Equal(2, flowRows[0].RequestedInventoryCount);
+        }
+
+        [Fact]
         public void FormatPerCycleFlow_LastNBounding_NewestFirst()
         {
             var rows = new List<LogisticsFlowPresentation.FlowRow>();
@@ -381,11 +496,13 @@ namespace Parsek.Tests.Logistics
             LogisticsFlowPresentation.FlowRowKind kind,
             string cycleId, int stopIndex, double ut, int sequence,
             Dictionary<string, double> actual, Dictionary<string, double> requested,
-            uint endpointPid, float kscFundsCost, int inventoryCount)
+            uint endpointPid, float kscFundsCost, int inventoryCount,
+            int requestedInventoryCount = 0)
         {
             return new LogisticsFlowPresentation.FlowRow(
                 kind, cycleId, stopIndex, ut, sequence,
-                actual, requested, endpointPid, kscFundsCost, inventoryCount);
+                actual, requested, endpointPid, kscFundsCost, inventoryCount,
+                requestedInventoryCount);
         }
 
         private static GameAction MakeDeliveredAction(

--- a/Source/Parsek/UI/LogisticsFlowPresentation.cs
+++ b/Source/Parsek/UI/LogisticsFlowPresentation.cs
@@ -61,7 +61,8 @@ namespace Parsek
                 IReadOnlyDictionary<string, double> requested,
                 uint endpointPid,
                 float kscFundsCost,
-                int inventoryCount)
+                int inventoryCount,
+                int requestedInventoryCount)
             {
                 Kind = kind;
                 CycleId = cycleId;
@@ -73,6 +74,7 @@ namespace Parsek
                 EndpointPid = endpointPid;
                 KscFundsCost = kscFundsCost;
                 InventoryCount = inventoryCount;
+                RequestedInventoryCount = requestedInventoryCount;
             }
 
             internal FlowRowKind Kind { get; }
@@ -102,6 +104,13 @@ namespace Parsek
 
             /// <summary>Count of stored-part inventory payloads moved on this row.</summary>
             internal int InventoryCount { get; }
+
+            /// <summary>
+            /// Count of requested stored-part inventory payloads, populated only
+            /// on an inventory shortfall (the inventory analogue of
+            /// <see cref="Requested"/>); 0 on a full fill.
+            /// </summary>
+            internal int RequestedInventoryCount { get; }
         }
 
         /// <summary>One rendered per-cycle line plus its shortfall tint flag.</summary>
@@ -170,7 +179,8 @@ namespace Parsek
                         kind, a.RouteCycleId, a.RouteStopIndex, a.UT, a.Sequence,
                         a.RouteResourceManifest, a.RouteRequestedResourceManifest,
                         a.RouteOriginVesselPid, a.RouteKscFundsCost,
-                        a.RouteInventoryManifest?.Count ?? 0));
+                        a.RouteInventoryManifest?.Count ?? 0,
+                        a.RouteRequestedInventoryManifest?.Count ?? 0));
                 }
             }
         }
@@ -212,6 +222,7 @@ namespace Parsek
             // Group rows by cycle id, tracking each cycle's earliest row UT for
             // ordering. Insertion order of the dictionary is not relied on.
             var byCycle = new Dictionary<string, List<FlowRow>>(System.StringComparer.Ordinal);
+            var minUtByCycle = new Dictionary<string, double>(System.StringComparer.Ordinal);
             var cycleIds = new List<string>();
             for (int i = 0; i < rows.Count; i++)
             {
@@ -221,7 +232,12 @@ namespace Parsek
                 {
                     bucket = new List<FlowRow>();
                     byCycle[row.CycleId] = bucket;
+                    minUtByCycle[row.CycleId] = row.Ut;
                     cycleIds.Add(row.CycleId);
+                }
+                else if (row.Ut < minUtByCycle[row.CycleId])
+                {
+                    minUtByCycle[row.CycleId] = row.Ut;
                 }
                 bucket.Add(row);
             }
@@ -232,7 +248,7 @@ namespace Parsek
             // deterministic tiebreak); ordinal = 1-based position in that order.
             cycleIds.Sort((idA, idB) =>
             {
-                int cmp = MinUt(byCycle[idA]).CompareTo(MinUt(byCycle[idB]));
+                int cmp = minUtByCycle[idA].CompareTo(minUtByCycle[idB]);
                 return cmp != 0 ? cmp : string.CompareOrdinal(idA, idB);
             });
 
@@ -248,14 +264,17 @@ namespace Parsek
             return lines;
         }
 
-        private static double MinUt(List<FlowRow> bucket)
+        /// <summary>
+        /// True when the row recorded any shortfall: a per-resource requested
+        /// amount exceeding the actual, OR a requested-inventory manifest
+        /// (populated only when the stored-part pickup/debit came up short, so
+        /// presence alone is the signal - entry counts can match on a
+        /// quantity-level shortfall within one identity).
+        /// </summary>
+        private static bool RowHasShortfall(FlowRow row)
         {
-            double min = double.MaxValue;
-            for (int i = 0; i < bucket.Count; i++)
-            {
-                if (bucket[i].Ut < min) min = bucket[i].Ut;
-            }
-            return min;
+            return LogisticsDeliveryPresentation.HasShortfall(row.Requested, row.Actual)
+                || row.RequestedInventoryCount > 0;
         }
 
         /// <summary>
@@ -293,7 +312,7 @@ namespace Parsek
             {
                 FlowRow row = bucket[i];
                 if (row.Ut > maxUt) maxUt = row.Ut;
-                if (LogisticsDeliveryPresentation.HasShortfall(row.Requested, row.Actual))
+                if (RowHasShortfall(row))
                     shortfall = true;
 
                 switch (row.Kind)
@@ -356,7 +375,8 @@ namespace Parsek
             if (kscFunds)
                 return;
 
-            string amounts = FormatAmounts(row.Actual, row.Requested, row.InventoryCount);
+            string amounts = FormatAmounts(
+                row.Actual, row.Requested, row.InventoryCount, row.RequestedInventoryCount);
             if (amounts == null)
                 return;
 
@@ -365,7 +385,7 @@ namespace Parsek
                 : (string.IsNullOrEmpty(originFallback) ? "the origin" : originFallback);
 
             string segment = "took " + amounts + " from " + source;
-            if (LogisticsDeliveryPresentation.HasShortfall(row.Requested, row.Actual))
+            if (RowHasShortfall(row))
                 segment += " (origin was short)";
             segments.Add(segment);
         }
@@ -374,13 +394,14 @@ namespace Parsek
             FlowRow row,
             IReadOnlyDictionary<uint, string> endpointNames)
         {
-            string amounts = FormatAmounts(row.Actual, row.Requested, row.InventoryCount)
+            string amounts = FormatAmounts(
+                row.Actual, row.Requested, row.InventoryCount, row.RequestedInventoryCount)
                 ?? "nothing";
             string source = row.EndpointPid != 0u
                 ? ResolveEndpointName(row.EndpointPid, endpointNames)
                 : "an unresolved source";
             string segment = "picked up " + amounts + " from " + source;
-            if (LogisticsDeliveryPresentation.HasShortfall(row.Requested, row.Actual))
+            if (RowHasShortfall(row))
                 segment += " (source was short)";
             return segment;
         }
@@ -389,11 +410,12 @@ namespace Parsek
             FlowRow row,
             IReadOnlyList<string> stopDestinationNames)
         {
-            string amounts = FormatAmounts(row.Actual, row.Requested, row.InventoryCount)
+            string amounts = FormatAmounts(
+                row.Actual, row.Requested, row.InventoryCount, row.RequestedInventoryCount)
                 ?? "nothing";
             string dest = ResolveStopDestination(row.StopIndex, stopDestinationNames);
             string segment = "delivered " + amounts + " to " + dest;
-            if (LogisticsDeliveryPresentation.HasShortfall(row.Requested, row.Actual))
+            if (RowHasShortfall(row))
                 segment += " (some cargo did not fit)";
             return segment;
         }
@@ -440,13 +462,17 @@ namespace Parsek
         /// on a shortfall (F1 + InvariantCulture, full stock keys - the
         /// <see cref="LogisticsDeliveryPresentation.FormatRealizedDelivery"/>
         /// number idiom), plus "N inventory item(s)" when stored parts moved
-        /// (the FormatWouldDeliver idiom). Returns null when nothing moved and
-        /// nothing was requested, so callers can skip or say "nothing".
+        /// (the FormatWouldDeliver idiom) or "K of N inventory item(s)" when
+        /// the requested-inventory entry count exceeds the actual (the resource
+        /// shortfall idiom; a fully blocked pickup renders "0 of N"). Returns
+        /// null when nothing moved and nothing was requested, so callers can
+        /// skip or say "nothing".
         /// </summary>
         private static string FormatAmounts(
             IReadOnlyDictionary<string, double> actual,
             IReadOnlyDictionary<string, double> requested,
-            int inventoryCount)
+            int inventoryCount,
+            int requestedInventoryCount)
         {
             var keys = new List<string>();
             if (actual != null)
@@ -489,11 +515,16 @@ namespace Parsek
                 }
             }
 
-            if (inventoryCount > 0)
+            if (inventoryCount > 0 || requestedInventoryCount > 0)
             {
                 if (sb.Length > 0) sb.Append(", ");
-                sb.Append(inventoryCount.ToString(CultureInfo.InvariantCulture))
-                  .Append(" inventory item(s)");
+                sb.Append(inventoryCount.ToString(CultureInfo.InvariantCulture));
+                if (requestedInventoryCount > inventoryCount)
+                {
+                    sb.Append(" of ")
+                      .Append(requestedInventoryCount.ToString(CultureInfo.InvariantCulture));
+                }
+                sb.Append(" inventory item(s)");
             }
 
             return sb.Length > 0 ? sb.ToString() : null;


### PR DESCRIPTION
## Summary

Closes a gap in the M6 per-cycle flow display (PR #1234): inventory-only shortfalls were invisible. `CollectRows` read `RouteInventoryManifest` but never `RouteRequestedInventoryManifest` (populated at the RouteCargoPickedUp and physical-debit emit sites only on a shortfall), and the cycle shortfall flag used only the resource-manifest `HasShortfall`. A pickup or debit cycle short only on stored-part inventory items rendered without the yellow tint or any annotation, and a fully blocked inventory pickup read as "picked up nothing from X" with no explanation.

## Changes

- `FlowRow` gains `RequestedInventoryCount` (sparse: populated only on a shortfall, mirroring the resource `Requested` contract); `CollectRows` fills it from `RouteRequestedInventoryManifest?.Count`.
- New row-level `RowHasShortfall` helper (resource `HasShortfall` OR `RequestedInventoryCount > 0`) drives the cycle tint flag and the "(source was short)" / "(origin was short)" / "(some cargo did not fit)" annotations. Presence of the requested manifest alone is the signal, so a quantity-level shortfall within one identity (equal entry counts) still flags.
- `FormatAmounts` renders "K of N inventory item(s)" when the requested entry count exceeds the actual, mirroring the resource "{actual} of {requested}" idiom; a fully blocked pickup now reads "picked up 0 of 2 inventory item(s) from X (source was short)". InvariantCulture throughout.
- Delivered rows are unaffected (the RouteCargoDelivered emit site carries no inventory manifests).
- Perf cleanup: the per-cycle min UT is precomputed during grouping instead of rescanning each bucket inside the `cycleIds.Sort` comparator.

## Tests

- 5 new xUnit tests in `LogisticsFlowPresentationTests` (pure data, no Sequential collection needed): inventory-only pickup shortfall flags + annotates, fully blocked pickup renders "0 of 2" (never "nothing"), inventory debit shortfall marks origin short, quantity-level shortfall with equal entry counts still flags, and `CollectRows` carries the requested count.
- Full suite: 16847 passed, 0 failed, 1 skipped (pre-existing environmental skip).