### PR TITLE
Fix EVA spawn walkback clobbered by degraded fallback + flaky zero-velocity landed reseed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to Parsek are documented here.
 
 ### Fixes
 
+- A recording's vessel or EVA kerbal no longer materializes overlapping another craft when the primary spawn path is rejected and the degraded fallback runs: the collision-avoidance walkback position is now preserved through the fallback, and a landed endpoint recorded with exactly zero velocity no longer flakily rejects the primary spawn.
 - A re-aimed looped landing's arrival approach no longer rotates the wrong way around the destination body: the arrival re-stitch read its rotation angle with an inverted sign on live KSP, doubling the gap at the SOI-entry seam instead of closing it. The touchdown site was never affected; caught by the in-game landing-coincidence canary on the first full test sweep.
 - The Settings "Defaults" button now also restores "Show supply route paths on map" to on; previously that single toggle was left unchanged while every other setting reset to its default.
 - A recorded vessel or EVA kerbal that re-materializes above the surface without a stored terminal orbit (breakup debris, an in-flight EVA, or a vessel left docked or coasting) no longer appears off-position and flips its situation a frame later. Its orbit was rebuilt by feeding an absolute world position and an unconverted velocity to KSP's state-vector API, which reads them in the wrong reference frame and produces an out-of-band orbit; the rebuild now converts them to the body-relative frame the API expects.

--- a/Source/Parsek.Tests/SpawnWalkbackFallbackTests.cs
+++ b/Source/Parsek.Tests/SpawnWalkbackFallbackTests.cs
@@ -1,0 +1,570 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    /// <summary>
+    /// Tests for the EvaSpawnWalkbackOnOverlap fallback fix (2026-07-10 sweep):
+    /// 1. Deterministic landed reseed: an exactly-zero recorded velocity on a landed
+    ///    endpoint reseeds to a NaN-SMA orbit; SpawnAtPosition now substitutes the
+    ///    canonical surface orbit instead of flakily rejecting the spawn (#620).
+    /// 2. Deliberate position-override stamp: the degraded-fallback snapshot repair
+    ///    must not clobber a walkback-corrected position back to the recorded endpoint.
+    /// </summary>
+    [Collection("Sequential")]
+    public class SpawnWalkbackFallbackTests : IDisposable
+    {
+        private readonly List<string> logLines = new List<string>();
+        private readonly object originalFlightGlobalsBodies;
+        private readonly VesselSpawner.ResolveBodyNameByIndexDelegate originalBodyNameResolver;
+        private readonly VesselSpawner.ResolveBodyByNameDelegate originalBodyResolver;
+        private readonly VesselSpawner.ResolveBodyIndexDelegate originalBodyIndexResolver;
+
+        public SpawnWalkbackFallbackTests()
+        {
+            RecordingStore.SuppressLogging = true;
+            RecordingStore.ResetForTesting();
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = false;
+            ParsekLog.TestSinkForTesting = line => logLines.Add(line);
+            originalBodyNameResolver = VesselSpawner.BodyNameResolverForTesting;
+            originalBodyResolver = VesselSpawner.BodyResolverForTesting;
+            originalBodyIndexResolver = VesselSpawner.BodyIndexResolverForTesting;
+            originalFlightGlobalsBodies = typeof(FlightGlobals)
+                .GetField("bodies", BindingFlags.Static | BindingFlags.NonPublic)
+                ?.GetValue(null);
+        }
+
+        public void Dispose()
+        {
+            VesselSpawner.BodyNameResolverForTesting = originalBodyNameResolver;
+            VesselSpawner.BodyResolverForTesting = originalBodyResolver;
+            VesselSpawner.BodyIndexResolverForTesting = originalBodyIndexResolver;
+            typeof(FlightGlobals)
+                .GetField("bodies", BindingFlags.Static | BindingFlags.NonPublic)
+                ?.SetValue(null, originalFlightGlobalsBodies);
+            TestBodyRegistry.Reset();
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = true;
+            RecordingStore.SuppressLogging = true;
+            RecordingStore.ResetForTesting();
+        }
+
+        private void InstallBodies()
+        {
+            TestBodyRegistry.Install(("Kerbin", 600000.0, 3.5316e12), ("Mun", 200000.0, 6.5138398e10));
+            VesselSpawner.BodyNameResolverForTesting = TestBodyRegistry.ResolveBodyNameByIndex;
+            VesselSpawner.BodyResolverForTesting = TestBodyRegistry.ResolveBodyByName;
+            VesselSpawner.BodyIndexResolverForTesting = TestBodyRegistry.ResolveBodyIndex;
+        }
+
+        private static ConfigNode BuildLandedSnapshotWithStaleOrbit(
+            string lat, string lon, string alt, string refIndex)
+        {
+            var snapshot = new ConfigNode("VESSEL");
+            snapshot.AddValue("sit", "LANDED");
+            snapshot.AddValue("lat", lat);
+            snapshot.AddValue("lon", lon);
+            snapshot.AddValue("alt", alt);
+            snapshot.AddNode("PART").AddValue("name", "kerbalEVA");
+            var orbitNode = new ConfigNode("ORBIT");
+            orbitNode.AddValue("SMA", "700000");
+            orbitNode.AddValue("ECC", "0.01");
+            orbitNode.AddValue("INC", "0.0");
+            orbitNode.AddValue("LPE", "0.0");
+            orbitNode.AddValue("LAN", "0.0");
+            orbitNode.AddValue("MNA", "0.0");
+            orbitNode.AddValue("EPH", "100.0");
+            orbitNode.AddValue("REF", refIndex);
+            snapshot.AddNode(orbitNode);
+            return snapshot;
+        }
+
+        #region HasNonFiniteOrbitElement (Half 1 predicate)
+
+        [Fact]
+        public void HasNonFiniteOrbitElement_NaNSma_ReturnsTrueNamingSma()
+        {
+            bool result = OrbitReseed.HasNonFiniteOrbitElement(
+                double.NaN, 1.0, 0.0, 0.0, 0.0, 0.0, 100.0,
+                out string offenders);
+
+            Assert.True(result);
+            Assert.Equal("SMA", offenders);
+        }
+
+        [Fact]
+        public void HasNonFiniteOrbitElement_NaNEcc_ReturnsTrueNamingEcc()
+        {
+            bool result = OrbitReseed.HasNonFiniteOrbitElement(
+                700000.0, double.NaN, 0.0, 0.0, 0.0, 0.0, 100.0,
+                out string offenders);
+
+            Assert.True(result);
+            Assert.Equal("ECC", offenders);
+        }
+
+        [Fact]
+        public void HasNonFiniteOrbitElement_PositiveInfinityEpoch_ReturnsTrueNamingEph()
+        {
+            bool result = OrbitReseed.HasNonFiniteOrbitElement(
+                700000.0, 0.01, 0.0, 0.0, 0.0, 0.0, double.PositiveInfinity,
+                out string offenders);
+
+            Assert.True(result);
+            Assert.Equal("EPH", offenders);
+        }
+
+        [Fact]
+        public void HasNonFiniteOrbitElement_NegativeInfinityInclination_ReturnsTrueNamingInc()
+        {
+            bool result = OrbitReseed.HasNonFiniteOrbitElement(
+                700000.0, 0.01, double.NegativeInfinity, 0.0, 0.0, 0.0, 100.0,
+                out string offenders);
+
+            Assert.True(result);
+            Assert.Equal("INC", offenders);
+        }
+
+        [Fact]
+        public void HasNonFiniteOrbitElement_MultipleOffenders_ListsAllInElementOrder()
+        {
+            bool result = OrbitReseed.HasNonFiniteOrbitElement(
+                double.NaN, double.NaN, 0.0, 0.0, double.PositiveInfinity, 0.0, 100.0,
+                out string offenders);
+
+            Assert.True(result);
+            Assert.Equal("SMA,ECC,LAN", offenders);
+        }
+
+        [Fact]
+        public void HasNonFiniteOrbitElement_AllFinite_ReturnsFalseWithNullOffenders()
+        {
+            bool result = OrbitReseed.HasNonFiniteOrbitElement(
+                700000.0, 0.01, 45.0, 12.0, 33.0, 0.7, 100.0,
+                out string offenders);
+
+            Assert.False(result);
+            Assert.Null(offenders);
+        }
+
+        [Fact]
+        public void HasNonFiniteOrbitElement_NullOrbit_ReturnsTrue()
+        {
+            bool result = OrbitReseed.HasNonFiniteOrbitElement((Orbit)null, out string offenders);
+
+            Assert.True(result);
+            Assert.Equal("(null orbit)", offenders);
+        }
+
+        #endregion
+
+        #region IsLandedLikeSituation / WriteCanonicalSurfaceOrbitValues (Half 1 helpers)
+
+        [Theory]
+        [InlineData("LANDED", true)]
+        [InlineData("SPLASHED", true)]
+        [InlineData("landed", true)]
+        [InlineData("splashed", true)]
+        [InlineData("ORBITING", false)]
+        [InlineData("FLYING", false)]
+        [InlineData("SUB_ORBITAL", false)]
+        [InlineData("PRELAUNCH", false)]
+        [InlineData("DOCKED", false)]
+        [InlineData("", false)]
+        [InlineData(null, false)]
+        public void IsLandedLikeSituation_MatchesOnlyLandedAndSplashed(string sit, bool expected)
+        {
+            Assert.Equal(expected, VesselSpawner.IsLandedLikeSituation(sit));
+        }
+
+        [Fact]
+        public void WriteCanonicalSurfaceOrbitValues_WritesSurfaceTupleWithBodyIndex()
+        {
+            var orbitNode = new ConfigNode("ORBIT");
+
+            VesselSpawner.WriteCanonicalSurfaceOrbitValues(orbitNode, 3);
+
+            Assert.Equal("0", orbitNode.GetValue("SMA"));
+            Assert.Equal("1", orbitNode.GetValue("ECC"));
+            Assert.Equal("0", orbitNode.GetValue("INC"));
+            Assert.Equal("0", orbitNode.GetValue("LPE"));
+            Assert.Equal("0", orbitNode.GetValue("LAN"));
+            Assert.Equal("0", orbitNode.GetValue("MNA"));
+            Assert.Equal("0", orbitNode.GetValue("EPH"));
+            Assert.Equal("3", orbitNode.GetValue("REF"));
+        }
+
+        [Fact]
+        public void WriteCanonicalSurfaceOrbitValues_NullNode_DoesNotThrow()
+        {
+            VesselSpawner.WriteCanonicalSurfaceOrbitValues(null, 0);
+        }
+
+        [Fact]
+        public void WriteCanonicalSurfaceOrbitValues_MatchesApplySurfaceOrbitToSnapshotShape()
+        {
+            InstallBodies();
+            var snapshot = BuildLandedSnapshotWithStaleOrbit("1.0", "2.0", "3.0", "0");
+            Assert.True(VesselSpawner.TryResolveBodyByName("Kerbin", out CelestialBody kerbin));
+
+            Assert.True(VesselSpawner.ApplySurfaceOrbitToSnapshot(snapshot, kerbin, "shape-test"));
+
+            var direct = new ConfigNode("ORBIT");
+            VesselSpawner.WriteCanonicalSurfaceOrbitValues(direct, 0);
+            ConfigNode applied = snapshot.GetNode("ORBIT");
+            foreach (string key in new[] { "SMA", "ECC", "INC", "LPE", "LAN", "MNA", "EPH", "REF" })
+                Assert.Equal(direct.GetValue(key), applied.GetValue(key));
+        }
+
+        #endregion
+
+        #region Deliberate position-override stamp (Half 2 marker)
+
+        [Fact]
+        public void OverrideSnapshotPosition_StampsDeliberateOverrideMarkerAndLogs()
+        {
+            var snapshot = new ConfigNode("VESSEL");
+            snapshot.AddValue("lat", "0.0");
+            snapshot.AddValue("lon", "0.0");
+            snapshot.AddValue("alt", "10.0");
+
+            VesselSpawner.OverrideSnapshotPosition(snapshot, 1.5, 2.5, 73.5, 0, "Stamp Test");
+
+            Assert.Equal("True", snapshot.GetValue(VesselSpawner.DeliberatePositionOverrideKey));
+            Assert.True(VesselSpawner.HasDeliberatePositionOverrideStamp(snapshot));
+            Assert.Contains(logLines, l =>
+                l.Contains("[Spawner]")
+                && l.Contains("Snapshot position override")
+                && l.Contains("Stamp Test")
+                && l.Contains("[deliberate-override stamped]"));
+        }
+
+        [Fact]
+        public void HasDeliberatePositionOverrideStamp_AbsentKey_ReturnsFalse()
+        {
+            var snapshot = new ConfigNode("VESSEL");
+
+            Assert.False(VesselSpawner.HasDeliberatePositionOverrideStamp(snapshot));
+        }
+
+        [Fact]
+        public void HasDeliberatePositionOverrideStamp_NullSnapshot_ReturnsFalse()
+        {
+            Assert.False(VesselSpawner.HasDeliberatePositionOverrideStamp(null));
+        }
+
+        [Theory]
+        [InlineData("True", true)]
+        [InlineData("true", true)]
+        [InlineData("False", false)]
+        [InlineData("garbage", false)]
+        public void HasDeliberatePositionOverrideStamp_ParsesValue(string value, bool expected)
+        {
+            var snapshot = new ConfigNode("VESSEL");
+            snapshot.AddValue(VesselSpawner.DeliberatePositionOverrideKey, value);
+
+            Assert.Equal(expected, VesselSpawner.HasDeliberatePositionOverrideStamp(snapshot));
+        }
+
+        [Fact]
+        public void StripDeliberatePositionOverrideStamp_RemovesKeyAndLogs()
+        {
+            var snapshot = new ConfigNode("VESSEL");
+            snapshot.AddValue(VesselSpawner.DeliberatePositionOverrideKey, "True");
+
+            bool stripped = VesselSpawner.StripDeliberatePositionOverrideStamp(snapshot, "strip-test");
+
+            Assert.True(stripped);
+            Assert.False(snapshot.HasValue(VesselSpawner.DeliberatePositionOverrideKey));
+            Assert.Contains(logLines, l =>
+                l.Contains("[Spawner]")
+                && l.Contains("Stripped deliberate position-override stamp")
+                && l.Contains("strip-test"));
+        }
+
+        [Fact]
+        public void StripDeliberatePositionOverrideStamp_AbsentKey_ReturnsFalse()
+        {
+            var snapshot = new ConfigNode("VESSEL");
+
+            Assert.False(VesselSpawner.StripDeliberatePositionOverrideStamp(snapshot, "strip-test"));
+        }
+
+        #endregion
+
+        #region DecideSurfaceRepairCoordinateSource (Half 2 decision, exhaustive)
+
+        // Exhaustive truth table over (hasStamp, hasSnapshotPos, hasSnapshotBody,
+        // hasEndpointCoords, bodyMismatch in {null, false, true}) = 48 rows.
+        // Contract:
+        //   1. stamp && pos && mismatch != true            -> StampedSnapshot
+        //   2. else endpointCoords                          -> Endpoint (pre-stamp behavior)
+        //   3. else pos && body && mismatch != true         -> Snapshot (pre-stamp behavior)
+        //   4. else                                         -> Reject
+        [Theory]
+        // stamp=F pos=F body=F ep=F
+        [InlineData(false, false, false, false, null, VesselSpawner.SurfaceRepairCoordinateSource.Reject)]
+        [InlineData(false, false, false, false, false, VesselSpawner.SurfaceRepairCoordinateSource.Reject)]
+        [InlineData(false, false, false, false, true, VesselSpawner.SurfaceRepairCoordinateSource.Reject)]
+        // stamp=F pos=F body=F ep=T
+        [InlineData(false, false, false, true, null, VesselSpawner.SurfaceRepairCoordinateSource.Endpoint)]
+        [InlineData(false, false, false, true, false, VesselSpawner.SurfaceRepairCoordinateSource.Endpoint)]
+        [InlineData(false, false, false, true, true, VesselSpawner.SurfaceRepairCoordinateSource.Endpoint)]
+        // stamp=F pos=F body=T ep=F
+        [InlineData(false, false, true, false, null, VesselSpawner.SurfaceRepairCoordinateSource.Reject)]
+        [InlineData(false, false, true, false, false, VesselSpawner.SurfaceRepairCoordinateSource.Reject)]
+        [InlineData(false, false, true, false, true, VesselSpawner.SurfaceRepairCoordinateSource.Reject)]
+        // stamp=F pos=F body=T ep=T
+        [InlineData(false, false, true, true, null, VesselSpawner.SurfaceRepairCoordinateSource.Endpoint)]
+        [InlineData(false, false, true, true, false, VesselSpawner.SurfaceRepairCoordinateSource.Endpoint)]
+        [InlineData(false, false, true, true, true, VesselSpawner.SurfaceRepairCoordinateSource.Endpoint)]
+        // stamp=F pos=T body=F ep=F
+        [InlineData(false, true, false, false, null, VesselSpawner.SurfaceRepairCoordinateSource.Reject)]
+        [InlineData(false, true, false, false, false, VesselSpawner.SurfaceRepairCoordinateSource.Reject)]
+        [InlineData(false, true, false, false, true, VesselSpawner.SurfaceRepairCoordinateSource.Reject)]
+        // stamp=F pos=T body=F ep=T
+        [InlineData(false, true, false, true, null, VesselSpawner.SurfaceRepairCoordinateSource.Endpoint)]
+        [InlineData(false, true, false, true, false, VesselSpawner.SurfaceRepairCoordinateSource.Endpoint)]
+        [InlineData(false, true, false, true, true, VesselSpawner.SurfaceRepairCoordinateSource.Endpoint)]
+        // stamp=F pos=T body=T ep=F
+        [InlineData(false, true, true, false, null, VesselSpawner.SurfaceRepairCoordinateSource.Snapshot)]
+        [InlineData(false, true, true, false, false, VesselSpawner.SurfaceRepairCoordinateSource.Snapshot)]
+        [InlineData(false, true, true, false, true, VesselSpawner.SurfaceRepairCoordinateSource.Reject)]
+        // stamp=F pos=T body=T ep=T
+        [InlineData(false, true, true, true, null, VesselSpawner.SurfaceRepairCoordinateSource.Endpoint)]
+        [InlineData(false, true, true, true, false, VesselSpawner.SurfaceRepairCoordinateSource.Endpoint)]
+        [InlineData(false, true, true, true, true, VesselSpawner.SurfaceRepairCoordinateSource.Endpoint)]
+        // stamp=T pos=F body=F ep=F
+        [InlineData(true, false, false, false, null, VesselSpawner.SurfaceRepairCoordinateSource.Reject)]
+        [InlineData(true, false, false, false, false, VesselSpawner.SurfaceRepairCoordinateSource.Reject)]
+        [InlineData(true, false, false, false, true, VesselSpawner.SurfaceRepairCoordinateSource.Reject)]
+        // stamp=T pos=F body=F ep=T (stamp never blocks a genuine endpoint repair)
+        [InlineData(true, false, false, true, null, VesselSpawner.SurfaceRepairCoordinateSource.Endpoint)]
+        [InlineData(true, false, false, true, false, VesselSpawner.SurfaceRepairCoordinateSource.Endpoint)]
+        [InlineData(true, false, false, true, true, VesselSpawner.SurfaceRepairCoordinateSource.Endpoint)]
+        // stamp=T pos=F body=T ep=F
+        [InlineData(true, false, true, false, null, VesselSpawner.SurfaceRepairCoordinateSource.Reject)]
+        [InlineData(true, false, true, false, false, VesselSpawner.SurfaceRepairCoordinateSource.Reject)]
+        [InlineData(true, false, true, false, true, VesselSpawner.SurfaceRepairCoordinateSource.Reject)]
+        // stamp=T pos=F body=T ep=T
+        [InlineData(true, false, true, true, null, VesselSpawner.SurfaceRepairCoordinateSource.Endpoint)]
+        [InlineData(true, false, true, true, false, VesselSpawner.SurfaceRepairCoordinateSource.Endpoint)]
+        [InlineData(true, false, true, true, true, VesselSpawner.SurfaceRepairCoordinateSource.Endpoint)]
+        // stamp=T pos=T body=F ep=F
+        [InlineData(true, true, false, false, null, VesselSpawner.SurfaceRepairCoordinateSource.StampedSnapshot)]
+        [InlineData(true, true, false, false, false, VesselSpawner.SurfaceRepairCoordinateSource.StampedSnapshot)]
+        [InlineData(true, true, false, false, true, VesselSpawner.SurfaceRepairCoordinateSource.Reject)]
+        // stamp=T pos=T body=F ep=T
+        [InlineData(true, true, false, true, null, VesselSpawner.SurfaceRepairCoordinateSource.StampedSnapshot)]
+        [InlineData(true, true, false, true, false, VesselSpawner.SurfaceRepairCoordinateSource.StampedSnapshot)]
+        [InlineData(true, true, false, true, true, VesselSpawner.SurfaceRepairCoordinateSource.Endpoint)]
+        // stamp=T pos=T body=T ep=F
+        [InlineData(true, true, true, false, null, VesselSpawner.SurfaceRepairCoordinateSource.StampedSnapshot)]
+        [InlineData(true, true, true, false, false, VesselSpawner.SurfaceRepairCoordinateSource.StampedSnapshot)]
+        [InlineData(true, true, true, false, true, VesselSpawner.SurfaceRepairCoordinateSource.Reject)]
+        // stamp=T pos=T body=T ep=T
+        [InlineData(true, true, true, true, null, VesselSpawner.SurfaceRepairCoordinateSource.StampedSnapshot)]
+        [InlineData(true, true, true, true, false, VesselSpawner.SurfaceRepairCoordinateSource.StampedSnapshot)]
+        [InlineData(true, true, true, true, true, VesselSpawner.SurfaceRepairCoordinateSource.Endpoint)]
+        public void DecideSurfaceRepairCoordinateSource_TruthTable(
+            bool hasStamp,
+            bool hasSnapshotPos,
+            bool hasSnapshotBody,
+            bool hasEndpointCoords,
+            bool? bodyMismatch,
+            VesselSpawner.SurfaceRepairCoordinateSource expected)
+        {
+            Assert.Equal(expected, VesselSpawner.DecideSurfaceRepairCoordinateSource(
+                hasStamp, hasSnapshotPos, hasSnapshotBody, hasEndpointCoords, bodyMismatch));
+        }
+
+        #endregion
+
+        #region Repair precedence through BuildValidatedRespawnSnapshot (Half 2 integration)
+
+        [Fact]
+        public void BuildValidatedRespawnSnapshot_StampedSnapshotWithValidCoords_PreservesWalkbackCoords()
+        {
+            InstallBodies();
+
+            // Walkback-corrected snapshot: coords differ from the recording endpoint,
+            // stale non-surface orbit forces the landed-like repair to run.
+            var snapshot = BuildLandedSnapshotWithStaleOrbit(
+                "-0.098282", "-74.557675", "73.5", "0");
+            snapshot.AddValue(VesselSpawner.DeliberatePositionOverrideKey, "True");
+
+            var rec = new Recording
+            {
+                VesselName = "Walkback Keeper",
+                VesselSnapshot = snapshot,
+                TerminalStateValue = TerminalState.Landed,
+                EndpointPhase = RecordingEndpointPhase.TerminalPosition,
+                EndpointBodyName = "Kerbin",
+                TerminalPosition = new SurfacePosition
+                {
+                    body = "Kerbin",
+                    latitude = -0.0983,
+                    longitude = -74.5570,
+                    altitude = 66.8
+                }
+            };
+
+            ConfigNode validated = VesselSpawner.BuildValidatedRespawnSnapshot(
+                rec,
+                currentUT: 123.0,
+                logContext: "spawn-test");
+
+            Assert.NotNull(validated);
+            // Deliberate walkback coordinates survive; the endpoint did NOT clobber them.
+            Assert.Equal("-0.098282", validated.GetValue("lat"));
+            Assert.Equal("-74.557675", validated.GetValue("lon"));
+            Assert.Equal("73.5", validated.GetValue("alt"));
+            // The orbit is still repaired to the canonical surface tuple.
+            ConfigNode repairedOrbit = validated.GetNode("ORBIT");
+            Assert.NotNull(repairedOrbit);
+            Assert.Equal("0", repairedOrbit.GetValue("SMA"));
+            Assert.Equal("1", repairedOrbit.GetValue("ECC"));
+            Assert.Equal("0", repairedOrbit.GetValue("REF"));
+            // The stamp never rides the validated copy toward a ProtoVessel load.
+            Assert.False(validated.HasValue(VesselSpawner.DeliberatePositionOverrideKey));
+            Assert.Contains(logLines, l =>
+                l.Contains("[Spawner]")
+                && l.Contains("using stamped-override surface coordinates")
+                && l.Contains("Walkback Keeper"));
+        }
+
+        [Fact]
+        public void BuildValidatedRespawnSnapshot_UnstampedSnapshotWithEndpointCoords_EndpointStillWins()
+        {
+            InstallBodies();
+
+            // Same shape as the stamped test but WITHOUT the stamp: the historical
+            // endpoint-first contract must be preserved exactly (stale EVA-start
+            // snapshots are moved to the trajectory endpoint).
+            var snapshot = BuildLandedSnapshotWithStaleOrbit(
+                "-0.098282", "-74.557675", "73.5", "0");
+
+            var rec = new Recording
+            {
+                VesselName = "Endpoint First",
+                VesselSnapshot = snapshot,
+                TerminalStateValue = TerminalState.Landed,
+                EndpointPhase = RecordingEndpointPhase.TerminalPosition,
+                EndpointBodyName = "Kerbin",
+                TerminalPosition = new SurfacePosition
+                {
+                    body = "Kerbin",
+                    latitude = 4.0,
+                    longitude = 5.0,
+                    altitude = 6.0
+                }
+            };
+
+            ConfigNode validated = VesselSpawner.BuildValidatedRespawnSnapshot(
+                rec,
+                currentUT: 123.0,
+                logContext: "spawn-test");
+
+            Assert.NotNull(validated);
+            Assert.Equal("4", validated.GetValue("lat"));
+            Assert.Equal("5", validated.GetValue("lon"));
+            Assert.Equal("6", validated.GetValue("alt"));
+            Assert.False(validated.HasValue(VesselSpawner.DeliberatePositionOverrideKey));
+            Assert.Contains(logLines, l =>
+                l.Contains("using endpoint surface coordinates")
+                && l.Contains("Endpoint First"));
+        }
+
+        [Fact]
+        public void BuildValidatedRespawnSnapshot_StampedButNonFiniteCoords_EndpointRepairStillApplies()
+        {
+            InstallBodies();
+
+            // Stamped snapshot whose position is unusable (NaN lat): the stamp must
+            // never block a genuine repair: endpoint coordinates still apply.
+            var snapshot = BuildLandedSnapshotWithStaleOrbit(
+                "NaN", "-74.557675", "73.5", "0");
+            snapshot.AddValue(VesselSpawner.DeliberatePositionOverrideKey, "True");
+
+            var rec = new Recording
+            {
+                VesselName = "Stamp No Blocker",
+                VesselSnapshot = snapshot,
+                TerminalStateValue = TerminalState.Landed,
+                EndpointPhase = RecordingEndpointPhase.TerminalPosition,
+                EndpointBodyName = "Kerbin",
+                TerminalPosition = new SurfacePosition
+                {
+                    body = "Kerbin",
+                    latitude = 4.0,
+                    longitude = 5.0,
+                    altitude = 6.0
+                }
+            };
+
+            ConfigNode validated = VesselSpawner.BuildValidatedRespawnSnapshot(
+                rec,
+                currentUT: 123.0,
+                logContext: "spawn-test");
+
+            Assert.NotNull(validated);
+            Assert.Equal("4", validated.GetValue("lat"));
+            Assert.Equal("5", validated.GetValue("lon"));
+            Assert.Equal("6", validated.GetValue("alt"));
+            Assert.False(validated.HasValue(VesselSpawner.DeliberatePositionOverrideKey));
+            Assert.Contains(logLines, l =>
+                l.Contains("using endpoint surface coordinates")
+                && l.Contains("Stamp No Blocker"));
+        }
+
+        [Fact]
+        public void BuildValidatedRespawnSnapshot_StampedWithBodyMismatch_EndpointRepairStillApplies()
+        {
+            InstallBodies();
+
+            // Stamped snapshot pointing at Kerbin (REF=0) while the recording endpoint
+            // is on Mun: the body mismatch invalidates the stamped coordinates and the
+            // endpoint repair applies (a stamp never keeps coordinates on the wrong body).
+            var snapshot = BuildLandedSnapshotWithStaleOrbit(
+                "-0.098282", "-74.557675", "73.5", "0");
+            snapshot.AddValue(VesselSpawner.DeliberatePositionOverrideKey, "True");
+
+            var rec = new Recording
+            {
+                VesselName = "Wrong Body Stamp",
+                VesselSnapshot = snapshot,
+                TerminalStateValue = TerminalState.Landed,
+                EndpointPhase = RecordingEndpointPhase.TerminalPosition,
+                EndpointBodyName = "Mun",
+                TerminalPosition = new SurfacePosition
+                {
+                    body = "Mun",
+                    latitude = 4.0,
+                    longitude = 5.0,
+                    altitude = 6.0
+                }
+            };
+
+            ConfigNode validated = VesselSpawner.BuildValidatedRespawnSnapshot(
+                rec,
+                currentUT: 123.0,
+                logContext: "spawn-test");
+
+            Assert.NotNull(validated);
+            Assert.Equal("4", validated.GetValue("lat"));
+            Assert.Equal("5", validated.GetValue("lon"));
+            Assert.Equal("6", validated.GetValue("alt"));
+            ConfigNode repairedOrbit = validated.GetNode("ORBIT");
+            Assert.NotNull(repairedOrbit);
+            Assert.Equal("1", repairedOrbit.GetValue("REF"));
+            Assert.Contains(logLines, l =>
+                l.Contains("using endpoint surface coordinates")
+                && l.Contains("Wrong Body Stamp"));
+        }
+
+        #endregion
+    }
+}

--- a/Source/Parsek/OrbitReseed.cs
+++ b/Source/Parsek/OrbitReseed.cs
@@ -418,6 +418,60 @@ namespace Parsek
             return true;
         }
 
+        /// <summary>
+        /// Pure predicate: does the reseeded orbit carry any non-finite Kepler element?
+        /// The failure shape this guards: a landed endpoint with EXACTLY zero velocity
+        /// reseeds to h=0 / ecc=1, and <c>Orbit.UpdateFromStateVectors</c> then computes
+        /// SMA = -semiLatusRectum/(ecc^2-1) = 0/0 = NaN. A float-residue near-zero
+        /// velocity instead yields a finite ~r/2 SMA, so the NaN appears run-to-run
+        /// flakily. Returns the offending element names (comma-joined) for logging.
+        /// </summary>
+        internal static bool HasNonFiniteOrbitElement(
+            double semiMajorAxis,
+            double eccentricity,
+            double inclination,
+            double argumentOfPeriapsis,
+            double lan,
+            double meanAnomalyAtEpoch,
+            double epoch,
+            out string nonFiniteElements)
+        {
+            var offenders = new System.Collections.Generic.List<string>(7);
+            if (!IsFinite(semiMajorAxis)) offenders.Add("SMA");
+            if (!IsFinite(eccentricity)) offenders.Add("ECC");
+            if (!IsFinite(inclination)) offenders.Add("INC");
+            if (!IsFinite(argumentOfPeriapsis)) offenders.Add("LPE");
+            if (!IsFinite(lan)) offenders.Add("LAN");
+            if (!IsFinite(meanAnomalyAtEpoch)) offenders.Add("MNA");
+            if (!IsFinite(epoch)) offenders.Add("EPH");
+
+            nonFiniteElements = offenders.Count > 0 ? string.Join(",", offenders) : null;
+            return offenders.Count > 0;
+        }
+
+        /// <summary>
+        /// Orbit-taking convenience wrapper over the pure element predicate.
+        /// A null orbit counts as non-finite (nothing usable to serialize).
+        /// </summary>
+        internal static bool HasNonFiniteOrbitElement(Orbit orbit, out string nonFiniteElements)
+        {
+            if (orbit == null)
+            {
+                nonFiniteElements = "(null orbit)";
+                return true;
+            }
+
+            return HasNonFiniteOrbitElement(
+                orbit.semiMajorAxis,
+                orbit.eccentricity,
+                orbit.inclination,
+                orbit.argumentOfPeriapsis,
+                orbit.LAN,
+                orbit.meanAnomalyAtEpoch,
+                orbit.epoch,
+                out nonFiniteElements);
+        }
+
         internal static double WrapLongitudeDegrees(double longitude)
         {
             if (!IsFinite(longitude))

--- a/Source/Parsek/VesselSpawner.cs
+++ b/Source/Parsek/VesselSpawner.cs
@@ -27,6 +27,19 @@ namespace Parsek
         internal const int MaxCollisionBlocks = 150;
         internal const int TerminalOrbitSpawnSafetyScanSteps = 180;
 
+        /// <summary>
+        /// Snapshot marker written by <see cref="OverrideSnapshotPosition(ConfigNode,double,double,double,int,string,string,Quaternion?,Quaternion?,string)"/>:
+        /// the snapshot's lat/lon/alt were deliberately rewritten by Parsek's spawn
+        /// position resolution (endpoint override, collision walkback, terminal orbit
+        /// propagation). The degraded-fallback repair
+        /// (<see cref="TryRepairSnapshotBodyProvenance"/>) honors this stamp and keeps
+        /// the deliberate coordinates instead of clobbering them back to the recorded
+        /// endpoint. Stripped from every spawn copy before ProtoVessel load
+        /// (<see cref="StripDeliberatePositionOverrideStamp"/>) so it never persists
+        /// into KSP save files.
+        /// </summary>
+        internal const string DeliberatePositionOverrideKey = "parsekDeliberatePosOverride";
+
         internal static ResolveBodyNameByIndexDelegate BodyNameResolverForTesting;
         internal static ResolveBodyByNameDelegate BodyResolverForTesting;
         internal static ResolveBodyIndexDelegate BodyIndexResolverForTesting;
@@ -1143,6 +1156,8 @@ namespace Parsek
                     return 0;
                 }
 
+                StripDeliberatePositionOverrideStamp(spawnNode, "RespawnVessel");
+
                 pv = new ProtoVessel(spawnNode, HighLogic.CurrentGame);
                 HighLogic.CurrentGame.flightState.protoVessels.Add(pv);
                 pv.Load(HighLogic.CurrentGame.flightState);
@@ -1549,15 +1564,51 @@ namespace Parsek
                 // no-override branch is regression-guarded in-game by
                 // RuntimeTests.SpawnAtPosition_NoOverrideStationAltitude_ReseedsInBand).
                 Orbit orbit = orbitOverride;
+                bool orbitWasReseeded = false;
                 if (orbit == null)
                 {
                     orbit = new Orbit();
                     Vector3d worldPos = body.GetWorldSurfacePosition(lat, lon, alt);
                     OrbitReseed.FromWorldPosAndRecordedVelocity(orbit, body, worldPos, velocity, ut);
+                    orbitWasReseeded = true;
                 }
                 spawnNode.RemoveNode("ORBIT");
                 ConfigNode orbitNode = new ConfigNode("ORBIT");
-                SaveOrbitToNode(orbit, orbitNode, body);
+                // Deterministic landed reseed (#620 flake): a landed endpoint with an
+                // EXACTLY zero recorded velocity reseeds to h=0 / ecc=1, and KSP's
+                // Orbit.UpdateFromStateVectors then computes SMA = 0/0 = NaN, which the
+                // finite-metadata gate below rejects (a float-residue near-zero velocity
+                // yields a finite ~r/2 SMA instead, hence run-to-run flakiness). A
+                // landed/splashed vessel does not need the reseeded state-vector orbit at
+                // all: substitute the canonical surface orbit tuple, the same shape
+                // ApplySurfaceOrbitToSnapshot writes. Non-landed situations keep the
+                // reseeded orbit (rejecting a non-finite orbit is correct there).
+                bool substitutedSurfaceOrbit = false;
+                if (orbitWasReseeded
+                    && IsLandedLikeSituation(sit)
+                    && OrbitReseed.HasNonFiniteOrbitElement(orbit, out string nonFiniteOrbitElements))
+                {
+                    if (TryResolveBodyIndex(body, out int surfaceBodyIndex))
+                    {
+                        WriteCanonicalSurfaceOrbitValues(orbitNode, surfaceBodyIndex);
+                        substitutedSurfaceOrbit = true;
+                        ParsekLog.Info("Spawner", string.Format(CultureInfo.InvariantCulture,
+                            "SpawnAtPosition: landed reseed produced non-finite orbit element(s) [{0}] " +
+                            "(sit={1}, body={2}, |vel|={3:F3}): substituting canonical surface orbit " +
+                            "(REF={4}); exactly-zero landed velocity reseeds to ecc=1/h=0 (NaN SMA)",
+                            nonFiniteOrbitElements, sit, body.name, velocity.magnitude, surfaceBodyIndex));
+                    }
+                    else
+                    {
+                        ParsekLog.Warn("Spawner", string.Format(CultureInfo.InvariantCulture,
+                            "SpawnAtPosition: landed reseed produced non-finite orbit element(s) [{0}] " +
+                            "(sit={1}, |vel|={2:F3}) but body index for '{3}' could not be resolved: " +
+                            "keeping reseeded orbit (finite-metadata validation will reject)",
+                            nonFiniteOrbitElements, sit, velocity.magnitude, body?.name ?? "(null)"));
+                    }
+                }
+                if (!substitutedSurfaceOrbit)
+                    SaveOrbitToNode(orbit, orbitNode, body);
                 spawnNode.AddNode(orbitNode);
                 if (sit == "ORBITING")
                     NormalizeOrbitalSpawnMetadata(spawnNode, ut);
@@ -1599,6 +1650,8 @@ namespace Parsek
                     LogMaterializationSnapshotRejected("SpawnAtPosition", materializationRejectionReason);
                     return 0;
                 }
+
+                StripDeliberatePositionOverrideStamp(spawnNode, "SpawnAtPosition");
 
                 pv = new ProtoVessel(spawnNode, HighLogic.CurrentGame);
                 HighLogic.CurrentGame.flightState.protoVessels.Add(pv);
@@ -2002,10 +2055,14 @@ namespace Parsek
                 }
 
                 // SpawnAtPosition failed — fall through to RespawnVessel as last-resort.
-                // The earlier OverrideSnapshotPosition call on this path keeps the snapshot's
-                // lat/lon/alt pointing at the recorded endpoint so the fallback still produces
-                // a vessel at the right position on frame 0 (though the stale-orbit bug may
-                // re-appear on frame 1 — acceptable for a degraded fallback).
+                // The earlier OverrideSnapshotPosition call on this path wrote the resolved
+                // spawn coordinates (endpoint, or the collision-walkback correction) into the
+                // snapshot AND stamped it with the deliberate-override marker, so the fallback's
+                // landed-like repair (TryRepairSnapshotBodyProvenance) preserves those
+                // coordinates instead of clobbering them back to the recorded endpoint. The
+                // fallback still produces a vessel at the resolved position on frame 0 (though
+                // the stale-orbit bug may re-appear on frame 1, acceptable for a degraded
+                // fallback).
                 ParsekLog.Warn("Spawner",
                     $"SpawnAtPosition returned 0 for #{index} ({rec.VesselName}) — " +
                     $"falling through to validated snapshot respawn (degraded fallback)");
@@ -3277,6 +3334,11 @@ namespace Parsek
             snapshot.SetValue("lat", lat.ToString("R", CultureInfo.InvariantCulture), true);
             snapshot.SetValue("lon", lon.ToString("R", CultureInfo.InvariantCulture), true);
             snapshot.SetValue("alt", alt.ToString("R", CultureInfo.InvariantCulture), true);
+            // Stamp the deliberate override so the degraded-fallback repair
+            // (TryRepairSnapshotBodyProvenance) does not clobber a walkback/endpoint
+            // correction back to the raw recorded endpoint. Stripped before every
+            // ProtoVessel load so it never reaches KSP save files.
+            snapshot.SetValue(DeliberatePositionOverrideKey, "True", true);
 
             bool rotationRequested = surfaceRelativeRotation.HasValue;
             string rotationContext = $"Snapshot override #{index} ({vesselName})";
@@ -3294,7 +3356,38 @@ namespace Parsek
                 $"alt {oldAlt} → {alt.ToString("R", CultureInfo.InvariantCulture)}" +
                 (rotationUpdated
                     ? $" (rot updated from surface-relative frame{(!string.IsNullOrEmpty(rotationSource) ? $", source={rotationSource}" : "")})"
-                    : rotationRequested ? " (rot unchanged)" : ""));
+                    : rotationRequested ? " (rot unchanged)" : "") +
+                " [deliberate-override stamped]");
+        }
+
+        /// <summary>
+        /// True when the snapshot carries the deliberate position-override stamp
+        /// written by <see cref="OverrideSnapshotPosition(ConfigNode,double,double,double,int,string,string,Quaternion?,Quaternion?,string)"/>.
+        /// </summary>
+        internal static bool HasDeliberatePositionOverrideStamp(ConfigNode snapshot)
+        {
+            return snapshot != null
+                && string.Equals(
+                    snapshot.GetValue(DeliberatePositionOverrideKey),
+                    "True",
+                    StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// Removes the deliberate position-override stamp from a spawn copy so the
+        /// Parsek-internal marker never rides a ProtoVessel load into KSP save files.
+        /// Tolerant of the key being absent. Returns true when a stamp was removed.
+        /// </summary>
+        internal static bool StripDeliberatePositionOverrideStamp(ConfigNode snapshot, string logContext)
+        {
+            if (snapshot == null || !snapshot.HasValue(DeliberatePositionOverrideKey))
+                return false;
+
+            snapshot.RemoveValue(DeliberatePositionOverrideKey);
+            ParsekLog.Verbose("Spawner",
+                $"Stripped deliberate position-override stamp for {logContext ?? "(unknown)"} " +
+                "(pre-ProtoVessel-load hygiene)");
+            return true;
         }
 
         /// <summary>
@@ -4251,6 +4344,11 @@ namespace Parsek
                 return null;
             }
 
+            // The stamp has served its purpose (the repair above consulted it);
+            // strip it from the validated copy so it never rides a ProtoVessel
+            // load into KSP save files.
+            StripDeliberatePositionOverrideStamp(snapshot, resolvedContext);
+
             return snapshot;
         }
 
@@ -4469,7 +4567,52 @@ namespace Parsek
             return RespawnVessel(snapshot, excludeCrew, preserveIdentity);
         }
 
-        private static bool TryRepairSnapshotBodyProvenance(
+        /// <summary>
+        /// Coordinate source chosen by the landed-like snapshot repair.
+        /// Public (not internal) only because xUnit theory methods must be public
+        /// and the exhaustive truth-table test takes it as a parameter.
+        /// </summary>
+        public enum SurfaceRepairCoordinateSource
+        {
+            /// <summary>No usable coordinates: reject the materialization.</summary>
+            Reject = 0,
+            /// <summary>Keep the snapshot's coordinates: they carry the deliberate
+            /// position-override stamp (walkback / endpoint correction).</summary>
+            StampedSnapshot,
+            /// <summary>Rewrite the snapshot to the recording endpoint coordinates
+            /// (the pre-stamp default; moves stale EVA-start snapshots to the endpoint).</summary>
+            Endpoint,
+            /// <summary>Keep the snapshot's coordinates: no endpoint coordinates exist
+            /// and the snapshot's position/body are usable.</summary>
+            Snapshot
+        }
+
+        /// <summary>
+        /// Pure decision: which coordinate source the landed-like snapshot repair uses.
+        /// A stamped snapshot with a finite position on a non-mismatched body keeps its
+        /// deliberately-overridden coordinates (the walkback correction must survive the
+        /// degraded fallback). Unstamped snapshots keep the historical endpoint-first
+        /// contract EXACTLY (that path exists to move stale EVA-start snapshots to the
+        /// trajectory endpoint). A stamp never blocks a genuine repair: with a missing or
+        /// non-finite snapshot position the endpoint repair still applies.
+        /// </summary>
+        internal static SurfaceRepairCoordinateSource DecideSurfaceRepairCoordinateSource(
+            bool hasDeliberateOverrideStamp,
+            bool hasSnapshotPos,
+            bool hasSnapshotBody,
+            bool hasEndpointCoords,
+            bool? bodyMismatch)
+        {
+            if (hasDeliberateOverrideStamp && hasSnapshotPos && bodyMismatch != true)
+                return SurfaceRepairCoordinateSource.StampedSnapshot;
+            if (hasEndpointCoords)
+                return SurfaceRepairCoordinateSource.Endpoint;
+            if (hasSnapshotPos && hasSnapshotBody && bodyMismatch != true)
+                return SurfaceRepairCoordinateSource.Snapshot;
+            return SurfaceRepairCoordinateSource.Reject;
+        }
+
+        internal static bool TryRepairSnapshotBodyProvenance(
             ConfigNode snapshot,
             Recording rec,
             double currentUT,
@@ -4544,25 +4687,28 @@ namespace Parsek
 
             if (landedLike)
             {
-                bool useEndpointCoords = hasEndpointCoords;
-                bool useSnapshotCoords = !useEndpointCoords
-                    && hasSnapshotPos
-                    && hasSnapshotBody
-                    && bodyMismatch != true;
+                bool hasDeliberateOverrideStamp = HasDeliberatePositionOverrideStamp(snapshot);
+                SurfaceRepairCoordinateSource coordsSource = DecideSurfaceRepairCoordinateSource(
+                    hasDeliberateOverrideStamp,
+                    hasSnapshotPos,
+                    hasSnapshotBody,
+                    hasEndpointCoords,
+                    bodyMismatch);
 
-                if (!useEndpointCoords && !useSnapshotCoords)
+                if (coordsSource == SurfaceRepairCoordinateSource.Reject)
                 {
                     rejectionReason =
                         "surface snapshot repair needs usable coordinates " +
                         $"(endpointCoords={hasEndpointCoords}, snapshotPos={hasSnapshotPos}, " +
-                        $"snapshotBody={snapshotBodyName ?? "(none)"}, endpointBody={endpointBodyName ?? "(none)"})";
+                        $"snapshotBody={snapshotBodyName ?? "(none)"}, endpointBody={endpointBodyName ?? "(none)"}, " +
+                        $"deliberateOverrideStamp={hasDeliberateOverrideStamp})";
                     ParsekLog.Error("Spawner",
                         $"Spawn validation failed for {logContext}: " +
                         rejectionReason);
                     return false;
                 }
 
-                if (useEndpointCoords)
+                if (coordsSource == SurfaceRepairCoordinateSource.Endpoint)
                 {
                     OverrideSnapshotPosition(
                         snapshot,
@@ -4574,9 +4720,16 @@ namespace Parsek
                 }
 
                 ApplySurfaceOrbitToSnapshot(snapshot, body, logContext);
+                string coordsSourceLabel =
+                    coordsSource == SurfaceRepairCoordinateSource.StampedSnapshot ? "stamped-override"
+                    : coordsSource == SurfaceRepairCoordinateSource.Endpoint ? "endpoint"
+                    : "snapshot";
                 ParsekLog.Warn("Spawner",
                     $"Spawn validation repaired snapshot for {logContext} " +
-                    $"using {(useEndpointCoords ? "endpoint" : "snapshot")} surface coordinates on body '{repairBodyName}'");
+                    $"using {coordsSourceLabel} surface coordinates on body '{repairBodyName}' " +
+                    $"(deliberateOverrideStamp={hasDeliberateOverrideStamp}, snapshotPos={hasSnapshotPos}, " +
+                    $"endpointCoords={hasEndpointCoords}, " +
+                    $"bodyMismatch={(bodyMismatch.HasValue ? bodyMismatch.Value.ToString() : "unknown")})");
                 return true;
             }
 
@@ -4758,14 +4911,7 @@ namespace Parsek
 
             snapshot.RemoveNode("ORBIT");
             ConfigNode orbitNode = new ConfigNode("ORBIT");
-            orbitNode.AddValue("SMA", "0");
-            orbitNode.AddValue("ECC", "1");
-            orbitNode.AddValue("INC", "0");
-            orbitNode.AddValue("LPE", "0");
-            orbitNode.AddValue("LAN", "0");
-            orbitNode.AddValue("MNA", "0");
-            orbitNode.AddValue("EPH", "0");
-            orbitNode.AddValue("REF", bodyIndex.ToString(CultureInfo.InvariantCulture));
+            WriteCanonicalSurfaceOrbitValues(orbitNode, bodyIndex);
             snapshot.AddNode(orbitNode);
             // VerboseRateLimited (not Info): this fires once per TryBackupSnapshot for
             // every landed/splashed-vessel snapshot. The recorder's periodic snapshot
@@ -4777,6 +4923,27 @@ namespace Parsek
                 $"{(string.IsNullOrEmpty(logContext) ? "snapshot" : logContext)} on body " +
                 $"'{DescribeBodyForLog(body)}' (REF={bodyIndex})");
             return true;
+        }
+
+        /// <summary>
+        /// Writes the canonical KSP surface orbit tuple (SMA=0, ECC=1, INC/LPE/LAN/MNA/EPH=0)
+        /// for a landed/splashed vessel into an ORBIT node. Single implementation shared by
+        /// <see cref="ApplySurfaceOrbitToSnapshot"/> and the SpawnAtPosition landed-reseed
+        /// substitution; keep the shape in sync with <see cref="HasCanonicalSurfaceOrbitSignature"/>.
+        /// </summary>
+        internal static void WriteCanonicalSurfaceOrbitValues(ConfigNode orbitNode, int bodyIndex)
+        {
+            if (orbitNode == null)
+                return;
+
+            orbitNode.AddValue("SMA", "0");
+            orbitNode.AddValue("ECC", "1");
+            orbitNode.AddValue("INC", "0");
+            orbitNode.AddValue("LPE", "0");
+            orbitNode.AddValue("LAN", "0");
+            orbitNode.AddValue("MNA", "0");
+            orbitNode.AddValue("EPH", "0");
+            orbitNode.AddValue("REF", bodyIndex.ToString(CultureInfo.InvariantCulture));
         }
 
         private static bool TryResolveBodyIndex(CelestialBody body, out int index)
@@ -6011,6 +6178,18 @@ namespace Parsek
                 node.SetValue(key, newPid.ToString(CultureInfo.InvariantCulture), true);
                 count++;
             }
+        }
+
+        /// <summary>
+        /// Pure decision: is this spawn situation string a landed-like surface state
+        /// (LANDED / SPLASHED)? Used by SpawnAtPosition to decide whether a non-finite
+        /// reseeded orbit may be substituted with the canonical surface orbit tuple.
+        /// </summary>
+        internal static bool IsLandedLikeSituation(string situation)
+        {
+            if (string.IsNullOrEmpty(situation)) return false;
+            return situation.Equals("LANDED", StringComparison.OrdinalIgnoreCase)
+                || situation.Equals("SPLASHED", StringComparison.OrdinalIgnoreCase);
         }
 
         /// <summary>

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -26,6 +26,25 @@ When referencing prior item numbers from source comments or plans, consult the r
 
 ---
 
+## ~~FIXED~~ - EVA spawn walkback clobbered by the degraded fallback + flaky zero-velocity landed reseed (found by the 2026-07-10 in-game sweep, branch `fix-spawn-walkback-fallback`)
+
+**Found by:** the 2026-07-10 re-run sweep (`logs/2026-07-10_2114_rerun-freeze`, KSP.log lines 14014-14094). `FlightIntegrationTests.EvaSpawnWalkbackOnOverlap` failed with "Walkback should move the EVA off the overlapping endpoint (was 0.0 m)": the walkback found a clear position (cleared at segment [21-22]) and `OverrideSnapshotPosition` wrote it into the snapshot, yet the EVA materialized exactly at the overlapping endpoint (distFromParent=17.3 m = the original overlap distance). The 1935 sweep had passed the same test - run-to-run flaky. Beyond the test this is a real product defect: on the degraded fallback path a vessel could materialize inside an overlap the walkback had just cleared (collision/explosion risk in real gameplay).
+
+**Root cause (two stacked):**
+
+1. *Flaky #620 rejection of the primary spawn.* `SpawnAtPosition` rebuilds the ORBIT node via `OrbitReseed.FromWorldPosAndRecordedVelocity` with the recorded endpoint velocity. A landed endpoint with EXACTLY zero recorded velocity reseeds to h=0 / ecc=1, and KSP's `Orbit.UpdateFromStateVectors` computes SMA = -semiLatusRectum/(ecc^2-1) = 0/0 = NaN; `TryValidateFiniteMaterializationMetadata` then rejects the spawn ("orbit metadata 'SMA' is missing or non-finite", #620) and `SpawnAtPosition` returns 0. A float-residue near-zero velocity yields a finite ~r/2 SMA instead - hence the run-to-run flakiness.
+2. *Endpoint clobber in the landed-like repair.* The caller fell through to the degraded fallback (`RespawnValidatedRecording` -> `BuildValidatedRespawnSnapshot` -> `TryRepairSnapshotBodyProvenance`). The landed-like repair branch unconditionally overrode the snapshot position with the recording ENDPOINT coordinates (`bool useEndpointCoords = hasEndpointCoords;`), clobbering the deliberate walkback correction.
+
+**Fix:**
+
+- *Deterministic landed reseed:* when the computed situation is LANDED/SPLASHED and the reseeded orbit carries any non-finite element (`OrbitReseed.HasNonFiniteOrbitElement`, pure + pinned), `SpawnAtPosition` substitutes the canonical surface orbit tuple instead (single implementation `WriteCanonicalSurfaceOrbitValues`, shared with `ApplySurfaceOrbitToSnapshot`). Non-landed situations keep the current rejection (correct there).
+- *Deliberate-override stamp:* `OverrideSnapshotPosition` stamps the snapshot with `parsekDeliberatePosOverride=True`; the landed-like repair dispatches through the pure decision predicate `DecideSurfaceRepairCoordinateSource(hasStamp, hasSnapshotPos, hasSnapshotBody, hasEndpointCoords, bodyMismatch?)` -> {StampedSnapshot, Endpoint, Snapshot, Reject}. A stamped snapshot with a finite position on a non-mismatched body keeps its coordinates (the orbit is still repaired); unstamped snapshots keep the endpoint-first contract EXACTLY (that path moves stale EVA-start snapshots to the trajectory endpoint); a stamp never blocks a genuine repair (missing/NaN coords or a body mismatch still get the endpoint repair). The stamp is stripped from every spawn copy before ProtoVessel load (`BuildValidatedRespawnSnapshot`, `SpawnAtPosition`, `RespawnVessel`) so it never persists into KSP save files.
+- Tests: exhaustive 48-row truth table for the decision predicate, non-finite-element pins, stamp lifecycle pins, and repair-precedence integration pins through `BuildValidatedRespawnSnapshot` (`SpawnWalkbackFallbackTests.cs`).
+
+**Verify:** isolated re-run of `FlightIntegrationTests.EvaSpawnWalkbackOnOverlap` in FLIGHT (Ctrl+Shift+T): distFromEndpoint must be > 0 and the #620 "orbit metadata 'SMA'" rejection must not appear on the landed EVA spawn (grep for the new "substituting canonical surface orbit" Info line instead).
+
+---
+
 ## Added (headless-verified, in-game pin pending) - Pre-Parsek save safety backup (branch `pre-parsek-save-backup`)
 
 **Feature.** The first time Parsek cold-loads a save with no Parsek footprint, it copies that save - before any Parsek write - into a sibling `saves/<Name> (pre-Parsek <local-ts>)/` folder that appears in KSP's Load menu, so a player who tries Parsek and uninstalls it can return to their pristine career. Runs once per save; skips brand-new empty careers; toggle under Settings > Data Management (`autoBackupExistingSaves`, default on).


### PR DESCRIPTION
## Problem

The 2026-07-10 in-game sweep re-run failed `FlightIntegrationTests.EvaSpawnWalkbackOnOverlap` with "Walkback should move the EVA off the overlapping endpoint (was 0.0 m)" (`logs/2026-07-10_2114_rerun-freeze`, KSP.log 14014-14094). The walkback had found a clear position and written it into the snapshot, yet the EVA materialized exactly at the overlapping endpoint (distFromParent=17.3 m, the original overlap distance). The 1935 sweep passed the same test: run-to-run flaky. Beyond the test, this is a real product defect: on the degraded fallback path a vessel can materialize inside an overlap the walkback had just cleared.

Two stacked root causes:

1. **Flaky #620 rejection of the primary spawn.** `SpawnAtPosition` rebuilds the ORBIT node via `OrbitReseed.FromWorldPosAndRecordedVelocity` with the recorded endpoint velocity. A landed endpoint with EXACTLY zero velocity reseeds to h=0 / ecc=1, and KSP's `Orbit.UpdateFromStateVectors` computes SMA = -semiLatusRectum/(ecc^2-1) = 0/0 = NaN; the finite-metadata gate then rejects the spawn and `SpawnAtPosition` returns 0. A float-residue near-zero velocity yields a finite ~r/2 SMA instead, hence the flakiness.
2. **Endpoint clobber in the landed-like repair.** The caller falls through to the degraded fallback (`RespawnValidatedRecording` -> `BuildValidatedRespawnSnapshot` -> `TryRepairSnapshotBodyProvenance`), whose landed-like branch unconditionally overrode the snapshot position with the recording ENDPOINT coordinates, clobbering the deliberate walkback correction.

## Fix

- **Deterministic landed reseed:** when the computed situation is LANDED/SPLASHED and the reseeded orbit carries any non-finite element (`OrbitReseed.HasNonFiniteOrbitElement`, pure and pinned), `SpawnAtPosition` substitutes the canonical surface orbit tuple via the single shared implementation `WriteCanonicalSurfaceOrbitValues` (extracted from `ApplySurfaceOrbitToSnapshot`, no duplicate). Non-landed situations keep the current rejection (correct there). One Info line names the substitution with sit, body, |vel|, and the offending elements.
- **Deliberate-override stamp:** `OverrideSnapshotPosition` stamps the snapshot with `parsekDeliberatePosOverride=True`. The landed-like repair dispatches through the pure decision predicate `DecideSurfaceRepairCoordinateSource(hasStamp, hasSnapshotPos, hasSnapshotBody, hasEndpointCoords, bodyMismatch?)` returning {StampedSnapshot, Endpoint, Snapshot, Reject}:
  - stamped + finite position + no body mismatch: keep the snapshot's coordinates (orbit still repaired via `ApplySurfaceOrbitToSnapshot`);
  - unstamped snapshots keep the endpoint-first contract EXACTLY (stale EVA-start snapshots still move to the trajectory endpoint);
  - a stamp never blocks a genuine repair (missing/NaN coords or a body mismatch still get the endpoint repair).
  The repair logs which source it used and why. The stamp is stripped from every spawn copy before ProtoVessel load (`BuildValidatedRespawnSnapshot` after the repair, `SpawnAtPosition` and `RespawnVessel` after their validation) so it never persists into KSP save files. The stale fallback comment describing the old endpoint-only contract is updated.

## Tests

- 82 new xUnit cases (`SpawnWalkbackFallbackTests.cs`): exhaustive 48-row truth table for the decision predicate, non-finite-element pins (NaN SMA/ECC, +/-Infinity, multiple offenders, all-finite, null orbit), `IsLandedLikeSituation` pins, canonical-surface-orbit shape parity with `ApplySurfaceOrbitToSnapshot`, stamp lifecycle (write/read/strip with log assertions), and repair-precedence integration through `BuildValidatedRespawnSnapshot` (stamped-keeps-walkback-coords, unstamped-endpoint-wins pinned, stamped-but-NaN-coords endpoint still applies, stamped-with-body-mismatch endpoint still applies).
- Full suite: 17497 passed, 1 known skip. `Source/Parsek` also compiles with `-p:SkipKspDeploy=true`.

## Verify in-game

Isolated re-run of `FlightIntegrationTests.EvaSpawnWalkbackOnOverlap` in FLIGHT (Ctrl+Shift+T): distFromEndpoint must be > 0 and the #620 "orbit metadata 'SMA'" rejection must not appear on the landed EVA spawn (the new "substituting canonical surface orbit" Info line should appear instead when the endpoint velocity is exactly zero).
