### PR TITLE
chore: bump version to 0.10.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to Parsek are documented here.
 
 ---
 
+## 0.10.4
+
 ## 0.10.3
 
 ### Features

--- a/GameData/Parsek/Parsek.version
+++ b/GameData/Parsek/Parsek.version
@@ -1,7 +1,7 @@
 {
     "NAME": "Parsek",
     "URL": "https://raw.githubusercontent.com/vl3c/Parsek/main/GameData/Parsek/Parsek.version",
-    "VERSION": { "MAJOR": 0, "MINOR": 10, "PATCH": 3 },
+    "VERSION": { "MAJOR": 0, "MINOR": 10, "PATCH": 4 },
     "KSP_VERSION": { "MAJOR": 1, "MINOR": 12, "PATCH": 5 },
     "KSP_VERSION_MIN": { "MAJOR": 1, "MINOR": 12, "PATCH": 0 },
     "KSP_VERSION_MAX": { "MAJOR": 1, "MINOR": 12, "PATCH": 99 }

--- a/Source/Parsek/Properties/AssemblyInfo.cs
+++ b/Source/Parsek/Properties/AssemblyInfo.cs
@@ -17,7 +17,7 @@ using System.Runtime.InteropServices;
 
 [assembly: Guid("a1b2c3d4-e5f6-7890-abcd-ef1234567890")]
 
-[assembly: AssemblyVersion("0.10.3.0")]
-[assembly: AssemblyFileVersion("0.10.3.0")]
+[assembly: AssemblyVersion("0.10.4.0")]
+[assembly: AssemblyFileVersion("0.10.4.0")]
 
 [assembly: KSPAssembly("Parsek", 0, 10)]


### PR DESCRIPTION
Opens the next development cycle after the **v0.10.3** release (published as Latest).

- Bump `Parsek.version` PATCH 3 -> 4 and `AssemblyInfo.cs` AssemblyVersion / AssemblyFileVersion to `0.10.4.0` (keeps `release.py`'s version-match check green).
- Add an empty `## 0.10.4` CHANGELOG section above `## 0.10.3` for incoming work.

Mirrors the prior `chore: bump version to 0.10.3` commit shape. No code or behavior change.