### PR TITLE
Fix S4 arrival re-stitch rotation sign: prograde bearing is atan2(z, x) on live KSP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to Parsek are documented here.
 
 ### Fixes
 
+- A re-aimed looped landing's arrival approach no longer rotates the wrong way around the destination body: the arrival re-stitch read its rotation angle with an inverted sign on live KSP, doubling the gap at the SOI-entry seam instead of closing it. The touchdown site was never affected; caught by the in-game landing-coincidence canary on the first full test sweep.
 - The Settings "Defaults" button now also restores "Show supply route paths on map" to on; previously that single toggle was left unchanged while every other setting reset to its default.
 - A recorded vessel or EVA kerbal that re-materializes above the surface without a stored terminal orbit (breakup debris, an in-flight EVA, or a vessel left docked or coasting) no longer appears off-position and flips its situation a frame later. Its orbit was rebuilt by feeding an absolute world position and an unconverted velocity to KSP's state-vector API, which reads them in the wrong reference frame and produces an out-of-band orbit; the rebuild now converts them to the body-relative frame the API expects.
 - A campaign save whose committed trees and missions failed to load (leaving the in-memory store empty while the recording sidecars still exist on disk) is no longer hollowed out by the next save: Parsek now detects that load fault and re-writes the trees and missions from the on-disk save instead of overwriting it with an empty set, so a one-time load failure can no longer progressively erase a save's committed recordings.

--- a/Source/Parsek.Tests/ArrivalRestitchTests.cs
+++ b/Source/Parsek.Tests/ArrivalRestitchTests.cs
@@ -12,9 +12,13 @@ namespace Parsek.Tests
     // the touchdown at the RECORDED body-fixed site (the ratified product decision).
     //
     // Frame convention under test: the .xzy-unswizzled WORLD frame, whose reference-plane normal
-    // (= the zero-tilt body spin axis) is +Y, NOT +Z (the PR #1196 .z-vs-.y world-frame trap).
-    // In-plane components are x and z; prograde-positive bearing = atan2(-z, x) degrees; positive
-    // rotation is the prograde sense, shared by prograde orbits and prograde body spin.
+    // (= the zero-tilt body spin axis LINE) is Y, NOT Z (the PR #1196 .z-vs-.y world-frame trap).
+    // In-plane components are x and z; prograde-positive bearing = atan2(z, x) degrees; positive
+    // rotation is the prograde sense, shared by prograde orbits and prograde body spin. The sense
+    // is LIVE-KSP-CALIBRATED by the in-game canary (ReaimLandingCoincidenceInGameTest): KSP's
+    // world frame carries prograde angular momentum along -Y, so a live LAN=+theta orbit pair
+    // measures +theta in the atan2(z, x) sense (the earlier atan2(-z, x) pole choice read it as
+    // -theta and rotated the arrival chain the wrong way - the 2026-07-10 sweep failure).
     public class ArrivalRestitchTests
     {
         private const double DunaTrot = 65517.859375;
@@ -43,10 +47,12 @@ namespace Parsek.Tests
         [Fact]
         public void Rotation_QuarterTurnPrograde_IsPlus90()
         {
-            // recorded along +x, new along -z: +90 deg prograde (about +Y) carries recorded onto
-            // new (for a prograde orbit at +x the velocity points -z: Cross(r, v) = +Y).
+            // recorded along +x, new along +z: +90 deg prograde carries recorded onto new (for a
+            // prograde orbit at +x the velocity points +z in KSP's world frame: a LAN advance of
+            // +90 moves the position from +x to +z, the canary-measured live contract; the
+            // prograde angular momentum Cross(r, v) points -Y).
             double theta = ArrivalRestitch.ComputeRestitchRotationDeg(
-                new Vector3d(1.0e7, 0.0, 0.0), new Vector3d(0.0, 0.0, -1.0e7),
+                new Vector3d(1.0e7, 0.0, 0.0), new Vector3d(0.0, 0.0, 1.0e7),
                 out _, out _);
             Assert.Equal(90.0, theta, 9);
         }
@@ -55,7 +61,7 @@ namespace Parsek.Tests
         public void Rotation_QuarterTurnRetrograde_IsMinus90()
         {
             double theta = ArrivalRestitch.ComputeRestitchRotationDeg(
-                new Vector3d(0.0, 0.0, -1.0e7), new Vector3d(1.0e7, 0.0, 0.0),
+                new Vector3d(0.0, 0.0, 1.0e7), new Vector3d(1.0e7, 0.0, 0.0),
                 out _, out _);
             Assert.Equal(-90.0, theta, 9);
         }
@@ -72,8 +78,10 @@ namespace Parsek.Tests
         [Fact]
         public void Rotation_MagnitudesIrrelevant_OnlyBearingsCount()
         {
+            // bearings: recorded atan2(1, 1) = +45, new atan2(5e8, -5e8) = +135: a +90 prograde
+            // quarter turn regardless of the wildly different magnitudes.
             double a = ArrivalRestitch.ComputeRestitchRotationDeg(
-                new Vector3d(1.0, 0.0, -1.0), new Vector3d(-5.0e8, 0.0, -5.0e8), out _, out _);
+                new Vector3d(1.0, 0.0, 1.0), new Vector3d(-5.0e8, 0.0, 5.0e8), out _, out _);
             Assert.Equal(90.0, a, 9);
         }
 
@@ -126,10 +134,10 @@ namespace Parsek.Tests
         [Fact]
         public void VelocityResidual_PerfectlyRotatedVelocity_IsZero()
         {
-            // new velocity = recorded velocity rotated by +90 prograde: residual after the +90
-            // re-stitch is 0.
+            // new velocity = recorded velocity rotated by +90 prograde (bearing 0 -> +90, i.e.
+            // +x -> +z): residual after the +90 re-stitch is 0.
             double r = ArrivalRestitch.VelocityBearingResidualDeg(
-                new Vector3d(3000.0, 0.0, 0.0), new Vector3d(0.0, 0.0, -3000.0), 90.0);
+                new Vector3d(3000.0, 0.0, 0.0), new Vector3d(0.0, 0.0, 3000.0), 90.0);
             Assert.Equal(0.0, r, 9);
         }
 
@@ -137,9 +145,9 @@ namespace Parsek.Tests
         public void VelocityResidual_ReportsTheKink()
         {
             // new velocity 30 deg past the rotated recorded velocity: residual +30 (bearing 120
-            // in the prograde atan2(-z, x) sense = x-component cos120, z-component -sin120).
+            // in the prograde atan2(z, x) sense = x-component cos120, z-component sin120).
             double vx = 3000.0 * Math.Cos(120.0 * Math.PI / 180.0);
-            double vz = -3000.0 * Math.Sin(120.0 * Math.PI / 180.0);
+            double vz = 3000.0 * Math.Sin(120.0 * Math.PI / 180.0);
             double r = ArrivalRestitch.VelocityBearingResidualDeg(
                 new Vector3d(3000.0, 0.0, 0.0), new Vector3d(vx, 0.0, vz), 90.0);
             Assert.Equal(30.0, r, 6);

--- a/Source/Parsek/Reaim/ArrivalRestitch.cs
+++ b/Source/Parsek/Reaim/ArrivalRestitch.cs
@@ -15,9 +15,10 @@ namespace Parsek.Reaim
     /// the approach by theta is exactly compensated by waiting theta/omega_rot longer for the site
     /// to rotate under the rotated deorbit point. Any other axis would change the reachable
     /// latitude, i.e. move the landing site. In KSP all bodies have zero axial tilt, so the spin
-    /// axis equals the orbital reference-plane normal - which in the .xzy-unswizzled WORLD frame
-    /// is +Y, NOT +Z (the PR #1196 .z-vs-.y trap; see the frame note on TryBearingAndLatitude) -
-    /// and the rotation is applied as a LAN advance on the destination-bodied OrbitSegments
+    /// axis line equals the orbital reference-plane normal - the Y axis of the .xzy-unswizzled
+    /// WORLD frame, NOT Z (the PR #1196 .z-vs-.y trap), with prograde angular momentum pointing
+    /// -Y (see the frame note on TryBearingAndLatitude) - and the rotation is applied as a LAN
+    /// advance on the destination-bodied OrbitSegments
     /// (<see cref="ReaimSegmentAssembler.RotateLanForParkRephase"/>).</para>
     ///
     /// <para>All helpers are pure (no Unity) and xUnit-tested. The live entry-state extraction
@@ -38,8 +39,8 @@ namespace Parsek.Reaim
         /// destination-relative SOI-entry direction onto the RE-AIMED transfer's actual
         /// destination-relative SOI-entry direction: the in-plane bearing difference
         /// <c>bearing(newEntry) - bearing(recordedEntry)</c> about the reference-plane normal of
-        /// the .xzy-unswizzled (world) frame, which is <b>+Y</b> (= the zero-tilt body spin axis;
-        /// prograde-positive bearing = atan2(-z, x) - see the frame note on the private helper).
+        /// the .xzy-unswizzled (world) frame (the zero-tilt body spin axis line is Y;
+        /// prograde-positive bearing = atan2(z, x) - see the frame note on the private helper).
         /// <paramref name="recordedLatitudeDeg"/> / <paramref name="newLatitudeDeg"/>
         /// report each direction's out-of-plane latitude (degrees; the residual a spin-axis
         /// rotation cannot and must not close - closing it would move the landing site).
@@ -105,15 +106,21 @@ namespace Parsek.Reaim
         /// <summary>
         /// In-plane bearing and out-of-plane latitude (degrees) of a direction in the
         /// .xzy-unswizzled frame - which is KSP's WORLD frame, whose reference-plane normal (world
-        /// up, and with zero axial tilt every body's spin axis) is <b>+Y, NOT +Z</b>. This is the
-        /// same .z-vs-.y world-frame trap the plane-tilt achievability gate hit and fixed in
-        /// PR #1196 (see <see cref="ReaimTransferSynthesizer"/>'s AchievablePlaneInclinationDegrees
-        /// frame note): using z as "up" here would read the in-plane angle as "latitude" and
-        /// quantize every real bearing toward 0 / 180. In-plane components are x and z; the
-        /// PROGRADE-positive bearing is <c>atan2(-z, x)</c>, calibrated against the shipped
-        /// park-rephase pairing (for a prograde orbit <c>Cross(r, v)</c> points +Y and a LAN
-        /// advance of +D moves the position +D in this sense - the same sense the body spin
-        /// advances a surface site, so the <see cref="SiteAlignOffsetSeconds"/> pairing holds).
+        /// up, and with zero axial tilt the LINE of every body's spin axis) is <b>Y, NOT Z</b>.
+        /// This is the same .z-vs-.y world-frame trap the plane-tilt achievability gate hit and
+        /// fixed in PR #1196 (see <see cref="ReaimTransferSynthesizer"/>'s
+        /// AchievablePlaneInclinationDegrees frame note): using z as "up" here would read the
+        /// in-plane angle as "latitude" and quantize every real bearing toward 0 / 180. In-plane
+        /// components are x and z; the PROGRADE-positive bearing is <c>atan2(z, x)</c>. The sense
+        /// is LIVE-KSP-CALIBRATED, not derived: KSP's world frame carries prograde angular momentum
+        /// along <b>-Y</b> (<c>CelestialBody.angularVelocity</c> points -Y for prograde rotators),
+        /// so a LAN advance of +D moves a prograde orbit's position +D in the <c>atan2(z, x)</c>
+        /// sense - the same sense the body spin advances a surface site, which keeps the
+        /// <see cref="SiteAlignOffsetSeconds"/> pairing intact. The in-game canary
+        /// <c>ReaimLandingCoincidenceInGameTest</c> measures both live rotations and this helper
+        /// against each other (the 2026-07-10 sweep caught the earlier <c>atan2(-z, x)</c> pole
+        /// choice reading every live LAN=+theta pair as -theta: the arrival chain rotated the
+        /// wrong way, a 2*theta tear at the SOI-entry seam).
         /// Latitude = <c>asin(y/|v|)</c>. False on NaN / infinite components or a degenerate
         /// (near-zero) in-plane projection. Pure.
         /// </summary>
@@ -128,7 +135,7 @@ namespace Parsek.Reaim
             double mag = Math.Sqrt(planar * planar + v.y * v.y);
             if (!(planar > 0.0) || !(mag > 0.0))
                 return false; // zero / axis-aligned vector: no bearing
-            bearingDeg = Math.Atan2(-v.z, v.x) * 180.0 / Math.PI;
+            bearingDeg = Math.Atan2(v.z, v.x) * 180.0 / Math.PI;
             latitudeDeg = Math.Asin(v.y / mag) * 180.0 / Math.PI;
             return true;
         }

--- a/Source/Parsek/Reaim/ReaimPlaybackResolver.cs
+++ b/Source/Parsek/Reaim/ReaimPlaybackResolver.cs
@@ -630,7 +630,9 @@ namespace Parsek.Reaim
         // plan.RecordedArrivalUT) onto the RE-AIMED transfer's actual destination-relative entry bearing
         // (transferOrbit vs targetBody.orbit at the refined SOI-entry UT, both parent-relative
         // .xzy-unswizzled, so the difference is destination-relative in the same frame; the bearing math
-        // in ArrivalRestitch measures about the frame's +Y pole). soiEntryUT can come from the coarse
+        // in ArrivalRestitch measures prograde-positive about the live-KSP-calibrated pole - see the
+        // frame note on TryBearingAndLatitude: prograde angular momentum points -Y in the world frame,
+        // so a live LAN=+theta advance reads +theta). soiEntryUT can come from the coarse
         // proximity fallback (96 samples over the transfer - up to tof/96 late = deep inside the SOI),
         // so it is REFINED to the actual SOI-sphere crossing by bisection first, and a residual radius
         // far off the SOI declines rather than rotating on flyby-depth-contaminated bearing. Returns 0

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -14,6 +14,18 @@ When referencing prior item numbers from source comments or plans, consult the r
 
 ---
 
+## ~~FIXED~~ - S4 arrival re-stitch rotation sign inverted on live KSP (found by the 2026-07-10 in-game sweep, branch `fix-s4-restitch-bearing`)
+
+**Found by:** the first full Ctrl+Shift+T sweep on 0.10.3 main (`logs/2026-07-10_1935_ingame-test-sweep`, 5 scenes, 2 failures). `ReaimLandingCoincidenceInGameTest.S4Restitch_RotatedDeorbitPoint_MeetsRecordedSiteAtTrigger` - the exact canary the S4 PR added for the sign question headless tests cannot prove - measured `ComputeRestitchRotationDeg` reading a live LAN=+30 orbit pair as -30 (`S4 frame validation` log line; the physical LAN-advance and body-spin rotations both measured +30 about the live spin axis `(0,-1,0)`).
+
+**Root cause:** the adversarial-review commit (`26922fd28`, S4 BLOCKER 1) fixed the latitude AXIS (Y, not Z) but picked the bearing SENSE as `atan2(-z, x)` from the derivation "Cross(r, v_prograde) points +Y". Live KSP refutes the premise: prograde angular momentum points -Y in the world frame (`CelestialBody.angularVelocity` is -Y for prograde rotators), so `atan2(-z, x)` reads every prograde advance inverted. Production consequence: `RotateLanForParkRephase` turned the arrival chain by -theta instead of +theta (a 2*theta tear at the SOI-entry seam - the exact defect S4 exists to close); the landing site itself was never at risk (the rotation/trigger-offset pairing is sign-agnostic, so the touchdown stayed at the recorded site).
+
+**Fix:** `ArrivalRestitch.TryBearingAndLatitude` bearing = `atan2(z, x)` (live-KSP-calibrated by the canary, not re-derived); doc comments rewritten to name the canary as the calibration source; the four sign-sensitive `ArrivalRestitchTests` pins re-pinned to the corrected sense (quarter-turn prograde/retrograde, magnitude-irrelevance, both velocity-residual cases). The connectivity / recorded-site-invariant / assembler pins are sign-agnostic and unchanged.
+
+**Verify:** re-run the FLIGHT sweep (or just the Periodicity category) in-game: the canary must read +30/+30 with residual 0. The Duna One (s15) looped landing playtest remains the S4 merge-gate observation for the approach visibly connecting.
+
+---
+
 ## Added (headless-verified, in-game pin pending) - Pre-Parsek save safety backup (branch `pre-parsek-save-backup`)
 
 **Feature.** The first time Parsek cold-loads a save with no Parsek footprint, it copies that save - before any Parsek write - into a sibling `saves/<Name> (pre-Parsek <local-ts>)/` folder that appears in KSP's Load menu, so a player who tries Parsek and uninstalls it can return to their pristine career. Runs once per save; skips brand-new empty careers; toggle under Settings > Data Management (`autoBackupExistingSaves`, default on).


### PR DESCRIPTION
## Summary

The first full in-game test sweep on 0.10.3 main (2026-07-10, 5 scenes, `logs/2026-07-10_1935_ingame-test-sweep`) failed the S4 landing-coincidence canary `ReaimLandingCoincidenceInGameTest.S4Restitch_RotatedDeorbitPoint_MeetsRecordedSiteAtTrigger` - the exact live-frame validation the S4 PR added for the sign question headless tests cannot prove.

**Measured:** `ComputeRestitchRotationDeg` read a live LAN=+30 orbit pair as **-30**, while both physical rotations (the LAN-advance world rotation and the body-spin rotation over the trigger offset) measured **+30** about the live spin axis `(0,-1,0)`:

```
S4 landing coincidence: theta=30.00deg ... lanAdvance=30.0000deg siteAdvance=30.0000deg residual=0.0000deg spinAxis=(0.000,-1.000,0.000)
S4 frame validation: ComputeRestitchRotationDeg on live LAN+30.0 orbit pair = -30.0000deg (latA=0.000 latB=0.000)
```

## Root cause

The adversarial-review commit (26922fd28, S4 BLOCKER 1) fixed the latitude AXIS (Y, not Z - correct, latitudes read 0.000) but derived the bearing SENSE as `atan2(-z, x)` from the premise "Cross(r, v_prograde) points +Y". Live KSP refutes the premise: prograde angular momentum points **-Y** in the world frame (`CelestialBody.angularVelocity` is -Y for prograde rotators), so a bearing about the +Y pole reads every prograde advance inverted.

**Production consequence:** `RotateLanForParkRephase` turned the arrival chain by -theta instead of +theta - a 2*theta tear at the SOI-entry seam, the exact defect S4 exists to close. The landing site was never at risk: the rotation/trigger-offset pairing is sign-agnostic, so the touchdown stayed at the recorded site.

## Fix

- `ArrivalRestitch.TryBearingAndLatitude`: bearing = `atan2(z, x)` - live-KSP-calibrated by the canary, not re-derived.
- Doc comments rewritten to name the canary as the calibration source and record the -Y angular-momentum fact.
- The four sign-sensitive `ArrivalRestitchTests` pins re-pinned to the corrected sense (quarter-turn prograde/retrograde, magnitude-irrelevance, both velocity-residual cases). Connectivity / recorded-site-invariant / assembler pins are sign-agnostic and unchanged.
- CHANGELOG + todo doc entries.

## Validation

- Full xUnit suite green: 17415 passed / 0 failed / 1 known skip.
- In-game re-verify pending operator: re-run the Periodicity category (Ctrl+Shift+T); the canary must read +30/+30 with residual 0. The Duna One (s15) looped-landing playtest remains the S4 observational merge gate for the approach visibly connecting.