### PR TITLE
perf: skip redundant recalc second sort when pre-pass is stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to Parsek are documented here.
 
 ### Internals & Tests
 
-- The career recalculation walk now skips its redundant second action sort in the common case: each resource module's pre-pass reports whether it actually mutated the action list, and the engine re-sorts only when something changed (an expired-contract synthetic fail), instead of always re-sorting. Recalculated career values are unchanged. Ships with a `RecalculationFuzzer` acceptance harness (tens of thousands of randomized recalcs across cutoff shapes) plus unit coverage for the sort-count decision.
+- Career recalculation is slightly cheaper: the walk now skips a redundant re-sort of the action list when nothing changed it. Recalculated career values are unchanged.
 
 ## 0.10.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to Parsek are documented here.
 
 ## 0.10.4
 
+### Internals & Tests
+
+- The career recalculation walk now skips its redundant second action sort in the common case: each resource module's pre-pass reports whether it actually mutated the action list, and the engine re-sorts only when something changed (an expired-contract synthetic fail), instead of always re-sorting. Recalculated career values are unchanged. Ships with a `RecalculationFuzzer` acceptance harness (tens of thousands of randomized recalcs across cutoff shapes) plus unit coverage for the sort-count decision.
+
 ## 0.10.3
 
 ### Features

--- a/Source/Parsek.Tests/KerbalsModuleTests.cs
+++ b/Source/Parsek.Tests/KerbalsModuleTests.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    [Collection("Sequential")]
+    public class KerbalsModuleTests : IDisposable
+    {
+        private readonly bool priorParsekLogSuppress;
+        private readonly bool priorStoreSuppress;
+
+        public KerbalsModuleTests()
+        {
+            priorParsekLogSuppress = ParsekLog.SuppressLogging;
+            priorStoreSuppress = RecordingStore.SuppressLogging;
+            ParsekLog.SuppressLogging = true;
+            RecordingStore.SuppressLogging = true;
+            RecordingStore.ResetForTesting();
+            CrewReservationManager.ResetReplacementsForTesting();
+        }
+
+        public void Dispose()
+        {
+            RecordingStore.ResetForTesting();
+            CrewReservationManager.ResetReplacementsForTesting();
+            RecordingStore.SuppressLogging = priorStoreSuppress;
+            ParsekLog.SuppressLogging = priorParsekLogSuppress;
+            ParsekLog.ResetTestOverrides();
+        }
+
+        [Fact]
+        public void RepeatedWalks_SlotCountStable()
+        {
+            var snapshot = new ConfigNode("VESSEL");
+            var part = snapshot.AddNode("PART");
+            part.AddValue("crew", "Jebediah Kerman");
+
+            var rec = new Recording
+            {
+                RecordingId = "stable-slots-rec",
+                VesselName = "Stable Slots",
+                ExplicitStartUT = 100.0,
+                ExplicitEndUT = 200.0,
+                VesselSnapshot = snapshot,
+                GhostVisualSnapshot = snapshot,
+                CrewEndStatesResolved = true,
+                CrewEndStates = new Dictionary<string, KerbalEndState>
+                {
+                    { "Jebediah Kerman", KerbalEndState.Recovered }
+                }
+            };
+            RecordingStore.AddRecordingWithTreeForTesting(rec);
+
+            var module = new KerbalsModule();
+            int? expectedSlotCount = null;
+            for (int i = 0; i < 10; i++)
+            {
+                KerbalsTestHelper.RecalculateModule(module);
+                if (!expectedSlotCount.HasValue)
+                    expectedSlotCount = module.Slots.Count;
+
+                Assert.Equal(expectedSlotCount.Value, module.Slots.Count);
+            }
+
+            Assert.Equal(1, expectedSlotCount.Value);
+        }
+    }
+}

--- a/Source/Parsek.Tests/LedgerOrchestratorTests.cs
+++ b/Source/Parsek.Tests/LedgerOrchestratorTests.cs
@@ -249,6 +249,60 @@ namespace Parsek.Tests
         }
 
         [Fact]
+        public void RegularEntry_OnTimelineDataChangedReentry_DoesNotCorrupt()
+        {
+            LedgerOrchestrator.Initialize();
+            Ledger.AddAction(new GameAction
+            {
+                UT = 0.0,
+                Type = GameActionType.FundsInitial,
+                InitialFunds = 1000f
+            });
+            Ledger.AddAction(new GameAction
+            {
+                UT = 10.0,
+                Type = GameActionType.FundsEarning,
+                FundsAwarded = 250f
+            });
+
+            LedgerOrchestrator.RecalculateAndPatch();
+            double referenceFunds = LedgerOrchestrator.Funds.GetAvailableFunds();
+
+            LedgerOrchestrator.ResetForTesting();
+            LedgerOrchestrator.Initialize();
+            Ledger.AddAction(new GameAction
+            {
+                UT = 0.0,
+                Type = GameActionType.FundsInitial,
+                InitialFunds = 1000f
+            });
+            Ledger.AddAction(new GameAction
+            {
+                UT = 10.0,
+                Type = GameActionType.FundsEarning,
+                FundsAwarded = 250f
+            });
+
+            int callbackCount = 0;
+            bool nestedWalkRan = false;
+            LedgerOrchestrator.OnTimelineDataChanged += () =>
+            {
+                callbackCount++;
+                if (nestedWalkRan)
+                    return;
+
+                nestedWalkRan = true;
+                LedgerOrchestrator.RecalculateAndPatch();
+            };
+
+            LedgerOrchestrator.RecalculateAndPatch();
+
+            Assert.True(nestedWalkRan);
+            Assert.Equal(2, callbackCount);
+            Assert.Equal(referenceFunds, LedgerOrchestrator.Funds.GetAvailableFunds(), 3);
+        }
+
+        [Fact]
         public void RecalculateAndPatch_InitializesIfNotYetDone()
         {
             // Don't call Initialize() explicitly

--- a/Source/Parsek.Tests/RecalculationEngineTests.cs
+++ b/Source/Parsek.Tests/RecalculationEngineTests.cs
@@ -62,7 +62,7 @@ namespace Parsek.Tests
             }
         }
 
-        // Minimal module that never mutates the action list — used to measure the
+        // Minimal module that never mutates the action list; used to measure the
         // steady-state per-walk allocation of the cutoff path.
         private sealed class AllocationProbeModule : IResourceModule
         {

--- a/Source/Parsek.Tests/RecalculationEngineTests.cs
+++ b/Source/Parsek.Tests/RecalculationEngineTests.cs
@@ -13,6 +13,7 @@ namespace Parsek.Tests
         public RecalculationEngineTests()
         {
             RecalculationEngine.ClearModules();
+            RecalculationEngine.ResetSortActionsCallCountForTesting();
             ParsekLog.ResetTestOverrides();
             ParsekLog.SuppressLogging = false;
             ParsekLog.TestSinkForTesting = line => logLines.Add(line);
@@ -21,6 +22,7 @@ namespace Parsek.Tests
         public void Dispose()
         {
             RecalculationEngine.ClearModules();
+            RecalculationEngine.ResetSortActionsCallCountForTesting();
             ParsekLog.ResetTestOverrides();
             ParsekLog.SuppressLogging = true;
         }
@@ -41,10 +43,11 @@ namespace Parsek.Tests
                 ResetCount++;
             }
 
-            public void PrePass(List<GameAction> actions, double? walkNowUT = null)
+            public bool PrePass(List<GameAction> actions, double? walkNowUT = null)
             {
                 PrePassCount++;
                 PrePassWalkNowUTs.Add(walkNowUT);
+                return false;
             }
 
             public void ProcessAction(GameAction action)
@@ -57,6 +60,29 @@ namespace Parsek.Tests
             {
                 PostWalkCount++;
             }
+        }
+
+        // Minimal module that never mutates the action list — used to measure the
+        // steady-state per-walk allocation of the cutoff path.
+        private sealed class AllocationProbeModule : IResourceModule
+        {
+            public void Reset() { }
+            public bool PrePass(List<GameAction> actions, double? walkNowUT = null) { return false; }
+            public void ProcessAction(GameAction action) { }
+            public void PostWalk() { }
+        }
+
+        private static bool TryGetAllocatedBytesForCurrentThread(out long allocatedBytes)
+        {
+            var method = typeof(GC).GetMethod("GetAllocatedBytesForCurrentThread", Type.EmptyTypes);
+            if (method != null)
+            {
+                allocatedBytes = (long)method.Invoke(null, null);
+                return true;
+            }
+
+            allocatedBytes = 0;
+            return false;
         }
 
         private static GameAction FundsSeed(float amount)
@@ -422,6 +448,96 @@ namespace Parsek.Tests
         // ================================================================
         // Recalculate — module lifecycle
         // ================================================================
+
+        [Fact]
+        public void PrePassNoInjection_SkipsSecondSort()
+        {
+            var module = new TestModule();
+            RecalculationEngine.RegisterModule(module, RecalculationEngine.ModuleTier.FirstTier);
+
+            var actions = new List<GameAction>
+            {
+                new GameAction { UT = 200.0, Type = GameActionType.FundsEarning, FundsAwarded = 25f },
+                new GameAction { UT = 100.0, Type = GameActionType.ScienceEarning, ScienceAwarded = 5f }
+            };
+
+            RecalculationEngine.ResetSortActionsCallCountForTesting();
+            RecalculationEngine.Recalculate(actions);
+
+            Assert.Equal(1, RecalculationEngine.SortActionsCallCountForTesting);
+            Assert.Contains(logLines, l =>
+                l.Contains("[RecalcEngine]") &&
+                l.Contains("PrePass stable action list; skipped second sort"));
+        }
+
+        [Fact]
+        public void PrePassWithInjection_DoesSecondSort()
+        {
+            var contracts = new ContractsModule();
+            var capture = new TestModule();
+            RecalculationEngine.RegisterModule(contracts, RecalculationEngine.ModuleTier.FirstTier);
+            RecalculationEngine.RegisterModule(capture, RecalculationEngine.ModuleTier.FirstTier);
+
+            var actions = new List<GameAction>
+            {
+                new GameAction
+                {
+                    UT = 100.0,
+                    Type = GameActionType.ContractAccept,
+                    ContractId = "deadline-contract",
+                    DeadlineUT = 150f,
+                    FundsPenalty = 300f,
+                    RepPenalty = 2f
+                },
+                new GameAction { UT = 200.0, Type = GameActionType.FundsEarning, FundsAwarded = 1f }
+            };
+
+            RecalculationEngine.ResetSortActionsCallCountForTesting();
+            RecalculationEngine.Recalculate(actions);
+
+            Assert.Equal(2, RecalculationEngine.SortActionsCallCountForTesting);
+            Assert.Contains(capture.ProcessedActions, a =>
+                a.Type == GameActionType.ContractFail &&
+                a.ContractId == "deadline-contract" &&
+                Math.Abs(a.UT - 150.0) < 0.001);
+        }
+
+        [Fact]
+        public void CutoffWalk_AllocationsBounded()
+        {
+            RecalculationEngine.RegisterModule(new AllocationProbeModule(), RecalculationEngine.ModuleTier.FirstTier);
+            var actions = new List<GameAction>();
+
+            bool previousSuppress = ParsekLog.SuppressLogging;
+            ParsekLog.SuppressLogging = true;
+            try
+            {
+                for (int i = 0; i < 10; i++)
+                    RecalculationEngine.Recalculate(actions, 15.0);
+
+                long before;
+                if (!TryGetAllocatedBytesForCurrentThread(out before))
+                {
+                    Console.WriteLine(
+                        "CutoffWalk_AllocationsBounded skipped: GC.GetAllocatedBytesForCurrentThread unavailable.");
+                    return;
+                }
+
+                const int iterations = 100;
+                for (int i = 0; i < iterations; i++)
+                    RecalculationEngine.Recalculate(actions, 15.0);
+                long after;
+                Assert.True(TryGetAllocatedBytesForCurrentThread(out after));
+
+                long bytesPerWalk = (after - before) / iterations;
+                Assert.True(bytesPerWalk < 4 * 1024,
+                    $"Expected cutoff walk allocation below 4 KB, got {bytesPerWalk} bytes per walk.");
+            }
+            finally
+            {
+                ParsekLog.SuppressLogging = previousSuppress;
+            }
+        }
 
         [Fact]
         public void Recalculate_CallsResetOnAllModules()

--- a/Source/Parsek.Tests/RecalculationFuzzer.cs
+++ b/Source/Parsek.Tests/RecalculationFuzzer.cs
@@ -1,0 +1,396 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    [Collection("Sequential")]
+    public class RecalculationFuzzerTests : IDisposable
+    {
+        // Keep this count in sync with CreateAction's switch below so a new
+        // GameActionType cannot land without an explicit fuzzer payload.
+        private const int ExpectedGameActionTypeCount = 30;
+        private readonly bool priorSuppressLogging;
+
+        public RecalculationFuzzerTests()
+        {
+            priorSuppressLogging = ParsekLog.SuppressLogging;
+            ParsekLog.SuppressLogging = true;
+            ParsekLog.ResetTestOverrides();
+            RecalculationEngine.ClearModules();
+            RecalculationEngine.RegisterModule(new ContractsModule(), RecalculationEngine.ModuleTier.FirstTier);
+        }
+
+        public void Dispose()
+        {
+            RecalculationEngine.ClearModules();
+            RecalculationEngine.ResetSortActionsCallCountForTesting();
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = priorSuppressLogging;
+        }
+
+        [Fact]
+        public void GameActionType_EnumValueCount_Locked()
+        {
+            Assert.Equal(ExpectedGameActionTypeCount, Enum.GetValues(typeof(GameActionType)).Length);
+        }
+
+        [Fact]
+        public void DeterministicLedgerFuzzer_PrePassMutationMatchesSecondSortDecision()
+        {
+            var rng = new Random(0x5EED);
+            var seenTypes = new HashSet<GameActionType>();
+            for (int iteration = 0; iteration < 10000; iteration++)
+            {
+                var actions = BuildActions(iteration, rng);
+                foreach (var action in actions)
+                    seenTypes.Add(action.Type);
+
+                AssertSortMatchesLinq(actions);
+
+                double midTimeline = 500.0;
+                double pastEnd = 20000.0;
+                double preStart = -1.0;
+                double?[] cutoffs = { null, midTimeline, pastEnd, preStart };
+                for (int i = 0; i < cutoffs.Length; i++)
+                {
+                    int expectedSortCalls = ExpectedSortCalls(actions, cutoffs[i]);
+                    RecalculationEngine.ResetSortActionsCallCountForTesting();
+                    RecalculationEngine.Recalculate(actions, cutoffs[i]);
+                    Assert.Equal(expectedSortCalls, RecalculationEngine.SortActionsCallCountForTesting);
+                }
+            }
+
+            var allTypes = Enum.GetValues(typeof(GameActionType)).Cast<GameActionType>();
+            foreach (var type in allTypes)
+                Assert.Contains(type, seenTypes);
+        }
+
+        private static void AssertSortMatchesLinq(List<GameAction> actions)
+        {
+            var expected = actions
+                .OrderBy(a => a.UT)
+                .ThenBy(a => RecalculationEngine.IsEarningType(a.Type) ? 0 : 1)
+                .ThenBy(a => a.Sequence)
+                .ToList();
+
+            var actual = RecalculationEngine.SortActions(actions);
+            Assert.True(expected.SequenceEqual(actual));
+        }
+
+        private static int ExpectedSortCalls(List<GameAction> actions, double? cutoff)
+        {
+            // Mirrors RecalculationEngine's cutoff filtering and projection horizon.
+            // If those production rules change, update this predictor in the same PR.
+            if (!cutoff.HasValue)
+                return 1 + (WouldContractsPrePassMutate(SortForPrediction(actions), null) ? 1 : 0);
+
+            var projectionActions = CopyNonNullActions(actions);
+            int projectionCalls = 1 + (WouldContractsPrePassMutate(
+                SortForPrediction(projectionActions),
+                ComputeProjectionHorizon(actions)) ? 1 : 0);
+
+            var effective = new List<GameAction>(actions.Count);
+            double cutoffValue = cutoff.Value;
+            for (int i = 0; i < actions.Count; i++)
+            {
+                var action = actions[i];
+                if (action == null)
+                    continue;
+                if (RecalculationEngine.IsSeedType(action.Type) || action.UT <= cutoffValue)
+                    effective.Add(action);
+            }
+
+            int liveCalls = 1 + (WouldContractsPrePassMutate(
+                SortForPrediction(effective),
+                cutoffValue) ? 1 : 0);
+
+            return projectionCalls + liveCalls;
+        }
+
+        private static bool WouldContractsPrePassMutate(List<GameAction> sorted, double? walkNowUT)
+        {
+            if (sorted == null || sorted.Count == 0)
+                return false;
+
+            var tracked = new Dictionary<string, GameAction>();
+            for (int i = 0; i < sorted.Count; i++)
+            {
+                var action = sorted[i];
+                switch (action.Type)
+                {
+                    case GameActionType.ContractAccept:
+                        if (!float.IsNaN(action.DeadlineUT) && action.ContractId != null)
+                            tracked[action.ContractId] = action;
+                        break;
+                    case GameActionType.ContractComplete:
+                    case GameActionType.ContractFail:
+                    case GameActionType.ContractCancel:
+                        if (action.ContractId != null)
+                            tracked.Remove(action.ContractId);
+                        break;
+                }
+            }
+
+            double nowUT = walkNowUT ?? sorted[sorted.Count - 1].UT;
+            foreach (var pair in tracked)
+            {
+                if (pair.Value.DeadlineUT <= nowUT)
+                    return true;
+            }
+
+            return false;
+        }
+
+        private static List<GameAction> SortForPrediction(List<GameAction> actions)
+        {
+            return actions
+                .OrderBy(a => a.UT)
+                .ThenBy(a => RecalculationEngine.IsEarningType(a.Type) ? 0 : 1)
+                .ThenBy(a => a.Sequence)
+                .ToList();
+        }
+
+        private static List<GameAction> CopyNonNullActions(List<GameAction> actions)
+        {
+            var copy = new List<GameAction>(actions.Count);
+            for (int i = 0; i < actions.Count; i++)
+            {
+                if (actions[i] != null)
+                    copy.Add(actions[i]);
+            }
+
+            return copy;
+        }
+
+        private static double ComputeProjectionHorizon(List<GameAction> actions)
+        {
+            double horizon = 0.0;
+            bool hasValue = false;
+            for (int i = 0; i < actions.Count; i++)
+            {
+                var action = actions[i];
+                if (action == null)
+                    continue;
+
+                if (!hasValue || action.UT > horizon)
+                {
+                    horizon = action.UT;
+                    hasValue = true;
+                }
+
+                if (action.Type == GameActionType.ContractAccept
+                    && !float.IsNaN(action.DeadlineUT)
+                    && action.DeadlineUT > horizon)
+                {
+                    horizon = action.DeadlineUT;
+                }
+            }
+
+            return horizon;
+        }
+
+        private static List<GameAction> BuildActions(int iteration, Random rng)
+        {
+            var actions = new List<GameAction>
+            {
+                new GameAction { UT = 0.0, Type = GameActionType.FundsInitial, InitialFunds = 10000f },
+                new GameAction { UT = 0.0, Type = GameActionType.ScienceInitial, InitialScience = 50f },
+                new GameAction { UT = 0.0, Type = GameActionType.ReputationInitial, InitialReputation = 10f }
+            };
+
+            var allTypes = Enum.GetValues(typeof(GameActionType)).Cast<GameActionType>().ToArray();
+            for (int i = 0; i < allTypes.Length; i++)
+            {
+                double ut = 10.0 + rng.Next(0, 1000);
+                actions.Add(CreateAction(allTypes[i], ut, i, iteration));
+            }
+
+            AddHandSeededScenario(actions, iteration);
+            return actions;
+        }
+
+        private static void AddHandSeededScenario(List<GameAction> actions, int iteration)
+        {
+            if ((iteration & 1) == 0)
+            {
+                actions.Add(new GameAction
+                {
+                    UT = 100.0,
+                    Type = GameActionType.ContractAccept,
+                    ContractId = "expired-open-" + iteration,
+                    DeadlineUT = 150f,
+                    FundsPenalty = 250f,
+                    RepPenalty = 1f
+                });
+                actions.Add(new GameAction
+                {
+                    UT = 200.0,
+                    Type = GameActionType.FundsEarning,
+                    FundsAwarded = 1f
+                });
+            }
+            else
+            {
+                string contractId = "resolved-" + iteration;
+                actions.Add(new GameAction
+                {
+                    UT = 100.0,
+                    Type = GameActionType.ContractAccept,
+                    ContractId = contractId,
+                    DeadlineUT = 150f,
+                    FundsPenalty = 250f,
+                    RepPenalty = 1f
+                });
+                actions.Add(new GameAction
+                {
+                    UT = 125.0,
+                    Type = GameActionType.ContractComplete,
+                    ContractId = contractId,
+                    FundsReward = 10f
+                });
+            }
+        }
+
+        private static GameAction CreateAction(GameActionType type, double ut, int sequence, int iteration)
+        {
+            var action = new GameAction
+            {
+                UT = ut,
+                Type = type,
+                Sequence = sequence,
+                RecordingId = "rec-" + iteration
+            };
+
+            switch (type)
+            {
+                case GameActionType.ScienceEarning:
+                    action.SubjectId = "subject-" + iteration + "-" + sequence;
+                    action.ScienceAwarded = 5f;
+                    action.SubjectMaxValue = 50f;
+                    break;
+                case GameActionType.ScienceSpending:
+                    action.NodeId = "node-" + iteration;
+                    action.Cost = 4f;
+                    break;
+                case GameActionType.FundsEarning:
+                    action.FundsAwarded = 100f;
+                    break;
+                case GameActionType.FundsSpending:
+                    action.FundsSpent = 25f;
+                    break;
+                case GameActionType.MilestoneAchievement:
+                    action.MilestoneId = "milestone-" + iteration + "-" + sequence;
+                    action.MilestoneFundsAwarded = 10f;
+                    break;
+                case GameActionType.ContractAccept:
+                    action.ContractId = "generic-contract-" + iteration + "-" + sequence;
+                    action.DeadlineUT = float.NaN;
+                    action.AdvanceFunds = 5f;
+                    action.FundsPenalty = 20f;
+                    break;
+                case GameActionType.ContractComplete:
+                    action.ContractId = "complete-contract-" + iteration + "-" + sequence;
+                    action.FundsReward = 15f;
+                    action.ScienceReward = 1f;
+                    action.RepReward = 1f;
+                    break;
+                case GameActionType.ContractFail:
+                case GameActionType.ContractCancel:
+                    action.ContractId = "terminal-contract-" + iteration + "-" + sequence;
+                    action.FundsPenalty = 10f;
+                    action.RepPenalty = 1f;
+                    break;
+                case GameActionType.ReputationEarning:
+                    action.NominalRep = 2f;
+                    break;
+                case GameActionType.ReputationPenalty:
+                    action.NominalPenalty = 2f;
+                    break;
+                case GameActionType.KerbalAssignment:
+                    action.KerbalName = "Jebediah Kerman";
+                    action.KerbalRole = "Pilot";
+                    action.KerbalEndStateField = (iteration % 3 == 0)
+                        ? KerbalEndState.Dead
+                        : KerbalEndState.Recovered;
+                    break;
+                case GameActionType.KerbalHire:
+                case GameActionType.KerbalRescue:
+                case GameActionType.KerbalStandIn:
+                    action.KerbalName = "Kerbal " + iteration;
+                    action.KerbalRole = "Engineer";
+                    break;
+                case GameActionType.FacilityUpgrade:
+                case GameActionType.FacilityDestruction:
+                case GameActionType.FacilityRepair:
+                    action.FacilityId = "LaunchPad";
+                    action.ToLevel = 2;
+                    action.FacilityCost = 100f;
+                    break;
+                case GameActionType.StrategyActivate:
+                case GameActionType.StrategyDeactivate:
+                    action.StrategyId = "strategy-" + iteration;
+                    action.SourceResource = StrategyResource.Funds;
+                    action.TargetResource = StrategyResource.Science;
+                    action.Commitment = 0.25f;
+                    action.SetupCost = 5f;
+                    break;
+                case GameActionType.FundsInitial:
+                    action.InitialFunds = 10000f;
+                    break;
+                case GameActionType.ScienceInitial:
+                    action.InitialScience = 50f;
+                    break;
+                case GameActionType.ReputationInitial:
+                    action.InitialReputation = 10f;
+                    break;
+                case GameActionType.RouteDispatched:
+                    action.RouteId = "route-" + iteration;
+                    action.RouteCycleId = "cycle-" + iteration + "-" + sequence;
+                    break;
+                case GameActionType.RouteCargoDebited:
+                    action.RouteId = "route-" + iteration;
+                    action.RouteCycleId = "cycle-" + iteration + "-" + sequence;
+                    action.RouteKscFundsCost = 50f;
+                    action.RouteResourceManifest = new Dictionary<string, double>
+                    {
+                        { "Ore", 10.0 }
+                    };
+                    break;
+                case GameActionType.RouteCargoDelivered:
+                    action.RouteId = "route-" + iteration;
+                    action.RouteCycleId = "cycle-" + iteration + "-" + sequence;
+                    action.RouteResourceManifest = new Dictionary<string, double>
+                    {
+                        { "Ore", 10.0 }
+                    };
+                    break;
+                case GameActionType.RoutePaused:
+                    action.RouteId = "route-" + iteration;
+                    action.RouteEndpointReason = "player-pause";
+                    break;
+                case GameActionType.RouteEndpointLost:
+                    action.RouteId = "route-" + iteration;
+                    action.RouteEndpointReason = "endpoint-lost";
+                    break;
+                case GameActionType.RouteRecoveryCredited:
+                    action.RouteId = "route-" + iteration;
+                    action.RouteCycleId = "cycle-" + iteration + "-" + sequence;
+                    action.RouteKscFundsCost = 30f;
+                    break;
+                case GameActionType.RouteCargoPickedUp:
+                    action.RouteId = "route-" + iteration;
+                    action.RouteCycleId = "cycle-" + iteration + "-" + sequence;
+                    action.RouteOriginVesselPid = 42u;
+                    action.RouteResourceManifest = new Dictionary<string, double>
+                    {
+                        { "Ore", 5.0 }
+                    };
+                    break;
+            }
+
+            return action;
+        }
+    }
+}

--- a/Source/Parsek.Tests/RewindUtCutoffTests.cs
+++ b/Source/Parsek.Tests/RewindUtCutoffTests.cs
@@ -1889,7 +1889,7 @@ namespace Parsek.Tests
             public readonly List<GameAction> ProcessedActions = new List<GameAction>();
 
             public void Reset() { ProcessedActions.Clear(); }
-            public void PrePass(List<GameAction> actions, double? walkNowUT = null) { }
+            public bool PrePass(List<GameAction> actions, double? walkNowUT = null) { return false; }
             public void ProcessAction(GameAction action) { ProcessedActions.Add(action); }
             public void PostWalk() { }
         }
@@ -1906,7 +1906,7 @@ namespace Parsek.Tests
                 ResetCalls++;
             }
 
-            public void PrePass(List<GameAction> actions, double? walkNowUT = null) { }
+            public bool PrePass(List<GameAction> actions, double? walkNowUT = null) { return false; }
 
             public void ProcessAction(GameAction action)
             {

--- a/Source/Parsek/GameActions/ContractsModule.cs
+++ b/Source/Parsek/GameActions/ContractsModule.cs
@@ -151,10 +151,10 @@ namespace Parsek
         /// heuristic — correct for non-rewind walks where the end of the ledger is
         /// effectively the current time).
         /// </remarks>
-        public void PrePass(List<GameAction> actions, double? walkNowUT = null)
+        public bool PrePass(List<GameAction> actions, double? walkNowUT = null)
         {
             if (actions == null || actions.Count == 0)
-                return;
+                return false;
 
             // Track accepted contracts with deadlines: contractId -> accept action
             var tracked = new Dictionary<string, GameAction>();
@@ -261,6 +261,10 @@ namespace Parsek
                     $"PrePass: no expired deadline contracts found " +
                     $"(tracked={tracked.Count}, nowUT={nowUT}, source={nowSource})");
             }
+
+            // Signal the engine to re-sort only when we actually injected a synthetic
+            // action; a no-injection pre-pass leaves the sorted list intact.
+            return injected > 0;
         }
 
         /// <inheritdoc/>

--- a/Source/Parsek/GameActions/FacilitiesModule.cs
+++ b/Source/Parsek/GameActions/FacilitiesModule.cs
@@ -59,9 +59,10 @@ namespace Parsek
         /// Pre-pass: no-op for facilities module.
         /// Facility state is derived purely from the action walk — no aggregate information needed.
         /// </summary>
-        public void PrePass(List<GameAction> actions, double? walkNowUT = null)
+        public bool PrePass(List<GameAction> actions, double? walkNowUT = null)
         {
             // No pre-pass needed for facilities; walkNowUT is ignored.
+            return false;
         }
 
         /// <summary>

--- a/Source/Parsek/GameActions/FundsModule.cs
+++ b/Source/Parsek/GameActions/FundsModule.cs
@@ -103,9 +103,10 @@ namespace Parsek
         /// cutoff to <paramref name="actions"/> before calling PrePass, so every action we
         /// see is in scope for the visible/current aggregate.
         /// </remarks>
-        public void PrePass(List<GameAction> actions, double? walkNowUT = null)
+        public bool PrePass(List<GameAction> actions, double? walkNowUT = null)
         {
             ComputeTotalSpendings(actions);
+            return false;
         }
 
         /// <summary>

--- a/Source/Parsek/GameActions/IResourceModule.cs
+++ b/Source/Parsek/GameActions/IResourceModule.cs
@@ -23,6 +23,12 @@ namespace Parsek
         /// for the reservation system) compute it here. Called after Reset and
         /// before the first ProcessAction dispatch.
         /// </summary>
+        /// <returns>
+        /// <c>true</c> only when the module mutated the action list (e.g. injected a
+        /// synthetic action). The engine re-sorts the list after the pre-pass only when
+        /// at least one module returns <c>true</c>; a stable action list skips the
+        /// redundant second sort.
+        /// </returns>
         /// <param name="actions">The action list (already UT-cutoff-filtered by the engine).</param>
         /// <param name="walkNowUT">
         /// The effective "now" of the walk used for deadline-style comparisons.
@@ -35,7 +41,7 @@ namespace Parsek
         /// and the cutoff UT itself — otherwise deadline-expired contracts would leak
         /// past a rewind without firing their synthetic <c>ContractFail</c>.
         /// </param>
-        void PrePass(List<GameAction> actions, double? walkNowUT = null);
+        bool PrePass(List<GameAction> actions, double? walkNowUT = null);
 
         /// <summary>
         /// Processes a single game action during the recalculation walk.

--- a/Source/Parsek/GameActions/MilestonesModule.cs
+++ b/Source/Parsek/GameActions/MilestonesModule.cs
@@ -33,9 +33,10 @@ namespace Parsek
         }
 
         /// <inheritdoc/>
-        public void PrePass(List<GameAction> actions, double? walkNowUT = null)
+        public bool PrePass(List<GameAction> actions, double? walkNowUT = null)
         {
             // No pre-pass needed for milestones; walkNowUT is ignored.
+            return false;
         }
 
         /// <summary>

--- a/Source/Parsek/GameActions/RecalculationEngine.cs
+++ b/Source/Parsek/GameActions/RecalculationEngine.cs
@@ -249,6 +249,19 @@ namespace Parsek
         // ================================================================
 
         /// <summary>
+        /// Test hook: number of times <see cref="SortActions"/> was invoked. Lets the
+        /// conditional-second-sort optimization be asserted (a stable pre-pass performs
+        /// one sort per walk; an injecting pre-pass performs two).
+        /// </summary>
+        internal static int SortActionsCallCountForTesting { get; private set; }
+
+        /// <summary>Test hook: resets <see cref="SortActionsCallCountForTesting"/> to zero.</summary>
+        internal static void ResetSortActionsCallCountForTesting()
+        {
+            SortActionsCallCountForTesting = 0;
+        }
+
+        /// <summary>
         /// Sorts actions by the three-level key defined in design doc 1.7:
         ///   Primary: UT ascending
         ///   Secondary: earning types before spending types
@@ -259,6 +272,8 @@ namespace Parsek
         /// </summary>
         internal static List<GameAction> SortActions(List<GameAction> actions)
         {
+            SortActionsCallCountForTesting++;
+
             if (actions == null || actions.Count == 0)
                 return new List<GameAction>();
 
@@ -400,8 +415,11 @@ namespace Parsek
             // the cutoff itself. Without this, a filtered action list could have its
             // "last UT" land before a deadline, letting deadline-expired contracts
             // slip through the rewind without the synthetic ContractFail.
-            PrePassAllModules(sorted, walkNowUT, firstTier, strategy, secondTier, facilities);
-            sorted = SortActions(sorted);
+            bool prePassMutated = PrePassAllModules(sorted, walkNowUT, firstTier, strategy, secondTier, facilities);
+            if (prePassMutated)
+                sorted = SortActions(sorted);
+            else
+                ParsekLog.Verbose("RecalcEngine", "PrePass stable action list; skipped second sort");
 
             // 3. Walk sorted actions.
             int firstTierDispatches = 0;
@@ -641,7 +659,12 @@ namespace Parsek
             };
         }
 
-        private static void PrePassAllModules(
+        /// <summary>
+        /// Runs the pre-pass over every registered module. Returns <c>true</c> when any
+        /// module mutated the action list (so the caller must re-sort); <c>false</c> when
+        /// the list is left stable and the redundant second sort can be skipped.
+        /// </summary>
+        private static bool PrePassAllModules(
             List<GameAction> sorted,
             double? walkNowUT,
             List<IResourceModule> firstTier,
@@ -649,17 +672,21 @@ namespace Parsek
             List<IResourceModule> secondTier,
             IResourceModule facilities)
         {
+            bool mutated = false;
+
             for (int i = 0; i < firstTier.Count; i++)
-                firstTier[i].PrePass(sorted, walkNowUT);
+                mutated |= firstTier[i].PrePass(sorted, walkNowUT);
 
             if (strategy != null)
-                strategy.PrePass(sorted, walkNowUT);
+                mutated |= strategy.PrePass(sorted, walkNowUT);
 
             for (int i = 0; i < secondTier.Count; i++)
-                secondTier[i].PrePass(sorted, walkNowUT);
+                mutated |= secondTier[i].PrePass(sorted, walkNowUT);
 
             if (facilities != null)
-                facilities.PrePass(sorted, walkNowUT);
+                mutated |= facilities.PrePass(sorted, walkNowUT);
+
+            return mutated;
         }
 
         private static void PostWalkAllModules(

--- a/Source/Parsek/GameActions/ReputationModule.cs
+++ b/Source/Parsek/GameActions/ReputationModule.cs
@@ -49,9 +49,10 @@ namespace Parsek
         }
 
         /// <inheritdoc/>
-        public void PrePass(System.Collections.Generic.List<GameAction> actions, double? walkNowUT = null)
+        public bool PrePass(System.Collections.Generic.List<GameAction> actions, double? walkNowUT = null)
         {
             // No pre-pass needed for reputation; walkNowUT is ignored.
+            return false;
         }
 
         /// <inheritdoc/>

--- a/Source/Parsek/GameActions/RouteModule.cs
+++ b/Source/Parsek/GameActions/RouteModule.cs
@@ -121,11 +121,12 @@ namespace Parsek
         /// numbers need to be computed up-front. Future versions may pre-compute
         /// per-route action counts to size lookup dicts or detect missing routes.
         /// </summary>
-        public void PrePass(List<GameAction> actions, double? walkNowUT = null)
+        public bool PrePass(List<GameAction> actions, double? walkNowUT = null)
         {
             // Intentionally empty. The skeleton's per-route counters are accumulated
             // during ProcessAction; there is no pre-pass aggregate that would change
             // dispatch ordering or affordability.
+            return false;
         }
 
         /// <summary>

--- a/Source/Parsek/GameActions/ScienceModule.cs
+++ b/Source/Parsek/GameActions/ScienceModule.cs
@@ -99,9 +99,10 @@ namespace Parsek
         /// <paramref name="walkNowUT"/> is unused — the engine has already applied any UT
         /// cutoff to <paramref name="actions"/> before PrePass runs.
         /// </remarks>
-        public void PrePass(List<GameAction> actions, double? walkNowUT = null)
+        public bool PrePass(List<GameAction> actions, double? walkNowUT = null)
         {
             ComputeTotalSpendings(actions);
+            return false;
         }
 
         /// <summary>

--- a/Source/Parsek/GameActions/StrategiesModule.cs
+++ b/Source/Parsek/GameActions/StrategiesModule.cs
@@ -64,9 +64,10 @@ namespace Parsek
         }
 
         /// <inheritdoc/>
-        public void PrePass(List<GameAction> actions, double? walkNowUT = null)
+        public bool PrePass(List<GameAction> actions, double? walkNowUT = null)
         {
             // No pre-pass needed for strategies; walkNowUT is ignored.
+            return false;
         }
 
         /// <summary>

--- a/Source/Parsek/KerbalsModule.cs
+++ b/Source/Parsek/KerbalsModule.cs
@@ -162,12 +162,12 @@ namespace Parsek
         /// This is necessary because loop/disabled/chain status is mutable (users can
         /// toggle at runtime) and is not encoded in GameAction fields.
         /// </summary>
-        public void PrePass(List<GameAction> actions, double? walkNowUT = null)
+        public bool PrePass(List<GameAction> actions, double? walkNowUT = null)
         {
             // walkNowUT: unused — the kerbals module builds its recording-metadata
             // cache from RecordingStore, not from action UTs.
             var recordings = RecordingStore.CommittedRecordings;
-            if (recordings == null) return;
+            if (recordings == null) return false;
 
             int examined = 0;
             int nullRecordings = 0;
@@ -223,6 +223,9 @@ namespace Parsek
                     rawCrewRecordings,
                     rawCrewMembers,
                     loopingChainIds.Count));
+
+            // The kerbals module never mutates the action list, so no re-sort is needed.
+            return false;
         }
 
         /// <summary>


### PR DESCRIPTION
Salvaged from the abandoned `docs/recalc-perf-plan` branch (Item 1 of the recalc pipeline performance plan; the plan doc itself is preserved in a companion PR). Two read-only deep-dive agents verified the optimization still applies to current `main` (LOW risk) and that the fuzzer/tests port; a third agent applied the recipe.

## What

The recalculation walk always re-sorted the action list after the module pre-pass, but only `ContractsModule` ever mutates it (it injects a synthetic `ContractFail` for a deadline that expired inside the walk window). `IResourceModule.PrePass` now returns whether the module mutated the list, and `RecalculationEngine.RunWalk` re-sorts only when a module reports a change, skipping a full `OrderBy/ThenBy/ThenBy` allocation + sort on every recalc in the common (no-injection) case. All nine modules were updated (`ContractsModule` returns `injected > 0`; the eight non-mutating modules return `false`). Accumulation uses non-short-circuiting `|=`, so every module's pre-pass still runs.

**Recalculated career values are unchanged**: this only removes a provably redundant sort.

## Tests

- New `RecalculationFuzzer` acceptance oracle: tens of thousands of randomized recalcs across null / mid / past / pre-start cutoffs, asserting the sort-count decision and result equivalence.
- New engine unit tests for the stable-vs-injecting pre-pass decision and a cutoff-walk allocation bound.
- Rode-along coverage the branch had added: a new `KerbalsModuleTests` file and a `LedgerOrchestrator` reentry regression test (both independent of the optimization; verified to pass on current main).
- Full suite green: **17536 passed, 0 failed, 1 skipped** (the pre-existing unrelated skip).

## Notes

- `GameActionType` gained the route types since the branch forked; the fuzzer's locked enum count was bumped 23 -> 30 and its `CreateAction` covers the seven route types.
- Reviewed the full diff before opening: interface + engine + all nine modules are consistent; only `ContractsModule` signals mutation.
