### PR TITLE
Automated testing initiative: plan, scenario catalog, and starter module design docs

### DIFF
--- a/docs/dev/automated-testing-plan.md
+++ b/docs/dev/automated-testing-plan.md
@@ -1,0 +1,544 @@
+# Parsek Automated Testing Plan (v2)
+
+Status: RATIFIED v2 (2026-07-11). v1 was reviewed by a clean-context
+adversarial pass; v2 integrates the review fixes, the scenario mining
+(repo design docs + community resources), the synthetic-recordings
+integration, and the Ledger Accuracy Campaign. Companion file:
+`automated-testing-scenario-catalog.md` (dimension registry D1-D18,
+blocks B1-B10, scenario ladder, regression list R1-R26, F-series fault
+scenarios, fixtures).
+
+## 0. Goal and end state
+
+Replace most manual playtesting with an unattended pipeline: scripted
+atomic missions flown on the dev PC while Parsek records, then correctness
+verified from recording files, save files, logs, and in-game canaries -
+including loop playback and, at the top of the ladder, full career
+accuracy. End-state targets:
+
+- Every coverage-dimension value (catalog section 1) exercised by at least
+  one automated scenario; high-risk dimension PAIRS covered by curated
+  combination scenarios; the R1-R26 regression list green on rotation.
+- The Ledger Accuracy Campaign end goal: a brand-new scripted career run
+  (science + funds + reputation) containing supply routes and repeated
+  rewind actions layering new actions onto the timeline, with the ledger
+  proven exact against an independent oracle at every session boundary.
+- A structured coverage ledger so "exhaustive" is measured, not vibes:
+  scenarios declare the dimension values they cover; a report shows
+  covered / uncovered / regression status.
+
+## 1. Current state (audited, corrected)
+
+Four detection layers. Shares of historical bugs each could have caught
+are ROUGH ESTIMATES from one pass over the bug archives: unit ~40%,
+file analysis ~10%, in-game ~30%, human-watch ~20%. The plan attacks the
+last two.
+
+Verified facts the plan builds on (all spot-checked by the review):
+
+- Headless seams exist and work: `RecordingStore.LoadTrajectorySidecarForTesting`
+  (RecordingStore.cs:6736), `CareerSaveParser` , `LedgerGroundTruthDiff.Compare`,
+  injectable `bodyResolver` (TrajectoryMath.cs:187-209), `TestBodyRegistry`.
+- In-game framework: 158+ tests / 68 categories, batch campaign isolation
+  (TestBatchMarker, .bak capture, crash reconcile, NRE-storm abort),
+  auto-export of `parsek-test-results.txt` (InGameTestRunner.cs:3324).
+  Trigger is interactive-only (Ctrl+Shift+T); no env hooks exist anywhere
+  in Source/Parsek (verified by grep).
+- Orbital ghost drift oracle is wired and asserted in-game
+  (RenderParityOracle, ComputeFaithfulOrbitParity, RenderParityBaselineTest,
+  anomaly lines behind mapRenderTracing). Non-orbital playback has no
+  equivalent oracle.
+- Log pipeline: validate-ksp-log.ps1 drives a real xUnit pass over KSP.log;
+  collect-logs.py snapshots state.
+- CORRECTION (review finding): the DefaultCareer "real fixture corpus" does
+  NOT load under current code. 9/14 .prec are pre-v0-reset TEXT sidecars
+  (hard-rejected at RecordingStore.cs:6733), the binary ones carry stale
+  generations vs CurrentRecordingSchemaGeneration=4, zero .pcrf, format
+  version mismatches. It serves byte-copy injection only. Phase 0 therefore
+  REGENERATES the corpus first (section 7).
+- CORRECTION: auto-record on launch / EVA / first-modification are shipped
+  defaults (ParsekSettings.cs:34-42). The automation problem is CONTROL
+  (turning it off for fixture arrangement and playback sessions, starting
+  and committing deliberately), not adding auto-record.
+
+## 2. Automation stack (decided)
+
+Primary: kRPC + MechJeb2 + KRPC.MechJeb driven by one external Python
+orchestrator. Secondary: kOS boot scripts (RAMP / ElWanderer libraries)
+for self-flying craft. Details and sources in catalog section 5 and the
+research report.
+
+- Pin an exact kRPC tag/commit (target 0.5.4; `git fetch --tags` in
+  mods/krpc and verify the TestingTools flag set AT THAT TAG - the local
+  clone is master-2026 and proves only master). TestingTools is NOT in
+  release binaries; the setup script builds it from source against KSP
+  1.12.5 DLLs (TestingTools.csproj exists; budget this step).
+- TestingTools AT v0.5.4 (VERIFIED at the tag, 2026-07-11; see
+  design-autotest-stack-setup.md GT-2) gives exactly these RPCs/properties:
+  CurrentSave, LoadSave, RemoveOtherVessels, SetCircularOrbit, SetOrbit,
+  ClearRotation, ApplyRotation. The `--krpc-auto-load-*` boot flags, Quit(),
+  and SetLanded() do NOT exist at v0.5.4 - they exist ONLY on unreleased
+  master (a single commit past the tag, "RPC Deprecation #926"). So at the
+  pinned release: BOOT is the M-A2 seam LoadGame verb (kRPC RPCs are not
+  available at the main menu), QUIT is the M-A2 seam FlushAndQuit verb
+  (commit-safe; master's Quit() is a bare Application.Quit() that does NOT
+  trigger Parsek scene-exit commit), and landed-start fixtures ride stock
+  Scenario saves or SetOrbit, NOT SetLanded.
+- KRPC.MechJeb version pairing (Genhis 0.7.1 vs darchambault 0.8.1) is
+  resolved at install time in the setup script; pin whichever pairs with
+  the chosen kRPC tag + MechJeb build.
+- Licensing: all four mods GPLv3. RPC use does not infect Parsek. Any
+  Parsek-side kRPC service add-on links both kRPC and Parsek.dll and is
+  clean ONLY because it is never distributed - state that, do not rely on
+  a GPL label. The primary control seam avoids kRPC linkage entirely
+  (section 3, file-drop).
+- KSP cannot run headless; use a real small low-detail window in a
+  DEDICATED cloned automation KSP instance (protects dev saves; pins
+  MAX_PHYSICS_DT, framerate cap, graphics preset, autostrut policy,
+  run-in-background). The harness copies Parsek.dll from bin/Debug and
+  verifies via the UTF-16-grep recipe; guard against a concurrent dev
+  build racing bin/Debug (copy to a staging path first, verify hash).
+
+## 3. Control architecture
+
+### 3.1 The command seam (Phase 1, replaces v1's H4-as-kRPC-service)
+
+`ParsekTestCommands`: a file-drop command channel, env-gated
+(`PARSEK_TEST_COMMANDS=1`), polled by a DDOL addon in the automation
+instance only. Commands are one-line entries in a command file next to the
+save; results append to a response file (both grep-able, crash-tolerant).
+No kRPC linkage, no GPL entanglement, testable in xUnit (pure
+parse/dispatch core).
+
+Command set (grows per phase): SetSetting (e.g. autoRecordOnLaunch=false),
+StartRecording, StopRecording, CommitTree, DiscardTree, RecordingState,
+LoadGame(save,name) (the BOOT CHANNEL: boots the automation instance into a
+save from the main menu, since kRPC RPCs are not available there),
+StartLoopPlayback(recordingId|missionId), StopPlayback, EnterWatchMode,
+InvokeRewind(rpId) + report of the 5-precondition gate, AnswerMergeDialog
+(choice), RunInvariantReport, RunTests(category), MissionMark(label),
+FlushAndQuit (commit-safe quit: force scenario save, then quit).
+
+Additions from the design-doc re-review (these make whole tracks drivable;
+spec them in Phase 1 even if implemented later):
+- KscAction(type, args): stock KSC-side actions kRPC does not expose -
+  tech unlock, facility upgrade, kerbal hire/dismiss, strategy activation.
+  Without this, L1/L2 are undrivable as specced.
+- SealSlot / StashSlot / FlySlot: the D9 MergeState transitions.
+- RouteCommand(create/confirm/pause/resume/link/retarget/cadence): the
+  route lifecycle is dialog- and UI-mediated; Tier 5 needs this.
+- MissionConfig(legTrim/exclude/clone/period): mission shaping (S3.4).
+- TimeJump(targetTip): the relative-state time jump (D18/S4.8).
+- SimulateStockSwitchClick(vesselPid, site=map|ts|ksc): arms the real
+  StockActionIntentMarker and invokes the PATCHED stock handler. kRPC's
+  active_vessel setter bypasses the patched path entirely - without this
+  command, switch-segment scenarios certify the wrong code path and go
+  green while the patch rots.
+- CrashAfterJournalPhase(X): test-only crash injection for merge-journal
+  recovery (F7).
+
+This seam is what makes T9/T12-class scenarios (rewind invoke, merge
+dialog answers) drivable at all - the review found v1 had no control
+surface for them. A kRPC ParsekTestService remains an OPTIONAL later
+convenience; every capability lands in the file seam first. Because the
+roadmap's Gloops extraction will relocate engine files and split
+assemblies, the seam and the analyzer pin against PUBLIC TEST APIs, never
+file/line internals.
+
+### 3.2 In-game hooks (all env-gated, inert in normal play)
+
+- H1 Auto-run batch: `PARSEK_AUTORUN_TESTS=<all|categories>` in
+  TestRunnerShortcut (already DDOL) after scene settle.
+- H2 Exit after tests: `PARSEK_AUTORUN_EXIT=1` after ExportResultsFile.
+- H3 Stable markers: `[Parsek][Info][TestRunner] BATCH_COMPLETE total=N
+  passed=N failed=N skipped=N` + MissionMark lines for orchestration.
+- H4 = the command seam above (Phase 1, not Phase 3).
+- H5 In-game RecordingInvariants category: same invariant set as the
+  offline analyzer, walked against live RecordingStore.
+
+### 3.3 Recording lifecycle policy (resolves the v1 ordering contradiction)
+
+Session-start sequence: boot the instance -> seam LoadGame into the injected
+save (the boot channel; there are no TestingTools boot flags at the pinned
+v0.5.4 release) -> SetSetting pins (auto-record OFF, tracing flags as the
+scenario needs) -> fixture arrangement. Missions that test recording start it
+explicitly (StartRecording) and commit deliberately: CommitTree via the seam,
+or scene-exit commit by kRPC scene change to Space Center, THEN FlushAndQuit.
+Fixture arrangement (SetOrbit teleports, RemoveOtherVessels) always happens
+with recording off - a teleport recorded as a trajectory is a corrupted
+fixture, not a test. Scenarios that specifically test auto-record behavior
+(D1 values) re-enable it as their first step.
+
+## 4. Coverage model (how "exhaustive" stays structured)
+
+The combinatorial space (initial state x vehicle x actions x destination x
+Parsek features x career mode x warp x scene) is far too large to
+enumerate. Structure:
+
+1. **Dimension registry** (catalog section 1, D1-D18; D18 = ghost chains /
+   paradox prevention, added by the design-doc re-review which found the
+   mod's headline promise had zero automated observers; D15 UI is out of
+   scope except the TimelineBuilder pure projection) is the single source
+   of truth for what exists to cover.
+2. **Scenario specs**: every scenario is a declarative file (YAML) in
+   `harness/scenarios/`: id, tier, fixture (template save + craft +
+   injected recordings), mission script ref, dimension values covered,
+   expectations manifest, runtime budget, retry policy.
+   The manifest vocabulary must express the designs' edge policies, not
+   just counts (re-review must-fix). Schema blocks:
+   - recordings: count, tree shape, section frame kinds, event kinds,
+     resource deltas with tolerances;
+   - perRecording: terminalState, endUT range (incl. stock-deletion-UT
+     cap), predictedTail flag, mergeState;
+   - rewind: supersedeCount, tombstoneCount, rpState (incl. reaper);
+   - loop: LoopStartUT/EndUT, first-play floor;
+   - route: hold-reason strings;
+   - world: vesselPid -> resource totals and roster states, verified by a
+     save-file world-diff verifier (CareerSaveParser extension - it
+     already parses per-vessel resource totals);
+   - logContracts: required decision/amber lines. The designs define
+     correctness as logged decisions plus fail-closed ambers ("observable
+     from logs alone" is a named principle in the missions, rewind, and
+     finalization docs) - hold reasons, amber fail-closed states,
+     chain-walker decisions, and cache-application summaries are
+     assertable TODAY as log contracts with zero new seams; route
+     assertions there before building heavier machinery.
+3. **Coverage ledger**: a generated report (harness tool) mapping registry
+   values -> scenarios covering them -> last green run. Uncovered values
+   are the visible backlog. This is how we stay structured instead of
+   drowning in combinations.
+4. **Combination strategy**: (a) each-value-once via the cheapest tier
+   that reaches it (B-blocks first); (b) curated high-risk PAIR list
+   (e.g. relative-frame x high-warp, loop x SOI transition, rewind x
+   routes, discard x contracts, cold-load x every module) driven by the
+   bug archives - each pair gets a dedicated scenario; (c) the regression
+   list R1-R26 pins historically bug-producing points regardless of pair
+   logic; (d) the L-track (section 6) runs its own action-set
+   combinatorics for the ledger, where enumeration IS tractable
+   (9 modules x 3 career modes x action sets).
+5. **Growth rule**: a new Parsek feature adds its dimension values to the
+   registry in the same PR; the coverage report immediately shows the gap.
+
+## 5. Scenario program
+
+The ladder (catalog sections 2-3): B1-B10 atomic blocks first, then tiers
+0-5, then torture tests (Apollo-style compact double-dock, one Jool-5 leg,
+Kessler swarm of satellites for simultaneous-ghost stress). Autopilot
+feasibility per archetype and known failure modes are cataloged; Tier 0-3
+is all TRIVIAL/SCRIPTED via kRPC.MechJeb; rover/SSTO/EVA-jetpack/Eve/ISRU
+are deferred (HARD, hand-built autopilots).
+
+Stock Scenario saves (Space Station 1, Mun Orbit, Powered Landing,
+ARM_Asteroid1/2, Dynawing Final Approach, EVA in Kerbin Orbit) are
+first-class fixtures: they isolate recorder-critical maneuvers with zero
+ramp-up flying and ship version-matched with KSP.
+
+Multi-session orchestration (catalog section 6) is a first-class harness
+capability from Phase 3 on: fly-commit-restart-observe cycles are the ONLY
+way to reach re-fly merges, routes, synodic re-aim cadence, and loop
+self-overlap.
+
+## 6. Ledger Accuracy Campaign (L-track)
+
+Dedicated track, runs alongside the mission tiers, because the ledger has
+what nothing else has: a computable independent oracle. Every stock career
+total (funds, science, rep, contract states, tech, facilities, roster) can
+be recomputed from the action history and diffed against the ledger's
+ERS/ELS output AND the raw persistent.sfs (CareerSaveParser +
+LedgerGroundTruthDiff already implement the diff; the harness supplies
+generated action histories and the oracle bookkeeping).
+
+Spine: every mission and L-script emits a machine-readable ACTION MANIFEST
+(what was earned / spent / reserved / killed, at what UT). The oracle
+computes expected state from accumulated manifests; any nonzero diff at
+any checkpoint is a caught bug localized to a UT window. Career-mode axis:
+every L-level runs in Career, Science, and Sandbox (module activation
+differs).
+
+Two oracle-correctness rules (re-review must-fixes - these are the two
+ways the L-track could produce confidently wrong verdicts):
+- INDEPENDENCE OF AMOUNTS: manifests capture stock-emitted reward/cost
+  magnitudes AT EVENT TIME (GameEvents callbacks, stock log lines,
+  pre-recalc snapshots of the stock currency singletons) - never by
+  calling Parsek's recalculation code, which would make L5 circular
+  (game-actions design 15.6 warns exactly this). Documented exception:
+  the reputation curve is asserted via SetReputation semantics (15.1).
+- RATIFIED-RESIDUAL CARVE-OUT: on a plain (non-rewind) discard, route
+  funds and physical route cargo persist BY DESIGN (logistics 10.6,
+  maintainer-ratified, [Rec-3 residual] diagnostic). L3's "discard rolls
+  back exactly the flight's effects" whitelists free-standing route rows
+  on non-rewind discard and asserts the residual diagnostic line instead.
+  Generally: rollback oracles consult ratified-behavior carve-outs before
+  declaring drift.
+
+- L0: per-module xUnit floor (largely exists) + ground-truth diff wired
+  into EVERY harness run as a standard verifier.
+- L1: single-module action scripts, stock actions only (complete contract,
+  research node, upgrade facility, hire/dismiss, strategy, milestone,
+  EVA science) -> snapshot -> zero drift. Automated BUG-A/BUG-F passive
+  safety (R1/R2). Includes warp, scene changes, save/load, cold restart.
+- L2: cross-module interactions (contract completion touches funds + rep +
+  science; strategy currency conversion; milestone-fed rewards; facility
+  spend + refund windows).
+- L3: actions x recording lifecycle: earn during recorded flight; commit
+  vs discard vs auto-merge; discard rolls back exactly the flight's
+  effects (R5); epoch isolation after revert.
+- L4: actions x rewind/re-fly: reservations across rewinds, tombstones
+  (kerbal death + bundled rep), supersede flips, recalc-from-UT=0 with
+  many actions at distinct UTs; then TIMELINE LAYERING: act, rewind to
+  mid-timeline, re-fly divergent branch, layer new actions, repeat K
+  times, verifying after each layer. Layering is save manipulation plus
+  short flights - cheap to automate, and it is where the combinatorial
+  depth lives.
+- L5: the grand oracle run (= S5.7): fresh career from zero, scripted
+  multi-mission progression with supply routes dispatching across warp
+  cycles, repeated rewinds interleaved, oracle diff at every session
+  boundary. This is the end-goal scenario: if L5 stays green, the ledger
+  is exact under everything we know how to throw at it.
+
+## 7. Offline Recording Analyzer (Phase 0) - corrected
+
+xUnit suite + thin CLI, input = any save directory. Invariants (corrected
+per review):
+
+1. UT monotonicity per section and per flat Points list.
+2. NO DOUBLE-COVER of a UT span by sections. (NOT "no gaps": BG on-rails
+   spans legitimately emit no TrackSections, and
+   TrackSection.boundaryDiscontinuityMeters models legitimate seam
+   discontinuities. Gaps are allowed where orbit segments cover the span;
+   uncovered-by-anything spans are flagged WARN, not FAIL, initially.)
+3. v6 RELATIVE contract: out-of-range lat/lon values only in RELATIVE
+   sections and only with anchorRecordingId present; ABSOLUTE sections
+   with out-of-range values WARN until KSP longitude normalization
+   behavior is cited, then FAIL (re-review: avoid false positives).
+4. Part-event PIDs resolve against the paired snapshot (100000 + idx*1111).
+5. Schema gate: every sidecar passes IsRecordingSchemaCompatible; the
+   analyzer inventories and reports reasons.
+6. Resource manifests: consistent WHERE PRESENT (optional for Gloops /
+   showcase ghosts - presence rules encoded per recording kind).
+7. Tree topology: all parent/branch/chain/anchor/supersede/tombstone links
+   resolve, no cycles. Chain-index contiguity is scoped PER
+   (ChainId, ChainBranch) - ChainBranch > 0 marks parallel ghost-only
+   continuations (flight-recorder 9A.4) - with a supersede-boundary
+   exemption for HEAD/TIP splits (verify against RecordingOptimizer's
+   supersede guard before shipping).
+7b. Annotation sidecars (.pann) consistent with their .prec (staleness
+   check, rendering design 17.3.1).
+8. Ledger: internal consistency, ERS/ELS computable, ground-truth diff vs
+   the save's career totals.
+9. RewindPoint .sfs parse + RecordingPaths ID validation.
+10. Codec round-trips at the CODEC seams (RecordingTreeRecordCodec,
+    RecordingManifestCodec, sidecar codecs) - NOT at ScenarioModule level
+    (not xUnit-drivable; known constraint).
+
+Every invariant cites its enforcing/defining code in the test source
+before implementation, so wrong contracts die in review, not as false
+alarms.
+
+**Fixture prerequisite (review must-fix #1):** regenerate the real-file
+corpus at current schema. Sources: (a) synthetic families via
+RecordingBuilder/ScenarioWriter at current generation; (b) one scripted
+in-game session (or early harness smoke runs) producing genuinely-real
+files; (c) thereafter, FIXTURE HARVESTING - curated recordings from every
+green harness run get promoted into the corpus. Versioning policy: each
+fixture set carries its schema generation stamp; a generation bump flags
+all stale fixtures and the regeneration script re-produces them; the
+analyzer refuses mismatched fixtures loudly. HARVESTED fixtures cannot be
+regenerated by script (no-migration policy): the coverage ledger tracks
+fixture provenance (synthetic vs harvested), and a generation bump emits a
+re-harvest queue - scenarios whose green runs must re-donate fixtures
+before the invariants they alone backed count as covered again.
+
+## 8. Synthetic recordings integration
+
+The existing synthetic system is a pillar, not a parallel world:
+
+1. Same analyzer, three data sources: builder-synthetic, mission-flown,
+   and harvested fixtures all pass through the identical invariant suite.
+   Builders that emit invariant-violating data get caught; analyzer rules
+   that are wrong get exposed by known-good-by-construction builder output.
+2. Injection is the cheap playback path: InjectAllRecordings +
+   inject-recordings.ps1 seed playback-observation sessions (loop canaries,
+   parity baselines, map render) with zero flying. Flown missions are
+   reserved for what synthesis cannot produce: real physics seams, real
+   SOI numerics, real ledger interactions.
+3. Injected base states unlock expensive scenario prerequisites: a tree
+   with a Crashed sibling + RP for re-fly scenarios; a committed dock-run
+   tree for route creation; a Jool-5-shaped tree for multi-moon holds.
+   New builder presets to add: Crashed-sibling tree, route-candidate tree,
+   multi-moon tree.
+4. Differential contract checks, INVARIANT-LEVEL ONLY (demoted per
+   re-review): synthetic recordings are approximations (identity
+   rotations, hand-placed points); the check is shared invariant
+   compliance between synthetic and flown analogs, never value equality -
+   anything stronger produces permanent noise.
+5. The generators become the fixture-regeneration engine for section 7's
+   versioning policy.
+
+## 9. Verification stack (every run)
+
+1. Mission validity gate (kRPC telemetry): mission failed to fly =>
+   verdict INVALID (autopilot flake), not Parsek failure. Retry once;
+   two invalids => quarantine entry.
+2. Offline Recording Analyzer over the produced save.
+3. Log validation + LogContract rules. KILLED-RUN VERDICT: a timeout-kill
+   produces a log that legitimately ends mid-session; the validator gets a
+   killed-run mode suppressing marker-pairing rules (review must-fix).
+4. parsek-test-results.txt: zero failures in auto-run categories.
+5. Anomaly sweep: zero parity-drift / icon-jump / line-blink lines during
+   playback sessions (documented bounded exceptions).
+6. Expectations manifest from the scenario spec (tolerances, never golden
+   trajectories).
+7. Ledger oracle diff (L-track verifier, on every run that has actions).
+8. collect-logs.py snapshot on any failure.
+
+## 10. Operational spine
+
+- **Cadence tiers**: per-PR = existing dotnet test + Phase 0 analyzer on
+  fixtures (minutes). Daily = B1-B3 + L1 + one playback session
+  (~30-45 min). Nightly = full B-set + active tier scenarios + regression
+  rotation slice (budget 3-6 h; KSP boot alone is 1.5-4 min per process,
+  ~15 boots/night). Weekly = torture tests + full R-list + L4/L5 as they
+  come online.
+- **Budgets**: every scenario spec declares a wall-clock budget; the
+  orchestrator timeout enforces it (timeout => kill => killed-run verdict,
+  never hang). Real-time planning numbers per archetype are in the catalog
+  (LKO 6-10 min, Mun round trip 25-45 min, docking 15-30 min); harness
+  records actuals from day one.
+- **Flake policy**: retry-once-then-invalid for autopilot stages; a
+  persistent flake ledger (scenario id, stage, rate); >20% flake rate over
+  a week => scenario quarantined and flagged for redesign (smaller craft,
+  more RCS, different autopilot) - MechJeb docking on heavy craft is the
+  known worst offender.
+- **Triage**: every red run auto-collects (collect-logs.py label =
+  scenario id); verdict taxonomy INVALID / PARSEK-FAIL / KILLED / FLAKE /
+  EXPECTED-FAIL keeps nightly red actionable. EXPECTED-FAIL (quarantined
+  by known bug) is keyed to todo-doc bug IDs so scenarios targeting
+  in-flux subsystems (re-aim: S3.3/S3.5, R10-R12) can land early without
+  poisoning triage, and auto-promote to live when the bug ID closes.
+- **Instance profiles**: TWO pinned automation instances (re-review fix -
+  the minimal-mods policy contradicted D17 coverage): stock-minimal
+  (default; kRPC + MechJeb + Parsek only) and modded-compat (adds
+  Waterfall + SWE, ReStock/+, BetterTimeWarp, PersistentRotation).
+  D17 scenarios and R25/R26 run only on modded-compat; NRE-storm detector
+  scoped per profile.
+- **Runner**: Windows scheduled task in an interactive session (KSP needs
+  a GPU + interactive desktop); the dev PC stays usable because runs are
+  scheduled off-hours. Results land in results/ + a one-line summary file
+  the next interactive session (or a chat session) can read.
+
+## 11. Phased roadmap
+
+- **Phase 0 (no KSP, no new mods)**: fixture-corpus regeneration +
+  versioning policy; offline Recording Analyzer with corrected invariants;
+  wire ground-truth diff as a standard verifier; non-orbital parity oracle
+  headless half. Exit criterion for the oracle (re-review must-fix): it
+  resolves TrackSection.referenceFrame per UT and dispatches through the
+  PRODUCTION resolvers (TryResolveRelativeWorldPosition, body-fixed
+  primary rules, authored-coverage spans only) - a naive flat-Points
+  reader would itself commit the documented RELATIVE-misread bug and
+  false-alarm on every parent-anchored debris recording. Independent of
+  everything else; start immediately.
+- **Phase 1 (Parsek hooks)**: command seam (3.1) with the starter command
+  set (incl. LoadGame, the boot channel); H1-H3; H5. First fully unattended
+  KSP-open cycle: boot, seam LoadGame into the injected save, auto-run batch,
+  exit, analyze.
+- **Phase 2 (stack install + smoke)**: automation instance; pin + build
+  kRPC tag / TestingTools / MechJeb / KRPC.MechJeb via setup script;
+  harness/run.py + B1 + B2 smoke end-to-end including deliberate
+  commit-then-quit; scenario spec format + coverage ledger tool.
+- **Phase 3 (breadth)**: B3-B8; L1-L2 (requires KscAction seam commands);
+  stock-Scenario fixtures; playback sessions (loop canaries at multiple
+  warp rates); fixture harvesting; multi-session orchestration primitive;
+  S1.5 rewind loop; F-series fault-injection family (boot cycles only -
+  highest severity-per-minute in the plan).
+- **Phase 4 (depth)**: B9-B10; L3-L4 (timeline layering); T4 tier
+  (re-fly, cross-tree, station) including S4.7 chain-rewind paradox
+  scenario and S4.8 time jump (D18); non-orbital parity oracle in-game
+  wiring; regression rotation R1-R26.
+- **Phase 5 (end goal)**: Tier 5 scenarios; routes end-to-end; L5 grand
+  oracle career run; torture tests; nightly/weekly cadence fully armed.
+
+Each phase lands via the normal worktree -> branch -> PR flow. Phase exit
+criteria: the coverage ledger shows the phase's target dimension values
+green for 3 consecutive scheduled runs.
+
+## 11b. Implementation process (modular, per development-workflow.md)
+
+This plan is the STRATEGY document; it is deliberately not a design doc.
+Implementation follows docs/dev/development-workflow.md per MODULE:
+
+- Steps 1-2 (vision + gameplay scenarios) are DONE for the initiative:
+  the vision statements and the scenario catalog are those artifacts.
+- Step 3: each module below gets its own design doc in the house format
+  (Problem / Terminology / Mental Model / Data Model / Behavior /
+  Edge Cases / What Doesn't Change / Diagnostic Logging / Test Plan with
+  "what makes it fail" justifications) before any code. Modules touching
+  serialization (M-A2 command file format, M-A5 fixture stamps, M-B2
+  manifest schema) are "new data that persists" - full workflow, no
+  shortcuts.
+- Step 4: per module, Explore + Plan agents produce the ephemeral task
+  breakdown (one agent session / 1-3 files / clear done condition per
+  task, TaskCreate + blockedBy ordering); clean-context implement ->
+  clean-context review -> clean-context fix. Plans are consumed, not
+  stored; the design doc and task list are the durable artifacts.
+- Step 5: land via PR (per current CLAUDE.md: PR-based landing, no local
+  merges into the main checkout; KSP deploy is intentional-only).
+
+Module decomposition (buildable units, each = one design doc + one
+plan/build/review cycle; phase mapping in parentheses):
+
+| Module | Contents | Depends on |
+|---|---|---|
+| M-A1 Offline Recording Analyzer | invariant framework, per-invariant rules, CLI wrapper (Ph 0) | - |
+| M-A2 Command seam | ParsekTestCommands file format, poll addon, dispatch core, response protocol (Ph 1) | - |
+| M-A3 Autorun hooks | H1-H3, H5 in-game invariant category (Ph 1) | - |
+| M-A4 Fixture regeneration + versioning | corpus rebuild, generation stamps, re-harvest queue, builder presets (Ph 0) | M-A1 |
+| M-A5 Harness core | run.py, KSP lifecycle, scenario spec schema, coverage ledger tool (Ph 2) | M-A2, M-A3 |
+| M-A6 Stack setup script | pin+build kRPC/TestingTools/MJ/KRPC.MechJeb, automation instance provisioning (Ph 2) | - |
+| M-B1 Mission library core | B1-B8 mission modules + stock-Scenario fixtures (Ph 2-3) | M-A5, M-A6 |
+| M-B2 Action manifest + ledger oracle | manifest schema, stock-amount capture, world-diff verifier (Ph 3) | M-A5 |
+| M-B3 L1-L2 ledger scripts | KscAction commands + per-module action scripts x 3 career modes (Ph 3) | M-A2, M-B2 |
+| M-B4 F-series fault injection | fault fixtures + CrashAfterJournalPhase + verdicts (Ph 3) | M-A1, M-A3 |
+| M-B5 Playback sessions | injection-seeded loop/parity sessions, anomaly sweep verifier (Ph 3) | M-A3, M-A5 |
+| M-C1 Multi-session orchestration | fly-commit-restart-observe primitive (Ph 3-4) | M-A5 |
+| M-C2 Rewind/re-fly + chain scenarios | S1.5, S4.7, S4.8, B9, TimeJump + rewind seam commands (Ph 4) | M-A2, M-C1 |
+| M-C3 L3-L4 + timeline layering | (Ph 4) | M-B3, M-C2 |
+| M-C4 Non-orbital parity oracle | headless half then in-game wiring (Ph 0 + 4) | M-A1 |
+| M-D1 Routes + Tier 5 + L5 grand oracle | (Ph 5) | M-C1..C3 |
+
+Independent start lanes: {M-A1, M-A2, M-A3, M-A6} have no dependencies
+and can begin in parallel worktrees immediately after ratification.
+
+## 12. Risks and open questions
+
+- (CLOSED 2026-07-11) kRPC 0.5.4-at-tag flag set: VERIFIED at the tag. The
+  `--krpc-auto-load-*` flags, Quit(), and SetLanded() are confirmed ABSENT at
+  v0.5.4 (present only on unreleased master); see
+  design-autotest-stack-setup.md GT-2/GT-3. Boot now goes through the M-A2
+  seam LoadGame verb, quit through FlushAndQuit. KRPC.MechJeb pairing
+  (genhis 0.7.1 for kRPC 0.5.4) resolved at install.
+- Residual risk: no SetLanded at the pin. Landed-start scenarios ride stock
+  Scenario fixtures (or SetOrbit) until a seam equivalent is justified; a
+  seam-side landed-placement verb is deferred, not planned, unless a scenario
+  demands a landing pose no stock fixture provides.
+- MechJeb landing/docking flakiness bounds how far TRIVIAL automation
+  carries; budgeted by the flake policy, may force kOS RAMP for some
+  archetypes.
+- Physics nondeterminism bounds assertion tightness; tolerances are per-
+  scenario and tuned from actuals (InGameFixtureMath float-grid approach).
+- Long-horizon scenarios (synodic re-aim cadence, inter-body routes) cost
+  real wall-clock even at max rails warp; may need TestingTools SetOrbit +
+  UT-jump orchestration rather than honest warping - validate that UT
+  jumps do not themselves distort the systems under test.
+- The 40/10/30/20 layer-share numbers are estimates, used only for
+  prioritization, not reporting.
+
+## 13. References
+
+Catalog: `automated-testing-scenario-catalog.md`. Research + audit + review
+reports: produced 2026-07-11 (agent outputs; key claims folded into this
+doc). Local clones: `mods/{krpc,MechJeb2,KOS,KRPC.MechJeb}`. Key external:
+krpc.github.io/krpc (TestingTools README), genhis.github.io/KRPC.MechJeb,
+github.com/xeger/kos-ramp, github.com/ElWanderer/kOS_scripts,
+github.com/KSP-KOS/KSLib (MIT).

--- a/docs/dev/automated-testing-scenario-catalog.md
+++ b/docs/dev/automated-testing-scenario-catalog.md
@@ -1,0 +1,339 @@
+# Parsek Automated Testing - Scenario Catalog
+
+Companion to `automated-testing-plan.md` (v2). This file is the coverage
+backbone: the dimension registry, the atomic mission blocks, the tiered
+scenario ladder, the regression replay list, and the fixture sources.
+Sources: repo design docs + bug archives (mined 2026-07-11), community
+mission resources (web survey 2026-07-11). Plain ASCII.
+
+---
+
+## 1. Coverage-dimension registry (D1-D17)
+
+Every scenario is a point in this dimension space. A scenario spec declares
+which dimension values it covers; the coverage report is computed against
+this registry. Full per-value source-file citations live in the mining
+report; headline values only here.
+
+- **D1 Recording lifecycle**: auto-record on launch / on EVA / on
+  first-modification-after-switch (all shipped defaults, ParsekSettings.cs),
+  manual Gloops ghost-only, stop-on-switch (no Stop decision), commit via
+  revert-merge / scene exit / abort, discard (career rollback), auto-merge,
+  sub-2-point drop, switch-segment (Fly / Switch-To) + no-op auto-discard,
+  scene-exit finalization, ballistic extrapolation, finalization cache.
+- **D2 Sampling**: density presets, proximity cadence (BG), structural-event
+  snapshots, threshold+debounce recording.
+- **D3 Reference frames** (per TrackSection): absolute, surface/body-fixed,
+  orbital checkpoint, relative-anchored non-loop (recorded anchor), relative
+  loop (live PID), parent-anchored debris, boundary seam sections.
+- **D4 Environment classification / optimizer**: Atmospheric / ExoPropulsive /
+  ExoBallistic / SurfaceMobile / SurfaceStationary + hysteresis, env/body
+  splits, surface graze suppression, cohesive cross-body coast, tail trim,
+  seed-event split, SplitAtUT.
+- **D5 Tree / chain topology**: single-node tree, undock split, staging debris
+  (TTL, promotion), EVA branch, controlled-decoupled child, dock merge
+  (same tree), cross-tree foreign dock, chain continuation across switch,
+  crash coalescing, BG recording, BG on-rails (NO TrackSections - modeled).
+- **D6 Playback / ghost engine**: basic playback, loop (period modes),
+  self-overlap, overlap expiry / soft caps, zone transitions
+  (2.3km/50km/120km), watch mode + retarget + explosion hold, spawn-at-end
+  (PID dedup), ghost map presence (TS icons, orbit lines, targeting),
+  non-orbital polyline, reentry FX, attitude preservation, SOI-crossing
+  playback, time-jump, CommNet relay, ghost audio.
+- **D7 Part events (28 types)**: decouple/stage/destroy, engine FX
+  (legacy + EFFECTS + Waterfall fallback), RCS, chute 2-phase/cut, shroud,
+  fairing, panels/antennas/radiators, gear, bays, lights, dock/undock,
+  inventory place/remove, flag plant.
+- **D8 Ledger / economy (9 modules + infra)**: Science, Funds, Reputation,
+  Milestones, Kerbals, Facilities, Contracts, Strategies, Route; recalc
+  engine, orchestrator, KspStatePatcher, tombstones, ERS/ELS routing,
+  ground-truth harness (CareerSaveParser + LedgerGroundTruthDiff), action
+  blocking, epoch isolation after revert.
+- **D9 Rewind / re-fly**: Rewind-to-Launch, Fast-Forward, Rewind-to-
+  Separation, re-fly gate (5 preconditions), Unfinished Flights / STASH,
+  Seal / Stash / Fly, supersede relation, tombstones, merge journal (crash
+  recovery), HEAD/TIP origin split, terminal-kind classify, load-time sweep,
+  RP disk usage + reaper, revert-during-re-fly dialog, read-back guard,
+  reconciliation bundle.
+- **D10 Logistics / routes**: candidate detection, KSC origin (funds +
+  recovery credit), docked-depot origin, dock / claw producers, delivery /
+  pickup / mixed direction, resource cargo, inventory cargo (multi-module,
+  stack, volume/mass admission), harvest provenance, multi-stop,
+  multi-origin escrow, round-trip pair, inter-body Nth-window, dispatch
+  cadence, hold reasons, destination-full gate, route map lines,
+  route x rewind interaction.
+- **D11 Missions / periodicity / re-aim**: default mission per tree, leg
+  trim, whole-mission loop on span clock, self-overlap, clone, phase-lock
+  (pad-align, Mun/Minmus window), zero-drift schedule, re-aim Lambert per
+  window, loiter compression, arrival hold, eccentric/inclined targets,
+  heliocentric-parking departure, station phase-lock, multi-moon config
+  hold, land+dock dual constraint, partner journey, S4 arrival re-stitch,
+  fail-closed-to-faithful.
+- **D12 Crew / kerbals**: reservation + auto-hire, stand-ins, seat matching,
+  rescue marker, dead-crew strip, tombstone + rep penalty, missed-EndUT
+  auto-free, crew swap, hire/dismiss patches.
+- **D13 Spawn safety**: proximity offset, bbox block, trajectory walkback,
+  terrain correction, KSC exclusion, situation correction, surface orbit
+  reseed, PID dedup, 3-cycle abandon, terminal-orbit safety, Real Spawn
+  Control.
+- **D14 Environment axes** (multipliers): body (Kerbin..Eeloo, Jool moons),
+  atmosphere, situation, SOI count, warp rate (1x / phys / rails / high),
+  scene (Flight / Map / TS / KSC / Editor), game mode (Career / Science /
+  Sandbox), cold-load UT=0 hazard.
+- **D15 UI surfaces**: OUT OF SCOPE for automation (no layer can observe
+  IMGUI; manual checklists per test-coverage-matrix remain the owner).
+  Exception, the one honest automated cell: TimelineBuilder is a pure
+  headless projection of ERS/ELS (timeline design 3.4) - assert every ELS
+  action maps to exactly one entry, UT-sorted, ineffective rows demoted.
+- **D16 Storage / format**: sidecar set (.prec binary v3 / .craft / .pcrf /
+  .pann annotations - stale-annotation-vs-prec consistency is an analyzer
+  invariant, rendering design 17.3.1), RP quicksaves, Deflate snapshots,
+  .txt mirrors, alias mode, .sfs scenario node, schema gate (format 1 /
+  generation 4), path validation, safe-write, pre-Parsek backup.
+- **D17 Mod compatibility**: Waterfall + SWE pristine fallback, ReStock/+,
+  PersistentRotation, BetterTimeWarp, RemoteTech/CommNet, Making History.
+  Runs ONLY on the modded-compat instance profile (plan section 10).
+- **D18 Ghost chains / paradox prevention** (flight-recorder design 12-14;
+  the mod's headline promise, previously uncovered): committed-interaction
+  vessel claiming, ghost conversion of quicksave vessels after rewind,
+  intermediate spawn suppression along a chain, chain-tip spawn preserving
+  the ORIGINAL vessel PID, cross-tree chain linking, ghost extension past
+  EndUT while blocked, background-event claims (12.9.6), chain terminated
+  by destruction/recovery (12.9.1/12.9.8), chain state re-derived (never
+  persisted - determinism across consecutive loads, 20.2), relative-state
+  time jump observables (14.5-14.7: positions/velocities/attitudes
+  unchanged, orbital epochs shifted by exactly the delta, earlier-tip
+  auto-spawn, jump-then-rewind leaves no persistent state), rewind strip ->
+  ReconcileSpawnStateAfterStrip -> re-spawn cycle (13.11), loop
+  first-run-is-real (exactly one real vessel across N loop cycles and
+  rewind re-crossings, 2.2 principle 9 / 12.7).
+
+The existing 68 in-game test categories are the canary layer over these
+dimensions; the full list is in the mining report and in
+`Source/Parsek/InGameTests/`.
+
+## 2. Atomic mission blocks (B1-B10)
+
+Smallest flights that together touch the most dimensions. Each block lists
+its fixture shortcut (synthetic recording or stock Scenario save).
+
+| Block | Mission | Dimensions | Fixture shortcut |
+|---|---|---|---|
+| B1 | Pad hop: launch, hop, land 2km, revert-merge | D1,D2,D4(atmo),D6,D7(SRB+chute),D13 | Flea Flight synthetic #3 |
+| B2 | Ascent to LKO, hold attitude, commit | D3(orbital),D6,D13,D14 | Orbit-1 synthetic #6 |
+| B3 | EVA branch: pad craft, EVA, walk, board | D1(EVA),D5(EVA),D12 | PadWalk synthetic #1; stock "EVA in Kerbin Orbit" for orbital variant |
+| B4 | Undock split in orbit, both children live | D5(undock,BG),D6(tree),D9(RP) | Undock tree synthetic #9 |
+| B5 | Stage AB stack: B to orbit, A debris | D5(staging,TTL),D9(RP multi) | - |
+| B6 | Rendezvous + dock + transfer + undock | D5(dock),D7(dock),D10(candidate),D8(manifest) | stock "Space Station 1" scenario save (target pre-exists) |
+| B7 | Mun transfer, land, return | D3,D4(SOI),D14(Mun) | stock "Mun Orbit" + "Powered Landing" saves skip legs |
+| B8 | Loop B7 tree as mission, phase-locked | D6(loop),D11(span,phase) | inject committed B7 tree |
+| B9 | Crash A from B5, rewind, re-fly, merge | D9(full),D8(recalc) | inject tree with Crashed sibling + RP |
+| B10 | Career passive safety: stock actions only, warp, scene change, cold load | D8(all),D14(career),D16 | fresh career save |
+
+B10 requires almost no flying and covers the historically most destructive
+regressions (R1/R2/R4-R7 below).
+
+B8 additional assertion (loop first-run-is-real, D18): after 3 loop cycles
+plus one rewind re-cross of the spawn window, exactly ONE real vessel with
+the recording's spawn PID exists (save parse).
+
+Investment note (from design-doc re-review): the test-coverage matrix
+already rates recording/boundary detection Strong across all modes; the
+destructive bug mass sits in career economy, save integrity, routes x
+rewind, and map render. Marginal flying hours beyond B1-B7 go to B10, the
+L-track, playback sessions, and the F-series - not to more recorder
+breadth.
+
+## 3. Scenario ladder (repo design-doc scenarios x community archetypes)
+
+Tiers 0-5. Repo scenarios (S*) from design docs; community archetypes (A*)
+from the mission-ladder survey with automation-readiness:
+TRIVIAL = one MechJeb/kRPC.MechJeb call; SCRIPTED = public script exists;
+HARD = hand-build; IMPRACTICAL = human needed.
+
+### Tier 0 - pad / trivial (TRIVIAL)
+- S0.1 pad hop + end-spawn ghost (B1); S0.2 pad-walk EVA ghost; S0.3
+  suborbital arc + chute; S0.4 destroyed-near-KSC fallback sphere.
+- A1 hover/hop, A2 suborbital (kRPC tutorial script + craft).
+
+### Tier 1 - orbit, one vessel (TRIVIAL/SCRIPTED)
+- S1.1 ascent to orbit + orbital-attitude spawn; S1.2 island cruise landed
+  spawn; S1.3 close-spawn 250m offset; S1.4 Gloops airshow loop.
+- S1.5 rewind loop (core loop, D18): fly B1, commit, warp past EndUT
+  (vessel spawns), quicksave, rewind via seam, assert vessel stripped,
+  ghost replays, vessel re-spawns at EndUT situation-corrected; crew
+  re-reservation + resource reset against the ledger oracle.
+- A3 LKO (MechJeb ascent), A5 exact-orbit satellite deploy (contract
+  params), A4 orbital EVA (HARD - jetpack control).
+
+### Tier 2 - multi-vessel split, one mission (SCRIPTED)
+- S2.1 undock split two children; S2.2 mid-flight EVA branch; S2.3 staging
+  with recoverable booster; S2.4 destruction-test tree (one child destroyed).
+- A6 rendezvous (MechJeb), A7 docking (TRIVIAL small craft; HARD large),
+  A14 rescue/tourist chain (ElWanderer kOS scripts).
+
+### Tier 3 - loop / mission / single-body SOI (SCRIPTED)
+- S3.1 Mun mission whole-tree loop phase-locked; S3.2 pad-aligned
+  launch+orbit loop; S3.3 Kerbin-Duna re-aim loop (synodic); S3.4 drop-pod
+  fork loop with camera handoff; S3.5 eccentric target re-aim (Eeloo/Moho).
+  NOTE: S3.3/S3.5 (and R10-R12) target the re-aim subsystem which is
+  actively in flux (launch-escape seam failed playtest, cross-SOI kink
+  open, Lambert-reliability branch in progress); they enter the coverage
+  ledger under the expected-fail/quarantined-by-known-bug state keyed to
+  todo-doc bug IDs, so they cannot poison nightly triage.
+- A8 Mun flyby free-return, A9 Mun landing, A10 Minmus landing,
+  A16 Duna round trip.
+
+### Tier 4 - rewind / re-fly / cross-tree / station (mixed)
+- S4.1 re-fly crashed booster (supersede + tombstone); S4.2 re-fly stranded
+  EVA kerbal; S4.3 4-probe constellation deploy + later flies; S4.4 station
+  rendezvous phase-locked loop; S4.5 cross-tree partner-journey loop;
+  S4.6 land+dock dual constraint.
+- S4.7 chain rewind (D18, the paradox-prevention scenario): commit B6
+  (docked to pre-existing station), rewind before its StartUT, assert
+  (i) station despawned + ghosted (log contract + kRPC vessel list),
+  (ii) docking physically impossible during ghost window (no dock events),
+  (iii) at tip UT combined vessel spawns with the ORIGINAL station PID
+  (save parse), (iv) with a second committed docking, intermediate spawn
+  at link 1 suppressed and ghost mesh transitions (12.9.5).
+- S4.8 time jump (D18): 80m rendezvous approach to a ghost (injected chain
+  fixture), TimeJump via seam, assert relative position delta within
+  tolerance, SMA/ecc/inc unchanged, MNA-at-epoch shifted exactly by delta,
+  earlier tips auto-spawned (14.6), jump-then-rewind leaves no state.
+- A13 station assembly (multi-launch dock), A15 asteroid claw (HARD),
+  Apollo-style (compact 2-dock + Mun SOI - best mid-tier torture test).
+
+### Tier 5 - career + routes + layered rewinds (the end goal)
+- S5.1 KSC-station supply route full cycle; S5.2 hub-and-spoke chained
+  routes; S5.3 inter-body Nth-window route; S5.4 multi-stop + round-trip
+  pair; S5.5 Jool-5 multi-moon loop; S5.6 route x rewind interaction;
+  S5.7 grand career oracle run (see L-track in the plan).
+- A19 Jool-5 single leg (flagship many-SOI test), Kessler swarm (N
+  satellites for simultaneous-ghost stress). A18 Eve ascent, A11 rover,
+  A12 SSTO, A17 ISRU: HARD, defer; A20 grand tour: IMPRACTICAL, segment.
+
+## 4. Regression replay list (R1-R26)
+
+Historically bug-producing situations, highest value first. Full citations
+in the mining report; bug sources are todo-and-known-bugs.md + v7 archive.
+
+| # | Scenario | Systems |
+|---|---|---|
+| R1 | Pure-stock career play: science/funds must not drift (BUG-A/B) | D8,D14 |
+| R2 | Cold-load established career: no economy wipe at UT=0 (BUG-F) | D8,D16 |
+| R3 | Stock Revert must not delete unrelated live craft (BUG-H) | D9,D13 |
+| R4 | First atmosphere crossing: no world-record recalc freeze | D8,D4 |
+| R5 | Discard recording: contract/science/milestone earned live survives | D1,D8 |
+| R6 | Scene change: no silent facility-upgrade refund | D8 |
+| R7 | Stock contract re-fire: no N-fold reward bake | D8 |
+| R8 | Loop Mun leg, warp through orbit-raise gap + SOI (warp-reseed-lag) | D6,D14 |
+| R9 | Quickload mid-recording then commit (Limbo tree serialization) | D1,D16,D9 |
+| R10 | Re-aimed heliocentric transfer renders in-plane | D11 |
+| R11 | Re-aim transfer line reaches destination (no arc-clip truncation) | D11 |
+| R12 | Span>synodic re-aim: correct transfer at EVERY relaunch | D11 |
+| R13 | TS Fly loads right vessel with ghost trajectories | D6,D15 |
+| R14 | Route ghost docks recorded station, not 20km copy; no dup ghost | D10,D6 |
+| R15 | Route rewind: funds spent must re-deliver goods | D10,D9 |
+| R16 | Route to full destination holds, no debit-then-drop | D10 |
+| R17 | Multi-module inventory delivery fills beyond first container | D10 |
+| R18 | EVA spawn walkback clears overlapping endpoint | D13,D1 |
+| R19 | Dock/undock: no triple identical-UT structural snapshots | D5,D2 |
+| R20 | Stand-in kerbal not duplicated across live vessels | D12 |
+| R21 | Static GameEvent OnLoad NRE must not wipe recording index | D16 |
+| R22 | OnSave must not hollow a save whose load faulted | D16 |
+| R23 | Committed-restore-clone discard reverts cleanly | D1 |
+| R24 | TS ghost icon must not circle underground on clipped orbit | D6 |
+| R25 | Save-load-into-flight with BTW/Waterfall: no NRE flood | D14,D17 |
+| R26 | Waterfall SWE !EFFECTS{} does not kill ghost plumes | D17,D7 |
+
+The done/ archives hold 300+ resolved bugs; this list is the rotation seed,
+extend as tiers come online.
+
+R13 caveat: kRPC's `active_vessel` setter does NOT pass through the patched
+stock handlers (MapContextMenuOptions.FocusObject.OnSelect /
+SpaceTracking.FlyVessel), so R13 certifies the wrong code path unless the
+command seam's SimulateStockSwitchClick command (arms the real
+StockActionIntentMarker) is used. Do not claim switch-segment coverage
+without it.
+
+## 4b. Fault-injection family (F-series, never-corrupt contract)
+
+Cheapest severe-bug coverage in the catalog: boot cycles only, no flying.
+Sources: flight-recorder design 19.2-19.7, storage safe-write,
+PreParsekBackup, merge journal.
+
+| # | Fault | Assert |
+|---|---|---|
+| F1 | Truncated .prec | recording shown "damaged", no partial parse, zero loss elsewhere, log contract line |
+| F2 | Deleted _vessel.craft | "missing data" state, tree intact |
+| F3 | Wrong-generation sidecar | reject with reason generation-older/newer, rest of save loads |
+| F4 | Cycle-injected tree topology | rejected, no chain-walker hang, no ghosting, no loss |
+| F5 | Kill during safe-write | .tmp recovery on next load, no hollowed file |
+| F6 | First cold-load backup | pre-Parsek sibling save exists and is pristine |
+| F7 | Crash after merge-journal phase X (test command CrashAfterJournalPhase) | RunFinisher rolls back or completes per phase, for every X |
+| F8 | Stale .pann vs regenerated .prec | annotation consistency invariant flags it |
+
+## 5. Fixture sources
+
+### 5.1 Stock Scenario saves (ship with KSP, version-matched, zero flying)
+Space Station 1 (docking target pre-built), Mun Orbit, Mun Rover, Powered
+Landing, Impending Impact, ARM_Asteroid1/2 (claw), Refuel at Minmus,
+Prospecting Eeloo, Exploring Gilly, Jool Aerobrake, EVA in Kerbin Orbit,
+EVA on Duna, Dynawing Re-entry / Final Approach, Transmissions.
+Enumerate live from `KSP/Scenarios/*.sfs`. Highest value: Space Station 1,
+Mun Orbit, Powered Landing, ARM_Asteroid1, Dynawing Final Approach - each
+isolates one recorder-critical maneuver with no ramp-up flight.
+
+### 5.2 Craft files (pin exact files in repo)
+- kRPC tutorial craft (co-designed with their scripts): suborbital +
+  LaunchIntoOrbit.craft - default for Tier 0/1.
+- Bundled stock craft: Kerbal X (LKO/Mun), Kerbal 1/2 (suborbital),
+  Dumpling (satellite), Aeris 4A (SSTO, defer), Acapello + Dynawing
+  (Making History; Apollo-style and shuttle profiles).
+- KerbalX only as last resort; verify stock-parts-only.
+
+### 5.3 Synthetic recordings + injected saves
+The existing `docs/dev/synthetic-recordings.md` library (pad walk, Flea
+Flight, suborbital, destroyed-vessel, Orbit-1, close-spawn, island cruise,
+undock trees #9-11) plus `InjectAllRecordings` remain the zero-flight
+fixture path for playback-facing tests and D9 base states (inject a tree
+with a Crashed sibling + RP for re-fly scenarios).
+
+### 5.4 Autopilot scripts (external, per archetype)
+- kRPC.MechJeb: ascent, maneuver, rendezvous, docking, landing (one call
+  each) - primary for Tiers 0-3.
+- Art Whaley kRPC demos (rendezvous.py, docking), kRPC official tutorials.
+- kOS: RAMP (xeger/kos-ramp, near-turnkey launch/node/rendezvous/dock/land),
+  ElWanderer kOS_scripts (satellite/tourist/rescue boot scripts), KSLib
+  (MIT building blocks).
+
+### 5.5 Known autopilot failure modes (build detection into the harness)
+- MechJeb ascent: warp stutter during coast (noisy velocity), weak on
+  low-TWR/wobbly stacks.
+- MechJeb landing: arms only below altitude threshold, can silently abort
+  or brake late (overshoot); worse with atmosphere.
+- MechJeb docking: reliable only for small RCS-balanced craft - keep test
+  craft small or budget retries.
+- Timewarp entry can shift orbit params in edge cases; guard recorder
+  assertions around warp transitions.
+
+## 6. What simple missions CANNOT reach (needs multi-session orchestration)
+
+- Re-fly merge / supersede / tombstone / journal crash recovery (2+ sessions
+  + quicksave reload, or injected base state).
+- Cross-tree foreign dock / partner journey (two independent launches).
+- Supply routes end-to-end (committed dock run first, then N loop cycles
+  across warp and save/load to observe dispatch, escrow, recovery credit).
+- Multi-stop / multi-origin / round-trip / inter-body routes (multi-window,
+  game-days of UT).
+- Re-aim per-window correctness over many synodic windows.
+- Multi-moon config hold (needs a Jool-5-shaped tree fixture).
+- Loop self-overlap caps (several relaunch cycles under warp).
+- Ledger recalc-from-UT=0 with many actions at distinct UTs.
+- Quickload/rewind against in-progress recording (save-state manipulation).
+- Warp-reseed-lag (scripted high-warp crossing of specific gaps).
+- Cold-load / OnSave fault injection (process restarts).
+
+Harness implication: three fixture tiers - (a) autopilot-flown atomic
+blocks, (b) injected synthetic base states, (c) multi-session orchestration
+scripts (fly-commit-restart-observe).

--- a/docs/dev/design-autotest-autorun-hooks.md
+++ b/docs/dev/design-autotest-autorun-hooks.md
@@ -1,0 +1,756 @@
+# Design: Autorun Hooks (Module M-A3)
+
+Status: DRAFT (2026-07-11). Module M-A3 of the Automated Testing Plan
+(`docs/dev/automated-testing-plan.md`, sections 3.2, 7, 9, 11b). This is the
+per-module design doc the plan's section 11b requires before any code. Sibling
+modules: M-A1 (offline Recording Analyzer, owns the invariant core this doc
+consumes), M-A2 (command seam), M-A5 (harness core / orchestrator).
+
+## Problem
+
+The in-game test framework (`InGameTestRunner`, 158+ tests across 68 categories)
+is the only layer that can exercise ghost visuals, PartLoader resolution, live
+crew roster, CommNet, and the batch campaign-isolation machinery. Today it is
+reachable only by a human pressing Ctrl+Shift+T and clicking Run All / Run
+category (the Run All / Run category buttons in `TestRunnerShortcut.DrawWindow`). An
+unattended nightly pipeline (plan section 10) cannot press that button, cannot
+read the pass/fail outcome without a human eyeballing a table, and cannot make
+KSP exit so the orchestrator can move to the next scenario. The result today is
+that ~30 percent of the historical bug surface (in-game layer, plan section 1)
+stays behind a manual gate.
+
+M-A3 removes that gate with four env-gated hooks so an external orchestrator can:
+boot KSP into a prearranged save, have a test batch run itself once the scene
+settles (H1), read a stable machine-readable completion marker from the log (H3),
+walk the live `RecordingStore` through the same structural invariant core the
+offline analyzer uses (H5), and have KSP quit itself cleanly without corrupting
+the campaign save (H2). Every hook is inert when its env var is unset, so normal
+interactive play and normal `dotnet test` are byte-identical to today.
+
+## Terminology
+
+- Autorun batch: a test batch started by H1 in response to
+  `PARSEK_AUTORUN_TESTS`, as opposed to a human-initiated batch from the
+  Ctrl+Shift+T window. The two use the identical runner entry points; "autorun"
+  names only the trigger.
+- Scene settle: the concrete condition H1 waits for before invoking the runner,
+  so tests do not run against a half-initialized scene. Defined precisely in
+  Behavior (H1).
+- Arming / single-fire: H1 fires the runner at most once per scene-entry. "Arm"
+  = the hook is enabled and has not yet fired for the current scene.
+- BATCH_COMPLETE line: the grep-stable machine-readable log line H3 emits at
+  batch end. Its exact format is a CONTRACT consumed by the orchestrator.
+- Invariant core: M-A1's pure, file-I/O-free `IRecordingInvariant` rule set that
+  runs over an `AnalyzerModel` (materialized `Recording` / `RecordingTree` /
+  `TrackSection` objects plus tombstones / supersede rows / raw ledger). Owned by
+  M-A1; consumed by M-A3's H5, which builds an `AnalyzerModel` from live state
+  (types defined below).
+- Killed-run verdict: the plan's timeout self-defense (section 9 item 3). If a
+  batch hangs, the EXTERNAL orchestrator kills the KSP process; the hooks do not
+  implement their own watchdog. Out of scope for M-A3 (see What Doesn't Change).
+
+## Mental Model
+
+```
+  external orchestrator (M-A5, Python)
+        |
+        | sets env before launch:
+        |   PARSEK_AUTORUN_TESTS=RecordingInvariants,GhostVisual
+        |   PARSEK_AUTORUN_EXIT=1
+        v
+  KSP process boots ---> loads the prearranged save ---> scene settles
+        |                                                     |
+        |                              H1 (TestRunnerShortcut.Update poll):
+        |                              armed? scene settled? crash-reconcile done?
+        |                                                     |
+        |                                                     v
+        |                              runner.RunCategory("RecordingInvariants")
+        |                              (or RunAll if PARSEK_AUTORUN_TESTS=all)
+        |                                                     |
+        |                              RunBatch coroutine (UNCHANGED core):
+        |                                CaptureBatchBaseline -> tests ->
+        |                                teardown restore -> ExportResultsFile
+        |                                                     |
+        |                              H3: emit BATCH_COMPLETE line   <--- H5 category
+        |                              (in the batch-end region,           runs here as
+        |                               after ExportResultsFile)           an ordinary
+        |                                                     |            in-game test
+        |                              H2 (if PARSEK_AUTORUN_EXIT):        that walks the
+        |                                restore already done, export      live store
+        |                                already done -> quit KSP
+        v
+  orchestrator greps log for BATCH_COMPLETE + reads parsek-test-results.txt
+```
+
+Ordering is the whole game for H2. The batch-end region of `RunBatch`
+(`InGameTestRunner.RunBatch`) already runs, in order: NRE-storm
+sampling, `EndBatchExceptionMonitor`, isolation teardown
+(`TeardownDiskOnlyIsolation` / `CleanupBatchFlightBaselineSave`),
+`ClearTestBatchMarker`, then `ExportResultsFile`, then the optional Space Center
+bounce recovery. H2 attaches AT THE END of that chain, after export. A quit that
+fires before the teardown restore would leave `persistent.sfs` holding the
+test-batch mutations (the clean `.bak` never re-applied) and corrupt the
+campaign. So H2 is not "quit when tests finish"; it is "quit as the last step of
+the existing teardown ordering, after restore and after export."
+
+H1, H3, and H5 are additive and independent of that ordering:
+- H1 is a new arm/fire block in `TestRunnerShortcut.Update`, gated on the env var
+  and on scene-settle, that calls the SAME `RunAll` / `RunCategory` the button
+  calls.
+- H3 is one new log line in the batch-end region.
+- H5 is a new in-game test CATEGORY (`RecordingInvariants`), discovered and run
+  by the existing runner like any other category. It is not a hook into runner
+  plumbing at all; it is test content that happens to be what the autorun most
+  wants to run headlessly.
+
+## Data Model
+
+No serialized data. No ConfigNode schema change. No save-file footprint. The
+hooks read process environment variables and in-memory runner state only. This
+is deliberate (see Backward Compatibility): a corrupted or malformed env var can
+never persist into a save.
+
+### Env var surface (the external contract)
+
+```
+PARSEK_AUTORUN_TESTS   value: "all" | "<category>[,<category>...]"
+                       unset/empty  -> H1 inert (no autorun)
+                       "all"        -> runner.RunAll()
+                       "Cat"        -> runner.RunCategory("Cat")
+                       "A,B,C"      -> sequential RunCategory per token
+                                       (see Behavior H1 multi-category)
+                       case-sensitive category match (categories are
+                       Ordinal-compared everywhere in the runner)
+
+PARSEK_AUTORUN_EXIT    value: "1"
+                       "1"          -> H2 armed: quit after teardown+export
+                       anything else/unset -> H2 inert
+```
+
+### H3 line format (the versioned orchestrator contract)
+
+```
+[Parsek][INFO][TestRunner] BATCH_COMPLETE v1 total=<N> passed=<N> failed=<N> skipped=<N> category=<sel> scene=<Scene>
+```
+
+- Prefix `[Parsek][INFO][TestRunner] ` is produced by `ParsekLog.Info`
+  (ParsekLog.cs:461 renders `[Parsek][{level}][{subsystem}] {message}`; the level
+  token is the uppercase `INFO`, not the `Info` casing the plan's section 3.2
+  wrote illustratively).
+- `v1` is the CONTRACT VERSION. Any change to the token set or their meaning
+  bumps this to `v2` and updates the LogContract test (see Test Plan). The
+  orchestrator matches on `BATCH_COMPLETE v1 ` so a future `v2` line does not get
+  silently misparsed by an old orchestrator.
+- `total` = the runner's `considered` count (tests with `Status != NotRun` at
+  batch end, the same quantity the existing "Test run complete" summary logs at
+  InGameTestRunner.cs:1851-1853). `passed`/`failed`/`skipped` = `runner.Passed`
+  / `Failed` / `Skipped`.
+- `category` = the selector that produced this batch: `all`, a single category
+  name, or `multi:<count>` for a multi-category autorun (each constituent
+  category also emits its own line; see H1 multi-category).
+- `scene` = `HighLogic.LoadedScene` at emit time. Multi-scene runs emit one line
+  per batch (per scene), matching the per-scene accumulation in
+  `parsek-test-results.txt`.
+- Values never contain spaces (category names are single tokens; scene is an
+  enum). This keeps the line splittable on whitespace by a trivial grep/awk.
+
+### H5 dependency interface (consumed from M-A1)
+
+M-A1 owns the invariant core. M-A3 does NOT define its own core shape: it
+consumes M-A1's exact types (`AnalyzerModel`, `IRecordingInvariant`, `Finding`,
+`VerdictLevel`) unchanged. H5 constructs an `AnalyzerModel` from live in-game
+state and runs M-A1's `IRecordingInvariant` rule set over it, then maps M-A1's
+`Finding` verdicts to in-game outcomes. There is no `RecordingInvariantCore`,
+no `InvariantViolation`, and no `InvariantSeverity` in this design; those were an
+earlier incompatible sketch and are deleted. Rule ids follow M-A1's format
+(e.g. `INV1-UT-MONOTONIC`) everywhere in this doc.
+
+The in-game model builder (see Behavior H5) supplies each `AnalyzerModel` field
+from live state, walking the store RAW (no `EffectiveState` routing):
+
+```
+new AnalyzerModel {
+    SaveName          = HighLogic.SaveFolder,
+    Recordings        = RecordingStore.CommittedRecordings,   // RAW committed list
+    Trees             = RecordingStore.CommittedTrees,
+    Tombstones        = ParsekScenario.Instance ledger tombstones,
+    SupersedeRelations= ParsekScenario.Instance supersede rows,
+    Ledger            = Ledger.Actions,                        // RAW, unfiltered (INV8 filters internally)
+    CareerSave        = null,                                  // in-game FAIL career-diff is the LedgerGroundTruthHarness seam, not H5
+    LoadFaults        = empty,                                 // nothing parsed from disk here
+    FixtureStamp      = null,                                  // live store is not a stamped fixture corpus
+    BodyResolver      = FlightGlobals.Bodies lookup (name -> CelestialBody),
+}
+```
+
+Verdict mapping (M-A1 `VerdictLevel` -> in-game outcome):
+- `Fail` -> `InGameAssert` failure (the test fails, carrying RuleId + Target +
+  Message).
+- `Warn` -> a `ParsekLog.Warn` line; the test does NOT fail.
+- `Info` -> ignored (inventory / provenance; not surfaced as a test signal).
+- `StaleFixture` -> unreachable in-game (`FixtureStamp` is null, so no rule emits
+  it); if one ever did, it is treated as `Info` (ignored).
+
+This is what makes "same invariant core as the offline analyzer" literally true:
+one rule set, two model builders (M-A1's `SaveDirectoryLoader` offline, H5's
+live-store builder in-game). The load-bearing requirement is only that M-A1's
+rules are pure over `AnalyzerModel` so the in-game builder can feed them a
+live-store-sourced model.
+
+## Behavior
+
+### H1 - Autorun batch trigger
+
+Location: a new arm/fire path in `TestRunnerShortcut`, which is already the DDOL
+`[KSPAddon(Instantly, once=true)]` addon that survives scene transitions
+(the DDOL addon that survives scene transitions). It already polls every frame in
+`Update()` and already owns an `InGameTestRunner runner` field. H1 reuses that
+lifecycle; it does not add a second addon. NOTE: `TestRunnerShortcut` constructs
+the runner LAZILY, only when the Ctrl+Shift+T window is first opened, so under
+autorun (no window ever opened) the `runner` field can be null when H1 wants to
+fire. H1 must therefore instantiate the runner through the SAME lazy factory the
+window-open path uses (not a second construction path) before invoking
+`RunAll` / `RunCategory`, so autorun and interactive runs share one runner
+lifecycle.
+
+Read-once caching: the env var is read once in `Awake` (or first `Update`) into a
+parsed struct `{ enabled, selector, categories[] }`, so a per-frame
+`Environment.GetEnvironmentVariable` is avoided and a mid-process env mutation
+cannot change behavior (env is a launch-time contract).
+
+Arming scene: H1 arms in ANY game scene that the batch selector has eligible
+tests for, because the runner already filters by scene
+(`FilterSceneEligibleBatchCandidates`) and a category like `RecordingInvariants`
+is FLIGHT-scoped while another might be SPACECENTER-scoped. H1 does not itself
+decide "which scene" - it fires in whatever scene KSP settled into, and the
+runner's existing scene-eligibility filter runs the subset that fits. If zero
+tests are eligible for the current scene, the batch runs, marks everything
+scene-skipped, and still emits a BATCH_COMPLETE line (which is correct and
+informative for the orchestrator: "this scene had nothing to run").
+
+Scene-settle definition (concrete): H1 fires only once ALL of these hold on the
+same frame:
+1. `HighLogic.LoadedSceneIsGame` is true and the scene is not `LOADING`.
+2. `HighLogic.CurrentGame != null` and `!string.IsNullOrEmpty(HighLogic.SaveFolder)`
+   (a save is actually loaded - this is the same triple the runner's
+   `ClassifyBatchIsolationMode` inputs on, InGameTestRunner.cs:326-328).
+3. For FLIGHT scenes specifically: `FlightGlobals.ready == true` AND
+   `FlightGlobals.ActiveVessel != null` AND `!FlightGlobals.ActiveVessel.packed`
+   (the vessel is unpacked and physics-live). This mirrors what FLIGHT in-game
+   tests assume; running before unpack races the recorder and PartLoader.
+4. For non-FLIGHT game scenes (SPACECENTER, TRACKSTATION, EDITOR): condition 1+2
+   plus a settle delay (see below). There is no ActiveVessel gate there.
+5. A settle delay of N consecutive qualifying frames has elapsed
+   (`AutorunSettleFrames`, proposed 30 frames ~= 0.5 s at 60 fps) to let stock
+   one-frame-late initialization (camera, UI, ScenarioModule OnLoad) finish. The
+   counter resets to 0 if any condition regresses (e.g. a sub-scene reload).
+6. The crash-reconcile gate is clear (see interaction below).
+
+Single-fire per scene-entry, re-arm per scene: H1 keeps a
+`bool autorunFiredThisScene` flag reset on `GameEvents.onGameSceneLoadRequested`
+(the addon already subscribes to that event, TestRunnerShortcut.cs:68, for input
+lock reset). So:
+- One process that loads straight into FLIGHT and stays there: H1 fires exactly
+  once.
+- A batch that reloads the flight scene as part of isolation teardown (the
+  runner does FLIGHT->FLIGHT reloads): the reset would re-arm H1, which would
+  double-fire. GUARD: H1 also checks `!runner.IsRunning` before firing, and adds
+  a process-level `autorunConsumedForProcess` latch keyed by selector so that
+  once the FULL autorun selector has been consumed, re-entry does not restart it.
+  The intended single-process semantics are "run the selector once, then stop"
+  (the orchestrator restarts KSP for the next scenario). Re-arm-per-scene exists
+  only to support a selector whose categories legitimately span scenes that the
+  orchestrator drives by scripted scene changes; in v1 (see below) that path is
+  scoped out and the process-latch is the operative rule.
+
+Multi-category selector: `PARSEK_AUTORUN_TESTS=A,B` - v1 runs them by issuing
+`RunCategory` per token SEQUENTIALLY, waiting for `!runner.IsRunning` between
+tokens (the runner is single-batch; `RunCategory` early-returns if `isRunning`,
+InGameTestRunner.cs:349). Each token produces its own batch and its own
+BATCH_COMPLETE line, plus one final `category=multi:<count>` summary line
+aggregating the union counts. This keeps each category's campaign isolation
+independent (each `RunCategory` captures + tears down its own baseline).
+
+v1 scope / documented limitation - multi-scene batches: the runner accumulates
+results across scenes in `InGameTestInfo.ResultsByScene` and the export file
+unions them (FormatResultsReport, InGameTestRunner.cs:3358). But a single
+autorun PROCESS settles into ONE scene and H1 fires there. Driving a category
+whose tests span multiple scenes requires scripted scene changes between
+sub-batches, which is the orchestrator's job (M-A5 multi-session orchestration)
+via the command seam (M-A2), NOT H1's. v1 H1 therefore runs
+CURRENT-SCENE-eligible tests of the selector and relies on the orchestrator to
+relaunch/redrive for other scenes. This is stated as a limitation, not a bug:
+BATCH_COMPLETE always reports `scene=`, so the orchestrator knows exactly which
+scene's slice it got.
+
+Interaction with crash-reconcile: if a PRIOR batch in a DIFFERENT process was
+interrupted (KSP killed, hard quit), `ParsekScenario.OnLoad` runs
+`RunTestBatchCrashReconcile`, which reverts `persistent.sfs` from the `.bak`,
+restores the Parsek sidecar dir, and SCHEDULES A DEFERRED REAL in-memory reload
+(TestBatchMarker.cs:10-22). That reload changes `HighLogic.CurrentGame` out from
+under any batch. H1 MUST NOT fire until reconcile has fully completed, or the
+autorun batch would capture its baseline against a half-reverted save. GATE: H1
+checks that no `TestBatchMarker` reconcile is pending.
+
+This gate needs an observable signal that does not exist in source today, so
+M-A3 ADDS one: a NEW internal read-only predicate on `ParsekScenario`
+(`CrashReconcileInProgress`, working name). It does not exist now and must be
+introduced by this module. It is SET when `ParsekScenario.OnLoad` detects a
+recovery-reason marker and dispatches `RunTestBatchCrashReconcile` (which
+schedules the deferred real reload), and CLEARED at the deferred reload's own
+`OnLoad` once reconcile has fully completed. Both transitions log a line
+(`Info` "crash-reconcile in progress: <reason>" on set, `Info` "crash-reconcile
+complete; cleared" on clear) so the log alone shows why H1 held or released.
+Concretely, H1 requires that `ParsekScenario.CrashReconcileInProgress` is false
+AND `ShouldReconcileOnLoad` would now return a non-recovery reason for the live
+marker (the marker is same-process or absent). Until then H1 stays armed and
+keeps waiting; the settle counter does not advance. The predicate is a read-only
+observable flag; it does not change any crash-reconcile behavior, only exposes
+its in-flight state to the settle gate.
+
+### H2 - Exit after tests
+
+Location: the very end of the `RunBatch` batch-end region, AFTER
+`ExportResultsFile()` (`InGameTestRunner.ExportResultsFile`) and AFTER the H3 BATCH_COMPLETE
+emit, gated by the parsed `PARSEK_AUTORUN_EXIT == "1"` and by "this batch was an
+autorun batch" so a human clicking Run All in a process that happens to have the
+env var set does NOT quit under them (see Edge Cases).
+
+wasAutorunBatch handoff mechanism (new runner member): H1 signals the runner
+that the batch it is about to start is an autorun batch by calling a NEW runner
+method `runner.MarkNextBatchAutorun()` IMMEDIATELY before it invokes `RunAll` /
+`RunCategory`. That call sets a pending flag; `RunBatch` LATCHES it into the
+batch at batch start (into a per-batch `bool wasAutorunBatch` read at the
+batch-end region) and CLEARS the pending flag, so the mark applies to exactly the
+next batch and never leaks to a later human-initiated one. A human clicking Run
+All never calls `MarkNextBatchAutorun`, so its batch latches `wasAutorunBatch =
+false` and H2's gate is false. `MarkNextBatchAutorun` plus the per-batch
+`wasAutorunBatch` latch are new runner members added by this module.
+
+Ordering contract (the core edge-case cluster): the batch-end region already
+performs, in this order, the campaign-safety teardown:
+1. NRE-storm batch-end corruption sampling.
+2. `EndBatchExceptionMonitor` + `FlightCameraReloadPin.Disarm`.
+3. Isolation teardown: `TeardownDiskOnlyIsolation` (DiskOnly) or
+   `CleanupBatchFlightBaselineSave` (InMemoryAndDisk) - THIS is the step that
+   reverts `persistent.sfs` from the clean `.bak` and sweeps the slot/snapshot.
+4. `ClearTestBatchMarker`.
+5. `ExportResultsFile`.
+
+H2 runs as step 7 (step 6 is H3). It MUST NOT run before step 3. The quit is
+therefore placed textually after `ExportResultsFile` in the always-runs
+batch-end region, with no `yield` between the teardown and the quit so the
+decision cannot go stale (the same discipline the existing Space Center bounce
+uses, InGameTestRunner.cs:1776-1779).
+
+Quit precedence over Space Center bounce: if the batch corrupted the flight
+scene (NRE storm) the existing code arms a one-shot Space Center bounce to leave
+the OPERATOR in a usable scene (InGameTestRunner.cs:1866-1867). Under autorun
+there is no operator and the process is about to die, so H2 takes precedence:
+when H2 is armed, it SKIPS the Space Center bounce and quits. The disk save is
+already reverted by step 3 regardless, so skipping the bounce does not risk the
+campaign; it only skips an in-process scene recovery that autorun does not need.
+
+Quit mechanism: H2 calls a clean-quit path (`HighLogic.QuitGame()` if it triggers
+the stock main-menu-then-exit flow cleanly, else `Application.Quit()`). Because
+all Parsek-side campaign safety already ran in steps 1-5, the quit does not need
+to trigger any Parsek scene-exit commit (the plan notes TestingTools' `Quit()`
+is a bare `Application.Quit()` and does NOT commit; that is fine HERE because
+autorun sessions pin auto-record OFF and commit deliberately via the command
+seam BEFORE the batch, plan section 3.3). H2 emits a log line immediately before
+quitting so the last durable log record is unambiguous.
+
+### H3 - Stable machine-readable markers
+
+Location: the batch-end region, emitted once per batch, after
+`ExportResultsFile` and before H2. Reuses the counts the runner already computed
+(`Passed`/`Failed`/`Skipped`/`considered`). Emits via `ParsekLog.Info` so it
+lands in KSP.log with the standard structured prefix. Format is the versioned
+contract from Data Model. For a multi-category autorun, each constituent
+`RunCategory` batch emits its own line and a final aggregate line is emitted by
+H1's multi-category driver.
+
+The line COMPLEMENTS `parsek-test-results.txt` (which the orchestrator also
+reads for per-test detail and per-scene blocks). BATCH_COMPLETE is the cheap
+"did the batch finish and what was the tally" signal the orchestrator greps for
+without parsing the whole results file; the results file is the drill-down.
+
+### H5 - RecordingInvariants in-game category
+
+A new in-game test file under `Source/Parsek/InGameTests/` (proposed
+`RecordingInvariantsInGameTests.cs`) with tests carrying
+`[InGameTest(Category = "RecordingInvariants", Scene = GameScenes.FLIGHT)]`.
+FLIGHT-scoped because that is where a loaded career with a populated
+`RecordingStore` reliably exists after the autorun save loads; the category is
+also eligible to be manually run from the Ctrl+Shift+T window.
+
+What it does each run:
+1. Build an `AnalyzerModel` from live state via the model builder above: RAW
+   `RecordingStore.CommittedRecordings` + `RecordingStore.CommittedTrees`,
+   `ParsekScenario.Instance` tombstones + supersede rows, RAW `Ledger.Actions`,
+   `CareerSave=null`, empty `LoadFaults`, `FixtureStamp=null`, a `FlightGlobals`
+   body resolver. Log the counts up front (see step 4).
+2. Run M-A1's `IRecordingInvariant` rule set over the model, collecting
+   `Finding`s.
+3. Map verdicts: any `Fail` `Finding` fails the in-game test (via `InGameAssert`,
+   carrying RuleId + Target + Message); every `Warn` `Finding` is logged as a
+   `ParsekLog.Warn` line but does not fail the test; `Info` is ignored;
+   `StaleFixture` is unreachable (null stamp). This matches the offline
+   analyzer's Warn-vs-Fail policy (plan section 7 invariants 2 and 3).
+4. Empty store: the test PASSES (no recordings = no findings) but logs an
+   explicit "walked 0 recordings" line so an empty-store run is distinguishable
+   from a not-run one. The walk-count line (`recordings=<n> trees=<m>`, see
+   Diagnostic Logging) is emitted before evaluation on every run, empty or not.
+
+The invariant set is exactly M-A1's PURE-CORE subset that runs over an
+`AnalyzerModel` with no loader-supplied inputs: INV1 (UT monotonicity), INV2 (no
+double-cover of a UT span), INV3 (RELATIVE lat/lon contract), INV4 (part-event
+PID resolution), INV5 (schema-generation compatibility), INV6 (resource-manifest
+consistency-where-present), INV7 (tree topology: parent/branch/chain/anchor/
+supersede/tombstone links resolve, no cycles, chain-index contiguity per
+(ChainId, ChainBranch)), and INV8 (ledger ELS internal consistency; the
+career-diff FAIL variant is the `LedgerGroundTruthHarness` seam, not H5, since
+H5 passes `CareerSave=null`). The loader-scoped rules INV7b (annotation
+staleness), INV9 (rewind-point file validation), and INV10 (codec round-trips)
+are OFFLINE-ONLY: they depend on on-disk sidecar/RP files and `LoadFault` data
+the in-game builder does not populate, so they are absent from the live model's
+findings. INV5 is expected to PASS in-game (schema-incompatible recordings are
+rejected at load, so the live store never holds one), but it is kept in the H5
+set anyway as a cheap belt-and-suspenders check and to keep the rule set
+identical to the offline pure core. Because the rule set is shared, adding a
+pure-core invariant to M-A1 automatically strengthens H5 with no M-A3 change.
+
+Execution model (sync vs coroutine, required call): v1 is a SYNCHRONOUS `void`
+in-game test. The walk is read-only (it materializes references into an
+`AnalyzerModel` and runs pure rules; it mutates no live state), so a single-frame
+hitch inside the batch is acceptable and simpler than coroutine slicing. The
+walk-count line (step 4) logs `recordings=<n> trees=<m>` up front; above a stated
+store-size threshold (`AutorunInvariantWalkSizeWarnThreshold`, proposed 500
+recordings) the test additionally logs a `Warn` size line
+("RecordingInvariants walk over <n> recordings may hitch a frame; coroutine
+slicing deferred") so a pathologically large store's hitch is explained in the
+log rather than looking like a freeze. Coroutine slicing (yielding the walk
+across frames for very large stores) is DEFERRED, listed here as the known future
+cut; v1 ships the synchronous test.
+
+ERS/ELS grep-gate decision (required call): H5's walker reads
+`RecordingStore.CommittedRecordings` RAW, and it does NOT route through
+`EffectiveState.ComputeERS()`. Justification:
+- The invariant core validates the STRUCTURAL integrity of the persisted data,
+  including NotCommitted provisionals, superseded entries, and tombstone/supersede
+  link targets. ERS is defined as the visibility-filtered effective set (it skips
+  superseded and NotCommitted entries, EffectiveState.cs:1213+). Feeding H5 the
+  ERS view would HIDE exactly the rows whose links invariant 7 (tree topology)
+  exists to check - a superseded recording that ERS drops is still a row whose
+  `SupersedeTargetId` must resolve. The offline analyzer walks the whole save
+  directory including those rows; to produce the SAME verdict from the SAME core,
+  the in-game walker must feed the SAME complete set. This is the identical
+  rationale the allowlist already records for `RecordingStoreTestSnapshot`
+  ("supersede-aware filtering would corrupt the round-trip", allowlist lines
+  12-18).
+- No new allowlist entry is needed. The grep gate (`scripts/grep-audit-ers-els.ps1`)
+  allowlists the directory prefix `Source/Parsek/InGameTests/` (allowlist line
+  49). H5's walker lives there, so its raw `CommittedRecordings` read is already
+  covered. The invariant CORE (M-A1) never reads `CommittedRecordings` at all (it
+  takes materialized lists as arguments), so the core file needs no exemption
+  either - it is pure by construction. This keeps the gate meaningful: the only
+  raw read is in a test-surface file that is already trusted.
+
+## Edge Cases
+
+Each: scenario -> expected behavior -> v1 or deferred.
+
+1. `PARSEK_AUTORUN_TESTS` unset/empty. -> H1 fully inert; no batch auto-starts;
+   normal interactive play. -> v1.
+
+2. `PARSEK_AUTORUN_TESTS` set to a malformed value (whitespace only, stray
+   commas like `A,,B`, leading/trailing comma). -> Parser trims tokens and drops
+   empty ones; `A,,B` runs `A` then `B`; an all-empty value logs a WARN
+   ("autorun selector parsed to zero categories; H1 inert") and does not fire.
+   -> v1.
+
+3. `PARSEK_AUTORUN_TESTS=SomeCategoryThatDoesNotExist`. -> `RunCategory` runs an
+   empty batch (the `allTests.Where(t => t.Category == category)` filter yields
+   nothing). The batch completes with total=0; BATCH_COMPLETE emits
+   `total=0 ... category=SomeCategoryThatDoesNotExist`; a WARN logs "autorun
+   category matched 0 discovered tests". The orchestrator sees total=0 and can
+   treat it as a config error. -> v1.
+
+4. `PARSEK_AUTORUN_TESTS=all` in a scene where every test is scene-ineligible
+   (e.g. loads into SPACECENTER while the batch is mostly FLIGHT tests). -> Batch
+   runs, marks eligible-elsewhere tests Skipped-for-scene, BATCH_COMPLETE reports
+   the skip tally with `scene=SPACECENTER`. Not an error. -> v1.
+
+5. A batch is already running (human clicked Run All) when H1's fire conditions
+   are met. -> H1 checks `!runner.IsRunning` and does not fire; it stays armed
+   and re-checks next frame. If the human batch finishes and conditions still
+   hold, H1 then fires. -> v1.
+
+6. Crash-reconcile pending from a prior killed batch. -> H1 gate holds fire until
+   `CrashReconcileInProgress` clears and the deferred reload's OnLoad completes;
+   only then does the settle counter advance and H1 fire, so the autorun baseline
+   is captured against the reverted save, not the mutated one. -> v1.
+
+7. KSP loads into MainMenu (no save loaded) - e.g. the orchestrator's boot flag
+   failed to auto-load a save. -> Scene-settle condition 2 (`CurrentGame != null`,
+   non-empty `SaveFolder`) is false in MainMenu; H1 never fires; no batch, no
+   corruption. If `PARSEK_AUTORUN_EXIT=1` is also set, H2 does NOT fire either
+   (H2 only runs at a batch's end, and no batch ran), so the process stays up and
+   the orchestrator's timeout eventually kills it (killed-run verdict). A WARN is
+   logged after a bounded wait ("autorun armed but no game scene settled within
+   Ns; still waiting") so the log explains the eventual kill. -> v1.
+
+8. Second flight-scene load re-triggers autorun (the runner's own isolation
+   teardown reloads FLIGHT->FLIGHT, firing `onGameSceneLoadRequested`). -> The
+   per-scene re-arm would re-fire, but the `!runner.IsRunning` guard blocks it
+   during the batch, and the `autorunConsumedForProcess` latch blocks it after
+   the batch. Net: exactly one autorun batch per process. -> v1.
+
+9. `PARSEK_AUTORUN_EXIT=1` but `PARSEK_AUTORUN_TESTS` unset. -> No autorun batch
+   ever starts, so H2 (which fires only at a batch's end) never triggers. The
+   process does not quit on its own. This is intentional: EXIT is "quit after the
+   autorun tests", and there were none. A WARN logs at startup ("PARSEK_AUTORUN_EXIT
+   set but PARSEK_AUTORUN_TESTS unset; nothing will auto-run or auto-quit") so the
+   misconfiguration is visible. -> v1.
+
+10. Exit requested but `ExportResultsFile` throws. -> `ExportResultsFile` already
+    swallows its own exception and WARN-logs (InGameTestRunner.cs:3343-3346). H3
+    and H2 run regardless (they are after it in the region and not guarded by its
+    success). The orchestrator may get a BATCH_COMPLETE line but a missing/stale
+    results file; it treats the log line as authoritative for pass/fail and the
+    missing file as a soft error. -> v1.
+
+11. NRE-storm abort mid-autorun (a stock/mod bug floods exceptions after some
+    test). -> The existing storm detector aborts the batch, reverts the disk save,
+    and normally arms a Space Center bounce. Under autorun, H2 takes precedence:
+    the disk is already reverted (abort path calls
+    `ForceRevertCampaignDiskToBaseline`), H3 emits BATCH_COMPLETE with whatever
+    counts were reached, and H2 quits instead of bouncing. The orchestrator sees a
+    finished-with-failures batch and a clean process exit. -> v1.
+
+12. Exit fires but the quit call itself throws or the process lingers. -> H2
+    wraps the quit in try/catch, logs an ERROR on failure, and does nothing
+    further; the orchestrator's timeout kills the process (killed-run verdict).
+    The campaign is already safe (teardown ran before the quit attempt). -> v1.
+
+13. Human presses Ctrl+Shift+T and clicks Run All in a process that has the env
+    vars set (developer testing the autorun build interactively). -> H1's fire is
+    independent of the button, but H2's "was this an autorun batch" flag is false
+    for a button-initiated batch, so the human's manual batch does NOT quit KSP
+    under them. Only an H1-initiated batch quits. -> v1.
+
+14. Env var changes mid-process (some tool mutates the environment after launch).
+    -> Ignored: the selector is parsed once at startup and cached. Env is a
+    launch-time contract. -> v1.
+
+15. `PARSEK_AUTORUN_TESTS=RecordingInvariants` but the loaded save has an empty
+    `RecordingStore`. -> H5 tests pass (no recordings, no violations) and log
+    "walked 0 recordings"; BATCH_COMPLETE reports them passed. The orchestrator
+    distinguishes "0 recordings, invariants trivially hold" from "invariants
+    failed" via the results file and the walk-count log line. -> v1.
+
+16. Multi-category autorun where one category hangs (a test infinite-loops). ->
+    No hook-level watchdog (out of scope); the batch never reaches its end, so no
+    BATCH_COMPLETE for that category and no H2 quit. The orchestrator's timeout
+    kills the process. The partial log (earlier categories' BATCH_COMPLETE lines)
+    tells the orchestrator how far it got. -> v1 (watchdog deferred; see What
+    Doesn't Change).
+
+## What Doesn't Change
+
+- Normal interactive play: with both env vars unset, `TestRunnerShortcut`,
+  `InGameTestRunner`, and the whole batch-isolation machinery behave exactly as
+  today. H1's added `Update` block early-returns on the unset selector before any
+  work.
+- `dotnet test` and the xUnit suite: unaffected. The env vars are read only by the
+  in-game addon, which does not run under xUnit.
+- Ship-default state: neither env var is ever set by Parsek, any build script, or
+  any config file. The hooks are enabled ONLY by an external orchestrator setting
+  process environment before launch. There is no Settings-UI checkbox and no
+  persisted flag.
+- The batch campaign-isolation contract (`TestBatchMarker`, `.bak` capture,
+  `CaptureBatchBaseline`, teardown restore): behavior UNCHANGED. Autorun uses the
+  identical `RunAll` / `RunCategory` entry points, so it inherits the identical
+  isolation. H2 attaches strictly AFTER teardown; it does not reorder or skip any
+  isolation step. The crash-reconcile path is behavior-unchanged but gains ONE
+  observable addition: the new read-only `ParsekScenario.CrashReconcileInProgress`
+  flag (set at OnLoad reconcile detection, cleared at the deferred reload's
+  OnLoad) that H1's settle gate reads. The flag only exposes existing in-flight
+  state; it does not alter what `RunTestBatchCrashReconcile` or the deferred
+  reload do.
+- The `parsek-test-results.txt` format and `FormatResultsReport`: unchanged. H3
+  adds a log line; it does not touch the results file.
+- The runner's existing public entry points (`RunAll`,
+  `RunAllIncludingFlightRestore`, `RunCategory`,
+  `RunCategoryIncludingFlightRestore`, `RunSingle`), `AllowBatchExecution` /
+  `RunLast` semantics, and the NRE-storm abort logic: behavior unchanged. Autorun
+  v1 uses `RunAll` / `RunCategory` (the ordinary batch-safe path), not the
+  flight-restore variants (those are for `[isolated]` destructive tests a human
+  opts into). M-A3 does ADD one new runner member, `MarkNextBatchAutorun` (plus
+  the per-batch `wasAutorunBatch` latch it feeds), used only by H1/H2; it does not
+  change any existing entry point's behavior and is inert when H1 never calls it.
+- Timeout self-defense / watchdog: OUT OF SCOPE for M-A3 v1. If a batch hangs, the
+  EXTERNAL orchestrator kills KSP (killed-run verdict, plan section 9 item 3). The
+  hooks deliberately implement no internal watchdog timer; a self-kill risks
+  masking a real hang as a clean exit and racing the teardown. The log-validation
+  killed-run mode (plan section 9) handles the truncated log a kill produces.
+- ERS/ELS routing and the grep gate: unchanged. H5 reads the raw committed list
+  from an already-allowlisted directory; no allowlist edit, no new exemption.
+
+## Backward Compatibility
+
+No serialized data, so there is nothing to migrate. Saves written by a build
+with these hooks are byte-identical to saves from a build without them, because
+the hooks never write to a save. A save that happened to be open when an autorun
+batch ran is protected by the UNCHANGED batch isolation (teardown reverts
+`persistent.sfs` from the `.bak`), exactly as a human-run batch is today. Older
+builds simply ignore the env vars (they do not read them). The BATCH_COMPLETE
+line is additive to KSP.log; older log consumers that do not know it just skip an
+unrecognized INFO line. The `v1` version token guarantees a future format change
+cannot silently break an orchestrator pinned to `BATCH_COMPLETE v1`.
+
+## Diagnostic Logging
+
+Subsystem tag `TestRunner` for hook-plumbing lines (matching
+`TestRunnerShortcut` / `InGameTestRunner`), `RecordingInvariants` for H5 walker
+lines. Every decision point below emits a line so the log alone reconstructs why
+the autorun did or did not do something - critical because autorun runs with no
+human watching.
+
+H1 (arm/fire):
+- Startup: `Info` "autorun selector parsed: enabled=<b> selector='<raw>'
+  categories=[<parsed>] exit=<b>" - one line at addon Awake, records the exact
+  env contract the process launched with.
+- Scene-settle waiting: `VerboseRateLimited` (key `autorun-settle`, 1 Hz) "autorun
+  armed, waiting for settle: scene=<s> game=<b> save=<b> flightReady=<b>
+  vessel=<b> packed=<b> settleFrames=<n>/<N> reconcilePending=<b>" - so a
+  never-firing autorun shows exactly which condition is stuck.
+- Fire: `Info` "autorun FIRING: selector=<sel> scene=<s> eligibleCount=<n>" at the
+  moment `RunAll`/`RunCategory` is invoked.
+- Not-firing decisions: `Verbose` one-liners for each blocked reason: batch
+  already running, reconcile pending, already-consumed latch, re-arm suppressed.
+- Malformed/empty selector: `Warn` "autorun selector parsed to zero categories;
+  H1 inert" (edge case 2). `Warn` "autorun category '<c>' matched 0 discovered
+  tests" (edge case 3, emitted when the batch's eligible count is 0 for a named
+  category).
+- Multi-category: `Info` "autorun multi-category: running <c> tokens sequentially:
+  [<list>]" then per-token fire lines, then a final `Info`
+  "autorun multi-category complete: <count> batches" before the aggregate H3 line.
+- No-scene timeout: `Warn` "autorun armed but no game scene settled within <N>s;
+  still waiting for orchestrator save load" (edge case 7).
+
+H2 (exit):
+- Config warn: `Warn` "PARSEK_AUTORUN_EXIT set but PARSEK_AUTORUN_TESTS unset;
+  nothing will auto-run or auto-quit" (edge case 9), at startup.
+- Precedence over bounce: `Info` "autorun exit armed; skipping Space Center bounce
+  recovery (process is quitting)" when H2 supersedes the bounce (edge case 11).
+- Just before quit: `Info` "autorun exit: teardown+export complete, quitting KSP
+  cleanly (mechanism=<QuitGame|ApplicationQuit>)" - the intended last durable log
+  line of the session.
+- Quit failure: `Error` "autorun exit quit call failed: <ex>; orchestrator timeout
+  will reap the process" (edge case 12).
+
+H3 (marker):
+- The BATCH_COMPLETE line itself (`Info`, the versioned contract). This is both a
+  diagnostic and the machine contract.
+
+H5 (invariant walker):
+- `Info` "RecordingInvariants walk: recordings=<n> trees=<m>" at start (the
+  walk-count line; `recordings=0` distinguishes empty-store from not-run, edge
+  case 15). Above `AutorunInvariantWalkSizeWarnThreshold` recordings, an
+  additional `Warn` size line ("walk over <n> recordings may hitch a frame;
+  coroutine slicing deferred") explains the one-frame hitch (execution model).
+- Per Fail `Finding`: the `InGameAssert` failure message carries
+  `RuleId + Target + Message`; additionally `Warn`
+  "RecordingInvariants FAIL <ruleId> target=<t>: <message>".
+- Per Warn `Finding`: `Warn` "RecordingInvariants WARN <ruleId> target=<t>:
+  <message>" (does not fail the test).
+- `Info` "RecordingInvariants summary: fails=<n> warns=<n> over recordings=<n>"
+  at end (batch-count convention: one summary line, not per-recording spam).
+
+## Test Plan
+
+Every test states the regression it catches.
+
+Unit tests (xUnit, pure - the hooks' parse/decision logic is extracted to
+`internal static` pure methods so it is testable without Unity):
+
+- `AutorunSelectorParser` tests: `""` -> inert; `"all"` -> {all}; `"A"` -> {A};
+  `"A,B,C"` -> {A,B,C}; `"A,,B"` and `" A , B "` and `",A,"` -> {A,B} (trim + drop
+  empties); whitespace-only -> zero categories + inert flag.
+  Fails if: a malformed env var silently runs the wrong categories or crashes the
+  addon (edge cases 2, 3). Guards the external contract's parsing.
+- `SceneSettleDecision` pure predicate tests: table-drive (scene, game, save,
+  flightReady, vessel, packed, settleFrames, reconcilePending) -> shouldFire.
+  Assert FLIGHT requires ready+vessel+unpacked; MainMenu never fires; settle
+  counter must reach N; reconcilePending blocks.
+  Fails if: H1 fires against a half-initialized scene (races recorder/PartLoader)
+  or against a pending crash-reconcile (captures baseline on a half-reverted save)
+  - edge cases 6, 7.
+- `AutorunFireGate` tests: `IsRunning` blocks fire; `autorunConsumedForProcess`
+  latch blocks re-fire; re-arm-per-scene resets the per-scene flag but not the
+  process latch.
+  Fails if: the FLIGHT->FLIGHT isolation reload double-fires the autorun (edge
+  cases 5, 8).
+- `H3FormatBatchCompleteLine` tests: given (total, passed, failed, skipped,
+  selector, scene) assert the exact string
+  `BATCH_COMPLETE v1 total=.. passed=.. failed=.. skipped=.. category=.. scene=..`,
+  no spaces inside values, `v1` present.
+  Fails if: a code change silently alters the orchestrator contract without a
+  version bump - this is the guard that makes the contract a contract.
+- `H2ExitDecision` tests: exit armed only when (`PARSEK_AUTORUN_EXIT=="1"` AND
+  wasAutorunBatch); button-initiated batch (wasAutorunBatch=false) never quits
+  even with the env var set (edge case 13); exit supersedes bounce when both are
+  armed (edge case 11).
+  Fails if: a developer's interactive Run All quits KSP under them, or exit fires
+  before teardown.
+
+Log-assertion tests (xUnit, via `ParsekLog.TestSinkForTesting`):
+
+- H1 emits the startup selector-parse line and the FIRING line with the right
+  fields; the settle-waiting line names the stuck condition.
+  Fails if: a never-firing autorun leaves no diagnostic trail (the whole point of
+  the settle log).
+- H3 BATCH_COMPLETE line is emitted exactly once per batch at Info level with the
+  structured `[Parsek][INFO][TestRunner]` prefix (assert via the same
+  `StructuredLinePattern` used in `LogContractTests`).
+- H2 emits the pre-quit line before invoking the quit (assert the line is present
+  and the quit callback - injected as a test seam - is invoked AFTER it).
+  Fails if: the quit races ahead of the durable log record, or fires without the
+  teardown-complete evidence.
+
+LogContract test (new FMT rule in `LogContractTests.cs`, plan requirement that H3
+join the log-contract surface):
+
+- `BATCH_COMPLETE line matches the versioned contract`: emit a synthetic
+  BATCH_COMPLETE via the H3 formatter through `TestObserverForTesting`, assert it
+  matches `^\[Parsek\]\[INFO\]\[TestRunner\] BATCH_COMPLETE v1 total=\d+ passed=\d+
+  failed=\d+ skipped=\d+ category=\S+ scene=\S+$`.
+  Fails if: any future edit changes the token order, names, spacing, or drops the
+  version tag - the contract test is what forces a `v2` bump to be deliberate.
+
+In-game tests (`RecordingInvariants` category, FLIGHT):
+
+- The H5 tests themselves are the deliverable: one test per invariant (or a small
+  set) that builds an `AnalyzerModel` from the live store and asserts zero Fail
+  `Finding`s from the M-A1 rule set. These double as the coverage: a
+  builder-synthetic corpus injected via
+  `InjectAllRecordings` before an in-game run should pass; a deliberately
+  malformed synthetic recording (e.g. UT non-monotonic, dangling supersede
+  target) must produce a Fail.
+  Fails if: the in-game walker feeds the core the wrong set (e.g. ERS-filtered,
+  hiding superseded rows) so a broken link goes undetected - this is the test that
+  proves the raw-`CommittedRecordings` decision is correct.
+- `RecordingInvariants on empty store passes and logs walk=0`: asserts edge case
+  15 (empty store is a pass, not a skip, and is logged as such).
+- ERS grep-gate regression: the existing `GrepAuditTests` (runs
+  `scripts/grep-audit-ers-els.ps1`) must stay green with the H5 walker added.
+  Fails if: the H5 walker is placed outside `Source/Parsek/InGameTests/` (losing
+  its directory allowlisting) or the invariant core accidentally reads
+  `CommittedRecordings` (which would need - and lack - an exemption).
+
+Edge-case tests: one per numbered edge case above where a pure decision exists
+(1, 2, 3, 5, 6, 7, 8, 9, 11, 13, 14 are covered by the unit/log tests listed;
+4, 10, 12, 15, 16 are covered by the in-game and log-assertion tests). Each
+reproduces the scenario against the pure decision method and asserts the
+documented behavior.

--- a/docs/dev/design-autotest-command-seam.md
+++ b/docs/dev/design-autotest-command-seam.md
@@ -1,0 +1,744 @@
+# Design: ParsekTestCommands (M-A2 command seam)
+
+Module M-A2 of the automated-testing initiative (`docs/dev/automated-testing-plan.md`
+sections 3.1, 3.3, 11b). This is the "new data that persists" full-workflow design
+doc the plan mandates for the command-file format. Implements the v1 command subset
+only; the wire protocol is designed to carry the phase 3+ commands without a format
+break.
+
+---
+
+## Problem
+
+The automated-testing harness needs to drive a running KSP + Parsek instance from an
+external Python orchestrator: boot the instance into a chosen save from the main menu,
+change settings, start and commit recordings on purpose, run the in-game test batch, mark
+mission checkpoints, and quit in a commit-safe way.
+There is no control surface today. The in-game test runner is interactive-only
+(`Ctrl+Shift+T`, `TestRunnerShortcut.Update`), and the plan's audit confirmed "no env
+hooks exist anywhere in Source/Parsek". kRPC could drive some of this, but linking a
+kRPC service against Parsek.dll entangles GPL and does not cover Parsek-specific
+actions (commit, discard, rewind-invoke, merge-dialog answers) that kRPC never exposes.
+
+We need a control channel that: needs no kRPC linkage (works headless-of-kRPC, no GPL
+entanglement), is inert and unshippable in normal play, survives a mid-run KSP crash
+without re-running a non-idempotent command, is human-readable and grep-able for
+debugging, and whose parse/validate/dispatch logic is pure and xUnit-testable without
+Unity.
+
+## Terminology
+
+- **Orchestrator**: the external Python process (M-A5 harness) that writes commands and
+  reads responses. It is the ONLY writer of the command file and the ONLY reader of the
+  response file.
+- **Addon**: the in-game DDOL `MonoBehaviour` (`ParsekTestCommandAddon`) that polls the
+  command file, executes commands on the Unity main thread, and appends responses. Runs
+  only in the automation instance, only when env-gated on.
+- **Command**: one line in the command file. Carries a unique **command id**, a **verb**
+  (the action), and zero or more `key=value` **args**.
+- **Verdict**: the terminal outcome the addon writes for a command id: `OK`, `ERROR`,
+  `REJECTED`, `TIMEOUT`, or `INTERRUPTED`.
+- **Journal**: an append-only write-ahead log (`.journal` file) recording per-command-id
+  lifecycle phases (`CLAIMED` / `EXECUTED` / `DONE`). It is the durable at-most-once
+  mechanism; it is NOT the response file.
+- **Safe point**: a main-thread moment at which a command may execute: not the `LOADING`
+  scene, not during a scene transition, scene has settled, and no in-game test batch is
+  running. Each verb additionally declares a scene/state precondition.
+- **Pump**: the per-frame step (in the addon's `Update`) that reads new command lines,
+  makes a dispatch decision for the head command, and executes or defers it.
+- **Reserved verb**: a phase 3+ command name the v1 parser recognizes by name but does
+  not implement. It is rejected with a distinct reason so the orchestrator can probe
+  capability, rather than being confused with a typo.
+
+## Mental Model
+
+```
+  external orchestrator (Python)                 automation KSP instance
+  -----------------------------                  -----------------------
+  append command lines  ---------------------->  parsek-test-commands.txt
+      (id, verb, args)                                     |
+                                                           v  Update() pump (main thread)
+                                              +--------------------------------+
+                                              | 1. read new whole lines        |
+                                              | 2. ParseLine  (pure)           |
+                                              | 3. DecideDispatch (pure):      |
+                                              |      Execute | Defer | Reject  |
+                                              |      Interrupted (from journal)|
+                                              | 4. journal CLAIMED  (WAL)      |
+                                              | 5. run side effect (Unity)     |
+                                              | 6. journal EXECUTED            |
+                                              | 7. append response line        |
+                                              | 8. journal DONE                |
+                                              +--------------------------------+
+                                                           |
+  read/tail response lines <-------------------  parsek-test-responses.txt
+      (id, verdict, payload)                     parsek-test-commands.journal (WAL)
+                                                 parsek-test-commands.lock (session)
+```
+
+Strict FIFO: the pump only looks at the oldest not-yet-terminal command. If that command
+must defer (its scene/state is not ready), later commands wait behind it until it runs or
+times out. The orchestrator controls ordering by controlling append order.
+
+At-most-once via a three-phase journal: execution happens ONLY on the transition from
+"no journal entry for this id" to `CLAIMED` -> `EXECUTED`. If a crash leaves an id at
+`CLAIMED` (side effect maybe-partially ran), the addon does NOT re-execute; it reports
+`INTERRUPTED`. If a crash leaves an id at `EXECUTED` (side effect definitely ran, response
+maybe not written), the addon does NOT re-execute; it just (re)writes the response and
+marks `DONE`. A non-idempotent command therefore runs zero-or-one times, never twice.
+
+## Data Model
+
+All files live in the **KSP root** (`KSPUtil.ApplicationRootPath`), NOT next to the save.
+
+### File location decision and justification
+
+The four channel files sit at the KSP root with fixed names:
+
+| File | Writer | Reader | Semantics |
+|---|---|---|---|
+| `parsek-test-commands.txt` | orchestrator | addon | append-only command log |
+| `parsek-test-responses.txt` | addon | orchestrator | append-only verdict log |
+| `parsek-test-commands.journal` | addon | addon (on restart) | append-only WAL |
+| `parsek-test-commands.lock` | addon | addon | single-session guard |
+
+KSP root, not save-scoped (`saves/<save>/...`), because:
+
+1. **Discovery timing.** `RecordingPaths.TryGetSaveContext` resolves the save folder from
+   `HighLogic.SaveFolder`, which is empty at the main menu and during early boot. The
+   first commands an orchestrator sends (pin settings, or the `LoadGame` boot command)
+   arrive before any save is loaded, so a save-scoped path cannot be resolved yet.
+2. **FlushAndQuit from menu scenes.** FlushAndQuit must work with no game loaded (quit
+   from the main menu). A save-scoped channel would be unreachable there.
+3. **One channel per instance.** The orchestrator drives a single dedicated automation
+   instance and selects the save via the `LoadGame` boot command (the boot channel;
+   kRPC/TestingTools RPCs are not available at the main menu). A single fixed root-level
+   channel is simpler than tracking which save is active.
+4. **Multiple saves** are handled by the orchestrator sequencing load/quit, not by
+   per-save files; the channel is per-instance, not per-save.
+
+`KSPUtil.ApplicationRootPath` is always available (it is used unconditionally in
+`RecordingPaths.TryGetSaveContext` before any save context), so the channel exists from
+process start.
+
+### Command line grammar
+
+One command per line, newline (`\n`) terminated. Tokens are whitespace-separated
+`key=value` pairs. Two keys are reserved and required first: `id` then `cmd`. Remaining
+tokens are verb-specific args in any order. Example:
+
+```
+id=0001 cmd=SetSetting name=autoRecordOnLaunch value=false
+id=0002 cmd=StartRecording
+id=0003 cmd=RecordingState
+id=0004 cmd=CommitTree
+id=0005 cmd=RunTests category=RecordingInvariants
+id=0006 cmd=LoadGame save=DefaultCareer name=persistent
+id=0007 cmd=MissionMark label=mun%20landing%20start
+id=0008 cmd=FlushAndQuit
+```
+
+Grammar rules:
+
+- `id`: orchestrator-generated token, unique across the whole run (monotonic integer or
+  GUID). It is the ack correlation key and the journal dedup key. Ids must be unique
+  across process restarts within one logical run; the orchestrator either uses
+  monotonic-across-run ids or truncates the three channel files between runs (see
+  Backward Compatibility).
+- `cmd`: the verb. Case-sensitive, exact match against the known-verb table.
+- Optional `v=<n>`: protocol version, default `1`. Unknown keys are ignored (forward
+  compatibility), so phase-3 verbs may add new keys freely.
+- **Value encoding**: a value that contains whitespace, `=`, `%`, or a control character
+  MUST be percent-encoded (`%20` for space, `%25` for `%`, `%3D` for `=`). The parser
+  percent-decodes values. This keeps a value with spaces (a `MissionMark` label, a path)
+  on one token. Numeric values use `InvariantCulture` (no locale commas).
+- A line that does not end in `\n` is a partial write; the pump leaves it for the next
+  poll and does not parse it.
+- Blank lines and lines beginning with `#` are ignored (comments).
+
+`ParsedCommand` (pure result of `TestCommandParser.ParseLine`):
+
+```
+struct ParsedCommand
+    string     RawLine
+    int        LineNumber          // 1-based position in the file
+    string     Id                  // null if the id token was absent
+    string     Verb                // null if the cmd token was absent
+    Dictionary<string,string> Args // decoded values
+    bool       ParseOk
+    string     ParseError          // reason string when ParseOk == false
+```
+
+### Response line grammar
+
+One line per terminal outcome, appended by the addon, newline terminated:
+
+```
+id=0002 cmd=StartRecording verdict=OK seq=2 ut=1234.5 recordingId=abc123
+id=0004 cmd=CommitTree verdict=ERROR seq=4 ut=1240.0 msg=no-active-tree
+id=0003 cmd=RecordingState verdict=OK seq=3 ut=1235.1 recording=true tree=abc123 points=812
+id=0009 cmd=SetSetting verdict=REJECTED seq=9 msg=setting-not-whitelisted%20name%3Dfoo
+id=0005 cmd=RunTests verdict=OK seq=5 ut=1300.0 passed=42 failed=0 skipped=3 results=parsek-test-results.txt
+```
+
+Fields: `id`, `cmd`, `verdict`, `seq` (monotonic per-process response counter, so the
+orchestrator can order and detect gaps), `ut` (`Planetarium.GetUniversalTime()` when a
+game is loaded, omitted otherwise), then verb-specific payload keys, then an optional
+`msg` (percent-encoded free text; carries the reason for `ERROR`/`REJECTED`/`TIMEOUT`).
+Values are percent-encoded and `InvariantCulture`-formatted, matching the command grammar
+so one reader handles both.
+
+**seq caveat (per-process, resets on restart).** `seq` is a per-PROCESS counter: after a
+crash the restarted process starts `seq` from its base again, so a `seq` value the
+orchestrator sees may be a GAP (a response it missed) OR a RESET (a fresh process
+recounting). The orchestrator must not treat non-monotonic `seq` across a restart boundary
+as a lost response; it correlates outcomes by command `id` (stable across restarts) and
+uses `seq` only for ordering WITHIN one process run. A journal `session` change (or a
+`LoadGame`/restart it initiated) marks the boundary where `seq` may legitimately reset.
+
+**Orchestrator response contract (crash-recovery duplicates).** The addon normally writes
+exactly one terminal response line per command id, but a crash AFTER the response append
+and BEFORE the journal `DONE` leaves the id at `EXECUTED`; on restart the addon rewrites
+the response line from `EXECUTED` (it cannot know the first append survived). The
+orchestrator therefore treats the FIRST terminal response line for a given id as
+authoritative and IGNORES any later duplicate line for that same id -- later duplicates are
+crash-recovery rewrites, not new outcomes. (A rewritten line is byte-equivalent in verdict;
+only `seq` differs, since it is a fresh per-process counter.)
+
+### Journal line grammar (WAL)
+
+Append-only, newline terminated. One line per phase transition:
+
+```
+id=0002 phase=CLAIMED seq=2 verb=StartRecording session=7f3a... t=17390512.884
+id=0002 phase=EXECUTED seq=2 t=17390512.951
+id=0002 phase=DONE seq=2 verdict=OK t=17390512.960
+```
+
+`session` is `ParsekProcess.ProcessSessionId` (the AppDomain-lifetime GUID) so a journal
+can be attributed to a specific process run. `t` is wall-clock seconds (InvariantCulture).
+On addon startup the journal is replayed into an in-memory map `id -> highest phase seen`:
+
+- id at `DONE`  -> already fully handled; skip (no re-execute, no re-respond).
+- id at `EXECUTED` (no `DONE`) -> side effect ran; skip execution, (re)write the response
+  line, append `DONE`. This recovers a crash or an IO failure between side effect and
+  response.
+- id at `CLAIMED` (no `EXECUTED`) -> crashed mid-execution; do NOT re-execute; write an
+  `INTERRUPTED` terminal response and append `DONE`.
+
+Journal replay tolerates a TORN TRAILING LINE: a crash mid-append can leave a final journal
+line without a terminating `\n`; replay ignores any trailing line that is not
+newline-terminated (it was never durably committed), exactly as the orchestrator ignores a
+torn trailing response line. Only whole, newline-terminated journal lines drive the phase
+map.
+
+**Durability threat model.** The journal's durability guarantee TARGET is
+append-visible-on-process-kill: a newline-terminated line that was flushed before the KSP
+process was killed (crash, `Application.Quit`, orchestrator SIGKILL) is visible on the next
+process's replay. That is the scope the at-most-once mechanism defends. Full power loss /
+OS crash (unflushed OS page cache lost) is explicitly OUT OF SCOPE: the automation instance
+runs on a dev PC under a scheduled task, not a datacenter with fsync guarantees, and a
+power-loss mid-append is treated like any torn trailing line (ignored) with no stronger
+promise. We do not fsync every journal append.
+
+### Lock file grammar
+
+Single line written once on addon startup after the env gate passes:
+
+```
+session=7f3a... pid=48213 t=17390510.101 root=C:\...\KSP
+```
+
+Used only to detect two automation instances pointed at the same KSP root
+(`DecideLockOwnership` pure predicate). A lock whose `session` matches our own
+`ProcessSessionId` is ours (reclaim). For a foreign lock, ownership is decided by PID
+LIVENESS, not by `t`: the addon probes whether `pid` is still a live process
+(`Process.GetProcessById` succeeds and, where cheaply checkable, the process path matches a
+KSP instance). A live foreign pid means another instance owns the channel; we stand down
+(log Warn, do not consume). A dead foreign pid means the previous owner crashed; the lock is
+reclaimed with a Warn. `t` is NOT the staleness primary -- it is a tie-break / log detail
+only, because `t` is written once at startup and never refreshed, so a long-lived healthy
+instance would look "stale" by `t` while a just-crashed instance would look "fresh". PID
+liveness is the correct liveness signal; `t` is retained purely for human-readable logging
+and as a last-resort tie-break when a PID cannot be probed.
+
+### SetSetting whitelist
+
+`SetSetting` may mutate ONLY the fields in an explicit allowlist, each mapped to a typed
+parse-and-range check. There is no reflective "set any field": the dispatcher switches on
+the whitelisted name and calls a typed setter, so the command is data, never code.
+
+The **persistence route** column is load-bearing. 8 of the 16 whitelisted settings are
+NOT authoritatively persisted through `GameParameters.CustomParameterNode`: for
+`writeReadableSidecarMirrors`, `showCommittedFutureOverlays`, `blockCommittedActions`,
+`showRouteLines`, `autoBackupExistingSaves`, `ghostRenderTracing`, `mapRenderTracing`,
+and `ledgerTracing`, the `ParsekSettingsPersistence` sidecar
+(`GameData/Parsek/settings.cfg`) is authoritative -- `ParsekScenario.OnLoad` calls
+`ParsekSettingsPersistence.ApplyTo(ParsekSettings.Current)`, which OVERWRITES the
+`GameParameters` values on EVERY save load. A dispatcher that only mutated the live field
+would see its change silently reverted at the next save load (including a load driven by
+the new `LoadGame` verb). So the dispatcher routes those tracked names through the
+`ParsekSettingsPersistence.Record*` path (mirroring `UI/SettingsWindowUI.cs`, which does
+the same), not through the `GameParameters` field alone.
+
+| name | type | validation | field on `ParsekSettings` | persistence route |
+|---|---|---|---|---|
+| `autoRecordOnLaunch` | bool | true/false | `autoRecordOnLaunch` | GameParameters |
+| `autoRecordOnEva` | bool | true/false | `autoRecordOnEva` | GameParameters |
+| `autoRecordOnFirstModificationAfterSwitch` | bool | true/false | same field | GameParameters |
+| `autoMerge` | bool | true/false | `autoMerge` | GameParameters |
+| `verboseLogging` | bool | true/false | `verboseLogging` | GameParameters |
+| `ghostRenderTracing` | bool | true/false | `ghostRenderTracing` | GameParameters + `ParsekSettingsPersistence.Record*` |
+| `mapRenderTracing` | bool | true/false | `mapRenderTracing` | GameParameters + `ParsekSettingsPersistence.Record*` |
+| `ledgerTracing` | bool | true/false | `ledgerTracing` | GameParameters + `ParsekSettingsPersistence.Record*` |
+| `writeReadableSidecarMirrors` | bool | true/false | `writeReadableSidecarMirrors` | GameParameters + `ParsekSettingsPersistence.Record*` |
+| `autoBackupExistingSaves` | bool | true/false | `autoBackupExistingSaves` | GameParameters + `ParsekSettingsPersistence.Record*` |
+| `showCommittedFutureOverlays` | bool | true/false | `showCommittedFutureOverlays` | GameParameters + `ParsekSettingsPersistence.Record*` |
+| `blockCommittedActions` | bool | true/false | `blockCommittedActions` | GameParameters + `ParsekSettingsPersistence.Record*` |
+| `showRouteLines` | bool | true/false | `showRouteLines` | GameParameters + `ParsekSettingsPersistence.Record*` |
+| `samplingDensity` | int | 0..2 | `samplingDensity` | GameParameters |
+| `ghostAudioVolume` | float | 0.0..1.0 (InvariantCulture) | `ghostAudioVolume` | GameParameters |
+| `transitedBodyRotationModeIndex` | int | 0..2 | `transitedBodyRotationModeIndex` | GameParameters |
+
+An unknown name -> `REJECTED msg=setting-not-whitelisted`. A value that fails the typed
+parse or range -> `REJECTED msg=setting-value-invalid`. The setter mutates the live
+`ParsekSettings.Current` and, for a GameParameters-only setting, persists through the
+existing `GameParameters.CustomParameterNode` save path on the next game save (which
+`FlushAndQuit` forces), so no new serialization is added. For the 8
+`ParsekSettingsPersistence`-authoritative settings, the setter ALSO calls the matching
+`ParsekSettingsPersistence.Record*` so the value survives the next `ApplyTo` at save load;
+without this, the tracing flags an automation run pins would silently revert at the next
+save load, including a `LoadGame`.
+
+### Known-verb table (v1 vs reserved)
+
+- **Implemented (v1)**: `SetSetting`, `StartRecording`, `StopRecording`, `CommitTree`,
+  `DiscardTree`, `RecordingState`, `RunTests`, `LoadGame`, `MissionMark`, `FlushAndQuit`.
+- **Reserved (recognized, `REJECTED msg=not-implemented-v1`)**: `StartLoopPlayback`,
+  `StopPlayback`, `EnterWatchMode`, `InvokeRewind`, `AnswerMergeDialog`, `KscAction`,
+  `SealSlot`, `StashSlot`, `FlySlot`, `RouteCommand`, `MissionConfig`, `TimeJump`,
+  `SimulateStockSwitchClick`, `CrashAfterJournalPhase`, `RunInvariantReport`.
+- **Anything else**: `REJECTED msg=unknown-command`.
+
+Reserving the phase-3 names now means the envelope (id/cmd/args, percent-encoding,
+journal, verdicts) is designed once and the later commands slot in without a format break.
+
+## Behavior
+
+### Addon lifecycle
+
+`ParsekTestCommandAddon` mirrors `TestRunnerShortcut`: `[KSPAddon(KSPAddon.Startup.Instantly, true)]`
+with `DontDestroyOnLoad(gameObject)` in `Awake`, a singleton guard (destroy the duplicate),
+and per-frame work in `Update`. It subscribes `GameEvents.onGameSceneLoadRequested` to
+set a `sceneTransitioning` flag and a small settle counter (cleared a couple of frames
+into the new scene), exactly the scene-scoped-state pattern `TestRunnerShortcut` uses for
+its input lock.
+
+`Awake` env gate: if `Environment.GetEnvironmentVariable("PARSEK_TEST_COMMANDS") != "1"`
+(exact match, fail-closed), the addon logs one Verbose line and disables itself (no
+polling, no file access). Only the literal `1` arms it.
+
+On first armed frame: acquire/inspect the lock (`DecideLockOwnership`), replay the journal
+into the in-memory phase map, reconcile any `CLAIMED`/`EXECUTED` leftovers (crash
+recovery, above), and seed the in-memory processed-id set + command-file byte offset.
+
+### The pump (per `Update`, main thread)
+
+1. If not armed, return. If `HighLogic.LoadedScene == LOADING`, `sceneTransitioning`, or
+   the settle counter > 0, return (no safe point).
+2. If an in-game test batch is running (`InGameTestRunner.IsRunning` on the runner the
+   addon owns for `RunTests`), return - do not execute other commands mid-batch.
+3. Read any whole new lines appended since the last byte offset. Parse each into the
+   pending FIFO queue (skipping ids already terminal per the journal / processed set). The
+   addon opens the command file for reading with `FileShare.ReadWrite` so the external
+   orchestrator (which holds its own share-all append handle) can keep appending while the
+   addon reads; neither side takes an exclusive lock on the command file.
+4. Look at the head command only. Build a `DispatchState` snapshot from Unity
+   (scene, `HighLogic.CurrentGame != null`, `ParsekSettings.Current != null`, recorder
+   recording, `activeTree != null`, transitioning, batch running, journal phase for this
+   id) and call the pure `DecideDispatch(parsed, state)`:
+   - `Reject(reason)`: write terminal `REJECTED`, journal `CLAIMED`+`EXECUTED`+`DONE`
+     (no side effect), advance.
+   - `Interrupted`: write terminal `INTERRUPTED`, journal `DONE`, advance (crash recovery).
+   - `Defer(reason)`: leave at head; if it has exceeded its per-command deferral budget,
+     convert to `TIMEOUT` terminal and advance; else return and retry next frame.
+   - `Execute`: journal `CLAIMED`, run the verb handler (below), journal `EXECUTED`, write
+     the terminal response, journal `DONE`, advance. `RunTests` and `FlushAndQuit` are
+     multi-frame/terminal-process and handled specially (below).
+
+Per-poll logging follows the batch-counting convention (one summary line: lines read, N
+parsed, N deferred), with bounded per-command Info lines (command counts are small).
+
+### Verb handlers and their preconditions
+
+| Verb | Scene/state precondition | Action | Success payload |
+|---|---|---|---|
+| `SetSetting` | game loaded (`ParsekSettings.Current != null`), any scene; else Defer | typed whitelist setter mutates `ParsekSettings.Current` | `name`, `value` echoed |
+| `StartRecording` | FLIGHT with a loaded, unpacked active vessel, not restoring/re-fly/merge-journal; else Defer | `ParsekFlight.StartRecording(...)` | `recordingId`, `already=true` if a recorder was live |
+| `StopRecording` | FLIGHT; else Defer | `ParsekFlight.StopRecording()` (idempotent: OK with `idle=true` if no recorder) | `stopped` bool |
+| `CommitTree` | FLIGHT with `activeTree != null`; if no tree -> `ERROR msg=no-active-tree` (mirrors `CommitTreeFlight`'s guard) | `ParsekFlight.CommitTreeFlight()` | `committed=true` |
+| `DiscardTree` | FLIGHT; if no active tree -> OK `nothing=true` | stop recorder if live, then `ParsekFlight.AutoDiscardActiveTreeWithMessage(reason, screenMessage, ledgerRecalcReason)` (the wrong-context-caller entry point) with test-command-specific strings | `discarded` bool |
+| `RecordingState` | any scene (read-only) | snapshot recorder/tree state (reuses `ParsekLog.FormatRecState` inputs) | `recording`, `tree`, `points`, `scene` |
+| `RunTests` | any scene the runner supports; else Defer | `InGameTestRunner.RunAll()` (no `category`) or `RunCategory(category)`; response deferred until `IsRunning` goes true->false and `ExportResultsFile` ran | `passed`, `failed`, `skipped`, `results=parsek-test-results.txt` |
+| `LoadGame` | any scene incl. MAINMENU (the BOOT CHANNEL); Reject if a recorder is live (`msg=recording-active`) or a load is already in flight (`msg=load-in-flight`) | long-running two-phase (like `RunTests`): journal `CLAIMED` -> initiate load (`HighLogic.SaveFolder = dir`; `GamePersistence.LoadGame(...)`; `FlightDriver.StartAndFocusVessel(...)` - the same Assembly-CSharp-only sequence as v0.5.4 `TestingTools.LoadSave`, no kRPC types); response deferred until the new scene settles with `HighLogic.CurrentGame != null`, then journal `EXECUTED` + terminal response; a null / incompatible game -> `ERROR msg=load-failed` | `scene`, `save` |
+| `MissionMark` | any scene | emit a stable `[Parsek][Info][TestCommands] MISSIONMARK label=<label> ut=<ut>` log line (H3-style correlation) | `label` echoed |
+| `FlushAndQuit` | any scene (incl. menus) | if a game is loaded, force a scenario/game save so committed data is durable, THEN `Application.Quit()` deferred one frame; response + journal `DONE` written and flushed BEFORE quitting. Deliberately replaces kRPC master's `Quit()` RPC (a bare `Application.Quit()`, not commit-safe). | `saved` bool |
+
+Notes:
+- `StartRecording` when already recording relies on `FlightRecorder`/`ParsekFlight`
+  guards (`CanStartRecorderWithActiveTreeHead`); the handler reports `OK already=true`
+  rather than forcing a second recorder.
+- `DiscardTree` entry point: there is no whole-tree UI "Discard" button to reuse, so the
+  handler calls `ParsekFlight.AutoDiscardActiveTreeWithMessage(reason, screenMessage,
+  ledgerRecalcReason)`, which exists precisely for wrong-context callers and lets the
+  command supply test-command-specific strings. It deliberately does NOT call
+  `AutoDiscardIdleActiveTree`, which hardcodes an "idle on pad" screen toast and the wrong
+  ledger-recalc reason for a scripted discard.
+- `RunTests` and `LoadGame` are the two long-running verbs: each is `CLAIMED` + started,
+  then the pump gates all other commands until the operation settles. For `RunTests`, when
+  the batch finishes and results export, the handler reads `Passed/Failed/Skipped`, writes
+  the terminal response, and marks `EXECUTED`+`DONE`. A crash mid-batch leaves it `CLAIMED`
+  -> reported `INTERRUPTED` on restart (the batch's own `TestBatchMarker` crash-reconcile
+  handles the save side).
+- `LoadGame` is the BOOT CHANNEL: it is the seam's way to boot the automation instance into
+  a specific save without any kRPC linkage (kRPC RPCs are not available at the main menu).
+  Its `save=<folder> name=<file>` values are percent-encoded like every other arg. It
+  executes at `MAINMENU` because the pump's safe-point gate permits any non-`LOADING`,
+  settled scene, and `LoadGame` declares no FLIGHT/game precondition. It is two-phase like
+  `RunTests`: `CLAIMED` when the load is kicked off, then the pump defers all other commands
+  until the new scene settles with `HighLogic.CurrentGame != null`, at which point the
+  handler writes the terminal response (`scene=`, `save=`) and marks `EXECUTED`+`DONE`. A
+  crash mid-load leaves it `CLAIMED` -> reported `INTERRUPTED` on restart (the journal file
+  survives the scene load). Mid-flight, `LoadGame` is Rejected while a recorder is live
+  (`recording-active`); the orchestrator must `CommitTree` / `DiscardTree` first, so the
+  verb never silently discards an in-flight recording.
+- `FlushAndQuit` does NOT auto-commit an in-flight recording. Committing is done only by
+  explicit `CommitTree` or a real scene-exit; a bare quit from flight has never persisted
+  a live uncommitted recorder, and the command preserves that. To keep an in-flight
+  recording, the orchestrator sends `CommitTree` before `FlushAndQuit`.
+
+### Deferral budgets (per-command TIMEOUT)
+
+Each command carries a deferral budget: the maximum wall-clock time it may sit at the head
+of the queue in `Defer` before the pump converts it to a `TIMEOUT` terminal and advances
+(so a never-satisfiable command never wedges the run). The DEFAULT budget is 60 s
+wall-clock. Some verbs need a different bound and override the default:
+
+| Verb | Deferral budget | Rationale |
+|---|---|---|
+| (default) | 60 s | covers ordinary scene-settle / game-loaded waits |
+| `StartRecording` | scene-wait budget | may wait for FLIGHT with an unpacked active vessel; sized to the scene-arrival wait rather than a fixed 60 s |
+| `RunTests` | batch budget from the scenario spec | a full in-game batch can run minutes; the budget comes from the scenario's declared runtime budget, not a fixed default |
+| `LoadGame` | load budget (e.g. 300 s) | a cold `GamePersistence.LoadGame` + scene settle can take minutes on a large save; longer than the default, shorter than an infinite hang |
+
+Budgets are measured from when the command first reaches the head and begins deferring. On
+expiry the pump writes `TIMEOUT` with `msg` carrying the last defer reason and advances.
+
+### Reserved / phase-3 forward map (design only, not implemented)
+
+The reserved verbs are recognized so the envelope is stable. Two carry
+implementation notes for when they land, because they touch documented traps:
+
+- `AnswerMergeDialog(choice)`: the merge dialog's buttons run their action IN the
+  `DialogGUIButton` callback (`MergeDialog.ShowTreeDialog` wires `MergeCommit` /
+  `MergeDiscard` directly inside the button lambdas). Per the project's deferred-field
+  PopupDialog callback trap, `AnswerMergeDialog` must locate the live popup by
+  `MergeDialog.DialogName` ("ParsekMerge") and invoke the chosen button's action
+  directly, NOT set a `pendingChoice` field that some `DrawWindow` reads later. NOTE:
+  `MergeDialog.DialogName` is a PRIVATE `const` today; the phase-3 implementation of
+  `AnswerMergeDialog` must internal-ize `DialogName` (make it `internal const`) so the
+  addon can look the live popup up by name. This is a phase-3 change, not a v1 one.
+- `InvokeRewind(rpId)`: must surface the `RewindInvoker.CanInvoke(rp, out reason)` gate
+  (scene invokable, no pending invocation, not corrupted, quicksave present on disk, no
+  active re-fly marker, deep-parse precondition) in the response `msg` when it declines,
+  so the orchestrator sees WHY a rewind was refused rather than a bare failure.
+
+## Edge Cases
+
+Exhaustive. Each: scenario -> expected behavior -> v1 or deferred.
+
+1. **Command file appears mid-scene-transition.** Pump is gated off during
+   `sceneTransitioning` and the settle counter; commands are read but the head defers
+   until the scene settles. -> Deferred-until-safe. v1.
+2. **Malformed line (unparseable kv, garbage).** `ParseLine` returns `ParseOk=false`;
+   terminal `REJECTED msg=malformed`, journaled through to `DONE`, pump advances. If an
+   `id` token was present it is used; otherwise the response uses `id=line#<n>` so the
+   orchestrator can correlate by position. v1.
+3. **Line missing `id`.** Treated as malformed; response `id=line#<n>
+   verdict=REJECTED msg=missing-id`. v1.
+4. **Line missing `cmd`.** `REJECTED msg=missing-cmd` under the real id. v1.
+5. **Unknown command name.** `REJECTED msg=unknown-command`. v1.
+6. **Reserved (phase-3) command in a v1 addon.** `REJECTED msg=not-implemented-v1`
+   (distinct from unknown-command so the orchestrator can detect capability). v1.
+7. **Duplicate id in the command file.** The journal/processed-set already has the id;
+   the second occurrence is skipped with a Warn and NO second response line (one response
+   per id). v1.
+8. **KSP crashes after the side effect but before the response is written.** Journal is at
+   `EXECUTED`. On restart the addon does NOT re-execute; it writes the response and marks
+   `DONE`. At-most-once preserved (ran exactly once). v1.
+9. **KSP crashes after `CLAIMED` but before/partway through the side effect.** Journal at
+   `CLAIMED`. Addon does NOT re-execute; writes `INTERRUPTED`. The command ran zero or a
+   partial number of times; the orchestrator treats `INTERRUPTED` as "unknown outcome" and
+   reconciles (e.g. sends `RecordingState`). At-most-once preserved (never twice). v1.
+10. **Response file append fails (locked by the orchestrator's reader).** The guarded
+    append retries with bounded backoff; the journal is only marked `DONE` after the line
+    lands, and the side effect is guarded by `EXECUTED`, so a persistent failure leaves the
+    id at `EXECUTED` and the response is (re)written next frame or next restart WITHOUT
+    re-executing. An ack is never silently dropped. v1.
+11. **Two KSP instances sharing the same KSP root/files.** The lock file records
+    `ProcessSessionId` and `pid`. A second instance decides ownership by probing the
+    recorded `pid`'s liveness: a live foreign pid -> stand down (Warn, does not consume); a
+    dead foreign pid (previous owner crashed) -> reclaim with a Warn. `t` is not used as the
+    staleness bound. This configuration is out of scope by design (the plan uses one
+    dedicated automation instance) but is detected, not silently double-executed, and a
+    crashed owner does not wedge a fresh run. v1.
+12. **FlushAndQuit during active recording.** FlushAndQuit forces a save of committed
+    state then quits; the in-flight uncommitted recorder is discarded by design (a bare
+    quit never persisted one). Orchestrator sends `CommitTree` first to keep it. v1
+    (behavior documented, not a bug).
+13. **StartRecording when already recording.** Underlying guards prevent a second
+    recorder; handler reports `OK already=true`. v1.
+14. **CommitTree with no active tree.** `ERROR msg=no-active-tree`, mirroring
+    `CommitTreeFlight`'s existing "No active tree to commit" guard. v1.
+15. **DiscardTree with no active tree.** `OK nothing=true` (idempotent no-op). v1.
+16. **SetSetting mid-recording.** Allowed. Live-read settings (e.g. `samplingDensity`
+    thresholds, tracing flags) take effect immediately for subsequent samples; launch-only
+    settings (`autoRecordOnLaunch`) are inert until the next launch. Does not corrupt the
+    in-flight recording. v1.
+17. **SetSetting before any game is loaded (main menu).** `ParsekSettings.Current` is
+    null; the command Defers until a game loads, or `TIMEOUT`s if the orchestrator
+    sequenced it wrong. v1.
+18. **SetSetting non-whitelisted name / out-of-range value.** `REJECTED
+    msg=setting-not-whitelisted` or `setting-value-invalid`; the field is never touched.
+    v1 (security-critical).
+19. **RunTests while a batch is already running.** Strict FIFO plus the `IsRunning` gate
+    defers the next command until the batch finishes. v1.
+20. **StartRecording issued in a scene that never becomes FLIGHT.** Defers until its
+    per-command budget expires -> `TIMEOUT`, pump advances so the run is not wedged. v1.
+21. **Env var set to something other than `1`** (`0`, `true`, empty). Fail-closed: addon
+    stays inert. v1 (security).
+22. **Partial trailing line** (orchestrator mid-write when the pump polls). The pump only
+    processes newline-terminated lines; the fragment is left for the next poll. v1.
+23. **Value with spaces / `=` (e.g. a MissionMark label or a path).** Percent-encoded by
+    the orchestrator, decoded by the parser onto one token; a bad encoding is `REJECTED
+    msg=malformed`. v1.
+24. **Command file grows large over a long run.** Steady state uses the in-memory byte
+    offset + processed-set (O(new lines) per poll); only startup does a full rescan +
+    journal replay. The orchestrator rotates the files between runs. v1.
+25. **Orchestrator forgot to truncate files between runs.** Leftover `DONE` journal makes
+    all old ids no-ops; the addon logs "no fresh commands". If the orchestrator reuses old
+    ids it must truncate; monotonic-across-run ids avoid the issue entirely (documented
+    contract). v1.
+26. **Response line torn by a crash mid-append.** A response line is written in a single
+    append call ending in `\n`; the orchestrator ignores any trailing line without a
+    newline. The journal `DONE` combined with the terminal response is the source of truth
+    (a torn response with no `DONE` is rewritten on restart from `EXECUTED`). v1.
+27. **LoadGame naming a nonexistent / incompatible save.** After the load sequence the
+    scene settles with `HighLogic.CurrentGame == null` (or a game that fails to load);
+    the handler writes `ERROR msg=load-failed` and marks `DONE`. The instance stays at the
+    menu; the orchestrator reconciles. v1.
+28. **KSP crashes mid-LoadGame (during the scene load).** The journal is at `CLAIMED`
+    (the load was initiated, the settle never completed). On restart the addon does NOT
+    re-initiate the load; it writes `INTERRUPTED` and marks `DONE`. The journal file
+    survives the scene load, so at-most-once is preserved and the orchestrator treats the
+    outcome as unknown and re-issues `LoadGame`. v1.
+29. **LoadGame at MAINMENU (the boot path).** This is the intended boot channel: the first
+    command an orchestrator sends after process start selects the save. The pump's
+    safe-point gate permits execution at `MAINMENU` (not `LOADING`, settled), and `LoadGame`
+    declares no game precondition, so it executes there rather than deferring. v1.
+30. **LoadGame mid-flight with a live recorder or active tree.** Rejected with
+    `msg=recording-active` (a live recorder) so the load never silently discards an
+    in-flight recording; the orchestrator must send `CommitTree` or `DiscardTree` first.
+    A second `LoadGame` while one is already in flight is Rejected `msg=load-in-flight`.
+    v1 (behavior documented, not a bug).
+
+## What Doesn't Change
+
+- No recording format, schema generation, sidecar, tree, ledger, or save-file field
+  changes. `RecordingStore.CurrentRecordingFormatVersion` /
+  `CurrentRecordingSchemaGeneration` are untouched; no migration path is added.
+- No gameplay behavior in normal play. The addon is env-gated and inert unless
+  `PARSEK_TEST_COMMANDS=1`; it is never shipped enabled and adds no Settings-UI toggle.
+- `TestRunnerShortcut` and the `Ctrl+Shift+T` runner are unchanged; `RunTests` reuses the
+  existing `InGameTestRunner.RunAll` / `RunCategory` / `ExportResultsFile` surface.
+- `ParsekSettings` serialization is unchanged; `SetSetting` mutates existing fields
+  through their existing persistence routes - `GameParameters.CustomParameterNode` for
+  GameParameters-only settings, and additionally `ParsekSettingsPersistence.Record*` for
+  the 8 sidecar-authoritative settings (mirroring `UI/SettingsWindowUI.cs`). No new
+  serialization format is added.
+- No kRPC reference is added; no assembly is linked that would create a GPL entanglement.
+- No new `GameEvents` subscriptions that affect gameplay - the addon only tracks scene
+  transitions for its own safe-point gating, matching `TestRunnerShortcut`.
+- Recording lifecycle policy (plan 3.3) is unchanged; this module supplies the control
+  verbs the policy assumes (pin auto-record off via `SetSetting`, `StartRecording` /
+  `CommitTree` deliberately).
+
+## Backward Compatibility
+
+- The channel files are ephemeral test artifacts, not versioned save data, so there is no
+  save migration concern. They exist only in the automation instance.
+- **Protocol forward/backward compatibility.** The command line carries an optional `v=`
+  field (default 1) and readers ignore unknown keys, so phase-3 verbs may add keys without
+  breaking a v1 parser; a v1 addon `REJECT`s (does not crash on) reserved and unknown
+  verbs. A future response consumer ignores unknown payload keys the same way. New
+  verbs and new whitelist entries are additive.
+- **Cross-run reuse.** The orchestrator either (a) uses ids that are unique across process
+  restarts within a run and truncates all four files when starting a fresh logical run, or
+  (b) uses globally unique ids (GUIDs). The addon trusts the journal for at-most-once; it
+  never rewrites or deletes the orchestrator's command file.
+- No existing recordings, saves, or settings files are read or rewritten by this module
+  beyond the live `ParsekSettings.Current` mutation, which round-trips through the
+  unchanged parameters-save path.
+
+## Diagnostic Logging
+
+Subsystem tag: `TestCommands`. Format is the standard `[Parsek][LEVEL][TestCommands]
+message` (`ParsekLog.Write`). Per-poll iteration uses the batch-counting convention;
+per-command lines are bounded (few commands) so per-command Info is allowed. Numeric
+values use InvariantCulture.
+
+Env gate and lifecycle:
+- Awake gate decision: `Info` "armed" (with `PARSEK_TEST_COMMANDS=1`) or `Verbose`
+  "inert: PARSEK_TEST_COMMANDS=<value-or-unset>".
+- Lock: `Info` "lock acquired session=<id> pid=<n>", or `Warn` "standing down: foreign
+  live lock session=<other> pid=<n> (alive) t=<t>", or `Warn` "reclaimed crashed lock
+  session=<other> pid=<n> (dead) t=<t>". `t` is logged for context; pid liveness is the
+  decision.
+- Startup journal replay: `Info` summary "journal replay: N done, N executed-not-done
+  (rewriting response), N claimed-not-executed (INTERRUPTED)".
+
+Per poll:
+- `Verbose` (rate-limited, shared key) one summary line: "poll: read=N lines, parsed=N,
+  deferred-head=<verb/none>".
+
+Per command (Info unless noted):
+- Receipt: "recv id=<id> cmd=<verb> args=<count>".
+- Dispatch decision: one line per decision path, never silent -
+  "dispatch id=<id> -> EXECUTE", "dispatch id=<id> -> DEFER reason=<r>" (rate-limited per
+  id while it keeps deferring), "dispatch id=<id> -> REJECT reason=<r>",
+  "dispatch id=<id> -> INTERRUPTED (journal=<phase>)".
+- Journal writes: `Verbose` "journal id=<id> phase=CLAIMED|EXECUTED|DONE".
+- Execution: "exec id=<id> cmd=<verb> start" then "exec id=<id> verdict=<v> <payload>".
+- Response append: `Verbose` "response appended id=<id> verdict=<v>"; on IO failure
+  `Warn` "response append failed id=<id> attempt=<n>: <ex>" and, if exhausted, `Error`
+  "response append giving up this frame id=<id>; will retry (journal=EXECUTED)".
+- Timeout: `Warn` "timeout id=<id> cmd=<verb> deferred=<seconds>s reason=<lastDeferReason>".
+- Duplicate id: `Warn` "duplicate id=<id> ignored".
+- Malformed / unknown / reserved: `Warn` "reject id=<id> cmd=<verb> reason=<malformed|
+  unknown-command|not-implemented-v1>".
+
+Per verb specifics:
+- `SetSetting`: `Info` "setting name=<name> old=<old> new=<new>", or `Warn`
+  "setting rejected name=<name> reason=<not-whitelisted|value-invalid> raw=<value>".
+- `StartRecording`/`StopRecording`/`CommitTree`/`DiscardTree`: `Info` with the resulting
+  tree/recording id and whether it was a no-op (already/idle/nothing).
+- `RunTests`: `Info` "runtests start category=<cat|all>" and "runtests complete passed=N
+  failed=N skipped=N results=<path>".
+- `LoadGame`: `Info` "loadgame start save=<folder> name=<file> scene=<current>" and
+  "loadgame complete scene=<new> save=<folder> game-loaded=<bool>", or `Warn`
+  "loadgame rejected reason=<recording-active|load-in-flight>", or `Error`
+  "loadgame failed save=<folder>: game null/incompatible". The start/complete pair brackets
+  the boot channel so a KSP.log reader can see the instance booted into the intended save.
+- `MissionMark`: `Info` "MISSIONMARK label=<label> ut=<ut>" (stable, grep-able for
+  orchestration correlation).
+- `FlushAndQuit`: `Info` "flushandquit: saved=<bool> game-loaded=<bool>; quitting" -
+  logged and flushed BEFORE `Application.Quit`.
+
+Goal: a developer reading KSP.log can reconstruct, for every command id, that it was
+received, which dispatch branch it took and why, whether it executed, and the terminal
+verdict - without the source.
+
+## Test Plan
+
+Pure core (`TestCommandParser`, `DecideDispatch`, whitelist setters, response/journal
+formatters, `DecideLockOwnership`, percent codec) is `internal static` and xUnit-tested
+without Unity. Only the thin addon (`ParsekTestCommandAddon`) touches Unity/KSP and is
+exercised in-game.
+
+Unit tests (each: input -> expected -> what makes it fail):
+
+- **Parse valid line round-trip.** `id=0001 cmd=SetSetting name=x value=false` ->
+  id/verb/args populated. Fails if the parser mis-splits `key=value` tokens or drops args.
+- **Parse malformed lines.** Missing `id`, missing `cmd`, a bare token with no `=`, a
+  value with an illegal raw space. Each -> `ParseOk=false` with the right reason. Fails if
+  a malformed line is accepted and later executed as a real command.
+- **Percent codec round-trip.** `mun%20landing`/`a%3Db`/`50%25` decode to the literals and
+  re-encode back. Fails if a `MissionMark` label with spaces is split across tokens or a
+  `%` value is corrupted.
+- **Whitelist accept + type/range.** Each whitelisted name parses to the typed value;
+  `samplingDensity=1` sets 1, `samplingDensity=5` -> reject, `ghostAudioVolume=0,7`
+  (comma locale) -> reject (InvariantCulture only), `autoMerge=yes` -> reject. Fails if an
+  out-of-range or locale-broken value is written, or a non-bool passes a bool setting.
+- **Whitelist rejects arbitrary field.** `name=someOtherField` -> `REJECTED
+  not-whitelisted`; assert no reflective set occurs. Fails if the dispatcher can set a
+  non-whitelisted field (the security-critical test - proves commands are data, not code).
+- **Tracked-setting persistence route.** Each of the 8
+  `ParsekSettingsPersistence`-authoritative names (`writeReadableSidecarMirrors`,
+  `showCommittedFutureOverlays`, `blockCommittedActions`, `showRouteLines`,
+  `autoBackupExistingSaves`, `ghostRenderTracing`, `mapRenderTracing`, `ledgerTracing`)
+  routes through the matching `ParsekSettingsPersistence.Record*` call (asserted via the
+  persistence seam / a spy), and the 8 GameParameters-only names do NOT. Fails if a tracked
+  setting is written only to the live field, which `ParsekScenario.OnLoad`'s `ApplyTo`
+  would silently revert at the next save load (the exact bug this column fixes).
+- **Dispatch decision matrix.** For each verb x state
+  (scene, game-loaded, recording, has-tree, transitioning, batch-running, journal-phase)
+  assert `Execute` / `Defer(reason)` / `Reject(reason)` / `Interrupted`. Key rows:
+  `StartRecording` outside FLIGHT -> Defer; `CommitTree` with no tree -> the handler's
+  `no-active-tree` error path; `SetSetting` with no game -> Defer; `RunTests` while a
+  batch runs -> Defer; `LoadGame` at MAINMENU with no recorder -> Execute (boot channel);
+  `LoadGame` with a live recorder -> Reject(`recording-active`); `LoadGame` while another
+  load is in flight -> Reject(`load-in-flight`). Fails if a command executes in an unsafe
+  scene/state, or if `LoadGame` silently discards an in-flight recording.
+- **Three-phase journal at-most-once.** Given a journal with an id at `CLAIMED` ->
+  decision `Interrupted` (no execute). At `EXECUTED` -> skip execute, rewrite response,
+  `DONE`. At `DONE` -> skip entirely. Fresh id -> `Execute`. Fails if a mid-execution
+  crash re-runs a non-idempotent command (the core correctness guarantee).
+- **LoadGame journal at-most-once (long-running boot).** A `LoadGame` id at `CLAIMED`
+  (crashed mid-scene-load) -> `Interrupted`, never re-initiate the load; at `EXECUTED`
+  (loaded, response not written) -> rewrite response, `DONE`; at `DONE` -> skip. Fails if
+  a crash mid-boot re-triggers `GamePersistence.LoadGame` or double-acks the boot.
+- **Duplicate id.** Two lines with the same id -> second returns "already handled", no
+  second response. Fails if a command is executed or acked twice.
+- **Strict FIFO / no reordering.** A deferring head command blocks a later ready command
+  until it times out. Fails if the pump jumps ahead and violates ordering.
+- **Timeout conversion.** A command deferred past its budget -> `TIMEOUT` terminal, pump
+  advances. Fails if a never-satisfiable command wedges the run forever.
+- **Reserved vs unknown verb.** A reserved phase-3 name -> `not-implemented-v1`; a
+  gibberish name -> `unknown-command`. Fails if v1 silently executes or mis-buckets a
+  future command.
+- **Response formatter stability.** Assert the exact grep-able shape (`id=`, `cmd=`,
+  `verdict=`, `seq=` present; payload keys percent-encoded; InvariantCulture floats).
+  Fails if a field is dropped or a locale comma leaks into `ut`.
+- **Lock ownership decision.** Own-session lock -> reclaim; foreign lock with a LIVE pid ->
+  stand down; foreign lock with a DEAD pid -> reclaim-with-warn; the injected pid-liveness
+  probe is the primary, `t` only a tie-break/log detail. Fails if two instances both
+  consume, if a live foreign lock is stolen (pid-liveness ignored in favor of a fresh `t`),
+  or if a crashed instance's lock wedges a fresh run (dead pid not reclaimed because `t`
+  looked recent).
+- **Env gate predicate.** `"1"` -> armed; `null`/`"0"`/`"true"`/`""` -> inert. Fails if
+  the addon consumes commands without the exact gate (ships enabled by accident).
+
+Log-assertion tests (via `ParsekLog.TestSinkForTesting`, per `RewindLoggingTests`):
+
+- Every dispatch branch (Execute/Defer/Reject/Interrupted) emits a `[TestCommands]` line
+  with the id and reason. Fails if a decision branch is silent (a debugging blind spot),
+  or if the receipt/verdict lines lose their grep-able shape under refactor.
+- `MissionMark` emits the stable `MISSIONMARK label= ut=` line. Fails if the orchestration
+  correlation marker format drifts.
+
+In-game tests (`InGameTests`, live KSP only - the addon's Unity side):
+
+- With `PARSEK_TEST_COMMANDS` unset, `ParsekTestCommandAddon` performs no file access and
+  no polling (assert inert). Fails if the shipped default is not fully inert.
+- A `StartRecording` -> `RecordingState` -> `CommitTree` -> `RecordingState` sequence
+  through the file channel produces the expected verdicts and a committed tree in FLIGHT.
+  Fails if the addon's main-thread execution or safe-point gating is wrong. (This is the
+  end-to-end path M-A5 depends on; per the plan and MEMORY note on in-game sweeps, it is
+  delivered as an automated in-game test plus a PENDING-OPERATOR runbook, since an agent
+  cannot pilot KSP.)
+- A cold-boot `LoadGame` -> `RecordingState` sequence: the addon armed at process start,
+  the first command a `LoadGame save=<folder> name=<file>` issued at `MAINMENU`, drives the
+  instance into FLIGHT and a following `RecordingState` returns `OK` with the loaded
+  scene/save. Fails if the boot channel does not execute at the menu or the safe-point gate
+  wrongly defers it (the automation instance would never leave the menu). Delivered as an
+  automated in-game test plus a PENDING-OPERATOR runbook.

--- a/docs/dev/design-autotest-offline-analyzer.md
+++ b/docs/dev/design-autotest-offline-analyzer.md
@@ -1,0 +1,780 @@
+# Design: Offline Recording Analyzer (Module M-A1)
+
+Status: DRAFT (2026-07-11). Module M-A1 of the automated testing initiative
+(`docs/dev/automated-testing-plan.md` section 11b). This is the Step 3 design
+doc; the vision + scenarios are the plan (section 7) and the scenario catalog.
+Plain ASCII, no em dashes.
+
+---
+
+## Problem
+
+Parsek's correctness lives almost entirely in files it writes: recording trees
+in `persistent.sfs`, trajectory / snapshot / ghost / annotation sidecars under
+`saves/<save>/Parsek/Recordings/`, rewind quicksaves under
+`saves/<save>/Parsek/RewindPoints/`, and the ledger state under
+`saves/<save>/Parsek/GameState/`. Today the only way to know a save is
+internally consistent is to load it into KSP and watch. Bugs that corrupt these
+files (a RELATIVE section written with body-fixed lat/lon, a chain with a broken
+`ChainIndex` run, a supersede row pointing at a missing recording, a sidecar
+whose schema generation drifted from the tree metadata) are invisible until
+playback misbehaves, and by then the failing frame has scrolled past.
+
+We need a headless, no-KSP tool that takes any save directory and answers "is
+every recording tree + sidecar set + `ParsekScenario` node structurally valid
+against the contracts the production code enforces?" It has to run three ways:
+as a per-PR CI regression floor over a fixture corpus (minutes, no game), as a
+post-run verifier over saves produced by scripted missions (the harness reads
+its verdict), and as ad hoc triage over a user bug-report save (a human reads
+its report). The same rule set must later be walkable in-game against the live
+`RecordingStore` (module M-A3 / hook H5), so the rules cannot bake in any
+file-I/O assumption.
+
+## Terminology
+
+- **Invariant / rule**: one named check over loaded data structures. A rule
+  produces zero or more **findings**. Each rule declares the production member
+  that defines or enforces the contract it checks (its `CitedContract`), so a
+  rule asserting a wrong contract dies in code review rather than as a false
+  alarm in nightly.
+- **Finding**: one observation with a **verdict level** (FAIL / WARN / INFO /
+  STALE-FIXTURE), a rule id, a target (recording id / tree id / section index /
+  file path), and a human message.
+- **Verdict level**:
+  - **FAIL**: a contract the production loader would reject or that guarantees
+    broken playback. A run with any FAIL is red.
+  - **WARN**: suspected wrong but not proven a bug yet, or a contract not yet
+    pinned to citable production behavior (e.g. ABSOLUTE lat/lon range before
+    KSP longitude normalization is cited). Visible, does not fail the run.
+  - **INFO**: inventory / provenance / counts. Never fails a run.
+  - **STALE-FIXTURE**: the analyzed data carries a schema generation that does
+    not match the fixture set's stamp. Distinct from FAIL: the data is not
+    wrong, the fixture is out of date (plan section 7 versioning policy).
+- **Analysis subject**: one save directory. The analyzer emits exactly one
+  machine-readable report file and one human summary per subject.
+- **Loaded model**: the in-memory `Recording` / `RecordingTree` /
+  `TrackSection` / `OrbitSegment` / ledger objects after the analyzer has
+  hydrated them from disk. Rules run over the loaded model, never over raw
+  bytes.
+- **Codec seam**: a headless-callable serialize/deserialize pair that never
+  touches Unity or `ScenarioModule` (e.g. `RecordingTreeRecordCodec`,
+  `RecordingManifestCodec`, `TrajectorySidecarBinary`). Round-trip rules run
+  here, never at `ParsekScenario.OnSave/OnLoad` (not xUnit-drivable).
+
+## Mental Model
+
+```
+                 +-------------------------------------------+
+   save dir  --> |  LOADER (analyzer, file I/O lives here)   |
+                 |  parse .sfs -> trees; hydrate sidecars     |
+                 |  parse ledger; every parse failure is a    |
+                 |  FINDING, never a crash                     |
+                 +----------------------+--------------------+
+                                        |  loaded model (pure data)
+                                        v
+                 +-------------------------------------------+
+                 |  INVARIANT CORE (pure, no file I/O)        |
+                 |  IRecordingInvariant[] over the model      |
+                 |  each rule -> findings + CitedContract     |
+                 +----------------------+--------------------+
+                                        |  List<Finding>
+                                        v
+                 +-------------------------------------------+
+                 |  REPORTERS                                 |
+                 |  machine report (stable JSON-ish .txt)     |
+                 |  + human summary (grep-friendly lines)     |
+                 +-------------------------------------------+
+
+   Three entry points, ONE core + ONE rule set:
+     - xUnit [Trait Manual] test  -> CI floor over fixture corpus
+     - scripts/analyze-recordings.ps1 -> harness post-run + ad hoc triage
+     - (future) in-game H5 category -> same rules over live RecordingStore
+```
+
+The hard separation is loader vs core. The loader owns all file I/O and all
+"the bytes did not parse" findings. The core is a set of pure functions over
+already-loaded objects: give it a `List<Recording>`, a `List<RecordingTree>`,
+the `ParsekScenario`-equivalent state (tombstones, supersede rows), and the
+parsed `CareerSaveSnapshot`, and it returns findings. The in-game H5 category
+(M-A3) will feed the same core the live `RecordingStore.CommittedRecordings`
+walked RAW (the whole committed list, NOT routed through `EffectiveState`) and
+get identical findings, because the core never asked where the data came from.
+H5 deliberately does not route through `EffectiveState.ComputeERS`: ERS is the
+visibility-filtered effective set and would HIDE the superseded rows INV7 exists
+to check (a superseded recording ERS drops is still a row whose
+`SupersedeTargetId` must resolve). The offline loader walks the whole save
+directory including those rows; the in-game walker feeds the same complete raw
+set so the same core produces the same verdict.
+
+Design decision, grounded: the core must resolve `TrackSection.referenceFrame`
+per UT and dispatch RELATIVE sections through the production offset contract,
+never read `TrajectoryPoint.latitude/longitude/altitude` as body-fixed lat/lon
+for a RELATIVE section. `TrackSection` (`TrackSection.cs`) stores anchor-local
+metre offsets in those exact fields for `ReferenceFrame.Relative`
+(`.claude/CLAUDE.md` RELATIVE contract; recorder side
+`FlightRecorder.ApplyRelativeOffset` -> `TrajectoryMath.ComputeRelativeLocalOffset`).
+A naive flat-`Points` reader would itself commit the documented RELATIVE-misread
+bug and WARN on every parent-anchored debris recording (plan section 11 Phase 0
+exit criterion).
+
+## Data Model
+
+All new types live in `Source/Parsek.Tests/Analyzer/` (justification in
+Behavior). None of them persist to save files, so there is no ConfigNode
+serialization to design for the model itself; the report format is a separate
+frozen output contract (see Report format below).
+
+### Core interfaces and records
+
+```
+namespace Parsek.Tests.Analyzer
+
+enum VerdictLevel { Info = 0, Warn = 1, Fail = 2, StaleFixture = 3 }
+
+struct Finding
+    string   RuleId          // stable, e.g. "INV1-UT-MONOTONIC"
+    VerdictLevel Level
+    string   Target          // recordingId / treeId / "<save>" / file path
+    int      SectionIndex     // -1 when not section-scoped
+    string   Message          // human, one line, ASCII
+    string   CitedContract    // production member the rule checks (REQUIRED)
+
+interface IRecordingInvariant
+    string RuleId { get; }
+    string CitedContract { get; }   // e.g. "RecordingStore.IsRecordingSchemaCompatible"
+    IEnumerable<Finding> Evaluate(AnalyzerModel model)
+
+// AnalyzerModel is the pure, already-loaded input. No Stream, no path, no
+// FileInfo on it. This is what the future in-game H5 category also builds.
+class AnalyzerModel
+    string SaveName
+    IReadOnlyList<Recording>      Recordings          // flat, all trees flattened
+    IReadOnlyList<RecordingTree>  Trees
+    IReadOnlyList<LedgerTombstone> Tombstones
+    IReadOnlyList<RecordingSupersedeRelation> SupersedeRelations
+    CareerSaveSnapshot            CareerSave          // null when not career / unparsable
+    IReadOnlyList<GameAction>     Ledger              // RAW Ledger.Actions (unfiltered); INV8 computes the ELS filter internally from Tombstones
+    IReadOnlyList<LoadFault>      LoadFaults          // parse failures the loader recorded
+    FixtureStamp?                 FixtureStamp        // null for non-fixture subjects
+    Func<string, CelestialBody>   BodyResolver        // injected; TestBodyRegistry in xUnit
+
+struct LoadFault                 // a file that failed to parse == a finding, not a crash
+    string FilePath
+    string FileKind              // "trajectory" / "snapshot" / "tree-node" / "ledger" / "rewindpoint" / "annotation"
+    string Reason                // parser's failure reason string
+    string RecordingId           // when resolvable from the path, else null
+
+struct FixtureStamp
+    int SchemaGeneration
+    string Provenance            // "synthetic" | "harvested"
+```
+
+### Loader output and report
+
+```
+class AnalysisReport
+    string SaveName
+    string AnalyzerVersion       // frozen report-format version, bumped only on format change
+    int    SubjectSchemaGeneration   // discovered from the data
+    List<Finding> Findings       // sorted: Level desc, then RuleId, then Target
+    Counts Counts                // { fail, warn, info, staleFixture }
+
+struct Counts { int Fail; int Warn; int Info; int StaleFixture; }
+```
+
+### Report format (frozen output contract)
+
+Two files per subject, written next to a results directory the caller picks:
+
+- `<save>.analysis.json`: machine-readable. A stable, sorted JSON object.
+  Fields in fixed order: `analyzerVersion`, `saveName`, `subjectSchemaGeneration`,
+  `counts` (`fail`/`warn`/`info`/`staleFixture`), then `findings` as an array of
+  `{ ruleId, level, target, sectionIndex, message, citedContract }` sorted by
+  (level desc, ruleId, target, sectionIndex). Determinism is a hard requirement:
+  the same input bytes produce byte-identical JSON (no timestamps, no absolute
+  paths, no dictionary-iteration order). Floats serialize with
+  `ToString("R", CultureInfo.InvariantCulture)` (house rule from `.claude/CLAUDE.md`).
+- `<save>.analysis.txt`: human summary. One header line
+  `[Analyzer] save=<name> generation=<n> FAIL=<a> WARN=<b> INFO=<c> STALE=<d>`
+  then one line per finding: `<LEVEL> <ruleId> target=<t>[#section] <message>`.
+  Grep-friendly, mirrors the `validate-ksp-log.ps1` output style.
+
+`AnalyzerVersion` is a constant in the analyzer; it is bumped only when the
+report schema changes, and a test pins the format (see Test Plan). Adding a new
+rule does NOT bump it (rules are data inside `findings`).
+
+## Behavior
+
+### Where the code lives (proposal + justification)
+
+- `Source/Parsek.Tests/Analyzer/` holds the invariant core (`IRecordingInvariant`,
+  `AnalyzerModel`, `Finding`, the concrete rule classes), the loader
+  (`SaveDirectoryLoader`), and the reporters. It lives in the Tests project
+  because it consumes the `internal` headless seams that are already exposed to
+  tests: `RecordingStore.LoadTrajectorySidecarForTesting`,
+  `RecordingStore.LoadSnapshotSidecarForTesting`,
+  `RecordingStore.TryProbeTrajectorySidecar`,
+  `RecordingStore.IsRecordingSchemaCompatible`, `RecordingTreeRecordCodec`,
+  `RecordingManifestCodec`, `CareerSaveParser.Parse`, `EffectiveState.ComputeERS`
+  / `ComputeELS`, and the `TrajectoryMath` `bodyResolver` seam with
+  `Tests.TestBodyRegistry`. Re-homing them to a separate assembly would require
+  making all those seams `public`; that is a bigger contract change than this
+  module should force, and the plan (section 3.1) says pin against public TEST
+  APIs, which these `internal`-to-Tests seams already are.
+- A `[Trait("Category", "Manual")]`-adjacent xUnit entry point
+  (`Analyzer/OfflineAnalyzerTests.cs`) runs the analyzer over the fixture corpus
+  in CI, and over an env-var-supplied directory for ad hoc use. It follows the
+  exact pattern of the existing `InjectAllRecordings` Manual test
+  (`docs/dev/synthetic-recordings.md`): env-var input, CI-safe skip when the
+  input directory is absent.
+- `scripts/analyze-recordings.ps1` is the thin CLI driver, modeled on
+  `scripts/validate-ksp-log.ps1` (which already "drives a real xUnit pass",
+  plan section 1). It resolves the target save dir, sets the env var, invokes
+  `dotnet test` filtered to the analyzer entry point, and surfaces the report
+  files. This keeps ONE execution path (the xUnit host) for all three run modes,
+  so the harness and the human get identical verdicts.
+
+### Run modes
+
+All three modes call the same `Analyzer.Run(saveDir, resultsDir)`. Both
+parameters are REQUIRED (there is no zero-arg overload): `resultsDir` is where
+the two report files are written and must be passed explicitly so a caller can
+never accidentally scatter reports next to a user's save. In CI mode the caller
+supplies the default `resultsDir` = the test output directory
+(`Source/Parsek.Tests/bin/Debug/net472/analyzer-results/`, resolvable from the
+xUnit working dir); the CLI driver defaults it to a `analysis/` folder beside the
+target save; the harness passes its per-run results directory.
+
+1. **CI regression floor**: input dir = the fixture corpus
+   (`PARSEK_ANALYZER_SAVE` unset -> default corpus path under the test tree);
+   `resultsDir` = the CI default test-output directory named above.
+   Any FAIL fails the build. STALE-FIXTURE also fails the build (a stale corpus
+   is a maintenance failure, per plan section 7).
+2. **Harness post-run**: input dir = a mission-produced save. The harness reads
+   `<save>.analysis.json` `counts.fail`; nonzero is a PARSEK-FAIL verdict
+   (plan section 9 step 2). WARN is surfaced but not failing.
+3. **Ad hoc triage**: input dir = a user bug-report save copied locally. The
+   human reads `<save>.analysis.txt`. Malformed input is expected and produces
+   findings, never a stack trace (see Edge Cases).
+
+### The loader
+
+`SaveDirectoryLoader.Load(saveDir, bodyResolver) -> AnalyzerModel`:
+
+1. Locate `persistent.sfs` (and any numbered `*.sfs` the caller names). Parse
+   with `ConfigNode.Load`. A parse failure is one `LoadFault{ FileKind="sfs" }`
+   and an empty model, not an exception.
+2. Find the `ParsekScenario` SCENARIO node. Hydrate recording-tree records via
+   `RecordingTreeRecordCodec.LoadRecordingFrom` per RECORDING node; each throw
+   is caught and recorded as a `LoadFault{ FileKind="tree-node", RecordingId=... }`.
+   Read `LedgerTombstones` and supersede relations from the scenario node.
+3. For each recording, resolve sidecar paths via `RecordingPaths`
+   (`BuildTrajectoryRelativePath`, `BuildVesselSnapshotRelativePath`,
+   `BuildGhostSnapshotRelativePath`, `BuildAnnotationsRelativePath`), validating
+   ids through `RecordingPaths.ValidateRecordingId`. Hydrate trajectory via
+   `RecordingStore.LoadTrajectorySidecarForTesting`, snapshots via
+   `RecordingStore.LoadSnapshotSidecarForTesting`. A `false` return or throw is
+   a `LoadFault` with the probe's failure reason
+   (`RecordingStore.TryProbeTrajectorySidecar` supplies `probe.FailureReason`).
+4. Parse the career save via `CareerSaveParser.Parse(gameNode)` when the save is
+   career; a null / unparsable result leaves `CareerSave = null` and records a
+   `LoadFault{ FileKind="career" }` only when the ledger rule needs it.
+5. Load the RAW ledger. The loader materializes `Ledger.Actions` verbatim into
+   `AnalyzerModel.Ledger` and the tombstone rows into `AnalyzerModel.Tombstones`,
+   with NO pre-filtering. The loader does NOT compute an ELS-ready list: the ELS
+   filter is a RULE concern, not a loader concern. INV8 owns computing the ELS
+   filter from the raw actions plus the tombstones (see INV8), so its
+   tombstone-resolves-against-a-real-action check has something to check. Pushing
+   an already-filtered "ELS-ready" list into the model would make that check
+   vacuous by construction (a filtered list can never contain a tombstone
+   pointing at an action it already dropped). The analyzer cannot call the live
+   static `EffectiveState.ComputeELS` anyway (it reads process statics); INV8
+   reconstructs the filter from the loaded `Tombstones` using the exact ELS
+   definition cited in `EffectiveState.cs` (ELS = actions minus any action whose
+   `ActionId` is tombstoned).
+
+`SuppressLogging` on `RecordingStore` is set true during load so the analyzer
+does not spam KSP-style logs; the loader emits its own analyzer-tagged lines.
+
+### The invariant rules
+
+Ten invariant families from plan section 7, plus 7b annotation staleness. Each
+is one `IRecordingInvariant` (or a small cluster sharing a `CitedContract`).
+
+- **INV1 UT monotonicity** (`RuleId INV1-UT-MONOTONIC`). Per `TrackSection`, the
+  `frames` / `bodyFixedFrames` / `checkpoints` UT sequences are non-decreasing;
+  the flat `Recording.Points` UT sequence is non-decreasing; per-section
+  `startUT <= endUT`. Violation = FAIL. CitedContract: `TrajectoryPoint.ut` +
+  `TrackSection.startUT/endUT` ordering assumed by `TrajectoryMath` sampling.
+- **INV2 no double-cover** (`RuleId INV2-NO-DOUBLE-COVER`). No two sections'
+  `[startUT,endUT]` spans overlap in interior UT. Gaps are allowed
+  (on-rails BG spans emit no TrackSections;
+  `TrackSection.boundaryDiscontinuityMeters` models legitimate seams). A gap not
+  covered by any section AND not bridged by an `OrbitSegment` -> WARN
+  (`INV2-UNCOVERED-SPAN`), not FAIL. Overlap -> FAIL. CitedContract:
+  `RecordingOptimizer.IsSplittableEnvOrBodyBoundary` (sections are disjoint
+  producers) + `TrackSection.boundaryDiscontinuityMeters` + the on-rails
+  no-TrackSection contract (`BackgroundRecorder` `BackgroundOnRailsState`).
+- **INV3 RELATIVE contract** (`RuleId INV3-RELATIVE-CONTRACT`). For a
+  `ReferenceFrame.Relative` section: `anchorRecordingId` (non-loop) OR
+  `anchorVesselId` (loop) must be present, and out-of-`[-90,90]`/`[-180,180]`
+  values in the `frames` lat/lon fields are EXPECTED (they are metre offsets)
+  and never flagged. For a `ReferenceFrame.Absolute` section, out-of-range
+  lat/lon -> WARN (`INV3-ABSOLUTE-RANGE`) until KSP longitude normalization is
+  cited, then promote to FAIL. A RELATIVE section with neither anchor -> FAIL.
+  CitedContract: `TrackSection.referenceFrame` / `anchorRecordingId` /
+  `anchorVesselId` + the RELATIVE offset contract
+  (`TrajectoryMath.ComputeRelativeLocalOffset` /
+  `ParsekFlight.TryResolveRelativeOffsetWorldPosition`).
+- **INV4 part-event PID resolution** (`RuleId INV4-PARTEVENT-PID`). Every part
+  event's PID resolves against the paired snapshot's part-PID set. For synthetic
+  ghosts the builder assigns `persistentId = 100000 + idx*1111`
+  (`VesselSnapshotBuilder.AddPart`); the rule checks membership, not the
+  formula. Unresolvable PID with a snapshot present -> FAIL; no snapshot present
+  (destroyed / showcase) -> INFO. CitedContract: `VesselSnapshotBuilder.AddPart`
+  PID assignment + the ghost-event lookup contract (`.claude/CLAUDE.md` ghost
+  event <-> snapshot PID).
+- **INV5 schema gate** (`RuleId INV5-SCHEMA-GATE`). Every recording +
+  trajectory sidecar passes `RecordingStore.IsRecordingSchemaCompatible`
+  (format 1, generation 4). A recording whose metadata and sidecar disagree, or
+  that fails the gate, -> FAIL with the exact reason string
+  (`generation-missing` / `generation-older` / `generation-newer` /
+  `format-version-mismatch`). The rule also inventories all generations seen as
+  INFO. CitedContract: `RecordingStore.IsRecordingSchemaCompatible`,
+  `RecordingStore.CurrentRecordingFormatVersion`,
+  `RecordingStore.CurrentRecordingSchemaGeneration`.
+- **INV6 resource manifest consistency** (`RuleId INV6-RESOURCE-MANIFEST`).
+  Where a resource manifest is present, it round-trips through
+  `RecordingManifestCodec.SerializeResourceManifest` /
+  `DeserializeResourceManifest` and its per-resource deltas are internally
+  consistent. Manifests are OPTIONAL: a Gloops / showcase ghost with no manifest
+  is INFO, not a finding. A missing manifest on a NORMAL committed flight
+  recording is also INFO in v1 (the presence-rule table lists recording kinds and
+  none currently require a manifest); tightening the flight-recording cell to
+  WARN is a candidate once fixture data shows manifests are universal on flown
+  recordings. CitedContract:
+  `RecordingManifestCodec.SerializeResourceManifest` +
+  `ResourceManifest.ComputeResourceDelta`.
+- **INV7 tree topology** (`RuleId INV7-TREE-TOPOLOGY`). All
+  `ParentRecordingId` / `ChainId` / `ChainBranch` / `anchorRecordingId` /
+  `ParentAnchorRecordingId` / `SupersedeTargetId` / tombstone links resolve to
+  an existing recording (or are null); no cycles in the parent graph or the
+  supersede graph. `ChainIndex` contiguity is scoped PER `(ChainId, ChainBranch)`
+  (`ChainBranch > 0` = parallel ghost-only continuations, flight-recorder 9A.4)
+  with a supersede-boundary exemption for HEAD/TIP splits. A dangling link or a
+  cycle -> FAIL; a `(ChainId, ChainBranch)` index gap not explained by a
+  supersede boundary -> FAIL; a gap AT a supersede boundary -> INFO. CitedContract:
+  `Recording.ChainId/ChainIndex/ChainBranch` + `RecordingTreeSplitter` HEAD/TIP
+  split + `RecordingOptimizer.CanAutoMerge` supersede guard (verify against the
+  optimizer's supersede guard before shipping, per plan section 7).
+- **INV7b annotation staleness** (`RuleId INV7B-ANNOTATION-STALE`). Where a
+  `.pann` sidecar exists, its recorded source epoch matches the paired `.prec`
+  sidecar's current epoch. `PannotationsSidecarBinary.TryProbe` yields
+  `probe.SourceSidecarEpoch` + `probe.SourceRecordingFormatVersion`; if the
+  `.prec`'s current epoch is newer, the annotation is stale -> WARN
+  (annotations are a derived cache, not authored data, rendering design 17.3.1).
+  A `.pann` for a recording with no `.prec` -> WARN (orphan). CitedContract:
+  `PannotationsSidecarBinary.TryProbe` (`SourceSidecarEpoch`) +
+  `RecordingPaths.BuildAnnotationsRelativePath`.
+- **INV8 ledger** (`RuleId INV8-LEDGER`). Two parts, distinct severities.
+  (a) ELS internal consistency, over the RAW model. The rule itself computes the
+  ELS filter from `model.Ledger` (raw actions) plus `model.Tombstones` using the
+  ELS definition cited in `EffectiveState.cs` (ELS = raw actions minus any action
+  whose `ActionId` is tombstoned), then asserts every tombstone's target
+  `ActionId` resolves against the RAW action list. Because the input is the raw
+  list, this check is non-vacuous: a tombstone pointing at an id absent from the
+  raw actions is a real dangling reference. A dangling tombstone -> FAIL. This
+  part runs for every save (career or not).
+  (b) Career-diff reconstruction, career saves only, WARN severity in v1. When
+  the save is career the rule reconstructs the ledger and diffs against the
+  save's parsed career totals via `LedgerGroundTruthDiff.Compare`. Any divergence
+  (hard or report-only) -> WARN in the offline analyzer, NOT FAIL.
+  OPEN QUESTION: the offline reconstruction is not yet specified end-to-end.
+  `LedgerGroundTruthDiff.Compare` needs a `LedgerReconstructionSnapshot`, which
+  in-game comes from `LedgerOrchestrator.RecalculateAndPatch` plus the module
+  running-readers, with `facilityMaxLevels` injected from live KSP. Headless,
+  this requires (1) proving the recalculation engine is Unity-free (or extracting
+  a Unity-free seam) and (2) a hardcoded stock facility-max-levels map to replace
+  the live-KSP injection. Until that seam is proven, the offline career diff is
+  informational-only and capped at WARN. The FAIL-severity career-diff variant
+  belongs to the in-game H5 path, where the `LedgerGroundTruthHarness` seam
+  already reconstructs against a live quicksave (module M-A3 / H5); there hard
+  divergence (`report.HardFailures`) -> FAIL, report-only per-identity divergence
+  -> WARN. Non-career save -> INFO (part (b) skipped). CitedContract:
+  `EffectiveState.ComputeELS` (ELS definition) + `CareerSaveParser.Parse` +
+  `LedgerGroundTruthDiff.Compare` + `LedgerGroundTruthHarness` (in-game FAIL path).
+- **INV9 rewind-point + id validation** (`RuleId INV9-REWINDPOINT`). Every
+  `RewindPoint` id passes `RecordingPaths.ValidateRecordingId`, its
+  `Parsek/RewindPoints/<id>.sfs` exists and parses as a ConfigNode, and every
+  recording id in the tree passes `ValidateRecordingId`. An invalid id, a
+  missing referenced RP file, or an unparsable RP -> FAIL; an orphan RP file on
+  disk with no referencing slot -> WARN. CitedContract:
+  `RecordingPaths.ValidateRecordingId` + `RecordingPaths.BuildRewindPointRelativePath`.
+- **INV10 codec round-trips** (`RuleId INV10-CODEC-ROUNDTRIP`). For each loaded
+  recording, re-serialize and re-deserialize at the CODEC seams and assert
+  structural equality: `RecordingTreeRecordCodec.SaveRecordingInto` ->
+  `LoadRecordingFrom`, `RecordingManifestCodec` serialize/deserialize pairs, and
+  the trajectory sidecar `TrajectorySidecarBinary` write/read. Round-trips run
+  ONLY at these seams, never at `ParsekScenario.OnSave/OnLoad` (not
+  xUnit-drivable; known constraint, plan section 7 invariant 10). A non-round-
+  tripping field -> FAIL naming the field. CitedContract:
+  `RecordingTreeRecordCodec.SaveRecordingInto` / `LoadRecordingFrom`,
+  `RecordingManifestCodec`, `TrajectorySidecarBinary`.
+
+### Fixture versioning
+
+The analyzer reads a `FixtureStamp` from a `fixture-generation.txt` file the
+fixture corpus carries (one line: `generation=<n> provenance=<synthetic|harvested>`).
+When the subject is the fixture corpus and its stamp generation differs from
+`RecordingStore.CurrentRecordingSchemaGeneration`, EVERY recording in it is
+reported STALE-FIXTURE, not FAIL, and the run advises re-running the M-A4
+regeneration script. Harvested fixtures (which cannot be regenerated by script
+per the no-migration policy) are reported STALE-FIXTURE with a re-harvest-queue
+note. Non-fixture subjects (harness / triage saves) have no stamp and skip this
+check entirely. CitedContract: `RecordingStore.CurrentRecordingSchemaGeneration`
++ plan section 7 versioning policy.
+
+## Edge Cases
+
+Each: scenario -> expected behavior -> v1 or deferred.
+
+1. **Truncated `.prec` (partial write / crash mid-save)**. Scenario: a
+   trajectory sidecar ends mid-record. Expected: `TryProbeTrajectorySidecar`
+   returns a probe with `Supported=false` or the read throws; the loader records
+   a `LoadFault{ FileKind="trajectory", Reason=<probe reason> }` and a
+   `INV5-SCHEMA-GATE` FAIL. The analyzer does not crash. v1.
+2. **Text-format `.prec` (pre-v0-reset corpus)**. Scenario: a 9/14-style legacy
+   text sidecar. Expected: `TryProbeTrajectorySidecar` returns
+   `Supported=false, FailureReason="text-sidecar-unsupported"`; loader records a
+   LoadFault; INV5 FAIL with that reason. Matches the production hard reject at
+   `RecordingStore.DeserializeTrajectorySidecar`. v1.
+3. **Pre-reset binary magic**. Scenario: a sidecar with the old binary magic
+   tag. Expected: `HasPreResetBinaryMagic` path yields a probe with the
+   pre-reset failure reason; LoadFault + INV5 FAIL. v1.
+4. **Recording metadata generation != sidecar generation**. Scenario: tree node
+   says gen 4, `.prec` probe says gen 3. Expected: INV5 FAIL reason
+   `generation-mismatch` (the loader mirrors the production check at
+   `RecordingSidecarStore.LoadRecordingFiles`). v1.
+5. **RELATIVE section with out-of-range lat/lon and a valid anchor**. Scenario:
+   parent-anchored debris with metre offsets in the lat/lon fields
+   (values > 90 / > 180). Expected: NOT flagged; the values are anchor-local
+   metres by contract. INV3 passes. This is the documented false-positive the
+   naive reader would produce. v1.
+6. **ABSOLUTE section with out-of-range longitude**. Scenario: a lon value of
+   185 in an Absolute section. Expected: WARN `INV3-ABSOLUTE-RANGE` (KSP may
+   normalize; not yet cited). Deferred to FAIL once normalization is cited. v1
+   as WARN.
+7. **BG on-rails span with no TrackSections between two authored sections**.
+   Scenario: a legitimate uncovered UT gap. Expected: WARN
+   `INV2-UNCOVERED-SPAN` only if no `OrbitSegment` bridges it; if an
+   `OrbitSegment` covers the gap, no finding. Never FAIL. v1.
+8. **Two overlapping sections**. Scenario: sections `[100,200]` and
+   `[150,250]`. Expected: INV2 FAIL (double cover). v1.
+9. **Gloops / showcase ghost with no resource manifest**. Scenario: a ghost-only
+   recording. Expected: INV6 INFO (manifest optional per recording kind), no
+   FAIL/WARN. v1.
+10. **Chain with a `ChainIndex` gap at a supersede boundary (HEAD/TIP split)**.
+    Scenario: `(ChainId=X, ChainBranch=0)` has indices 0,1,3 where 2 was split
+    into HEAD/TIP by a re-fly. Expected: INV7 INFO (supersede-boundary
+    exemption), not FAIL. v1.
+11. **Chain with a `ChainIndex` gap NOT at a supersede boundary**. Scenario:
+    indices 0,1,3 with no supersede row explaining the missing 2. Expected: INV7
+    FAIL. v1.
+12. **Parallel ghost-only continuation (`ChainBranch=2`)**. Scenario: two
+    branches share a `ChainId`, each with its own contiguous index run.
+    Expected: contiguity checked PER `(ChainId, ChainBranch)`; both pass
+    independently even though the combined index set has "gaps". v1.
+13. **Supersede row pointing at a missing recording**. Scenario:
+    `SupersedeTargetId` references an id absent from the tree. Expected: INV7
+    FAIL (dangling supersede link). v1.
+14. **Cycle in the parent graph**. Scenario: A.parent=B, B.parent=A (corrupt).
+    Expected: INV7 FAIL (cycle), and the walk terminates via a visited set
+    (no infinite loop). v1.
+15. **`.pann` newer-schema or stale-epoch**. Scenario: a `.pann` whose
+    `SourceSidecarEpoch` is behind the `.prec`'s current epoch. Expected:
+    INV7B WARN (stale annotation). Orphan `.pann` (no `.prec`) -> WARN. v1.
+16. **Career diff hard divergence**. Scenario: reconstructed funds differ from
+    the save's funds beyond tolerance with no uplift-clamp explanation.
+    Expected OFFLINE: INV8 WARN (part (b) is WARN-capped until the headless
+    reconstruction seam is proven; open question in INV8). Expected IN-GAME (H5,
+    module M-A3): INV8 FAIL via the `LedgerGroundTruthHarness` seam. v1.
+17. **Career diff report-only per-identity divergence**. Scenario: a per-subject
+    science facet differs but the seeded pools match. Expected: INV8 WARN both
+    offline and in-game (report-only under default
+    `StrictPerIdentityForTesting=false`). v1.
+17b. **Dangling tombstone (ELS internal inconsistency)**. Scenario: a tombstone
+    whose target `ActionId` is absent from the raw `Ledger.Actions`. Expected:
+    INV8 FAIL (part (a), non-vacuous because the model carries the RAW action
+    list). Runs for career and non-career saves alike. v1.
+18. **Non-career (Science/Sandbox) save**. Scenario: no career totals. Expected:
+    INV8 INFO (skipped), no FAIL. v1.
+19. **RewindPoint id with path traversal (`../evil`)**. Scenario: a corrupt or
+    malicious id. Expected: INV9 FAIL via `RecordingPaths.ValidateRecordingId`
+    rejecting the traversal sequence; the analyzer never touches the escaped
+    path. v1.
+20. **Orphan sidecar on disk (a `.prec` with no tree node)**. Scenario: a stale
+    file the tree no longer references. Expected: WARN `INV5-ORPHAN-SIDECAR`
+    (inventory), not FAIL. v1.
+21. **Empty save directory / no `ParsekScenario` node**. Scenario: a fresh save
+    or a non-Parsek save. Expected: one INFO
+    `Analyzer: no Parsek footprint`, zero FAIL, clean report. v1.
+22. **Stale fixture corpus (generation bump landed, fixtures not regenerated)**.
+    Scenario: corpus stamp gen 3, code gen 4. Expected: STALE-FIXTURE for every
+    recording; CI red with the distinct STALE verdict, not FAIL (so the failure
+    reads as "regenerate fixtures", not "code broke"). v1.
+23. **Snapshot sidecar present but unparsable**. Scenario: a corrupt
+    `_vessel.craft`. Expected: `LoadSnapshotSidecarForTesting` returns false;
+    LoadFault + INV4 downgrades to INFO for that recording's PID checks (cannot
+    resolve without the snapshot) plus a WARN that the snapshot failed to load.
+    v1.
+24. **Both loop (`anchorVesselId`) and non-loop (`anchorRecordingId`) anchors
+    absent on a RELATIVE section**. Scenario: a corrupt relative section.
+    Expected: INV3 FAIL (RELATIVE with no anchor). v1.
+25. **Concurrent codec-seam round-trip drift on a NaN/Inf float field**.
+    Scenario: an `OrbitSegment` with a NaN element. Expected: INV10 compares
+    with NaN-aware equality (NaN == NaN treated equal for round-trip stability);
+    a NaN that becomes a different value after round-trip -> FAIL. v1.
+
+## What Doesn't Change
+
+- No production Parsek source changes. The analyzer consumes existing
+  `internal`-to-Tests seams; it adds no new public API and no new serialized
+  field. If a rule needs a seam that is currently `private`, that seam is
+  promoted to `internal` in a separate, reviewed change, not silently here.
+- Recording / sidecar / ledger file formats are untouched. The analyzer reads;
+  it never writes to a save.
+- `ParsekScenario.OnSave/OnLoad`, the in-game test runner, and the command seam
+  (M-A2) are not modified by this module.
+- The RELATIVE / parent-anchored / schema-generation contracts are not
+  reinterpreted. The analyzer asserts them as-is; a rule that would require
+  changing a contract is a design bug, caught by the `CitedContract` review gate.
+- No migration or back-compat path is added for pre-generation-4 recordings
+  (pre-1.0 no-migration policy). Old-generation data is REPORTED (STALE-FIXTURE
+  for fixtures, FAIL for real saves via INV5), never silently upgraded.
+
+## Backward Compatibility
+
+There is nothing to migrate: this is a new read-only tool. The one
+compatibility surface is the report format. `AnalyzerVersion` freezes the
+`.analysis.json` schema; a format change bumps it and updates the
+report-format-stability test. Existing fixture corpora gain a
+`fixture-generation.txt` stamp (M-A4 owns writing it); a corpus without a stamp
+is treated as an unstamped non-fixture subject (stamp check skipped), so the
+analyzer runs against today's corpus before M-A4 lands, just without the
+STALE-FIXTURE gate.
+
+## Diagnostic Logging
+
+The analyzer emits its own lines under subsystem tag `Analyzer` (via
+`ParsekLog` when hosted in-process, or plain stdout in the CLI). Every decision
+point logs, per the house logging rule.
+
+- Loader, per subject: `Analyzer: load save='<name>' trees=<n> recordings=<n>
+  loadFaults=<n>` (Info, one-shot).
+- Loader, per parse failure: `Analyzer: loadFault kind=<k> recording=<id>
+  path='<p>' reason=<r>` (Warn). This is the "a file that failed to parse is
+  itself a finding" contract made observable.
+- Schema gate (INV5), per recording: on reject,
+  `Analyzer: INV5 reject recording=<id> reason=<generation-older|...>
+  metadataGen=<n> sidecarGen=<m>` (Warn), mirroring the production reason
+  strings so a triage grep matches both the analyzer and KSP.log.
+- No-double-cover (INV2), per overlap: `Analyzer: INV2 overlap recording=<id>
+  a=[<s>,<e>] b=[<s>,<e>]` (Warn); per uncovered span:
+  `Analyzer: INV2 uncovered recording=<id> span=[<s>,<e>] orbitBridged=<bool>`
+  (Verbose, since gaps are common and legitimate).
+- RELATIVE contract (INV3): per RELATIVE section resolved,
+  `Analyzer: INV3 relative recording=<id>#<sec> anchorRec=<id|none>
+  anchorVessel=<pid|0> offsetSample=<x,y,z>` (Verbose) so a reviewer can confirm
+  the analyzer dispatched through the offset contract, not the lat/lon reader.
+- Tree topology (INV7): per dangling/cycle,
+  `Analyzer: INV7 badlink recording=<id> field=<ParentRecordingId|SupersedeTargetId|...>
+  target=<id> kind=<dangling|cycle>` (Warn); per chain gap,
+  `Analyzer: INV7 chaingap chainId=<x> branch=<b> missingIndex=<n>
+  supersedeExempt=<bool>` (Info/Warn by verdict).
+- Ledger (INV8): `Analyzer: INV8 diff recording-set career hard=<n>
+  reportOnly=<n> facets=<n>` (Info), reusing the counts
+  `LedgerGroundTruthDiff.Compare` already logs.
+- Fixture stamp: `Analyzer: fixtureStamp generation=<n> provenance=<p>
+  codeGeneration=<m> stale=<bool>` (Info).
+- Report write: `Analyzer: report save='<name>' FAIL=<a> WARN=<b> INFO=<c>
+  STALE=<d> json='<path>'` (Info, one-shot per subject).
+- Every rule, at registration, logs its `CitedContract` once:
+  `Analyzer: rule <ruleId> cites <CitedContract>` (Verbose) so the contract
+  citations are visible in a run log, not just source.
+
+Batch-counting convention (house rule): the loader iterates recordings /
+sidecars with local counters and logs one summary line, not one line per item,
+except the bounded per-overlap / per-badlink findings which are inherently few.
+
+## Test Plan
+
+Every test states the bug it catches. Tests live in
+`Source/Parsek.Tests/Analyzer/`. Fixtures are built with `RecordingBuilder` /
+`VesselSnapshotBuilder` / `ScenarioWriter` / `DebrisFrameContractRecordingFixture`
+/ `RouteFixtureBuilder` so synthetic data flows through the identical invariant
+suite (plan section 8: builders that emit invariant-violating data get caught,
+and known-good builder output exposes wrong rules). Body resolution uses
+`TestBodyRegistry.Install` for the injected `bodyResolver`. Classes touching
+`RecordingStore` / `ParsekLog` statics use `[Collection("Sequential")]` +
+`ResetForTesting` (house rule).
+
+### Per-invariant tests (positive + violating fixture each)
+
+- **INV1 positive**: a monotonic recording -> zero INV1 findings. Fails if the
+  monotonicity check has an off-by-one that flags equal-UT structural snapshots
+  (`TrajectoryPoint.flags` bit 0 samples share the previous UT).
+- **INV1 violating**: a `RecordingBuilder` recording with a back-stepping UT
+  point -> INV1 FAIL. Fails if a regression makes the rule accept descending UT,
+  which would let a corrupt sidecar through that breaks
+  `TrajectoryMath` binary-search sampling.
+- **INV2 positive (with legitimate gap)**: two authored sections separated by an
+  orbit-segment-bridged gap -> no FAIL, no uncovered WARN. Fails if the rule
+  reverts to "no gaps" and false-alarms on every BG on-rails span.
+- **INV2 violating**: two overlapping sections -> INV2 FAIL. Fails if the
+  overlap detector misses interior overlap, letting double-covered UT (ambiguous
+  playback position) through.
+- **INV3 positive (RELATIVE metre offsets)**: a parent-anchored debris fixture
+  (`DebrisFrameContractRecordingFixture`) with lat/lon values > 180 and a valid
+  `anchorRecordingId` -> zero INV3 findings. Fails if the rule reads the offset
+  fields as body-fixed lat/lon and false-alarms (the documented RELATIVE-misread
+  bug, plan Phase 0 exit criterion).
+- **INV3 violating (ABSOLUTE out-of-range)**: an Absolute section with lon=185
+  -> INV3 WARN, not FAIL. Fails if a corrupt Absolute longitude is silently
+  accepted (would place a ghost at the wrong surface point) or wrongly FAILs
+  before normalization is cited.
+- **INV3 violating (no anchor)**: a RELATIVE section with both anchors absent
+  -> INV3 FAIL. Fails if an unanchored relative section passes, which would make
+  playback unable to resolve a world position.
+- **INV4 positive**: a ghost with events whose PIDs match its
+  `VesselSnapshotBuilder` parts -> zero INV4 FAIL. Fails if the membership check
+  is wrong and rejects valid `100000 + idx*1111` PIDs.
+- **INV4 violating**: an event PID absent from the snapshot -> INV4 FAIL. Fails
+  if unresolvable PIDs pass, which silently drops a part event at playback.
+- **INV5 positive**: a current-generation recording -> zero INV5 FAIL. Fails if
+  the gate rejects valid gen-4 data.
+- **INV5 violating (each reason)**: fixtures forced to gen 0 / gen 3 / gen 5 /
+  format 2 -> INV5 FAIL with reasons `generation-missing` / `generation-older`
+  / `generation-newer` / `format-version-mismatch`. Fails if the analyzer's
+  reasons drift from `RecordingStore.IsRecordingSchemaCompatible`, which would
+  make triage greps mismatch KSP.log.
+- **INV6 positive (manifest present)**: a recording with a resource manifest
+  that round-trips -> zero INV6 FAIL. Fails if a valid manifest is flagged.
+- **INV6 positive (manifest absent)**: a Gloops ghost with no manifest -> INV6
+  INFO, not FAIL. Fails if the rule wrongly requires manifests on ghost-only
+  recordings.
+- **INV6 violating**: a manifest whose deserialized deltas contradict its
+  serialized totals -> INV6 FAIL. Fails if manifest corruption passes.
+- **INV7 positive**: a valid multi-branch chain tree
+  (undock split, `ChainBranch=0` and a `ChainBranch=2` ghost continuation) ->
+  zero INV7 FAIL. Fails if per-branch contiguity is not scoped and the combined
+  index set's "gaps" false-alarm.
+- **INV7 violating (dangling)**: a `SupersedeTargetId` to a missing id -> INV7
+  FAIL. Fails if dangling supersede links pass (broken re-fly visibility).
+- **INV7 violating (cycle)**: a two-node parent cycle -> INV7 FAIL and the test
+  completes (no hang). Fails if the walker lacks a visited set and infinite-loops
+  on corrupt data.
+- **INV7 exemption**: a HEAD/TIP split gap -> INV7 INFO, not FAIL. Fails if the
+  supersede-boundary exemption regresses and false-alarms on every re-flown tree.
+- **INV7b positive**: a `.pann` whose `SourceSidecarEpoch` matches the `.prec`
+  -> zero INV7B finding. Fails if fresh annotations are flagged stale.
+- **INV7b violating**: a `.pann` with an older `SourceSidecarEpoch` -> INV7B
+  WARN. Fails if stale annotations pass, which would render a ghost from an
+  outdated smoothing cache.
+- **INV8 positive (career)**: a synthetic career save whose ledger reconstructs
+  to the parsed totals -> zero INV8 finding. Fails if `LedgerGroundTruthDiff`
+  wiring is wrong.
+- **INV8 ELS-consistency violating (dangling tombstone)**: a model whose
+  `Tombstones` reference an `ActionId` absent from the raw `Ledger.Actions` ->
+  INV8 FAIL (part (a)). Fails if the model were fed a pre-filtered ELS list,
+  which would make this check vacuous (the dangling reference could never appear
+  in an already-filtered list); this is the regression BLOCKER 2 guards.
+- **INV8 career-diff violating (hard, offline)**: a career save with a funds
+  mismatch beyond tolerance and no uplift-clamp -> INV8 WARN (part (b) is
+  WARN-capped offline until the headless reconstruction seam is proven). Fails
+  if the offline analyzer promotes it to FAIL before the seam exists (the
+  FAIL-severity variant is the in-game H5 path only).
+- **INV8 report-only**: a per-subject-science facet drift with matching pools
+  -> INV8 WARN under default strictness. Fails if report-only divergences are
+  wrongly promoted to FAIL and poison harness triage.
+- **INV8 non-career**: a Sandbox save -> INV8 part (b) INFO (skipped); part (a)
+  ELS consistency still runs. Fails if the ledger rule crashes or FAILs on a null
+  `CareerSaveSnapshot`.
+- **INV9 positive**: valid RP ids + present RP files -> zero INV9 FAIL. Fails if
+  a valid `Parsek/RewindPoints/<id>.sfs` is flagged missing.
+- **INV9 violating (bad id)**: an RP id containing `..` -> INV9 FAIL via
+  `RecordingPaths.ValidateRecordingId`, and the analyzer never opens the escaped
+  path. Fails if path-traversal ids reach the filesystem (security regression).
+- **INV9 violating (missing RP)**: a slot referencing an absent RP file -> INV9
+  FAIL. Fails if a dangling RP reference passes (re-fly would fail at load).
+- **INV10 positive**: every builder recording round-trips at
+  `RecordingTreeRecordCodec` + `RecordingManifestCodec` + `TrajectorySidecarBinary`
+  -> zero INV10 FAIL. Fails if a codec silently drops a field on save or load.
+- **INV10 violating**: a recording with a field the codec is known to mishandle
+  (constructed to differ post-round-trip) -> INV10 FAIL naming the field. Fails
+  if the round-trip comparison is too shallow to notice the drift.
+- **INV10 NaN stability**: an `OrbitSegment` with a NaN element round-trips
+  equal (NaN-aware equality) -> no FAIL. Fails if naive `==` flags stable NaN,
+  producing permanent noise on predicted-tail segments.
+
+### Verdict-level policy tests
+
+- **FAIL fails the run**: a model with one INV1 FAIL -> `Counts.Fail == 1` and
+  the CI entry point asserts red. Fails if FAIL is downgraded and CI goes green
+  on corruption.
+- **WARN does not fail**: a model with only INV3-ABSOLUTE-RANGE WARNs ->
+  `Counts.Fail == 0`, run green, WARNs present in the report. Fails if WARN is
+  wrongly escalated and blocks unrelated PRs.
+- **INFO never fails**: a model with only manifest-absent INFO -> green, INFO in
+  report. Fails if inventory INFO is treated as a finding.
+- **STALE-FIXTURE distinct from FAIL**: a stamped corpus at the wrong generation
+  -> `Counts.StaleFixture > 0`, `Counts.Fail == 0` (findings are STALE, not
+  FAIL), CI red with the STALE reason. Fails if a stale corpus reads as a code
+  bug (misdirected triage) or as green (silent staleness).
+
+### Malformed-input robustness tests
+
+- **Truncated `.prec`**: analyzer produces a LoadFault + INV5 FAIL, no
+  exception escapes `Analyzer.Run`. Fails if a corrupt sidecar crashes the tool
+  (ties into F-series fault scenarios; a crash instead of a finding is itself a
+  bug).
+- **Text / pre-reset sidecar**: LoadFault with the exact production reason
+  string, no crash. Fails if the analyzer diverges from the production reject
+  path.
+- **Corrupt `.sfs` (unbalanced braces)**: single `sfs` LoadFault + empty model
+  + clean report, no crash. Fails if a malformed save takes down triage.
+- **Missing snapshot for INV4**: INV4 downgrades to INFO + a snapshot-load WARN,
+  no crash. Fails if a missing snapshot NREs the PID rule.
+- **Empty / non-Parsek save**: one INFO, zero FAIL, no crash. Fails if the
+  analyzer requires a Parsek footprint and errors on a vanilla save.
+
+### Report format stability tests
+
+- **Byte-identical determinism**: analyzing the same model twice produces
+  byte-identical `.analysis.json` (findings sorted, no timestamps, no absolute
+  paths, InvariantCulture floats). Fails if dictionary-iteration order or a
+  wall-clock field leaks in, which would make report diffing in CI useless.
+- **Sort order pinned**: a model with mixed levels serializes findings sorted by
+  (level desc, ruleId, target, sectionIndex). Fails if a sort regression
+  reorders findings and every downstream diff shows spurious churn.
+- **AnalyzerVersion frozen**: a golden `.analysis.json` fixture is asserted
+  field-for-field; changing the schema without bumping `AnalyzerVersion` fails
+  this test. Fails if the output contract silently changes under a consumer
+  (the harness parser).
+- **Human summary contract**: the `.txt` header line matches
+  `[Analyzer] save=... generation=... FAIL=.. WARN=.. INFO=.. STALE=..` and each
+  finding line matches `<LEVEL> <ruleId> target=...`. Fails if a grep-based
+  triage script breaks on a format drift.
+
+### Core-purity test (H5 readiness)
+
+- **No file I/O in rules**: a test constructs an `AnalyzerModel` entirely
+  in-memory (no loader, no disk) and runs every rule -> findings computed. Fails
+  if any rule reaches for a file path or `Stream`, which would block the future
+  in-game RecordingInvariants category (M-A3/H5) from reusing the core.
+
+### CitedContract-presence test
+
+- **Every rule cites a contract**: reflection over all `IRecordingInvariant`
+  implementations asserts a non-empty `CitedContract`. Fails if a new rule ships
+  without naming the production member it checks, defeating the review gate that
+  keeps wrong contracts out (plan section 7: "wrong contracts die in review").

--- a/docs/dev/design-autotest-stack-setup.md
+++ b/docs/dev/design-autotest-stack-setup.md
@@ -1,0 +1,820 @@
+# Design: Automation Stack Setup Script (Module M-A6)
+
+Status: DRAFT (2026-07-11). Module M-A6 of the Automated Testing Plan
+(`docs/dev/automated-testing-plan.md`, sections 2, 10, 11b, 12). Ops/tooling
+module: the Data Model section describes manifest and profile FILE FORMATS
+rather than in-game structs. Follows the house design-doc template
+(`docs/dev/design-doc-template.md`) adapted for a provisioning tool.
+
+This doc records verified ground truth (the kRPC tag/flag audit, the
+KRPC.MechJeb pairing, the dev-install inventory) inline as the authority for
+the setup script. Where a fact could only be confirmed by downloading a
+release artifact at install time, it is marked OPEN with the exact command.
+
+---
+
+## Ground Truth (verified 2026-07-11)
+
+All findings below were gathered by read-only inspection of the local clones
+under `C:\Users\vlad3\Documents\Code\Parsek\mods\` and the dev install at
+`C:\Users\vlad3\Documents\Code\Parsek\Kerbal Space Program`. They supersede
+the capability description in automated-testing-plan.md section 2 where they
+conflict, because that section describes the local master snapshot, not the
+release tag.
+
+### GT-1: kRPC tags and the v0.5.4 pin
+
+- `git fetch --tags` in `mods/krpc` lists releases through `v0.5.4`, which is
+  the newest release tag. `v0.5.4` = commit `11f1f1366fa4301049f6eac6640604127a9d763b`,
+  tagged 2024-06-10. This is the correct pin for KSP 1.12.5 (kRPC 0.4.x/0.5.x
+  is the KSP 1.8-1.12 line; 0.5.4 is the last 0.5.x release).
+- The local clone HEAD is `9a155a1c448f093dec4747769aaddb62a684608a`, a
+  `master` snapshot dated 2026-07-11. **The clone proves master, not v0.5.4.**
+  Every capability claim MUST be checked at the tag with `git show v0.5.4:<path>`,
+  never against the working tree.
+
+### GT-2: TestingTools capability set AT v0.5.4 (the decision-forcing finding)
+
+TestingTools source at `tools/TestingTools/src/` at v0.5.4 contains exactly
+five files: `AutoLoadGame.cs`, `AutoSwitchVessel.cs`, `OrbitTools.cs`,
+`TestingTools.cs`, `TestingTools.csproj`. There is **no `TestingToolsOptions.cs`**
+at v0.5.4.
+
+RPC/property surface in `TestingTools.cs` at v0.5.4 (verified by
+`git show v0.5.4:tools/TestingTools/src/TestingTools.cs`):
+
+| Member | Signature | Notes |
+|---|---|---|
+| `CurrentSave` | property (string, get) | name of current save |
+| `LoadSave` | `(string directory, string name)` | loads + focuses active vessel |
+| `RemoveOtherVessels` | `()` | `.Die()` on all but active |
+| `SetCircularOrbit` | `(string body, double altitude)` | teleport to circular orbit |
+| `SetOrbit` | `(string body, double sma, ecc, inc, lan, argPe, meanAnomaly, epoch)` | full-element teleport |
+| `ClearRotation` | `(Vessel vessel = null)` | zero rotational velocity |
+| `ApplyRotation` | `(float angle, Tuple<float,float,float> axis, Vessel vessel = null)` | apply a rotation |
+
+`AutoLoadGame.cs` at v0.5.4 **hardcodes** `Game => "default"` and
+`Save => "persistent"` as read-only properties, auto-loads on `MAINMENU`
+after a 15-frame delayed callback, and `AutoSwitchVessel` switches to the
+first non-`SpaceObject` proto vessel after a 15-frame delay in `SPACECENTER`.
+
+**NOT present at v0.5.4:**
+- No `--krpc-auto-load-*` command-line flags. AutoLoadGame reads nothing from
+  the command line; save selection is a compiled-in constant.
+- No `Quit()` RPC.
+- No `SetLanded()` RPC (and no `SetLanded` extension in `OrbitTools.cs`).
+
+### GT-3: The master-only delta
+
+At the clone HEAD (`9a155a1c`, 2026-07-11) master adds, in
+`TestingToolsOptions.cs` (introduced at that commit; `git log --all` shows the
+file touched only by `9a155a1c "RPC Deprecation (#926)"`):
+
+- `const string AutoLoadPrefix = "--krpc-auto-load-";` and the seven
+  arguments: `game=`, `save=`, `vessel=`, `craft=`, `craft-directory=`,
+  `craft-fixture-dir=`, `launch-site=`, parsed from
+  `Environment.GetCommandLineArgs()`; `AutoLoadRequested` is true iff any
+  auto-load arg is supplied (default stays `default`/`persistent`).
+- `Quit()` (bare `Application.Quit()`) in `TestingTools.cs`.
+- `SetLanded(string body, double lat, double lon, double alt = 0)` RPC plus
+  the `OrbitTools.SetLanded(...)` extension.
+
+**Conclusion:** the automated-testing-plan section 2 capability list (auto-load
+boot flags, `Quit()`, `SetLanded()`) describes the master snapshot. It is NOT
+available from the v0.5.4 release. This resolves the section 12 risk
+("kRPC 0.5.4-at-tag flag set unverified"): the flags are confirmed ABSENT at
+v0.5.4. The setup script must choose a pin with eyes open (see Behavior,
+step PIN).
+
+### GT-4: TestingTools build coupling at v0.5.4
+
+`git show v0.5.4:tools/TestingTools/src/TestingTools.csproj` shows the project
+is bazel-tree-coupled and cannot be built standalone as-is:
+
+- KSP DLL HintPaths point at `..\..\..\lib\ksp\KSP_Data\Managed\*.dll` (a
+  bazel-staged `KSP_Data` layout, not the install's `KSP_x64_Data`).
+- References `Google.Protobuf.dll` and `KRPC.IO.Ports.dll` from
+  `..\..\..\bazel-bin\tools\build\ksp\`.
+- `ProjectReference`s `core/src/KRPC.Core.csproj` and
+  `service/SpaceCenter/src/KRPC.SpaceCenter.csproj`.
+- Compiles a generated `bazel-bin/tools/TestingTools/AssemblyInfo.cs`.
+
+It compiles four sources upstream (`AutoLoadGame.cs`, `AutoSwitchVessel.cs`,
+`OrbitTools.cs`, `TestingTools.cs`) and uses `using KRPC.Service;` (attributes
+in KRPC.Core) and `KRPC.SpaceCenter.Services.Vessel`. The setup script does
+NOT run bazel; it authors a standalone shim project (Behavior step BUILD-TT)
+that compiles only TWO of those four (`OrbitTools.cs`, `TestingTools.cs`) and
+DROPS `AutoLoadGame.cs` / `AutoSwitchVessel.cs` so the seam's `LoadGame` boot
+(M-A2) owns save selection without a racing auto-loader.
+
+### GT-5: kRPC release zip does not ship TestingTools
+
+TestingTools lives under `tools/` with its own project and is a developer
+testing utility, not part of the distributable. The mod release
+(`GameData/kRPC/` from krpc.github.io) ships the runtime binaries
+(`KRPC.dll`, `KRPC.Core.dll`, `KRPC.SpaceCenter.dll`, `Google.Protobuf.dll`,
+`KRPC.IO.Ports.dll`) but not `TestingTools.dll`. This matches the plan's
+"TestingTools is NOT in release binaries."
+OPEN (install-time confirm): after download,
+`unzip -l krpc-<ver>.zip | grep -i testingtools` must return empty; and
+`unzip -l | grep -iE 'KRPC.Core.dll|KRPC.SpaceCenter.dll|Google.Protobuf.dll'`
+must return the three compile references. If TestingTools ever appears in the
+zip, skip BUILD-TT and install the shipped DLL instead.
+
+### GT-6: KRPC.MechJeb pairing (resolves the plan's open question)
+
+`mods/KRPC.MechJeb` is the genhis repo (`origin https://github.com/genhis/KRPC.MechJeb`),
+HEAD `398bc337` (2024-12-23 "Prepare for next release"), sole tag `v0.7.1`.
+`CHANGELOG.md`:
+
+- `[0.7.1] - 2024-12-23` Changed: **"Updated for kRPC 0.5.4"**.
+- `[0.7.0] - 2023-03-30` Changed: "Updated for KSP 1.12 and kRPC 0.5.2 ...
+  Updated AscentAutopilot and AirplaneAutopilot for MechJeb 2.14.3.0".
+
+`KRPC.MechJeb.csproj` links `KRPC.dll`, `KRPC.Core.dll`, `KRPC.SpaceCenter.dll`,
+`Assembly-CSharp.dll`, `UnityEngine*.dll` from `lib/`, targeting `v4.5.2`.
+
+**Decision:** for a kRPC v0.5.4 pin, **genhis KRPC.MechJeb 0.7.1** is the
+CHANGELOG-proven pair. The darchambault 0.8.1 fork is NOT present locally and
+is only relevant if the script pins a kRPC newer than 0.5.4 (a master commit
+for the auto-load flags), where 0.7.1's ABI against release KRPC.dll may not
+hold. See Behavior step PAIR for the decision procedure.
+
+### GT-7: MechJeb2 has no release tags
+
+`mods/MechJeb2` HEAD `748ca68a` (2026-07-08), `git tag` empty. MechJeb2 ships
+dev builds numbered by CI (e.g. 2.15.x.x), not git tags; `AssemblyInfo.cs`
+carries the placeholder `1.0.0.0` (real version injected at build). The pin is
+therefore a **downloaded release build number** (the plan's target: MJ 2.15
+line), not a git ref. The local clone is source-only and untagged; do not try
+to `git checkout` a MechJeb version.
+
+### GT-8: Dev install inventory
+
+Path: `C:\Users\vlad3\Documents\Code\Parsek\Kerbal Space Program`. Managed DLL
+dir: `KSP_x64_Data\Managed`. `settings.cfg` present with these keys (verified):
+
+```
+AUTOSTRUT_SYMMETRY   = True
+SIMULATE_IN_BACKGROUND = True
+PHYSICS_FRAME_DT_LIMIT = 0.04
+CONIC_PATCH_DRAW_MODE = 3
+CONIC_PATCH_LIMIT    = 4
+UI_SCALE             = 1.2
+FULLSCREEN           = True
+QUALITY_PRESET       = 5
+TEXTURE_QUALITY      = 0
+SHADOWS_QUALITY      = 4
+FRAMERATE_LIMIT      = 120
+AERO_FX_QUALITY      = 3
+TERRAIN_SHADER_QUALITY = 3
+```
+
+`GameData/` mods present: `000_ClickThroughBlocker`, `000_Harmony`,
+`001_ToolbarControl`, `B9PartSwitch`, `BetterTimeWarp`, `CommunityDeltaVMaps`,
+`CommunityTechTree`, `DistantObject`, `HideEmptyTechTreeNodes`,
+`KSPCommunityFixes`, `KSPTextureLoader`, `Kopernicus`, `ModularFlightIntegrator`,
+`ModuleManager.4.2.3.dll` (+ `ModuleManager.ConfigCache`, `ConfigSHA`,
+`Physics`, `TechTree`), `Parsek`, `ProbesBeforeCrew`, `ReStock`, `ReStockPlus`,
+`RestockWaterfallExpansion`, `Squad`, `SquadExpansion`, `StockWaterfallEffects`
+(SWE), `Waterfall`, `WaterfallRestock`.
+
+Notes that drive the profile design:
+- `PersistentRotation` is listed in the plan's modded-compat profile but is
+  **NOT present** in the dev GameData. OPEN: either drop it from the profile or
+  source it separately (mark in manifest as `absent-source`). Do not silently
+  omit.
+- SWE = `StockWaterfallEffects` is present; ReStock/ReStockPlus and Waterfall
+  are present, so modded-compat can be assembled from the dev install for
+  those. `BetterTimeWarp` present.
+- ModuleManager cache files (`ConfigCache`/`ConfigSHA`/`Physics`/`TechTree`)
+  exist in the dev GameData; the stale-cache edge case (EC-2) is real.
+
+### GT-9: Parsek.Tests.csproj HintPath pattern (reference-resolution template)
+
+`Source/Parsek.Tests/Parsek.Tests.csproj` resolves KSP DLLs via `$(KSPDir)`
+(overridable by the `KSPDIR` env var, else an ancestor-walk probe of up to five
+parents for `Kerbal Space Program/`) and `HintPath`s into
+`$(KSPDir)\KSP_x64_Data\Managed\` (`UnityEngine.CoreModule`,
+`UnityEngine.IMGUIModule`, `Assembly-CSharp`) plus `0Harmony` from
+`$(KSPDir)\GameData\000_Harmony\0Harmony.dll`, each with `<Private>true</Private>`.
+The TestingTools shim reuses this exact HintPath approach.
+
+---
+
+## Problem
+
+The mission harness (M-A5) needs a byte-for-byte reproducible KSP automation
+environment: a pinned kRPC + TestingTools + MechJeb2 + KRPC.MechJeb stack, a
+dedicated cloned KSP instance per profile, the Parsek DLL under test deployed
+safely, and a manifest that lets the harness REFUSE to run against a drifted or
+mismatched instance. Today none of that is provisioned; the plan (section 2)
+even mis-describes the kRPC capability set because it was written from the
+master clone. Without a deterministic, idempotent, self-verifying setup step,
+every automated run is a bet that the environment matches what the scenarios
+assume, and the sibling-worktree DLL race (`.claude/CLAUDE.md`) can silently
+deploy the wrong Parsek build into an automation instance. M-A6 is the script
+that provisions the stack, records exactly what it installed, and fails loud
+on drift or partial failure.
+
+## Terminology
+
+- **Dev install**: the developer's working KSP at
+  `Code\Parsek\Kerbal Space Program`. Never modified by this script (read-only
+  source for cloning and for mod payloads).
+- **Automation instance**: a cloned KSP directory the harness launches.
+  Two profiles: `stock-minimal` and `modded-compat`.
+- **Profile**: a declarative spec (a file) naming the mod set, settings deltas,
+  and component pins that define one automation instance.
+- **Component**: a pinned installable (kRPC, TestingTools, MechJeb2,
+  KRPC.MechJeb, Parsek.dll, or a dev-sourced mod folder).
+- **Manifest**: the JSON record the script emits per instance, enumerating every
+  installed component with exact version/tag/commit/hash. The harness's
+  admission gate.
+- **Staging**: an intermediate directory the Parsek build is copied into and
+  hashed BEFORE it is installed, so a concurrent sibling build cannot race the
+  bytes mid-copy (`.claude/CLAUDE.md` DLL race).
+- **Pin**: an exact, reproducible identifier for a component: a git tag+commit,
+  a release build number + download URL + sha256, or a source folder + content
+  hash.
+- **Drift**: any difference between an instance's current on-disk state and its
+  manifest / profile expectation.
+
+## Mental Model
+
+```
+  DEV INSTALL (read-only)                 mods/ clones (read-only, pin refs)
+  Kerbal Space Program/                   krpc@v0.5.4  KRPC.MechJeb@v0.7.1
+    KSP_x64_Data/Managed/*.dll  --+         MechJeb2 (source; pin = download)
+    GameData/{Squad,ReStock,...}  |
+    settings.cfg  ----------------+
+                                  v
+                        +----------------------+
+                        |   provision.py        |   <-- M-A6, this doc
+                        |  (idempotent, logged) |
+                        +----------+-----------+
+       PIN -> DOWNLOAD -> BUILD-TT -> PAIR -> CLONE -> SETTINGS -> DEPLOY -> MANIFEST -> VERIFY
+                                  |
+             +--------------------+---------------------+
+             v                                            v
+   automation/stock-minimal/                  automation/modded-compat/
+     GameData/{Squad, Parsek, kRPC,             GameData/{...stock-minimal...,
+       TestingTools.dll, MechJeb2,                Waterfall, SWE, ReStock/+,
+       KRPC.MechJeb}                              BetterTimeWarp, PersistentRotation?}
+     settings.cfg (delta-applied)               settings.cfg (delta-applied)
+     Parsek/provision-manifest.json  <-- harness admission gate
+```
+
+The script is a converging function: given the pins and profiles, repeated runs
+drive each instance to the same state, report drift, and (optionally) repair it.
+It never touches the dev install's `GameData`. Parsek.dll flows dev-build ->
+staging (hash) -> instance (verify), never dev-`GameData` -> instance.
+
+Order rationale: PIN before anything (a wrong pin invalidates all downstream
+work); DOWNLOAD + BUILD-TT before CLONE (fail fast on a broken build before
+copying 5-8 GB); PAIR (resolve KRPC.MechJeb) alongside DOWNLOAD; CLONE creates
+the instance; SETTINGS + DEPLOY + payload-install populate it; MANIFEST records
+truth last; VERIFY re-reads the instance and cross-checks the manifest.
+
+## Data Model (file formats)
+
+Three persisted formats. All are "new data that persists" per the plan's
+section 11b, so they get round-trip tests.
+
+### Component pin file: `harness/provision/pins.toml`
+
+Single source of truth for what versions the stack targets. Hand-edited,
+reviewed, committed. TOML for human diff-ability.
+
+```toml
+schema = 1
+kspVersion = "1.12.5"
+
+[krpc]
+# GT-1/GT-2: v0.5.4 is the release pin; it LACKS the auto-load flags/Quit/SetLanded.
+mode = "tag"                       # "tag" | "commit"
+tag = "v0.5.4"
+commit = "11f1f1366fa4301049f6eac6640604127a9d763b"
+releaseZipUrl = "https://github.com/krpc/krpc/releases/download/v0.5.4/krpc-0.5.4.zip"
+releaseZipSha256 = "OPEN-fill-at-first-download"
+localClone = "mods/krpc"
+
+[testingtools]
+# Built from source at the same krpc ref via the standalone shim (BUILD-TT).
+buildFromSource = true
+# 2-FILE shim: only OrbitTools.cs + TestingTools.cs. AutoLoadGame.cs and
+# AutoSwitchVessel.cs are DROPPED: at v0.5.4 AutoLoadGame unconditionally fires
+# 15 frames after MAINMENU trying to load saves/default/persistent.sfs, which
+# would RACE the seam's boot (M-A2 LoadGame). BUILD-TT asserts the AutoLoadGame
+# type is ABSENT from the built assembly.
+sourceFiles = ["OrbitTools.cs", "TestingTools.cs"]
+# Recorded so the harness knows which control capabilities exist:
+capabilities = ["LoadSave", "RemoveOtherVessels", "SetCircularOrbit", "SetOrbit", "ClearRotation", "ApplyRotation"]
+# Boot is driven by the Parsek seam, NOT by TestingTools auto-load (which is dropped):
+bootChannel = "parsek-seam-LoadGame"
+missingVsMaster = ["autoLoadFlags", "Quit", "SetLanded"]   # GT-2/GT-3
+
+[mechjeb2]
+# GT-7: no git tags; pin is a downloaded build.
+mode = "release"
+buildNumber = "2.15.x.x-OPEN"      # fill with the exact MJ 2.15 dev build chosen
+downloadUrl = "OPEN"
+sha256 = "OPEN"
+
+[krpc_mechjeb]
+# GT-6: genhis 0.7.1 pairs with kRPC 0.5.4 (CHANGELOG-proven).
+fork = "genhis"                    # "genhis" | "darchambault"
+tag = "v0.7.1"
+commit = "398bc337492c5f725c83ab1aac85c32a1c0349ea"
+localClone = "mods/KRPC.MechJeb"
+pairedKrpcTag = "v0.5.4"           # asserted against [krpc].tag at PAIR
+pairedMechjebLine = "2.14.3+"      # from CHANGELOG 0.7.0/0.7.1
+```
+
+### Profile file: `harness/provision/profiles/<name>.toml`
+
+```toml
+schema = 1
+name = "stock-minimal"
+baseInstall = "Kerbal Space Program"       # dev install, relative to repo umbrella root
+instanceDir = "automation/stock-minimal"   # created by CLONE
+
+# Mods copied verbatim from the dev install's GameData (content-hashed into manifest).
+# stock-minimal keeps only what the stack needs plus stock.
+# NOTE: Squad + SquadExpansion are NOT listed here - they are stock asset payloads,
+# JUNCTIONED (not copied) by the CLONE step and recorded as junction targets in the
+# manifest (stock, negligible drift risk). Only non-stock mod folders are dev-sourced
+# copies so a dev-GameData change cannot silently drift an instance.
+devSourcedMods = [
+  "000_Harmony", "ModuleManager.4.2.3.dll",
+  "000_ClickThroughBlocker", "001_ToolbarControl",
+  "CommunityDeltaVMaps", "CommunityTechTree", "ProbesBeforeCrew",
+]
+# Stack components installed by the script (not from dev GameData): kRPC,
+# TestingTools.dll, MechJeb2, KRPC.MechJeb, Parsek.
+stackComponents = ["krpc", "testingtools", "mechjeb2", "krpc_mechjeb", "parsek"]
+
+# GT-8 verified keys. Delta = key -> pinned value; everything else copied from
+# the dev settings.cfg then overwritten here.
+[settings]
+PHYSICS_FRAME_DT_LIMIT = "0.03"    # tighter physics cap for determinism
+FRAMERATE_LIMIT = "60"             # cap CPU; automation window is small/low-detail
+QUALITY_PRESET = "0"
+TEXTURE_QUALITY = "3"              # lowest
+SHADOWS_QUALITY = "0"
+AERO_FX_QUALITY = "0"
+TERRAIN_SHADER_QUALITY = "0"
+UI_SCALE = "1.0"
+FULLSCREEN = "False"
+SCREEN_RESOLUTION_WIDTH = "1280"
+SCREEN_RESOLUTION_HEIGHT = "720"
+SIMULATE_IN_BACKGROUND = "True"    # MUST stay True: unattended runs lose focus
+AUTOSTRUT_SYMMETRY = "False"       # pin autostrut policy (plan section 2/10)
+CONIC_PATCH_DRAW_MODE = "3"
+```
+
+`modded-compat.toml` differs only by adding to `devSourcedMods`:
+`Waterfall`, `WaterfallRestock`, `RestockWaterfallExpansion`,
+`StockWaterfallEffects`, `ReStock`, `ReStockPlus`, `BetterTimeWarp`,
+`Kopernicus`, `ModularFlightIntegrator`, `B9PartSwitch`, `KSPCommunityFixes`,
+`DistantObject`, `KSPTextureLoader`, `HideEmptyTechTreeNodes`; and
+`PersistentRotation` guarded by GT-8 OPEN (if absent from dev GameData, the
+script records `absent-source` and does not fail unless the profile marks it
+`required = true`).
+
+### Version manifest: `<instanceDir>/GameData/Parsek/provision-manifest.json`
+
+Emitted per instance. The harness reads it at startup and refuses to run on
+mismatch (plan section 9/10).
+
+**Path decision (unified).** All three provisioning artifacts -- the manifest
+(`provision-manifest.json`), the log (`provision-log.txt`), and the lock /
+incomplete markers (`.provision.lock`, `.provision-incomplete`) -- live together
+under `<instanceDir>/GameData/Parsek/` so they travel with the mod folder and are
+trivially found by the harness. This is safe because KSP's `GameDatabase` only
+loads `.cfg` (and asset) files and IGNORES `.json` / `.txt` / dotfiles, so the
+manifest, log, and lock never become phantom config nodes or get parsed by KSP.
+
+```json
+{
+  "schema": 1,
+  "profile": "stock-minimal",
+  "generatedUtc": "2026-07-11T14:32:07Z",
+  "provisionScriptCommit": "<git HEAD of the worktree that ran provision.py>",
+  "kspVersion": "1.12.5",
+  "instanceDir": "automation/stock-minimal",
+  "components": {
+    "krpc":        { "kind": "release-zip", "tag": "v0.5.4", "commit": "11f1f13...", "sha256": "...", "installedDlls": {"KRPC.dll": "sha256...", "KRPC.Core.dll": "sha256...", "KRPC.SpaceCenter.dll": "sha256..."} },
+    "testingtools":{ "kind": "built-shim", "krpcRef": "v0.5.4", "dllSha256": "...", "sourceFiles": ["OrbitTools.cs","TestingTools.cs"], "capabilities": ["LoadSave","RemoveOtherVessels","SetCircularOrbit","SetOrbit","ClearRotation","ApplyRotation"], "bootChannel": "parsek-seam-LoadGame", "autoLoaderAbsent": true, "missing": ["autoLoadFlags","Quit","SetLanded"] },
+    "mechjeb2":    { "kind": "release", "buildNumber": "2.15.x.x", "sha256": "..." },
+    "krpc_mechjeb":{ "kind": "git", "fork": "genhis", "tag": "v0.7.1", "commit": "398bc33...", "dllSha256": "...", "pairedKrpc": "v0.5.4" },
+    "parsek":      { "kind": "staged-build", "assemblyVersion": "0.10.x", "dllSha256": "...", "stagedFrom": "Source/Parsek/bin/Debug/Parsek.dll", "sourceCommit": "<git HEAD>", "signatureStrings": {"<distinctive-utf16>": 1} }
+  },
+  "devSourcedMods": { "000_Harmony": "treehash...", "ModuleManager.4.2.3.dll": "sha256...", "PersistentRotation": "absent-source" },
+  "junctionTargets": { "GameData/Squad": "<devInstall>/GameData/Squad", "GameData/SquadExpansion": "<devInstall>/GameData/SquadExpansion", "KSP_x64_Data/StreamingAssets": "<devInstall>/KSP_x64_Data/StreamingAssets" },
+  "settingsDeltasApplied": { "FRAMERATE_LIMIT": "60", "QUALITY_PRESET": "0", "...": "..." },
+  "settingsBaseSha256": "<hash of dev settings.cfg the deltas were applied over>",
+  "settingsFinalSha256": "<sha256 of the instance settings.cfg as written; VERIFY re-hashes it>",
+  "buildId64Sha256": "<sha256 of the instance KSP_x64_Data/../buildID64.txt; asserts actual KSP version vs pins.kspVersion>",
+  "verify": { "utf16GrepPassed": true, "dllHashMatchesStaging": true, "settingsFinalHashMatches": true, "buildId64Matches": true, "kspRunningAtProvision": false }
+}
+```
+
+The harness admission check compares (profile name, kspVersion, every component
+pin+hash, Parsek `dllSha256` and `signatureStrings`, `settingsDeltasApplied`)
+against its expected pins. Any mismatch => refuse to run with the diff printed.
+
+### Provisioning log: `<instanceDir>/GameData/Parsek/provision-log.txt`
+
+Append-only, one decision per line, harness-archivable (plan section 10 triage).
+Format mirrors ParsekLog: `[Provision][LEVEL][Step] message`. Every component
+decision (found / installed / skipped / drift / repaired), every hash, every
+abort reason. See Diagnostic Logging.
+
+## Behavior
+
+Location decision: the script and its data live under a new `harness/provision/`
+package (`harness/provision/provision.py`, `pins.toml`, `profiles/`), keeping
+automation tooling under the same `harness/` root the plan establishes for
+`harness/scenarios/` and `harness/run.py`, and separate from `scripts/` (which
+holds dev-facing build/release/log tools). Entry point:
+`python harness/provision/provision.py --profile stock-minimal [--repair] [--dry-run]`.
+
+Steps run in this order; each is idempotent and logged.
+
+- **PREFLIGHT.** Resolve the umbrella root (`Code\Parsek`). Assert the dev
+  install, the `mods/` clones, and `pins.toml` exist. Assert KSP is not running
+  against any target instance (EC-1). Load the profile. On `--dry-run`, compute
+  and print the plan and drift, write nothing.
+
+- **PIN.** Read `pins.toml`. For git-pinned components (`krpc`, `krpc_mechjeb`),
+  in the LOCAL clone run read-only `git rev-parse <tag>` and assert it equals the
+  recorded `commit` (guards a moved/retagged ref). Do NOT check out the clone;
+  read via `git show <ref>:<path>` / `git archive <ref>`. Record the resolved
+  commits. Emit the GT-2 capability warning to the log: kRPC v0.5.4 TestingTools
+  has no auto-load flags / `Quit` / `SetLanded`; the harness must drive the
+  instance BOOT via the M-A2 `LoadGame` verb (the boot channel; kRPC RPCs are
+  not available at the main menu, so the boot cannot go through a kRPC RPC),
+  quit via the M-A2 `FlushAndQuit` verb, and land fixtures via `SetOrbit`, not
+  `SetLanded`. The TestingTools `LoadSave` RPC remains an OPTIONAL in-game-only
+  convenience (a mid-flight re-load once a scene is up), never the boot path.
+  This step depends on M-A2 shipping the `LoadGame` verb; without it there is no
+  main-menu boot channel and the automation instance cannot leave the menu.
+  - Tag choice: default pin is v0.5.4 (stable, GT-1). If a profile explicitly
+    sets `krpc.mode = "commit"` to a master commit for the auto-load flags, PIN
+    logs a loud AMBER: the flags come with an unreleased kRPC ABI and force the
+    PAIR re-decision (darchambault 0.8.1). v0.5.4 remains the recommended pin
+    because the M-A2 seam already covers boot (the `LoadGame` verb) and
+    commit-safe quit (`FlushAndQuit`), so the master auto-load flags buy little
+    for real ABI risk.
+
+- **DOWNLOAD.** For `krpc` and `mechjeb2`, download the pinned release to a
+  cache (`harness/provision/.cache/`), verify sha256 against `pins.toml`
+  (EC-6 disk, EC-3 drift). If `releaseZipSha256`/`sha256` is `OPEN`, download,
+  compute, print the hash, and ABORT asking the maintainer to record it (never
+  silently trust an unverified artifact). Confirm GT-5: assert the kRPC zip
+  contains `KRPC.Core.dll` + `KRPC.SpaceCenter.dll` + `Google.Protobuf.dll` and
+  does NOT contain `TestingTools.dll`.
+
+- **BUILD-TT.** Build TestingTools from source at the pinned kRPC ref via a
+  standalone shim (GT-4): the script extracts the TWO source files with
+  `git archive v0.5.4 tools/TestingTools/src/{OrbitTools,TestingTools}.cs`
+  into a temp build dir -- `AutoLoadGame.cs` and `AutoSwitchVessel.cs` are
+  DELIBERATELY DROPPED (at v0.5.4 `AutoLoadGame` unconditionally auto-loads
+  `saves/default/persistent.sfs` 15 frames after `MAINMENU`, which would race the
+  seam's `LoadGame` boot; save selection is the seam's job, M-A2). The script
+  writes a generated `TestingTools.shim.csproj`
+  (`TargetFramework net472`, `NoStdLib` off) that references (GT-9 pattern):
+  - KSP DLLs from `<devInstall>\KSP_x64_Data\Managed\` via `HintPath`
+    (`Assembly-CSharp`, `UnityEngine.CoreModule`, plus the modules TestingTools
+    uses);
+  - `KRPC.Core.dll` and `KRPC.SpaceCenter.dll` (KRPC.Service attributes +
+    `Services.Vessel`) and `Google.Protobuf.dll` from the extracted kRPC release
+    zip's `GameData/kRPC/`;
+  - a script-authored minimal `AssemblyInfo.cs` (replacing the bazel-generated
+    one).
+
+  Invocation: `dotnet build TestingTools.shim.csproj -c Release`
+  (fallback `msbuild /t:Rebuild /p:Configuration=Release` if `dotnet` cannot
+  resolve the net472 reference assemblies). Output `TestingTools.dll` is hashed
+  and cached. On build failure, ABORT with the compiler output and the exact
+  missing-reference (EC-4). Never install a stale/previous TestingTools.dll.
+
+- **PAIR.** Resolve KRPC.MechJeb (GT-6). If `krpc.tag == "v0.5.4"`, assert
+  `krpc_mechjeb.fork == "genhis"` and `tag == "v0.7.1"` (CHANGELOG-proven pair)
+  and build/stage its DLL from `mods/KRPC.MechJeb` at v0.7.1 against the release
+  KRPC.dll/KRPC.Core.dll/KRPC.SpaceCenter.dll. If a non-v0.5.4 kRPC is pinned,
+  the pairing is UNVERIFIED locally: log AMBER with the exact decision procedure
+  (web-verify at install time) -- `check the darchambault 0.8.1 release notes /
+  the genhis release matrix at https://github.com/Genhis/KRPC.MechJeb/releases
+  and https://github.com/darchambault/KRPC.MechJeb/releases for the fork+tag
+  whose "Updated for kRPC <ver>" line matches the pinned kRPC and whose MechJeb
+  line matches the pinned MJ build` -- and ABORT rather than guess.
+
+- **CLONE.** Create `<instanceDir>` by copying the dev install. Disk strategy
+  (GT-8, ~5-8 GB): copy the small mutable surface fully (`KSP_x64.exe`,
+  `KSP_x64_Data` EXCEPT the large read-only asset bundles, `settings.cfg`,
+  `Internals`, top-level files) and **junction the bulk read-only trees** on
+  Windows via `mklink /J`: `KSP_x64_Data\StreamingAssets` and the stock
+  `GameData\Squad` / `GameData\SquadExpansion` asset payloads point back at the
+  dev install (read-only). `Squad` / `SquadExpansion` are stock payloads (they
+  ship with KSP and never change between builds of the same KSP version), so the
+  drift risk of junctioning them is negligible; they are therefore NOT listed in
+  `devSourcedMods` and are junctioned like the other stock asset trees. Junction
+  chosen over hardlinking because KSP asset dirs are large trees where a single
+  directory junction is O(1) and trivially re-pointable, and over full copy
+  because two profiles would otherwise cost 10-16 GB. Non-stock GameData mod
+  folders that the profile lists as `devSourcedMods` and are content-hashed are
+  COPIED (not junctioned) so a dev GameData change cannot silently drift an
+  instance mid-campaign. Record each junction target in the manifest
+  (`junctionTargets`; EC-8: junction-target-moved is a verify failure).
+
+- **SETTINGS.** Read the dev `settings.cfg`, record its sha256
+  (`settingsBaseSha256`), apply the profile's `[settings]` deltas as pure
+  key-replacements (line-oriented, preserve unknown keys/order), write to the
+  instance `settings.cfg`. Suppress popups where the game exposes a setting
+  (e.g. disable the update/launcher nag, `CHECK_FOR_UPDATES = False` if present).
+  Record `settingsDeltasApplied` and the sha256 of the final written instance
+  `settings.cfg` (`settingsFinalSha256`) so VERIFY (and the harness) can detect a
+  manual edit made OUTSIDE the delta keys, which the per-key delta comparison
+  alone would miss.
+
+- **DEPLOY (Parsek).** Never touch the dev instance's GameData. Copy the Parsek
+  build from the STAGING location (guard the sibling-worktree bin/Debug race,
+  `.claude/CLAUDE.md`):
+  1. Determine the source build. Default `Source/Parsek/bin/Debug/Parsek.dll` in
+     the current worktree; require `--parsek-dll <path>` if ambiguous.
+  2. Copy source -> `harness/provision/.stage/Parsek.dll`; compute sha256.
+  3. Copy stage -> `<instanceDir>/GameData/Parsek/Plugins/Parsek.dll`; re-hash
+     the installed file; assert it equals the stage hash (EC-9 lock/partial).
+  4. UTF-16 grep verification (`.claude/CLAUDE.md` recipe): confirm one or more
+     distinctive UTF-16-LE signature strings appear in the installed DLL with
+     the expected counts. The signature set is read from a small pinned list so
+     the check survives builds; counts recorded in the manifest.
+  Also copy the rest of the Parsek GameData folder (version file, toolbar
+  textures) from the dev-sourced `Parsek/` EXCEPT `Plugins/Parsek.dll` (which
+  comes from staging) and EXCEPT any existing `provision-manifest.json`.
+
+- **INSTALL (stack payloads).** Extract the kRPC release into
+  `<instanceDir>/GameData/kRPC/`; drop the built `TestingTools.dll` alongside;
+  extract MechJeb2 into `GameData/MechJeb2/`; drop `KRPC.MechJeb.dll` into
+  `GameData/kRPC/` (per its README). Hash every installed DLL into the manifest.
+
+- **MM CACHE.** Delete the copied `ModuleManager.ConfigCache`, `ConfigSHA`,
+  `ModuleManager.Physics`, `ModuleManager.TechTree` from the instance GameData so
+  ModuleManager regenerates them against the instance's actual mod set on first
+  boot (EC-2). Rationale: the dev cache reflects the dev mod set; a stock-minimal
+  instance with a stale modded cache would load phantom patches. Regenerate, do
+  not copy.
+
+- **MANIFEST.** Write `provision-manifest.json` atomically (tmp + rename) with
+  every component pin, hash, settings delta, junction target, timestamp, the
+  provisioning script's git HEAD, the final instance `settings.cfg` sha256
+  (`settingsFinalSha256`, N-4), and the instance `buildID64.txt` sha256
+  (`buildId64Sha256`, N-5, cross-checked against `pins.kspVersion`).
+
+- **VERIFY.** Re-read the instance from scratch and cross-check against the
+  just-written manifest: every recorded DLL hash matches the on-disk file; the
+  UTF-16 grep still passes; junction targets resolve; `settings.cfg` contains the
+  deltas AND its full-file sha256 matches `settingsFinalSha256` (catches a manual
+  edit outside the delta keys, N-4); and the instance `buildID64.txt` sha256
+  matches `buildId64Sha256`, which pins the ACTUAL instance KSP version against
+  `pins.kspVersion` (catches an instance built from a different KSP build than the
+  pin claims, N-5). This catches a mid-run clobber (EC-10). On `--repair`, a
+  detected drift triggers a targeted re-install of only the drifted component,
+  then re-VERIFY. Without `--repair`, drift is reported and the run exits
+  non-zero.
+
+Idempotency: re-running with the same pins recomputes hashes, finds every
+component already at its pinned hash, logs `skip (up-to-date)` per component, and
+converges without rewriting bytes. Only drift or a pin change triggers work.
+
+## Edge Cases
+
+Each: trigger -> expected behavior -> v1 or deferred.
+
+- **EC-1 KSP running during provisioning.** Trigger: a KSP process holds an
+  instance's files (or the dev install) open. Expected: PREFLIGHT detects the
+  running process (by window/exe path against target instance dirs) and ABORTS
+  before any write, with a clear "close KSP for instance X" message. Never
+  half-provision. v1.
+- **EC-2 Stale ModuleManager cache.** Trigger: dev GameData's MM cache reflects
+  a different mod set than the target profile. Expected: MM CACHE step deletes
+  the copied cache so it regenerates on first boot; never copy the cache. v1.
+- **EC-3 GameData mod version drift between profiles / vs manifest.** Trigger: a
+  dev-sourced mod folder changed since the instance was built. Expected: VERIFY
+  compares the content tree-hash to the manifest; mismatch => drift report (or
+  `--repair` re-copies that folder). v1.
+- **EC-4 TestingTools build failure vs KSP DLL version.** Trigger: BUILD-TT
+  cannot resolve a reference or the source does not compile against the pinned
+  KSP DLLs. Expected: ABORT with compiler output and the missing reference;
+  never fall back to a stale TestingTools.dll. v1.
+- **EC-5 Manifest mismatch at harness start.** Trigger: the harness finds a
+  manifest whose pins/hashes differ from its expectations. Expected (harness
+  side, specced here): refuse to run, print the field-level diff, exit
+  non-zero. The setup script guarantees the manifest is written last and
+  atomically so a present manifest always describes a completed provision. v1.
+- **EC-6 Disk exhaustion.** Trigger: CLONE or DOWNLOAD runs out of space
+  (two 5-8 GB instances + caches). Expected: pre-check free space against an
+  estimate before CLONE; on write failure mid-copy, ABORT and leave a
+  `.provision-incomplete` marker under `<instanceDir>/GameData/Parsek/` so
+  VERIFY/next-run treats it as not-provisioned (never a silent partial). v1.
+- **EC-7 Windows path length.** Trigger: deep KSP asset paths under a long
+  umbrella root exceed 260 chars during copy. Expected: use extended-length
+  paths (`\\?\` prefix) for all file ops; if still exceeded, ABORT naming the
+  offending path. v1.
+- **EC-8 Junction target moved/deleted.** Trigger: a junctioned read-only tree's
+  target (dev install) was moved or removed. Expected: VERIFY resolves each
+  recorded junction target; a dangling junction is a verify FAILURE with a
+  repair hint (re-run CLONE). v1.
+- **EC-9 Parsek.dll locked / partial copy.** Trigger: the instance's Parsek.dll
+  is held open, or the copy is truncated. Expected: DEPLOY hashes the installed
+  file and asserts it equals the stage hash; a lock (EC-1 should have caught it)
+  or partial copy fails the hash and ABORTS. Never trust an mtime-only copy. v1.
+- **EC-10 Two provisioning runs racing.** Trigger: two `provision.py` invocations
+  target the same instance concurrently. Expected: a lockfile
+  (`<instanceDir>/GameData/Parsek/.provision.lock` with pid + timestamp) is acquired at
+  PREFLIGHT; a second run sees the lock and ABORTS. Stale locks (dead pid) are
+  reclaimed. v1.
+- **EC-11 Sibling-worktree bin/Debug race clobbers the staged DLL.** Trigger: a
+  concurrent `cd Source/Parsek && dotnet build` in another worktree overwrites
+  `bin/Debug/Parsek.dll` between source-select and stage-copy. Expected: DEPLOY
+  copies to staging FIRST, hashes the STAGE (not the source), and installs from
+  the stage; the stage is immutable for the rest of the run. If the source hash
+  differs from the stage hash on a later re-read, log AMBER (informational: the
+  dev build changed) but the installed instance is defined by the stage. v1.
+- **EC-12 PersistentRotation absent from dev GameData (GT-8).** Trigger:
+  modded-compat lists PersistentRotation but the dev install lacks it. Expected:
+  record `absent-source` in the manifest; fail only if the profile marks it
+  `required = true`; otherwise proceed and log a WARN. v1.
+- **EC-13 kRPC release sha256 unrecorded (OPEN pin).** Trigger: `pins.toml` has
+  `sha256 = "OPEN"`. Expected: DOWNLOAD computes and prints the hash, then
+  ABORTS asking the maintainer to commit it. Never install an unverified
+  artifact. v1.
+- **EC-14 Wrong kRPC/KRPC.MechJeb pairing under a non-v0.5.4 pin.** Trigger: a
+  master kRPC commit is pinned; genhis 0.7.1 ABI may not match. Expected: PAIR
+  detects the non-v0.5.4 pin, refuses to guess, prints the web-verification
+  decision procedure, and ABORTS. Deferred: automated fork/tag selection.
+- **EC-15 Dev settings.cfg missing a key a delta targets.** Trigger: a profile
+  delta names a key absent from the dev settings.cfg. Expected: settings-delta
+  application APPENDS the key (KSP tolerates it) and logs it; a delta key that is
+  a known typo (not in a validated key set) is a WARN. v1.
+
+## What Doesn't Change
+
+- The dev install (`Kerbal Space Program/`) is never written: not its GameData,
+  not its settings.cfg, not its saves. It is a read-only clone/payload source.
+- The Parsek build system, the `-p:ForceKspDeploy` gate, and the intentional-only
+  deploy behavior (`.claude/CLAUDE.md`) are untouched. This script does its own
+  DEPLOY into automation instances and never invokes the csproj post-build copy.
+- The `mods/` clones are read-only pin references. The script never checks them
+  out to a different ref (it uses `git show`/`git archive`).
+- The harness's scenario/coverage machinery (M-A5) is out of scope; this module
+  only produces the instances and manifests it consumes.
+- No changes to Parsek source, tests, or in-game hooks.
+
+## Backward Compatibility
+
+Greenfield module; no existing instances or manifests to migrate. Forward policy:
+the manifest and pin/profile files carry `schema = 1`; a schema bump makes the
+harness refuse an old manifest (EC-5 path) rather than silently mis-admit,
+consistent with the project's no-migration stance for versioned data. A pin
+change is a normal reviewed edit to `pins.toml`; the next provision run detects
+the resulting drift and (with `--repair`) converges the instances.
+
+## Diagnostic Logging
+
+Log to `<instanceDir>/GameData/Parsek/provision-log.txt`, append-only, one decision per
+line, format `[Provision][LEVEL][Step] message` (Info/Warn/Amber/Error mirroring
+ParsekLog), harness-archivable. Every branch logs.
+
+- **PREFLIGHT**: dev-install/mods/pins resolution (paths); KSP-running check
+  result; profile loaded (name, mod count); dry-run vs live.
+- **PIN**: per component, resolved `tag -> commit`, and `match`/`MISMATCH`
+  against `pins.toml`; the GT-2 capability warning (auto-load/Quit/SetLanded
+  absent at v0.5.4); the master-commit AMBER when a non-tag pin is used.
+- **DOWNLOAD**: url, bytes, `sha256 expected=... actual=... OK|FAIL`; the GT-5
+  zip-contents assertion result; OPEN-hash abort.
+- **BUILD-TT**: source ref, the two extracted files, csproj references resolved,
+  build command, `build OK dll-sha256=...` or `build FAIL <compiler tail>`, and
+  the `AutoLoadGame-absent OK|FAIL` reflection assertion (S-4).
+- **PAIR**: fork+tag chosen, the `pairedKrpcTag` assertion, and the
+  web-verify AMBER + abort on a non-v0.5.4 pin.
+- **CLONE**: bytes copied, dirs junctioned with targets (incl. Squad /
+  SquadExpansion, B-3), free-space pre-check, instance `buildID64.txt` sha256
+  vs `pins.kspVersion` `OK|MISMATCH` (N-5).
+- **SETTINGS**: `settingsBaseSha256`, each delta `key old=... new=...`, popup
+  suppressions, appended-key warnings (EC-15), `settingsFinalSha256` (N-4).
+- **DEPLOY**: source path, `stage-sha256`, `installed-sha256`,
+  `hashMatch OK|FAIL`, UTF-16 grep `string=<s> count=<n> expected=<n>`, the
+  EC-11 stage-vs-source AMBER.
+- **INSTALL**: each stack DLL installed with its hash.
+- **MM CACHE**: which cache files deleted and why (regenerate-not-copy).
+- **MANIFEST**: atomic write path + final component/hash summary line.
+- **VERIFY**: per component `on-disk sha256 == manifest OK|DRIFT`, junction
+  resolution, settings presence, `settingsFinalSha256` re-hash `OK|DRIFT` (N-4),
+  `buildId64Sha256` re-hash `OK|DRIFT` (N-5); on `--repair`,
+  `repairing <component>` + re-verify result. Final
+  `[Provision][Info][Verify] instance=<name> result=OK` or a `DRIFT`/`ABORT`
+  summary with the non-zero exit reason.
+- **ABORT/EC**: every edge case logs `[Provision][Error|Warn][<Step>] <ec-id>
+  <detail>` before exit; the `.provision-incomplete` / lock markers are logged
+  on write.
+
+Goal (per the plan): the harness, reading only `provision-log.txt` and
+`provision-manifest.json`, can reconstruct exactly what was installed, from
+which pins, with which hashes, and why any run aborted.
+
+## Test Plan
+
+Every test states the regression it guards. Split into pure-unit (the logic that
+does not touch KSP or the network) and a provisioning smoke run.
+
+### Unit-testable (pure functions, no KSP, no downloads)
+
+- **Manifest diff logic** (`compare_manifest(expected_pins, manifest) -> diff`).
+  Input: an expected pin set + a manifest dict; output: field-level diff.
+  Fails if: a changed component hash, a changed tag/commit, a missing component,
+  or a changed settings delta is NOT reported (guards EC-3/EC-5 silent admission
+  of a drifted instance). Cover: identical (empty diff), one hash drift, a pin
+  bump, an added/removed component, a settings-delta change.
+- **Settings-delta application** (`apply_settings(base_lines, deltas) -> lines`,
+  pure). Fails if: an existing key is not replaced, key/line order is not
+  preserved, an absent key is not appended, or an unrelated key is mutated
+  (guards EC-15 and non-determinism). Cover: replace existing, append missing,
+  no-op when equal, comment/blank-line preservation.
+- **Pin resolution / mismatch** (`resolve_pin(clone_ref_output, pin) -> ok|err`).
+  Fails if: a moved tag (tag resolves to a commit != recorded) is accepted
+  (guards GT-1 retag/move). Cover: match, mismatch, missing tag.
+- (DROPPED) A pure `testingtools_capabilities(krpc_ref) -> caps` pytest was
+  considered and dropped as near-vacuous: it would only restate the hand-authored
+  capability table back to itself. The real guard is the BUILD-TT reflection
+  smoke over the ACTUAL built assembly (see the provisioning smoke run), which
+  proves the six RPCs are exported and `AutoLoadGame`/`Quit`/`SetLanded` are
+  absent from the bytes that ship. The capability table in `pins.toml` / the
+  manifest stays as the harness's admission INPUT, not something a unit test
+  re-derives.
+- **Junction-target recording/resolution** (`verify_junctions(manifest, fs) ->
+  ok|dangling`). Fails if: a dangling junction is reported OK (guards EC-8).
+- **UTF-16 signature grep** (`count_utf16(dll_bytes, s) -> n`). Fails if: a
+  present signature counts 0 or an absent one counts >0 (guards the
+  `.claude/CLAUDE.md` DLL-identity check and EC-9/EC-11). Cover: synthetic byte
+  buffers with known UTF-16-LE substrings.
+- **Free-space / disk-budget estimator and path-length guard**
+  (`estimate_instance_bytes(profile)`, `is_path_too_long(path)`). Fail if an
+  over-budget profile or an over-260-char path is not flagged (guards
+  EC-6/EC-7).
+- **Lock acquire/reclaim** (`acquire_lock(dir, pid, now)`, pure over an injected
+  clock/pid). Fails if: a live lock is stolen or a stale (dead-pid) lock is not
+  reclaimed (guards EC-10).
+
+These follow the project convention: pure logic is `internal`/module-level and
+directly testable; put them in `harness/provision/` with a `test_provision.py`
+(pytest) so they run in the per-PR cadence without KSP.
+
+### Verified by a provisioning smoke run (needs the dev install + network)
+
+- **End-to-end stock-minimal provision** on a scratch umbrella copy: run
+  `provision.py --profile stock-minimal`, then assert the manifest exists, every
+  recorded DLL hash matches on disk, the UTF-16 grep passes, `settings.cfg`
+  carries the deltas, MM caches are absent, and junctions resolve. Fails if any
+  step half-provisions or the manifest disagrees with disk (the whole point of
+  M-A6). This is the harness's first real dependency and doubles as the Phase 2
+  smoke gate (plan section 11).
+- **Idempotency re-run**: run again immediately; assert every component logs
+  `skip (up-to-date)` and no bytes are rewritten (guards convergence).
+- **Drift + repair**: mutate one installed DLL, run `--repair`; assert only that
+  component is re-installed and VERIFY passes (guards EC-3 repair path).
+- **KSP-running abort**: hold a file in the instance open, run; assert clean
+  ABORT with no writes (guards EC-1/EC-9).
+- **BUILD-TT smoke**: assert TestingTools.dll builds from the v0.5.4 2-file shim
+  against the dev KSP DLLs + release kRPC binaries and exports the six RPCs
+  (reflect over the built assembly), that the flags/Quit/SetLanded are absent
+  (guards GT-2/GT-4), and that the `AutoLoadGame` type is ABSENT from the built
+  assembly (guards S-4: the dropped auto-loader must not race the seam's
+  `LoadGame` boot). This reflection smoke over the REAL built assembly is the
+  authoritative capability guard.
+
+The smoke runs are operator-driven (they need the GPU-less-but-interactive dev
+PC and network); the setup script emits its own pass/fail summary line so an
+unattended scheduled run can gate on it.
+
+---
+
+## Open Items (require web verification at install time)
+
+- **O-1 (EC-13)**: exact sha256 of `krpc-0.5.4.zip` and the chosen MJ 2.15 build
+  zip. Command: download from the pinned URLs, `sha256sum <file>`, record in
+  `pins.toml`. Until recorded, DOWNLOAD aborts by design.
+- **O-2 (GT-5)**: confirm the kRPC 0.5.4 zip layout.
+  `unzip -l krpc-0.5.4.zip | grep -iE 'testingtools|KRPC.Core.dll|KRPC.SpaceCenter.dll|Google.Protobuf.dll'`
+  -- expect no TestingTools, expect the three compile references.
+- **O-3 (GT-7)**: the exact MechJeb2 2.15 dev build number + download URL (no git
+  tag exists). Source: MechJeb2 CI / SpaceDock / CurseForge release matching KSP
+  1.12.
+- **O-4 (GT-8/EC-12)**: decide PersistentRotation for modded-compat -- drop it or
+  source a KSP-1.12 build separately. If sourced, add its pin+hash to
+  `pins.toml`.
+- **O-5 (GT-6/EC-14)**: only if a non-v0.5.4 kRPC is ever pinned -- confirm the
+  genhis-vs-darchambault fork+tag against the pinned kRPC and MJ build via the
+  two releases pages named in the PAIR step.


### PR DESCRIPTION
## Summary

Docs-only PR establishing the automated-testing initiative:

- **automated-testing-plan.md** (ratified v2): strategy for unattended mission-fly-record-verify pipelines - kRPC + MechJeb + Python orchestrator, file-drop command seam, coverage model over the D1-D18 dimension registry, Ledger Accuracy Campaign (L0-L5 up to the grand oracle career run), operational spine (cadence tiers, budgets, flake policy).
- **automated-testing-scenario-catalog.md**: coverage backbone - dimension registry, atomic blocks B1-B10, scenario ladder tiers 0-5, regression replay list R1-R26, F-series fault-injection family, fixture sources.
- **Four module design docs** (house step-3 format, each passed a clean-context adversarial review + fix round):
  - design-autotest-offline-analyzer.md (M-A1): invariant framework with CitedContract fields, pure core shared with the in-game H5 category
  - design-autotest-command-seam.md (M-A2): ParsekTestCommands file-drop channel, three-phase journal (at-most-once), LoadGame boot verb
  - design-autotest-autorun-hooks.md (M-A3): PARSEK_AUTORUN_TESTS/EXIT, BATCH_COMPLETE marker, RecordingInvariants category
  - design-autotest-stack-setup.md (M-A6): kRPC v0.5.4 pin with tag-verified TestingTools surface, two instance profiles, version manifest

## Key ground truth established during review

At kRPC tag v0.5.4 the TestingTools auto-load flags, Quit(), and SetLanded() do NOT exist (master-only, one unreleased commit past the tag). Boot channel is therefore the Parsek-side seam LoadGame verb; quit is seam FlushAndQuit; landed fixtures ride stock Scenario saves.

## Test plan

Docs only - no code changes. Each design doc carries its own Test Plan section for the implementation PRs that follow.