### PR TITLE
Fix stale escrow hold-token assertion in the multi-origin in-game test

### DIFF
--- a/Source/Parsek/InGameTests/LogisticsMultiOriginRuntimeTests.cs
+++ b/Source/Parsek/InGameTests/LogisticsMultiOriginRuntimeTests.cs
@@ -442,7 +442,7 @@ namespace Parsek.InGameTests
             AllowBatchExecution = false,
             RestoreBatchFlightBaselineAfterExecution = true,
             BatchSkipReason = IsolatedOnlyBatchSkipReason,
-            Description = "Cargo escrow (B2/B3, 19.2.5): route A reserves a shared source's LiquidFuel via RouteStore.ReserveCargo at dispatch; a competing route B gating the SAME source in the gap sees its available amount netted down by A's reservation (OtherRoutesReservedFor) and HOLDS naming the source, instead of double-claiming it. Drives the live LiveRouteRuntimeEnvironment.OriginHasCargo gate against an auto-spawned shared source vessel; skips when it cannot be provided")]
+            Description = "Cargo escrow (B2/B3, 19.2.5): route A reserves a shared source's LiquidFuel via RouteStore.ReserveCargo at dispatch; a competing route B gating the SAME source in the gap sees its available amount netted down by A's reservation (OtherRoutesReservedFor) and HOLDS with the M6 escrow token (source-reserved:<pid>:<name>:<resource>:<reservingRoute>) naming the source AND the reserving route A, instead of double-claiming it or claiming the depot is physically empty. Drives the live LiveRouteRuntimeEnvironment.OriginHasCargo gate against an auto-spawned shared source vessel; skips when it cannot be provided")]
         public IEnumerator Escrow_CompetingRouteSeesReservation_Holds()
         {
             IEnumerator unpackWait = LogisticsOriginDebitRuntimeTests.WaitForActiveVesselUnpack();
@@ -480,8 +480,14 @@ namespace Parsek.InGameTests
                         $"Shared source holds {sourceStored.ToString("R", IC)} LF >= 2x the pickup; cannot demonstrate " +
                         "the competing-route net (it could cover both). Re-run with a smaller source");
 
-                string routeAId = "ingame-escrow-A-" + Guid.NewGuid().ToString("N").Substring(0, 8);
-                string routeBId = "ingame-escrow-B-" + Guid.NewGuid().ToString("N").Substring(0, 8);
+                // Prefixes distinct within RouteIds.Short's 8 chars: the escrow hold token's
+                // reserving-route segment resolves via RouteStore.TryGetRoute -> fallback
+                // RouteIds.Short(reservingRouteId) (neither test route is ADDED to the store,
+                // only reserved for), and the assertion below pins that it names route A
+                // specifically - a shared "ingame-escrow-" prefix would truncate A and B to
+                // the same 8 chars and the pin could not tell them apart.
+                string routeAId = "esc-A-" + Guid.NewGuid().ToString("N").Substring(0, 8);
+                string routeBId = "esc-B-" + Guid.NewGuid().ToString("N").Substring(0, 8);
 
                 var env = new LiveRouteRuntimeEnvironment();
                 Route routeA = BuildSingleSourcePickupRoute(routeAId, sharedSource, PickupAmountA);
@@ -514,11 +520,28 @@ namespace Parsek.InGameTests
                         $"source={sourceStored.ToString("R", IC)} reservedByA={PickupAmountA.ToString("R", IC)} " +
                         $"needB={PickupAmountA.ToString("R", IC)}");
                     InGameAssert.IsNotNull(lackAfter, "The held gate must report a lacking-resource token");
+                    // M6 escrow-hold legibility contract (PR #1233): this short is ESCROW-caused
+                    // by construction (raw stored covers B's need; only the netted availability
+                    // falls short, and A's reservation is resolvable), so the gate must emit the
+                    // escrow token 'source-reserved:<pid>:<name>:<resource>:<reservingRoute>'
+                    // (RoutePickupSourceGate.BuildReservedHoldToken) - NOT the physical
+                    // 'source:...' token that would claim the depot is physically empty.
                     InGameAssert.IsTrue(
-                        lackAfter.IndexOf("source:", StringComparison.Ordinal) >= 0
-                        && lackAfter.IndexOf(sharedSource.persistentId.ToString(IC), StringComparison.Ordinal) >= 0,
+                        lackAfter.StartsWith("source-reserved:", StringComparison.Ordinal),
+                        "The hold token must be the M6 escrow-caused variant 'source-reserved:...' " +
+                        $"(raw covers, only netted falls short); token was '{lackAfter}'");
+                    InGameAssert.IsTrue(
+                        lackAfter.IndexOf(sharedSource.persistentId.ToString(IC), StringComparison.Ordinal) >= 0,
                         $"The hold token must name the shared source (pid {sharedSource.persistentId.ToString(IC)}); " +
                         $"token was '{lackAfter}'");
+                    // The reserving-route segment must name route A (via the RouteIds.Short
+                    // store-fallback: neither test route is added to RouteStore), not route B
+                    // and not the evaluated route itself.
+                    string expectedReservingName = RouteIds.Short(routeAId);
+                    InGameAssert.IsTrue(
+                        lackAfter.EndsWith(":" + expectedReservingName, StringComparison.Ordinal),
+                        $"The hold token must name the RESERVING route A ('{expectedReservingName}') as its " +
+                        $"final segment; token was '{lackAfter}'");
 
                     ParsekLog.Info("TestRunner",
                         $"Escrow_CompetingHold: PASS sharedSource={sharedSource.vesselName} " +

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -103,7 +103,21 @@ Rewired tests: `OriginDebit_UnloadedOriginVessel_WritesProtoSnapshot`,
 inventory-pickup tests are unchanged (no unloaded variant; an unloaded inventory
 fixture would need a stored cargo part the pad rocket may lack). Pure piece unit-
 tested in `Source/Parsek.Tests/UnloadedFuelVesselFixtureTests.cs`. Test-infra only
-(no user-facing CHANGELOG line). LIVE validation via Ctrl+Shift+T is pending.
+(no user-facing CHANGELOG line).
+
+**LIVE validation DONE (2026-07-10 sweep, `logs/2026-07-10_1935_ingame-test-sweep`):**
+the full FLIGHT Run All + Isolated pass ran every rewired Logistics test green except
+`Escrow_CompetingRouteSeesReservation_Holds`, which failed on a STALE ASSERTION, not
+production: the test still pinned the pre-M6 physical hold token prefix (`source:`)
+while the gate correctly emits the M6 escrow-legibility token
+(`source-reserved:<pid>:<name>:<resource>:<reservingRoute>`, PR #1233 - the test was
+written on the M4b branch in parallel and never updated). Fixed on branch
+`fix-escrow-ingame-token`: the assertion now pins the M6 escrow contract (the
+`source-reserved:` prefix - this scenario is escrow-caused by construction - plus the
+pid and the reserving route A as the final token segment, with the two test route ids
+given prefixes distinct within `RouteIds.Short`'s 8 chars so the pin can tell A from
+B; both previously truncated to the same `ingame-e`). Test-only; re-verify with one
+isolated re-run of the test in FLIGHT.
 
 ## TODO - Missions feature completion milestones (M-MIS roadmap; investigated 2026-06-10)
 


### PR DESCRIPTION
## Summary

The 2026-07-10 in-game sweep failed `LogisticsMultiOriginRuntimeTests.Escrow_CompetingRouteSeesReservation_Holds` on a **stale assertion, not a production bug**: the test still pinned the pre-M6 physical hold-token prefix (`source:`) while the gate correctly emits the M6 escrow-legibility token `source-reserved:<pid>:<name>:<resource>:<reservingRoute>` (PR #1233). The test was written on the M4b branch in parallel with M6 and never updated for the new contract.

Failure message from the sweep:

```
The hold token must name the shared source (pid 3175085636); token was 'source-reserved:3175085636:Kerbal X:LiquidFuel:ingame-e'
```

The token is exactly what M6 intends - `source-reserved:` does not contain the asserted substring `source:`, and the `ingame-e` tail is `RouteIds.Short` of the reserving route id (both test ids shared the first 8 chars).

## Fix (test-only)

- The assertion now pins the M6 escrow contract: the `source-reserved:` prefix (this scenario is escrow-caused by construction - raw stored covers the need, only the escrow-netted availability falls short), the shared source pid, and the reserving route A as the final token segment.
- The two test route ids get prefixes distinct within `RouteIds.Short`'s 8 chars (`esc-A-*` / `esc-B-*`) so the pin can tell route A from route B; both previously truncated to the same `ingame-e`.
- Test description + todo-doc LIVE-validation note updated. No CHANGELOG entry (test-infra only).

## Validation

- Full xUnit suite green: 17415 passed / 0 failed / 1 known skip (the change is in-game-test code; xUnit compile-covers it).
- In-game re-verify pending operator: one isolated re-run of the test in FLIGHT (Run+ on `Escrow_CompetingRouteSeesReservation_Holds`).