### PR TITLE
Review follow-up for #1282: rename hasInMemoryBaseline + record accepted tradeoffs

### DIFF
--- a/Source/Parsek.Tests/InGameTestRunnerTests.cs
+++ b/Source/Parsek.Tests/InGameTestRunnerTests.cs
@@ -927,17 +927,18 @@ namespace Parsek.Tests
         }
 
         [Fact]
-        public void ShouldSampleBatchEndCorruption_FlightBaselineOrStorm_Samples()
+        public void ShouldSampleBatchEndCorruption_InMemoryBaselineOrStorm_Samples()
         {
-            // A FLIGHT/TS-baseline batch performs scene reloads (each can trip stock
-            // Bug #4803), and a detected storm is the corruption signature regardless
-            // of isolation mode - both must run the batch-end settle-window check.
+            // An in-memory-baseline batch (captured in FLIGHT or the Tracking Station)
+            // performs scene reloads (each can trip stock Bug #4803), and a detected
+            // storm is the corruption signature regardless of isolation mode - both
+            // must run the batch-end settle-window check.
             Assert.True(InGameTestRunner.ShouldSampleBatchEndCorruption(
-                hasFlightBaseline: true, stormDetected: false));
+                hasInMemoryBaseline: true, stormDetected: false));
             Assert.True(InGameTestRunner.ShouldSampleBatchEndCorruption(
-                hasFlightBaseline: false, stormDetected: true));
+                hasInMemoryBaseline: false, stormDetected: true));
             Assert.True(InGameTestRunner.ShouldSampleBatchEndCorruption(
-                hasFlightBaseline: true, stormDetected: true));
+                hasInMemoryBaseline: true, stormDetected: true));
         }
 
         [Fact]
@@ -947,7 +948,7 @@ namespace Parsek.Tests
             // storm never reloads a scene; sampling would only add settle frames and
             // risk bouncing on an unrelated mod's error flood.
             Assert.False(InGameTestRunner.ShouldSampleBatchEndCorruption(
-                hasFlightBaseline: false, stormDetected: false));
+                hasInMemoryBaseline: false, stormDetected: false));
         }
 
         [Fact]

--- a/Source/Parsek/InGameTests/Helpers/FlightCameraReloadPin.cs
+++ b/Source/Parsek/InGameTests/Helpers/FlightCameraReloadPin.cs
@@ -125,7 +125,9 @@ namespace Parsek.InGameTests.Helpers
         /// through code paths other than onVesselChange. The caller (the restore core
         /// coroutine) yields WaitForEndOfFrame after the commit, then calls this; it
         /// pins if (and only if) the window is still armed. Exception-safe: runs during
-        /// scene teardown.
+        /// scene teardown. This backstop is restore-core-path-only by design: direct
+        /// TriggerQuickload callers are protected by the onVesselChange handler alone
+        /// (their tests leave no transient EVA vessels behind).
         /// </summary>
         internal static void PinNowIfArmed(string context)
         {
@@ -167,7 +169,10 @@ namespace Parsek.InGameTests.Helpers
         // under the switch target, which the imminent unload will destroy). Re-pin the
         // pivot straight back onto the DDOL root and log a Warn naming the vessel so
         // the late switch is diagnosable from KSP.log. Exception-safe: this runs during
-        // scene teardown.
+        // scene teardown. Accepted tradeoff: the TTL-expired AutoDisarm below
+        // self-removes this handler DURING onVesselChange dispatch, which can skip one
+        // co-subscriber for that single fire; confined to the degraded 60s-stale path
+        // and contained by the try/catch.
         private static void OnVesselChangeWhileArmed(Vessel vessel)
         {
             try

--- a/Source/Parsek/InGameTests/InGameTestRunner.cs
+++ b/Source/Parsek/InGameTests/InGameTestRunner.cs
@@ -704,15 +704,19 @@ namespace Parsek.InGameTests
         /// <summary>
         /// True when the batch-end corruption check should sample the flood detector at
         /// all: only batches that could have corrupted the scene are eligible - a batch
-        /// with a FLIGHT/TS baseline performs scene reloads (each one can trip stock Bug
-        /// #4803), and a detected exception storm is the corruption signature regardless
-        /// of mode. A plain disk-only batch (SPACECENTER / EDITOR / FLIGHT-no-vessel)
-        /// with no storm never reloads a scene, so sampling would only add settle-window
-        /// frames and risk bouncing on an unrelated mod's error flood. Pure.
+        /// with an in-memory baseline (captured in FLIGHT or the Tracking Station)
+        /// performs scene reloads (each one can trip stock Bug #4803), and a detected
+        /// exception storm is the corruption signature regardless of mode. A plain
+        /// disk-only batch (SPACECENTER / EDITOR / FLIGHT-no-vessel) with no storm never
+        /// reloads a scene, so sampling would only add settle-window frames and risk
+        /// bouncing on an unrelated mod's error flood. Accepted coarseness: this keys on
+        /// "baseline captured", not "a reload actually happened", so an in-memory-
+        /// baseline batch with zero restores still samples; blast radius is one Space
+        /// Center visit. Pure.
         /// </summary>
-        internal static bool ShouldSampleBatchEndCorruption(bool hasFlightBaseline, bool stormDetected)
+        internal static bool ShouldSampleBatchEndCorruption(bool hasInMemoryBaseline, bool stormDetected)
         {
-            return hasFlightBaseline || stormDetected;
+            return hasInMemoryBaseline || stormDetected;
         }
 
         // Subscribe the batch unhandled-exception counter and reset the count so each batch starts


### PR DESCRIPTION
## Summary

PR #1282 was merged while its clean-context review follow-up was still being written; this PR carries just that follow-up commit (603b19dcb).

Review verdict on #1282 was SHIP-WITH-NITS (all four findings NIT/accepted-tradeoff; the load-bearing disarm-ordering claim was independently verified against the decompiled FlightDriver). This applies the one actionable NIT and records the three accepted tradeoffs where the next reader will look:

- Renamed the misleading `ShouldSampleBatchEndCorruption(bool hasFlightBaseline, ...)` parameter to `hasInMemoryBaseline` (the baseline can be a Tracking Station baseline), including doc comment, call-site named arguments, and test naming.
- Comment: the batch-end corruption sample keys on "baseline captured", not "a reload actually happened"; accepted, blast radius is one Space Center visit.
- Comment: the end-of-frame PinNowIfArmed backstop is restore-core-path-only by design; direct TriggerQuickload callers are protected by the onVesselChange handler alone.
- Comment: the TTL-expired AutoDisarm self-removes during event dispatch (can skip one co-subscriber for that single fire); confined to the degraded 60s-stale path, contained by try/catch.

## Validation

Test-infra comments + one rename; full suite green: 17425 passed, 0 failed, 1 known skip.