### PR TITLE
M-A1: Offline Recording Analyzer (invariant suite + CLI)

### DIFF
--- a/Source/Parsek.Tests/Analyzer/AnalysisReport.cs
+++ b/Source/Parsek.Tests/Analyzer/AnalysisReport.cs
@@ -1,0 +1,67 @@
+using System.Collections.Generic;
+
+namespace Parsek.Tests.Analyzer
+{
+    // Loader/core output for one analysis subject (design doc "Loader output and
+    // report"). The report format is a frozen output contract: AnalyzerVersion is
+    // bumped only when the .analysis.json schema changes, never when a rule is
+    // added (rules are data inside findings).
+
+    /// <summary>Per-level finding tally. Never negative.</summary>
+    internal struct Counts
+    {
+        public int Fail;
+        public int Warn;
+        public int Info;
+        public int StaleFixture;
+
+        /// <summary>Aggregates a finding list into per-level counts.</summary>
+        public static Counts From(IEnumerable<Finding> findings)
+        {
+            var c = new Counts();
+            if (findings == null)
+                return c;
+            foreach (Finding f in findings)
+            {
+                switch (f.Level)
+                {
+                    case VerdictLevel.Fail: c.Fail++; break;
+                    case VerdictLevel.Warn: c.Warn++; break;
+                    case VerdictLevel.Info: c.Info++; break;
+                    case VerdictLevel.StaleFixture: c.StaleFixture++; break;
+                }
+            }
+            return c;
+        }
+    }
+
+    internal sealed class AnalysisReport
+    {
+        /// <summary>
+        /// Frozen report-format version. Bumped ONLY on a .analysis.json schema
+        /// change; the golden-JSON test fails if the schema drifts without a bump.
+        /// </summary>
+        public const string CurrentAnalyzerVersion = "1";
+
+        public string SaveName;
+
+        public string AnalyzerVersion = CurrentAnalyzerVersion;
+
+        /// <summary>Discovered from the analyzed data.</summary>
+        public int SubjectSchemaGeneration;
+
+        /// <summary>
+        /// Findings in insertion order. <see cref="ReportWriter"/> applies the
+        /// deterministic (level desc, ruleId, target, sectionIndex) sort on write.
+        /// </summary>
+        public List<Finding> Findings = new List<Finding>();
+
+        public Counts Counts;
+
+        /// <summary>
+        /// A run is red when it carries any FAIL or any STALE-FIXTURE (design run
+        /// modes: both fail the build; WARN/INFO never do).
+        /// </summary>
+        public bool IsRed => Counts.Fail > 0 || Counts.StaleFixture > 0;
+    }
+}

--- a/Source/Parsek.Tests/Analyzer/AnalyzerModel.cs
+++ b/Source/Parsek.Tests/Analyzer/AnalyzerModel.cs
@@ -187,13 +187,21 @@ namespace Parsek.Tests.Analyzer
         /// <summary>
         /// The analyzed save directory, set by <c>SaveDirectoryLoader.Load</c>; null
         /// for a purely in-memory model (the H5 in-game walker and the core-purity
-        /// test). The two file-scoped rules that must reach sidecars the loader does
-        /// not pre-materialize into the model -- INV7b (.pann annotation staleness,
+        /// test). Two SAVE-SCOPED rules read it to reach sidecars the loader does not
+        /// pre-materialize into the model -- INV7b (.pann annotation staleness,
         /// probed against the paired .prec) and INV9 (RewindPoint quicksave
-        /// existence) -- read it and no-op when it is null, so the pure invariant
-        /// core stays reusable. It is the ONLY path-bearing field on the model; the
-        /// design's "no path on the model" ideal yields here to the plan's explicit
+        /// existence) -- and no-op when it is null, so the pure invariant core stays
+        /// reusable. It is the ONLY path-bearing field on the model; the design's
+        /// "no path on the model" ideal yields here to the plan's explicit
         /// requirement that INV7b/INV9 probe files scoped to a save.
+        ///
+        /// Note these are not the only rules that touch the filesystem: INV10
+        /// round-trips the trajectory codec through a SCRATCH temp file (its own,
+        /// never save-scoped, so it does not read this field). The core-purity gate
+        /// (InvariantRegistryTests.CorePurity_AllRules_RunOverInMemoryModel_WithoutFileAccess)
+        /// therefore asserts NO RULE THROWS over an in-memory model (SaveDirectory
+        /// null), NOT that no rule performs any file I/O -- a rule may touch scratch
+        /// files as long as it stays exception-safe when the model carries no save.
         /// </summary>
         public string SaveDirectory { get; set; }
 

--- a/Source/Parsek.Tests/Analyzer/AnalyzerModel.cs
+++ b/Source/Parsek.Tests/Analyzer/AnalyzerModel.cs
@@ -183,5 +183,18 @@ namespace Parsek.Tests.Analyzer
 
         /// <summary>Injected body resolver; TestBodyRegistry in xUnit.</summary>
         public Func<string, CelestialBody> BodyResolver { get; set; }
+
+        /// <summary>
+        /// The analyzed save directory, set by <c>SaveDirectoryLoader.Load</c>; null
+        /// for a purely in-memory model (the H5 in-game walker and the core-purity
+        /// test). The two file-scoped rules that must reach sidecars the loader does
+        /// not pre-materialize into the model -- INV7b (.pann annotation staleness,
+        /// probed against the paired .prec) and INV9 (RewindPoint quicksave
+        /// existence) -- read it and no-op when it is null, so the pure invariant
+        /// core stays reusable. It is the ONLY path-bearing field on the model; the
+        /// design's "no path on the model" ideal yields here to the plan's explicit
+        /// requirement that INV7b/INV9 probe files scoped to a save.
+        /// </summary>
+        public string SaveDirectory { get; set; }
     }
 }

--- a/Source/Parsek.Tests/Analyzer/AnalyzerModel.cs
+++ b/Source/Parsek.Tests/Analyzer/AnalyzerModel.cs
@@ -1,0 +1,187 @@
+using System;
+using System.Collections.Generic;
+
+namespace Parsek.Tests.Analyzer
+{
+    // Core model types for the M-A1 offline recording analyzer (module M-A1,
+    // design doc docs/dev/design-autotest-offline-analyzer.md "Data Model").
+    //
+    // Everything here is the PURE, already-loaded input the invariant core runs
+    // over. No Stream, no path, no FileInfo lives on AnalyzerModel: the loader
+    // owns all file I/O (SaveDirectoryLoader) and the rules are pure functions
+    // over the loaded objects so the future in-game H5 category (module M-A3)
+    // can feed the same core a live RecordingStore and get identical findings.
+    //
+    // Types are internal because they expose internal-to-Tests production types
+    // (CareerSaveSnapshot, GameAction) that InternalsVisibleTo("Parsek.Tests")
+    // makes reachable here but not publicly re-exportable.
+
+    /// <summary>
+    /// Verdict severity for a single <see cref="Finding"/>. Numeric order is
+    /// load-bearing: report findings sort by (level DESC, ...), so StaleFixture
+    /// prints before Fail before Warn before Info.
+    /// </summary>
+    internal enum VerdictLevel
+    {
+        Info = 0,
+        Warn = 1,
+        Fail = 2,
+        StaleFixture = 3,
+    }
+
+    /// <summary>
+    /// One observation from one rule. Immutable value type. <see cref="CitedContract"/>
+    /// is REQUIRED on every finding (and every rule): it names the production
+    /// member that defines the contract the rule checks, so a rule asserting a
+    /// wrong contract dies in code review rather than as a nightly false alarm.
+    /// </summary>
+    internal struct Finding
+    {
+        /// <summary>Stable rule id, e.g. "INV1-UT-MONOTONIC".</summary>
+        public string RuleId;
+
+        public VerdictLevel Level;
+
+        /// <summary>recordingId / treeId / "&lt;save&gt;" / file path.</summary>
+        public string Target;
+
+        /// <summary>-1 when the finding is not section-scoped.</summary>
+        public int SectionIndex;
+
+        /// <summary>Human, one line, ASCII.</summary>
+        public string Message;
+
+        /// <summary>Production member the rule checks (REQUIRED, never empty).</summary>
+        public string CitedContract;
+
+        public Finding(
+            string ruleId,
+            VerdictLevel level,
+            string target,
+            int sectionIndex,
+            string message,
+            string citedContract)
+        {
+            RuleId = ruleId;
+            Level = level;
+            Target = target;
+            SectionIndex = sectionIndex;
+            Message = message;
+            CitedContract = citedContract;
+        }
+    }
+
+    /// <summary>
+    /// A file that failed to parse. In the analyzer a parse failure is a finding,
+    /// never a crash: the loader records one <see cref="LoadFault"/> and keeps
+    /// going. Rules (INV5 / INV4 / INV9) read these to emit their verdicts.
+    /// </summary>
+    internal struct LoadFault
+    {
+        public string FilePath;
+
+        /// <summary>
+        /// "sfs" / "trajectory" / "snapshot" / "tree-node" / "ledger" /
+        /// "rewindpoint" / "annotation" / "career".
+        /// </summary>
+        public string FileKind;
+
+        /// <summary>Parser's failure reason string.</summary>
+        public string Reason;
+
+        /// <summary>Recording id when resolvable from the path, else null.</summary>
+        public string RecordingId;
+
+        public LoadFault(string filePath, string fileKind, string reason, string recordingId)
+        {
+            FilePath = filePath;
+            FileKind = fileKind;
+            Reason = reason;
+            RecordingId = recordingId;
+        }
+    }
+
+    /// <summary>
+    /// Fixture-corpus provenance stamp read from a corpus's
+    /// <c>fixture-generation.txt</c>. Null for non-fixture subjects (harness /
+    /// triage saves), which skip the STALE-FIXTURE check entirely.
+    /// </summary>
+    internal struct FixtureStamp
+    {
+        public int SchemaGeneration;
+
+        /// <summary>"synthetic" | "harvested".</summary>
+        public string Provenance;
+
+        public FixtureStamp(int schemaGeneration, string provenance)
+        {
+            SchemaGeneration = schemaGeneration;
+            Provenance = provenance;
+        }
+    }
+
+    /// <summary>
+    /// One named invariant over the loaded model. Every implementation MUST
+    /// declare a non-empty <see cref="CitedContract"/> (enforced by the
+    /// CitedContract-presence reflection test) and MUST NOT touch a file or a
+    /// Stream (enforced by the core-purity test), so the same rule set is reusable
+    /// in-game (module M-A3 / hook H5) against a live RecordingStore.
+    /// </summary>
+    internal interface IRecordingInvariant
+    {
+        string RuleId { get; }
+
+        /// <summary>Production member the rule checks, e.g. "RecordingStore.IsRecordingSchemaCompatible".</summary>
+        string CitedContract { get; }
+
+        IEnumerable<Finding> Evaluate(AnalyzerModel model);
+    }
+
+    /// <summary>
+    /// The pure, already-loaded input to the invariant core. Built by
+    /// <c>SaveDirectoryLoader</c> offline and (future) by the in-game H5 walker.
+    /// No file I/O surface lives here.
+    /// </summary>
+    internal sealed class AnalyzerModel
+    {
+        public string SaveName { get; set; }
+
+        /// <summary>Flat list, all trees flattened.</summary>
+        public IReadOnlyList<Recording> Recordings { get; set; } = new List<Recording>();
+
+        public IReadOnlyList<RecordingTree> Trees { get; set; } = new List<RecordingTree>();
+
+        public IReadOnlyList<LedgerTombstone> Tombstones { get; set; } = new List<LedgerTombstone>();
+
+        public IReadOnlyList<RecordingSupersedeRelation> SupersedeRelations { get; set; }
+            = new List<RecordingSupersedeRelation>();
+
+        /// <summary>Null when not career / unparsable.</summary>
+        public CareerSaveSnapshot CareerSave { get; set; }
+
+        /// <summary>
+        /// RAW Ledger.Actions (unfiltered). INV8 computes the ELS filter internally
+        /// from <see cref="Tombstones"/>; the loader NEVER pre-filters (a pre-filtered
+        /// list would make INV8's dangling-tombstone check vacuous by construction).
+        /// </summary>
+        public IReadOnlyList<GameAction> Ledger { get; set; } = new List<GameAction>();
+
+        /// <summary>Parse failures the loader recorded.</summary>
+        public IReadOnlyList<LoadFault> LoadFaults { get; set; } = new List<LoadFault>();
+
+        /// <summary>Null for non-fixture subjects.</summary>
+        public FixtureStamp? FixtureStamp { get; set; }
+
+        /// <summary>
+        /// Side-table (correction C2) keyed by recording id, carrying the
+        /// (schemaGeneration, formatVersion) each trajectory sidecar probe reported
+        /// during load. INV5 uses it for the metadata-vs-sidecar generation-mismatch
+        /// case; keys with no matching recording are orphan sidecars.
+        /// </summary>
+        public IReadOnlyDictionary<string, (int Generation, int FormatVersion)> SidecarSchema { get; set; }
+            = new Dictionary<string, (int, int)>();
+
+        /// <summary>Injected body resolver; TestBodyRegistry in xUnit.</summary>
+        public Func<string, CelestialBody> BodyResolver { get; set; }
+    }
+}

--- a/Source/Parsek.Tests/Analyzer/AnalyzerModel.cs
+++ b/Source/Parsek.Tests/Analyzer/AnalyzerModel.cs
@@ -196,5 +196,16 @@ namespace Parsek.Tests.Analyzer
         /// requirement that INV7b/INV9 probe files scoped to a save.
         /// </summary>
         public string SaveDirectory { get; set; }
+
+        /// <summary>
+        /// Optional headless ledger reconstruction for INV8 part (b)'s career diff.
+        /// Null offline in v1: the full headless recalculation seam is deferred
+        /// (correction C5), so the loader never builds one and INV8(b) reports
+        /// reconstruction-not-available INFO for career saves. Present only when a
+        /// caller (a test, or a future headless recalc seam / the in-game H5 path)
+        /// supplies one, in which case INV8(b) diffs it via
+        /// <c>LedgerGroundTruthDiff.Compare</c>.
+        /// </summary>
+        public LedgerReconstructionSnapshot LedgerReconstruction { get; set; }
     }
 }

--- a/Source/Parsek.Tests/Analyzer/AnalyzerModelTests.cs
+++ b/Source/Parsek.Tests/Analyzer/AnalyzerModelTests.cs
@@ -1,0 +1,100 @@
+using System.Collections.Generic;
+using Xunit;
+
+namespace Parsek.Tests.Analyzer
+{
+    // Guards the M-A1 core model types (design doc "Data Model").
+    public class AnalyzerModelTests
+    {
+        // Guards: the report sort is (level DESC, ...). If the enum numbering
+        // drifts, StaleFixture/Fail/Warn/Info would sort in the wrong order and
+        // every downstream report diff would churn. Pin the numeric contract.
+        [Fact]
+        public void VerdictLevel_NumericOrder_IsInfoWarnFailStaleAscending()
+        {
+            Assert.Equal(0, (int)VerdictLevel.Info);
+            Assert.Equal(1, (int)VerdictLevel.Warn);
+            Assert.Equal(2, (int)VerdictLevel.Fail);
+            Assert.Equal(3, (int)VerdictLevel.StaleFixture);
+        }
+
+        // Guards: rules iterate model collections without null-guarding. A default
+        // AnalyzerModel must expose empty (non-null) collections so a rule over a
+        // no-footprint save cannot NRE.
+        [Fact]
+        public void AnalyzerModel_Defaults_AreEmptyNotNull()
+        {
+            var model = new AnalyzerModel();
+
+            Assert.NotNull(model.Recordings);
+            Assert.Empty(model.Recordings);
+            Assert.NotNull(model.Trees);
+            Assert.Empty(model.Trees);
+            Assert.NotNull(model.Tombstones);
+            Assert.Empty(model.Tombstones);
+            Assert.NotNull(model.SupersedeRelations);
+            Assert.Empty(model.SupersedeRelations);
+            Assert.NotNull(model.Ledger);
+            Assert.Empty(model.Ledger);
+            Assert.NotNull(model.LoadFaults);
+            Assert.Empty(model.LoadFaults);
+            Assert.NotNull(model.SidecarSchema);
+            Assert.Empty(model.SidecarSchema);
+            Assert.Null(model.CareerSave);
+            Assert.Null(model.FixtureStamp);
+        }
+
+        // Guards: the Finding constructor field wiring (positional args) matches
+        // the field it names, so a downstream reporter never mislabels a finding.
+        [Fact]
+        public void Finding_Constructor_AssignsAllFields()
+        {
+            var f = new Finding(
+                "INV1-UT-MONOTONIC",
+                VerdictLevel.Fail,
+                "rec-1",
+                3,
+                "back-stepping UT",
+                "TrajectoryPoint.ut");
+
+            Assert.Equal("INV1-UT-MONOTONIC", f.RuleId);
+            Assert.Equal(VerdictLevel.Fail, f.Level);
+            Assert.Equal("rec-1", f.Target);
+            Assert.Equal(3, f.SectionIndex);
+            Assert.Equal("back-stepping UT", f.Message);
+            Assert.Equal("TrajectoryPoint.ut", f.CitedContract);
+        }
+
+        // Guards: LoadFault / FixtureStamp positional field wiring.
+        [Fact]
+        public void LoadFault_And_FixtureStamp_Constructors_AssignAllFields()
+        {
+            var lf = new LoadFault("a/b.prec", "trajectory", "text-sidecar-unsupported", "rec-9");
+            Assert.Equal("a/b.prec", lf.FilePath);
+            Assert.Equal("trajectory", lf.FileKind);
+            Assert.Equal("text-sidecar-unsupported", lf.Reason);
+            Assert.Equal("rec-9", lf.RecordingId);
+
+            var stamp = new FixtureStamp(4, "synthetic");
+            Assert.Equal(4, stamp.SchemaGeneration);
+            Assert.Equal("synthetic", stamp.Provenance);
+        }
+
+        // Guards: SidecarSchema round-trips the (generation, formatVersion) tuple by
+        // named element, so INV5's generation-mismatch read stays correct.
+        [Fact]
+        public void SidecarSchema_TupleElements_AreNamed()
+        {
+            var model = new AnalyzerModel
+            {
+                SidecarSchema = new Dictionary<string, (int Generation, int FormatVersion)>
+                {
+                    ["rec-1"] = (4, 1),
+                },
+            };
+
+            Assert.Equal(4, model.SidecarSchema["rec-1"].Generation);
+            Assert.Equal(1, model.SidecarSchema["rec-1"].FormatVersion);
+        }
+    }
+}

--- a/Source/Parsek.Tests/Analyzer/InvariantRegistry.cs
+++ b/Source/Parsek.Tests/Analyzer/InvariantRegistry.cs
@@ -27,6 +27,7 @@ namespace Parsek.Tests.Analyzer
                 new Inv4PartEventPid(),
                 new Inv6ResourceManifest(),
                 new Inv10CodecRoundtrip(),
+                new Inv7bAnnotationStale(),
             };
     }
 

--- a/Source/Parsek.Tests/Analyzer/InvariantRegistry.cs
+++ b/Source/Parsek.Tests/Analyzer/InvariantRegistry.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Parsek;
 using Parsek.Tests.Analyzer.Rules;
 
 namespace Parsek.Tests.Analyzer
@@ -17,9 +18,13 @@ namespace Parsek.Tests.Analyzer
         /// The production rule set, in registration order. Concrete rules are
         /// added here (and as Analyzer/Rules/*.cs files) from Phase 2 onward.
         /// </summary>
-        internal static IReadOnlyList<IRecordingInvariant> AllRules { get; } =
-            new List<IRecordingInvariant>
+        internal static IReadOnlyList<IRecordingInvariant> AllRules { get; } = BuildRules();
+
+        private static IReadOnlyList<IRecordingInvariant> BuildRules()
+        {
+            var rules = new List<IRecordingInvariant>
             {
+                new LoadFaultRule(),
                 new Inv1UtMonotonic(),
                 new Inv2NoDoubleCover(),
                 new Inv3RelativeContract(),
@@ -33,6 +38,18 @@ namespace Parsek.Tests.Analyzer
                 new Inv8Ledger(),
                 new FixtureStampRule(),
             };
+
+            // Diagnostic logging (design "Diagnostic Logging"): every rule logs its
+            // CitedContract once at registration so the contract citations are
+            // visible in a run log, not just in source.
+            foreach (IRecordingInvariant rule in rules)
+            {
+                ParsekLog.Verbose("Analyzer",
+                    "rule " + rule.RuleId + " cites " + rule.CitedContract);
+            }
+
+            return rules;
+        }
     }
 
     internal static class Analyzer

--- a/Source/Parsek.Tests/Analyzer/InvariantRegistry.cs
+++ b/Source/Parsek.Tests/Analyzer/InvariantRegistry.cs
@@ -19,6 +19,7 @@ namespace Parsek.Tests.Analyzer
         internal static IReadOnlyList<IRecordingInvariant> AllRules { get; } =
             new List<IRecordingInvariant>
             {
+                new Inv1UtMonotonic(),
                 new Inv2NoDoubleCover(),
                 new Inv7TreeTopology(),
             };

--- a/Source/Parsek.Tests/Analyzer/InvariantRegistry.cs
+++ b/Source/Parsek.Tests/Analyzer/InvariantRegistry.cs
@@ -20,6 +20,7 @@ namespace Parsek.Tests.Analyzer
             new List<IRecordingInvariant>
             {
                 new Inv2NoDoubleCover(),
+                new Inv7TreeTopology(),
             };
     }
 

--- a/Source/Parsek.Tests/Analyzer/InvariantRegistry.cs
+++ b/Source/Parsek.Tests/Analyzer/InvariantRegistry.cs
@@ -25,6 +25,7 @@ namespace Parsek.Tests.Analyzer
                 new Inv7TreeTopology(),
                 new Inv5SchemaGate(),
                 new Inv4PartEventPid(),
+                new Inv6ResourceManifest(),
             };
     }
 

--- a/Source/Parsek.Tests/Analyzer/InvariantRegistry.cs
+++ b/Source/Parsek.Tests/Analyzer/InvariantRegistry.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Parsek.Tests.Analyzer.Rules;
 
 namespace Parsek.Tests.Analyzer
 {
@@ -16,7 +17,10 @@ namespace Parsek.Tests.Analyzer
         /// added here (and as Analyzer/Rules/*.cs files) from Phase 2 onward.
         /// </summary>
         internal static IReadOnlyList<IRecordingInvariant> AllRules { get; } =
-            new List<IRecordingInvariant>();
+            new List<IRecordingInvariant>
+            {
+                new Inv2NoDoubleCover(),
+            };
     }
 
     internal static class Analyzer

--- a/Source/Parsek.Tests/Analyzer/InvariantRegistry.cs
+++ b/Source/Parsek.Tests/Analyzer/InvariantRegistry.cs
@@ -24,6 +24,7 @@ namespace Parsek.Tests.Analyzer
                 new Inv3RelativeContract(),
                 new Inv7TreeTopology(),
                 new Inv5SchemaGate(),
+                new Inv4PartEventPid(),
             };
     }
 

--- a/Source/Parsek.Tests/Analyzer/InvariantRegistry.cs
+++ b/Source/Parsek.Tests/Analyzer/InvariantRegistry.cs
@@ -30,6 +30,7 @@ namespace Parsek.Tests.Analyzer
                 new Inv7bAnnotationStale(),
                 new Inv9RewindPoint(),
                 new Inv8Ledger(),
+                new FixtureStampRule(),
             };
     }
 

--- a/Source/Parsek.Tests/Analyzer/InvariantRegistry.cs
+++ b/Source/Parsek.Tests/Analyzer/InvariantRegistry.cs
@@ -28,6 +28,7 @@ namespace Parsek.Tests.Analyzer
                 new Inv6ResourceManifest(),
                 new Inv10CodecRoundtrip(),
                 new Inv7bAnnotationStale(),
+                new Inv9RewindPoint(),
             };
     }
 

--- a/Source/Parsek.Tests/Analyzer/InvariantRegistry.cs
+++ b/Source/Parsek.Tests/Analyzer/InvariantRegistry.cs
@@ -26,6 +26,7 @@ namespace Parsek.Tests.Analyzer
                 new Inv5SchemaGate(),
                 new Inv4PartEventPid(),
                 new Inv6ResourceManifest(),
+                new Inv10CodecRoundtrip(),
             };
     }
 

--- a/Source/Parsek.Tests/Analyzer/InvariantRegistry.cs
+++ b/Source/Parsek.Tests/Analyzer/InvariantRegistry.cs
@@ -23,6 +23,7 @@ namespace Parsek.Tests.Analyzer
                 new Inv2NoDoubleCover(),
                 new Inv3RelativeContract(),
                 new Inv7TreeTopology(),
+                new Inv5SchemaGate(),
             };
     }
 

--- a/Source/Parsek.Tests/Analyzer/InvariantRegistry.cs
+++ b/Source/Parsek.Tests/Analyzer/InvariantRegistry.cs
@@ -29,6 +29,7 @@ namespace Parsek.Tests.Analyzer
                 new Inv10CodecRoundtrip(),
                 new Inv7bAnnotationStale(),
                 new Inv9RewindPoint(),
+                new Inv8Ledger(),
             };
     }
 

--- a/Source/Parsek.Tests/Analyzer/InvariantRegistry.cs
+++ b/Source/Parsek.Tests/Analyzer/InvariantRegistry.cs
@@ -1,0 +1,78 @@
+using System.Collections.Generic;
+
+namespace Parsek.Tests.Analyzer
+{
+    // The invariant registry and the pure Evaluate entry point (task 0.3).
+    //
+    // Phase 0/1 ships the registry with an EMPTY rule set: the rules land in
+    // Phase 2+ under Analyzer/Rules/. The framework (Evaluate + verdict policy +
+    // the CitedContract-presence and core-purity gates) is proven now so every
+    // future rule slots in without reworking the harness.
+
+    internal static class InvariantRegistry
+    {
+        /// <summary>
+        /// The production rule set, in registration order. Concrete rules are
+        /// added here (and as Analyzer/Rules/*.cs files) from Phase 2 onward.
+        /// </summary>
+        internal static IReadOnlyList<IRecordingInvariant> AllRules { get; } =
+            new List<IRecordingInvariant>();
+    }
+
+    internal static class Analyzer
+    {
+        /// <summary>Evaluates the production rule set over the loaded model.</summary>
+        internal static AnalysisReport Evaluate(AnalyzerModel model)
+        {
+            return Evaluate(model, InvariantRegistry.AllRules);
+        }
+
+        /// <summary>
+        /// Pure core: runs the given rules over the model and aggregates findings
+        /// into a report. Never touches a file (the loader already ran); this is the
+        /// exact code path the future in-game H5 category reuses.
+        /// </summary>
+        internal static AnalysisReport Evaluate(AnalyzerModel model, IReadOnlyList<IRecordingInvariant> rules)
+        {
+            var report = new AnalysisReport
+            {
+                SaveName = model?.SaveName,
+                SubjectSchemaGeneration = DiscoverSubjectSchemaGeneration(model),
+            };
+
+            if (rules != null && model != null)
+            {
+                foreach (IRecordingInvariant rule in rules)
+                {
+                    if (rule == null)
+                        continue;
+                    IEnumerable<Finding> findings = rule.Evaluate(model);
+                    if (findings != null)
+                        report.Findings.AddRange(findings);
+                }
+            }
+
+            report.Counts = Counts.From(report.Findings);
+            return report;
+        }
+
+        /// <summary>
+        /// Discovers the subject's schema generation from the loaded data: the
+        /// highest <see cref="Recording.RecordingSchemaGeneration"/> across loaded
+        /// recordings, or 0 when the save has no recordings.
+        /// </summary>
+        internal static int DiscoverSubjectSchemaGeneration(AnalyzerModel model)
+        {
+            int gen = 0;
+            if (model?.Recordings != null)
+            {
+                foreach (Recording rec in model.Recordings)
+                {
+                    if (rec != null && rec.RecordingSchemaGeneration > gen)
+                        gen = rec.RecordingSchemaGeneration;
+                }
+            }
+            return gen;
+        }
+    }
+}

--- a/Source/Parsek.Tests/Analyzer/InvariantRegistry.cs
+++ b/Source/Parsek.Tests/Analyzer/InvariantRegistry.cs
@@ -21,6 +21,7 @@ namespace Parsek.Tests.Analyzer
             {
                 new Inv1UtMonotonic(),
                 new Inv2NoDoubleCover(),
+                new Inv3RelativeContract(),
                 new Inv7TreeTopology(),
             };
     }

--- a/Source/Parsek.Tests/Analyzer/InvariantRegistry.cs
+++ b/Source/Parsek.Tests/Analyzer/InvariantRegistry.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using Parsek.Tests.Analyzer.Rules;
 
@@ -36,6 +37,22 @@ namespace Parsek.Tests.Analyzer
 
     internal static class Analyzer
     {
+        /// <summary>
+        /// End-to-end entry point shared by all run modes (design "Run modes"):
+        /// load the save directory, evaluate the production rule set, and write both
+        /// report files into <paramref name="resultsDir"/>. Both parameters are
+        /// required so a caller can never scatter reports next to a user's save.
+        /// Returns the report so a caller (the harness / a test) can read the counts.
+        /// </summary>
+        internal static AnalysisReport Run(
+            string saveDir, string resultsDir, Func<string, CelestialBody> bodyResolver)
+        {
+            AnalyzerModel model = SaveDirectoryLoader.Load(saveDir, bodyResolver);
+            AnalysisReport report = Evaluate(model);
+            ReportWriter.Write(report, resultsDir);
+            return report;
+        }
+
         /// <summary>Evaluates the production rule set over the loaded model.</summary>
         internal static AnalysisReport Evaluate(AnalyzerModel model)
         {

--- a/Source/Parsek.Tests/Analyzer/InvariantRegistryTests.cs
+++ b/Source/Parsek.Tests/Analyzer/InvariantRegistryTests.cs
@@ -1,0 +1,180 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+
+namespace Parsek.Tests.Analyzer
+{
+    /// <summary>
+    /// A configurable in-memory rule used to prove verdict policy without a real
+    /// invariant. Parameterless-constructible (so the CitedContract-presence
+    /// reflection test can instantiate it) and pure (records nothing from disk),
+    /// so it is a valid IRecordingInvariant implementation in its own right.
+    /// </summary>
+    internal sealed class StubRule : IRecordingInvariant
+    {
+        public string RuleId { get; set; } = "STUB-RULE";
+        public string CitedContract { get; set; } = "StubContract";
+        public List<Finding> FindingsToReturn { get; set; } = new List<Finding>();
+
+        public IEnumerable<Finding> Evaluate(AnalyzerModel model)
+        {
+            return FindingsToReturn;
+        }
+    }
+
+    public class InvariantRegistryTests
+    {
+        private static AnalyzerModel InMemoryModel()
+        {
+            // Fully in-memory: no loader, no disk. The core must run over this.
+            return new AnalyzerModel
+            {
+                SaveName = "mem",
+                Recordings = new List<Recording>
+                {
+                    new Recording { RecordingId = "rec-1", RecordingSchemaGeneration = 4 },
+                },
+            };
+        }
+
+        private static List<IRecordingInvariant> Rules(params Finding[] findings)
+        {
+            return new List<IRecordingInvariant>
+            {
+                new StubRule { FindingsToReturn = findings.ToList() },
+            };
+        }
+
+        // Guards: a FAIL finding lands as Counts.Fail and marks the run red. If FAIL
+        // were downgraded, CI would go green on real corruption.
+        [Fact]
+        public void Evaluate_FailFinding_CountsFail_AndRunIsRed()
+        {
+            var report = Analyzer.Evaluate(
+                InMemoryModel(),
+                Rules(new Finding("INV1-UT-MONOTONIC", VerdictLevel.Fail, "rec-1", -1, "m", "c")));
+
+            Assert.Equal(1, report.Counts.Fail);
+            Assert.True(report.IsRed);
+        }
+
+        // Guards: WARN-only does not fail the run but is surfaced. A regression that
+        // escalated WARN would block unrelated PRs.
+        [Fact]
+        public void Evaluate_WarnOnly_NotRed_ButSurfaced()
+        {
+            var report = Analyzer.Evaluate(
+                InMemoryModel(),
+                Rules(new Finding("INV3-ABSOLUTE-RANGE", VerdictLevel.Warn, "rec-1", -1, "m", "c")));
+
+            Assert.Equal(0, report.Counts.Fail);
+            Assert.Equal(1, report.Counts.Warn);
+            Assert.False(report.IsRed);
+            Assert.Single(report.Findings);
+        }
+
+        // Guards: INFO never fails a run (inventory / provenance).
+        [Fact]
+        public void Evaluate_InfoOnly_NotRed()
+        {
+            var report = Analyzer.Evaluate(
+                InMemoryModel(),
+                Rules(new Finding("INV6-RESOURCE-MANIFEST", VerdictLevel.Info, "rec-1", -1, "m", "c")));
+
+            Assert.Equal(1, report.Counts.Info);
+            Assert.False(report.IsRed);
+        }
+
+        // Guards: STALE-FIXTURE is distinct from FAIL - it marks the run red but as
+        // a stale-corpus maintenance failure, not a code bug (no FAIL count).
+        [Fact]
+        public void Evaluate_StaleFixture_RedButDistinctFromFail()
+        {
+            var report = Analyzer.Evaluate(
+                InMemoryModel(),
+                Rules(new Finding("FIX-STALE", VerdictLevel.StaleFixture, "rec-1", -1, "m", "c")));
+
+            Assert.Equal(0, report.Counts.Fail);
+            Assert.Equal(1, report.Counts.StaleFixture);
+            Assert.True(report.IsRed);
+        }
+
+        // Guards: the shipped registry is empty in Phase 0/1, and Evaluate over the
+        // default rule set produces a clean, green report.
+        [Fact]
+        public void Evaluate_DefaultRegistry_IsEmpty_AndClean()
+        {
+            Assert.Empty(InvariantRegistry.AllRules);
+
+            var report = Analyzer.Evaluate(InMemoryModel());
+            Assert.Empty(report.Findings);
+            Assert.False(report.IsRed);
+        }
+
+        // Guards: SubjectSchemaGeneration is discovered from the recordings, not
+        // hardcoded, so the report reflects what the save actually carries.
+        [Fact]
+        public void Evaluate_DiscoversSubjectSchemaGeneration_FromRecordings()
+        {
+            var withRecordings = Analyzer.Evaluate(InMemoryModel());
+            Assert.Equal(4, withRecordings.SubjectSchemaGeneration);
+
+            var empty = Analyzer.Evaluate(new AnalyzerModel { SaveName = "empty" });
+            Assert.Equal(0, empty.SubjectSchemaGeneration);
+        }
+
+        // Guards (H5 readiness): every rule runs over a fully in-memory model with
+        // no loader. Fails if a rule reaches for a file/Stream, which would block the
+        // future in-game RecordingInvariants category from reusing the core. With
+        // the empty production set this proves the wiring; every rule added later is
+        // exercised here for free.
+        [Fact]
+        public void CorePurity_AllRules_RunOverInMemoryModel_WithoutFileAccess()
+        {
+            var model = InMemoryModel();
+
+            Exception thrown = Record.Exception(() => Analyzer.Evaluate(model, InvariantRegistry.AllRules));
+
+            Assert.Null(thrown);
+        }
+
+        // Guards the review gate (design "CitedContract-presence test"): reflection
+        // over EVERY IRecordingInvariant implementation in the assembly asserts a
+        // non-empty RuleId and CitedContract. Passes trivially with zero production
+        // rules today and enforces the contract on every future rule - a rule that
+        // ships without naming the production member it checks fails here.
+        [Fact]
+        public void EveryInvariantImplementation_DeclaresRuleIdAndCitedContract()
+        {
+            IEnumerable<Type> ruleTypes = SafeGetTypes(typeof(IRecordingInvariant).Assembly)
+                .Where(t => t != null
+                    && typeof(IRecordingInvariant).IsAssignableFrom(t)
+                    && !t.IsInterface
+                    && !t.IsAbstract
+                    && t.GetConstructor(Type.EmptyTypes) != null);
+
+            foreach (Type t in ruleTypes)
+            {
+                var rule = (IRecordingInvariant)Activator.CreateInstance(t);
+                Assert.False(string.IsNullOrWhiteSpace(rule.RuleId),
+                    $"{t.FullName} must declare a non-empty RuleId");
+                Assert.False(string.IsNullOrWhiteSpace(rule.CitedContract),
+                    $"{t.FullName} must declare a non-empty CitedContract (the production member it checks)");
+            }
+        }
+
+        private static Type[] SafeGetTypes(Assembly asm)
+        {
+            try
+            {
+                return asm.GetTypes();
+            }
+            catch (ReflectionTypeLoadException ex)
+            {
+                return ex.Types;
+            }
+        }
+    }
+}

--- a/Source/Parsek.Tests/Analyzer/InvariantRegistryTests.cs
+++ b/Source/Parsek.Tests/Analyzer/InvariantRegistryTests.cs
@@ -101,12 +101,15 @@ namespace Parsek.Tests.Analyzer
             Assert.True(report.IsRed);
         }
 
-        // Guards: the shipped registry is empty in Phase 0/1, and Evaluate over the
-        // default rule set produces a clean, green report.
+        // Guards: the shipped registry carries the registered production rules, and
+        // Evaluate over the default rule set produces a clean, green report on a
+        // well-formed in-memory model (a rule that false-alarms on clean data would
+        // turn this red). Phase 0/1 asserted an empty registry; from Phase 2 the
+        // registry is non-empty and this pins "clean data -> no findings".
         [Fact]
-        public void Evaluate_DefaultRegistry_IsEmpty_AndClean()
+        public void Evaluate_DefaultRegistry_HasRules_AndCleanModelIsGreen()
         {
-            Assert.Empty(InvariantRegistry.AllRules);
+            Assert.NotEmpty(InvariantRegistry.AllRules);
 
             var report = Analyzer.Evaluate(InMemoryModel());
             Assert.Empty(report.Findings);

--- a/Source/Parsek.Tests/Analyzer/LoaderLoggingTests.cs
+++ b/Source/Parsek.Tests/Analyzer/LoaderLoggingTests.cs
@@ -1,0 +1,105 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Parsek;
+using Parsek.Tests.Generators;
+using Xunit;
+
+namespace Parsek.Tests.Analyzer
+{
+    // Log-assertion tests for the loader's diagnostic lines (design "Diagnostic
+    // Logging"). Uses ParsekLog.TestSinkForTesting to capture emitted lines and
+    // asserts the code path executed and logged the expected data. Sequential:
+    // touches the ParsekLog + RecordingStore static state.
+    [Collection("Sequential")]
+    public class LoaderLoggingTests : IDisposable
+    {
+        private readonly string tempDir;
+        private readonly bool prevSuppress;
+        private readonly List<string> logLines = new List<string>();
+
+        public LoaderLoggingTests()
+        {
+            prevSuppress = RecordingStore.SuppressLogging;
+            RecordingStore.SuppressLogging = false;
+            RecordingStore.ResetForTesting();
+
+            // Capture ParsekLog output; keep Verbose enabled so the (a) summary
+            // (Verbose) is observable, and do NOT suppress ParsekLog (the loader
+            // suppresses RecordingStore's own logs internally, not ParsekLog).
+            ParsekLog.SuppressLogging = false;
+            ParsekLog.VerboseOverrideForTesting = true;
+            ParsekLog.TestSinkForTesting = line => logLines.Add(line);
+
+            tempDir = Path.Combine(Path.GetTempPath(),
+                "parsek-analyzer-loaderlog-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(tempDir);
+        }
+
+        public void Dispose()
+        {
+            ParsekLog.ResetTestOverrides();
+            RecordingStore.ResetForTesting();
+            RecordingStore.SuppressLogging = prevSuppress;
+            ParsekLog.SuppressLogging = true;
+
+            if (Directory.Exists(tempDir))
+            {
+                try { Directory.Delete(tempDir, true); }
+                catch { }
+            }
+        }
+
+        private string NewSaveDir(string name)
+        {
+            string dir = Path.Combine(tempDir, name);
+            Directory.CreateDirectory(dir);
+            return dir;
+        }
+
+        private static CelestialBody NullResolver(string name) => null;
+
+        // Guards (design "Diagnostic Logging" (a)): a clean load emits one Verbose
+        // per-subject summary line carrying the save name + tree / recording / fault
+        // counts. Fails if the loader stops logging its summary (the run log would
+        // lose the per-subject one-shot that ties findings to a subject).
+        [Fact]
+        public void Load_EmitsVerboseLoadSummaryLine()
+        {
+            string saveDir = NewSaveDir("logsummary");
+            var writer = new ScenarioWriter().AddRecordingAsTree(
+                new RecordingBuilder("Solo").WithRecordingId("solo0").AddPoint(100, 0, 0, 1000));
+            string scenarioText = writer.SerializeConfigNode(writer.BuildScenarioNode(), "SCENARIO", 1);
+            File.WriteAllText(Path.Combine(saveDir, "persistent.sfs"),
+                "GAME\n{\n\tFLIGHTSTATE\n\t{\n\t\tversion = 1.12.5\n\t}\n" + scenarioText + "}\n");
+
+            SaveDirectoryLoader.Load(saveDir, NullResolver);
+
+            Assert.Contains(logLines, l =>
+                l.Contains("[VERBOSE][Analyzer]")
+                && l.Contains("load save='logsummary'")
+                && l.Contains("trees=1")
+                && l.Contains("recordings=1")
+                && l.Contains("loadFaults=0"));
+        }
+
+        // Guards (design "Diagnostic Logging" (b)): every LoadFault emits a Warn line
+        // naming the file kind + reason. Fails if a parse failure is silent in the
+        // run log (the "a file that failed to parse is itself a finding" contract
+        // would lose its observable trace).
+        [Fact]
+        public void Load_EmitsWarnLinePerLoadFault()
+        {
+            string saveDir = NewSaveDir("logfault");
+            File.WriteAllText(Path.Combine(saveDir, "persistent.sfs"),
+                "GAME\n{\n\tSCENARIO\n\t{\n\t\tname = ParsekScenario\n{{{ broken unbalanced");
+
+            SaveDirectoryLoader.Load(saveDir, NullResolver);
+
+            Assert.Contains(logLines, l =>
+                l.Contains("[WARN][Analyzer]")
+                && l.Contains("loadFault kind=sfs")
+                && l.Contains("reason="));
+        }
+    }
+}

--- a/Source/Parsek.Tests/Analyzer/OfflineAnalyzerTests.cs
+++ b/Source/Parsek.Tests/Analyzer/OfflineAnalyzerTests.cs
@@ -1,0 +1,129 @@
+using System;
+using System.IO;
+using Parsek;
+using Parsek.Tests.Generators;
+using Xunit;
+
+namespace Parsek.Tests.Analyzer
+{
+    // The three-mode entry point (design "Run modes" + "Where the code lives").
+    //
+    // - CI regression floor: a non-Manual test synthesizes a fixture corpus with
+    //   ScenarioWriter, runs Analyzer.Run over it, and asserts the run is GREEN
+    //   (zero FAIL, zero STALE-FIXTURE) with both report files written. This is the
+    //   per-PR floor that fails the build if any rule false-alarms on known-good
+    //   builder output, or if a builder starts emitting invariant-violating data.
+    // - Harness post-run / ad hoc triage: a [Trait("Category","Manual")] test reads
+    //   PARSEK_ANALYZER_SAVE (and optional PARSEK_ANALYZER_RESULTS), runs the same
+    //   pipeline, and writes the reports. It SKIPS CLEANLY when the env var is unset
+    //   so it never runs (or fails) in the normal CI pass.
+    //
+    // Sequential because Analyzer.Run drives the loader, which touches
+    // RecordingStore statics.
+    [Collection("Sequential")]
+    public class OfflineAnalyzerTests : IDisposable
+    {
+        private readonly string tempDir;
+        private readonly bool prevSuppress;
+
+        public OfflineAnalyzerTests()
+        {
+            prevSuppress = RecordingStore.SuppressLogging;
+            RecordingStore.SuppressLogging = false;
+            RecordingStore.ResetForTesting();
+            ParsekLog.SuppressLogging = true;
+
+            tempDir = Path.Combine(Path.GetTempPath(),
+                "parsek-analyzer-offline-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(tempDir);
+        }
+
+        public void Dispose()
+        {
+            RecordingStore.ResetForTesting();
+            RecordingStore.SuppressLogging = prevSuppress;
+            ParsekLog.SuppressLogging = true;
+            if (Directory.Exists(tempDir))
+            {
+                try { Directory.Delete(tempDir, true); }
+                catch { }
+            }
+        }
+
+        private static CelestialBody Resolver(string name) => TestBodyRegistry.CreateBody(name);
+
+        // Default results dir when PARSEK_ANALYZER_RESULTS is unset:
+        // bin/Debug/net472/analyzer-results/ (AppContext.BaseDirectory IS that dir).
+        private static string DefaultResultsDir() =>
+            Path.Combine(AppContext.BaseDirectory, "analyzer-results");
+
+        private void SynthesizeCorpus(string saveDir)
+        {
+            Directory.CreateDirectory(saveDir);
+            var writer = new ScenarioWriter().WithV3Format()
+                .AddRecordingAsTree(new RecordingBuilder("Corpus A")
+                    .WithRecordingId("corpus0")
+                    .AddPoint(100, 0, 0, 1000)
+                    .AddPoint(110, 0.01, 0.02, 1500)
+                    .WithVesselSnapshot(VesselSnapshotBuilder.FleaRocket("Corpus A", "Jeb", pid: 8001)))
+                .AddRecordingAsTree(new RecordingBuilder("Corpus B")
+                    .WithRecordingId("corpus1")
+                    .AddPoint(200, 1, 1, 2000)
+                    .AddPoint(210, 1.01, 1.02, 2500)
+                    .WithVesselSnapshot(VesselSnapshotBuilder.ProbeShip("Corpus B", pid: 8002)));
+
+            string scenarioText = writer.SerializeConfigNode(writer.BuildScenarioNode(), "SCENARIO", 1);
+            string save =
+                "GAME\n{\n\tFLIGHTSTATE\n\t{\n\t\tversion = 1.12.5\n\t}\n" + scenarioText + "}\n";
+            File.WriteAllText(Path.Combine(saveDir, "persistent.sfs"), save);
+            writer.WriteSidecarFiles(saveDir);
+        }
+
+        // Guards (CI regression floor): the full analyzer pipeline over a known-good
+        // ScenarioWriter corpus is GREEN (zero FAIL, zero STALE) and writes both
+        // report files. Fails if a rule false-alarms on valid builder output, if a
+        // builder emits invariant-violating data, or if the report writer breaks.
+        [Fact]
+        public void CiFloor_SyntheticCorpus_IsGreen_AndWritesReports()
+        {
+            string saveDir = Path.Combine(tempDir, "corpus");
+            SynthesizeCorpus(saveDir);
+            string resultsDir = Path.Combine(tempDir, "results");
+
+            AnalysisReport report = Analyzer.Run(saveDir, resultsDir, Resolver);
+
+            Assert.Equal(0, report.Counts.Fail);
+            Assert.Equal(0, report.Counts.StaleFixture);
+            Assert.False(report.IsRed);
+
+            Assert.True(File.Exists(Path.Combine(resultsDir, "corpus.analysis.json")));
+            Assert.True(File.Exists(Path.Combine(resultsDir, "corpus.analysis.txt")));
+        }
+
+        // Harness post-run / ad hoc triage. Reads PARSEK_ANALYZER_SAVE; when unset
+        // it skips cleanly (no-op) so the normal CI pass never runs it. When set, it
+        // runs the pipeline over that save and writes the reports into
+        // PARSEK_ANALYZER_RESULTS (or the default analyzer-results dir). Malformed
+        // input is expected to produce findings, never a stack trace.
+        [Fact]
+        [Trait("Category", "Manual")]
+        public void Manual_AnalyzeEnvSave_WritesReports()
+        {
+            string saveDir = Environment.GetEnvironmentVariable("PARSEK_ANALYZER_SAVE");
+            if (string.IsNullOrEmpty(saveDir))
+                return; // env unset -> skip cleanly (CI-safe)
+
+            string resultsDir = Environment.GetEnvironmentVariable("PARSEK_ANALYZER_RESULTS");
+            if (string.IsNullOrEmpty(resultsDir))
+                resultsDir = DefaultResultsDir();
+
+            AnalysisReport report = Analyzer.Run(saveDir, resultsDir, Resolver);
+
+            string baseName = string.IsNullOrEmpty(report.SaveName) ? "analysis" : report.SaveName;
+            Assert.True(File.Exists(Path.Combine(resultsDir, baseName + ".analysis.json")),
+                "analyzer must write the machine report for a Manual run");
+            Assert.True(File.Exists(Path.Combine(resultsDir, baseName + ".analysis.txt")),
+                "analyzer must write the human report for a Manual run");
+        }
+    }
+}

--- a/Source/Parsek.Tests/Analyzer/ReportWriter.cs
+++ b/Source/Parsek.Tests/Analyzer/ReportWriter.cs
@@ -134,8 +134,19 @@ namespace Parsek.Tests.Analyzer
 
             string baseName = string.IsNullOrEmpty(report.SaveName) ? "analysis" : report.SaveName;
             var utf8NoBom = new UTF8Encoding(false);
-            File.WriteAllText(Path.Combine(resultsDir, baseName + ".analysis.json"), BuildJson(report), utf8NoBom);
+            string jsonPath = Path.Combine(resultsDir, baseName + ".analysis.json");
+            File.WriteAllText(jsonPath, BuildJson(report), utf8NoBom);
             File.WriteAllText(Path.Combine(resultsDir, baseName + ".analysis.txt"), BuildHumanSummary(report), utf8NoBom);
+
+            // Diagnostic logging (design "Diagnostic Logging"): one-shot report-write
+            // summary carrying the per-level counts + output path.
+            Parsek.ParsekLog.Info("Analyzer",
+                "report save='" + (report.SaveName ?? "") + "'"
+                + " FAIL=" + report.Counts.Fail.ToString(IC)
+                + " WARN=" + report.Counts.Warn.ToString(IC)
+                + " INFO=" + report.Counts.Info.ToString(IC)
+                + " STALE=" + report.Counts.StaleFixture.ToString(IC)
+                + " json='" + jsonPath + "'");
         }
 
         private static string JsonString(string value)

--- a/Source/Parsek.Tests/Analyzer/ReportWriter.cs
+++ b/Source/Parsek.Tests/Analyzer/ReportWriter.cs
@@ -1,0 +1,170 @@
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace Parsek.Tests.Analyzer
+{
+    // Emits the two frozen report files per subject (design doc "Report format").
+    // Determinism is a hard requirement: the same input produces byte-identical
+    // output, so there are no timestamps, no absolute paths, and no
+    // dictionary-iteration order. All numeric formatting uses InvariantCulture.
+    internal static class ReportWriter
+    {
+        private static readonly CultureInfo IC = CultureInfo.InvariantCulture;
+
+        // "\n" everywhere (not Environment.NewLine) so a report generated on
+        // Windows and Linux is byte-identical.
+        private const string Nl = "\n";
+
+        /// <summary>UPPERCASE token for a level, used in both report files.</summary>
+        internal static string LevelToken(VerdictLevel level)
+        {
+            switch (level)
+            {
+                case VerdictLevel.Fail: return "FAIL";
+                case VerdictLevel.Warn: return "WARN";
+                case VerdictLevel.StaleFixture: return "STALE";
+                default: return "INFO";
+            }
+        }
+
+        /// <summary>
+        /// Deterministic total order: level DESC (StaleFixture, Fail, Warn, Info),
+        /// then ruleId, target, sectionIndex ascending (all ordinal). Returns a new
+        /// list; the input is not mutated.
+        /// </summary>
+        internal static List<Finding> SortFindings(IEnumerable<Finding> findings)
+        {
+            return findings
+                .OrderByDescending(f => (int)f.Level)
+                .ThenBy(f => f.RuleId ?? "", System.StringComparer.Ordinal)
+                .ThenBy(f => f.Target ?? "", System.StringComparer.Ordinal)
+                .ThenBy(f => f.SectionIndex)
+                .ToList();
+        }
+
+        /// <summary>
+        /// Machine-readable, stable, sorted JSON. Field order is fixed:
+        /// analyzerVersion, saveName, subjectSchemaGeneration, counts, findings.
+        /// </summary>
+        internal static string BuildJson(AnalysisReport report)
+        {
+            var sb = new StringBuilder();
+            sb.Append("{").Append(Nl);
+            sb.Append("  \"analyzerVersion\": ").Append(JsonString(report.AnalyzerVersion)).Append(",").Append(Nl);
+            sb.Append("  \"saveName\": ").Append(JsonString(report.SaveName)).Append(",").Append(Nl);
+            sb.Append("  \"subjectSchemaGeneration\": ")
+                .Append(report.SubjectSchemaGeneration.ToString(IC)).Append(",").Append(Nl);
+
+            sb.Append("  \"counts\": {").Append(Nl);
+            sb.Append("    \"fail\": ").Append(report.Counts.Fail.ToString(IC)).Append(",").Append(Nl);
+            sb.Append("    \"warn\": ").Append(report.Counts.Warn.ToString(IC)).Append(",").Append(Nl);
+            sb.Append("    \"info\": ").Append(report.Counts.Info.ToString(IC)).Append(",").Append(Nl);
+            sb.Append("    \"staleFixture\": ").Append(report.Counts.StaleFixture.ToString(IC)).Append(Nl);
+            sb.Append("  },").Append(Nl);
+
+            List<Finding> sorted = SortFindings(report.Findings ?? new List<Finding>());
+            sb.Append("  \"findings\": [");
+            if (sorted.Count == 0)
+            {
+                sb.Append("]").Append(Nl);
+            }
+            else
+            {
+                sb.Append(Nl);
+                for (int i = 0; i < sorted.Count; i++)
+                {
+                    Finding f = sorted[i];
+                    sb.Append("    {").Append(Nl);
+                    sb.Append("      \"ruleId\": ").Append(JsonString(f.RuleId)).Append(",").Append(Nl);
+                    sb.Append("      \"level\": ").Append(JsonString(LevelToken(f.Level))).Append(",").Append(Nl);
+                    sb.Append("      \"target\": ").Append(JsonString(f.Target)).Append(",").Append(Nl);
+                    sb.Append("      \"sectionIndex\": ").Append(f.SectionIndex.ToString(IC)).Append(",").Append(Nl);
+                    sb.Append("      \"message\": ").Append(JsonString(f.Message)).Append(",").Append(Nl);
+                    sb.Append("      \"citedContract\": ").Append(JsonString(f.CitedContract)).Append(Nl);
+                    sb.Append("    }").Append(i == sorted.Count - 1 ? "" : ",").Append(Nl);
+                }
+                sb.Append("  ]").Append(Nl);
+            }
+
+            sb.Append("}").Append(Nl);
+            return sb.ToString();
+        }
+
+        /// <summary>
+        /// Human summary. One header line then one grep-friendly line per finding,
+        /// mirroring the validate-ksp-log.ps1 output style.
+        /// </summary>
+        internal static string BuildHumanSummary(AnalysisReport report)
+        {
+            var sb = new StringBuilder();
+            sb.Append("[Analyzer] save=").Append(report.SaveName ?? "")
+                .Append(" generation=").Append(report.SubjectSchemaGeneration.ToString(IC))
+                .Append(" FAIL=").Append(report.Counts.Fail.ToString(IC))
+                .Append(" WARN=").Append(report.Counts.Warn.ToString(IC))
+                .Append(" INFO=").Append(report.Counts.Info.ToString(IC))
+                .Append(" STALE=").Append(report.Counts.StaleFixture.ToString(IC))
+                .Append(Nl);
+
+            foreach (Finding f in SortFindings(report.Findings ?? new List<Finding>()))
+            {
+                string target = f.SectionIndex >= 0
+                    ? (f.Target ?? "") + "#" + f.SectionIndex.ToString(IC)
+                    : (f.Target ?? "");
+                sb.Append(LevelToken(f.Level)).Append(" ")
+                    .Append(f.RuleId ?? "").Append(" target=").Append(target)
+                    .Append(" ").Append(f.Message ?? "")
+                    .Append(Nl);
+            }
+
+            return sb.ToString();
+        }
+
+        /// <summary>
+        /// Writes <c>&lt;save&gt;.analysis.json</c> and <c>&lt;save&gt;.analysis.txt</c>
+        /// into <paramref name="resultsDir"/> (created if absent). UTF-8 without BOM,
+        /// so the bytes are deterministic across runs.
+        /// </summary>
+        internal static void Write(AnalysisReport report, string resultsDir)
+        {
+            if (!Directory.Exists(resultsDir))
+                Directory.CreateDirectory(resultsDir);
+
+            string baseName = string.IsNullOrEmpty(report.SaveName) ? "analysis" : report.SaveName;
+            var utf8NoBom = new UTF8Encoding(false);
+            File.WriteAllText(Path.Combine(resultsDir, baseName + ".analysis.json"), BuildJson(report), utf8NoBom);
+            File.WriteAllText(Path.Combine(resultsDir, baseName + ".analysis.txt"), BuildHumanSummary(report), utf8NoBom);
+        }
+
+        private static string JsonString(string value)
+        {
+            if (value == null)
+                return "\"\"";
+            var sb = new StringBuilder(value.Length + 2);
+            sb.Append('"');
+            foreach (char ch in value)
+            {
+                switch (ch)
+                {
+                    case '"': sb.Append("\\\""); break;
+                    case '\\': sb.Append("\\\\"); break;
+                    case '\b': sb.Append("\\b"); break;
+                    case '\f': sb.Append("\\f"); break;
+                    case '\n': sb.Append("\\n"); break;
+                    case '\r': sb.Append("\\r"); break;
+                    case '\t': sb.Append("\\t"); break;
+                    default:
+                        if (ch < 0x20)
+                            sb.Append("\\u").Append(((int)ch).ToString("x4", IC));
+                        else
+                            sb.Append(ch);
+                        break;
+                }
+            }
+            sb.Append('"');
+            return sb.ToString();
+        }
+    }
+}

--- a/Source/Parsek.Tests/Analyzer/ReportWriterTests.cs
+++ b/Source/Parsek.Tests/Analyzer/ReportWriterTests.cs
@@ -1,0 +1,228 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using Xunit;
+
+namespace Parsek.Tests.Analyzer
+{
+    // Guards the frozen report-format contract (design doc "Report format stability
+    // tests"). The harness parses .analysis.json and greps .analysis.txt, so any
+    // silent drift here breaks a downstream consumer.
+    public class ReportWriterTests : IDisposable
+    {
+        private readonly string tempDir;
+
+        public ReportWriterTests()
+        {
+            tempDir = Path.Combine(Path.GetTempPath(),
+                "parsek-analyzer-report-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(tempDir);
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(tempDir))
+            {
+                try { Directory.Delete(tempDir, true); }
+                catch { }
+            }
+        }
+
+        private static AnalysisReport SampleReport(List<Finding> findings)
+        {
+            return new AnalysisReport
+            {
+                SaveName = "testsave",
+                SubjectSchemaGeneration = 4,
+                Findings = findings,
+                Counts = Counts.From(findings),
+            };
+        }
+
+        private static List<Finding> TwoFindings()
+        {
+            return new List<Finding>
+            {
+                new Finding("INV1-UT-MONOTONIC", VerdictLevel.Fail, "rec-b", 2,
+                    "back-step at ut", "TrajectoryPoint.ut"),
+                new Finding("INV2-NO-DOUBLE-COVER", VerdictLevel.Warn, "rec-a", -1,
+                    "uncovered span", "TrackSection"),
+            };
+        }
+
+        // Guards: writing the same model twice produces byte-identical .analysis.json
+        // (no timestamps, no absolute paths, no dictionary order leak). If a wall
+        // clock or a HashSet iteration leaked in, CI report diffing would be useless.
+        [Fact]
+        public void Write_SameModelTwice_ProducesByteIdenticalJson()
+        {
+            string dir1 = Path.Combine(tempDir, "run1");
+            string dir2 = Path.Combine(tempDir, "run2");
+
+            ReportWriter.Write(SampleReport(TwoFindings()), dir1);
+            ReportWriter.Write(SampleReport(TwoFindings()), dir2);
+
+            byte[] a = File.ReadAllBytes(Path.Combine(dir1, "testsave.analysis.json"));
+            byte[] b = File.ReadAllBytes(Path.Combine(dir2, "testsave.analysis.json"));
+            Assert.Equal(a, b);
+        }
+
+        // Guards: the JSON is order-independent of the input finding list, because
+        // the writer sorts. Two identical finding SETS in different order must
+        // serialize identically.
+        [Fact]
+        public void BuildJson_IsInputOrderIndependent()
+        {
+            var forward = TwoFindings();
+            var reversed = new List<Finding>(forward);
+            reversed.Reverse();
+
+            Assert.Equal(
+                ReportWriter.BuildJson(SampleReport(forward)),
+                ReportWriter.BuildJson(SampleReport(reversed)));
+        }
+
+        // Guards: the deterministic total order is (level desc, ruleId, target,
+        // sectionIndex). A sort regression would churn every downstream diff.
+        [Fact]
+        public void SortFindings_OrdersByLevelDescThenRuleIdThenTargetThenSection()
+        {
+            var findings = new List<Finding>
+            {
+                new Finding("INV2", VerdictLevel.Info, "z", 0, "m", "c"),
+                new Finding("INV2", VerdictLevel.Fail, "b", 1, "m", "c"),
+                new Finding("INV2", VerdictLevel.Fail, "b", 0, "m", "c"),
+                new Finding("INV1", VerdictLevel.Fail, "b", 5, "m", "c"),
+                new Finding("INV9", VerdictLevel.StaleFixture, "a", 0, "m", "c"),
+                new Finding("INV2", VerdictLevel.Fail, "a", 9, "m", "c"),
+            };
+
+            var sorted = ReportWriter.SortFindings(findings);
+
+            // StaleFixture first (level desc).
+            Assert.Equal("INV9", sorted[0].RuleId);
+            Assert.Equal(VerdictLevel.StaleFixture, sorted[0].Level);
+            // Then Fail block, ordered by ruleId: INV1 before INV2.
+            Assert.Equal("INV1", sorted[1].RuleId);
+            // Within INV2 Fails: target asc (a before b), then sectionIndex asc.
+            Assert.Equal("INV2", sorted[2].RuleId);
+            Assert.Equal("a", sorted[2].Target);
+            Assert.Equal("INV2", sorted[3].RuleId);
+            Assert.Equal("b", sorted[3].Target);
+            Assert.Equal(0, sorted[3].SectionIndex);
+            Assert.Equal("b", sorted[4].Target);
+            Assert.Equal(1, sorted[4].SectionIndex);
+            // Info last.
+            Assert.Equal(VerdictLevel.Info, sorted[5].Level);
+        }
+
+        // Guards: the exact .analysis.json schema. Changing a field name, order, or
+        // the AnalyzerVersion without a deliberate bump fails this golden.
+        [Fact]
+        public void BuildJson_MatchesGoldenSchema()
+        {
+            string golden = string.Join("\n", new[]
+            {
+                "{",
+                "  \"analyzerVersion\": \"1\",",
+                "  \"saveName\": \"testsave\",",
+                "  \"subjectSchemaGeneration\": 4,",
+                "  \"counts\": {",
+                "    \"fail\": 1,",
+                "    \"warn\": 1,",
+                "    \"info\": 0,",
+                "    \"staleFixture\": 0",
+                "  },",
+                "  \"findings\": [",
+                "    {",
+                "      \"ruleId\": \"INV1-UT-MONOTONIC\",",
+                "      \"level\": \"FAIL\",",
+                "      \"target\": \"rec-b\",",
+                "      \"sectionIndex\": 2,",
+                "      \"message\": \"back-step at ut\",",
+                "      \"citedContract\": \"TrajectoryPoint.ut\"",
+                "    },",
+                "    {",
+                "      \"ruleId\": \"INV2-NO-DOUBLE-COVER\",",
+                "      \"level\": \"WARN\",",
+                "      \"target\": \"rec-a\",",
+                "      \"sectionIndex\": -1,",
+                "      \"message\": \"uncovered span\",",
+                "      \"citedContract\": \"TrackSection\"",
+                "    }",
+                "  ]",
+                "}",
+                "",
+            });
+
+            Assert.Equal(golden, ReportWriter.BuildJson(SampleReport(TwoFindings())));
+        }
+
+        // Guards: empty findings still emits a valid, stable JSON with an empty array.
+        [Fact]
+        public void BuildJson_NoFindings_EmitsEmptyArray()
+        {
+            string json = ReportWriter.BuildJson(SampleReport(new List<Finding>()));
+            Assert.Contains("\"findings\": []", json);
+        }
+
+        // Guards: the human header line + per-finding line format that grep-based
+        // triage scripts key on.
+        [Fact]
+        public void BuildHumanSummary_HeaderAndFindingLines_MatchContract()
+        {
+            string summary = ReportWriter.BuildHumanSummary(SampleReport(TwoFindings()));
+            string[] lines = summary.Split('\n');
+
+            Assert.Equal(
+                "[Analyzer] save=testsave generation=4 FAIL=1 WARN=1 INFO=0 STALE=0",
+                lines[0]);
+            // Section-scoped finding carries #section.
+            Assert.Equal(
+                "FAIL INV1-UT-MONOTONIC target=rec-b#2 back-step at ut",
+                lines[1]);
+            // Non-section finding omits the #section suffix.
+            Assert.Equal(
+                "WARN INV2-NO-DOUBLE-COVER target=rec-a uncovered span",
+                lines[2]);
+        }
+
+        // Guards: string escaping so a message with a quote/backslash cannot break
+        // the JSON the harness parses.
+        [Fact]
+        public void BuildJson_EscapesSpecialCharactersInStrings()
+        {
+            var findings = new List<Finding>
+            {
+                new Finding("INV1", VerdictLevel.Fail, "rec\"x", -1,
+                    "line\\path\tand\"quote", "C"),
+            };
+            string json = ReportWriter.BuildJson(SampleReport(findings));
+
+            Assert.Contains("\"target\": \"rec\\\"x\"", json);
+            Assert.Contains("\"message\": \"line\\\\path\\tand\\\"quote\"", json);
+        }
+
+        // Guards: IsRed policy - any FAIL or STALE is red; WARN/INFO alone is green.
+        [Fact]
+        public void IsRed_TrueOnFailOrStale_FalseOnWarnInfoOnly()
+        {
+            Assert.True(SampleReport(new List<Finding>
+            {
+                new Finding("INV1", VerdictLevel.Fail, "t", -1, "m", "c"),
+            }).IsRed);
+
+            Assert.True(SampleReport(new List<Finding>
+            {
+                new Finding("FIX", VerdictLevel.StaleFixture, "t", -1, "m", "c"),
+            }).IsRed);
+
+            Assert.False(SampleReport(new List<Finding>
+            {
+                new Finding("INV2", VerdictLevel.Warn, "t", -1, "m", "c"),
+                new Finding("INV6", VerdictLevel.Info, "t", -1, "m", "c"),
+            }).IsRed);
+        }
+    }
+}

--- a/Source/Parsek.Tests/Analyzer/Rules/FixtureStampRule.cs
+++ b/Source/Parsek.Tests/Analyzer/Rules/FixtureStampRule.cs
@@ -1,0 +1,65 @@
+using System.Collections.Generic;
+using System.Globalization;
+using Parsek;
+
+namespace Parsek.Tests.Analyzer.Rules
+{
+    // Fixture-generation stamp check (design doc "Fixture versioning", edge
+    // case 22).
+    //
+    // When the analyzed subject is a fixture corpus (it carries a
+    // fixture-generation.txt stamp the loader parsed into model.FixtureStamp) and
+    // that stamp's generation differs from RecordingStore.CurrentRecordingSchemaGeneration,
+    // EVERY recording in it is reported STALE-FIXTURE -- a DISTINCT verdict from
+    // FAIL: the data is not wrong, the fixture corpus is out of date and needs the
+    // M-A4 regeneration script re-run (a synthetic stamp) or a re-harvest (a
+    // harvested stamp, which the no-migration policy cannot regenerate by script).
+    // A STALE-FIXTURE run is red but reads as "regenerate fixtures", not "code
+    // broke". A non-fixture subject (no stamp -> null) skips this check entirely.
+    internal sealed class FixtureStampRule : IRecordingInvariant
+    {
+        internal const string RuleIdConst = "FIXTURE-STALE";
+
+        public string RuleId => RuleIdConst;
+
+        public string CitedContract => "RecordingStore.CurrentRecordingSchemaGeneration";
+
+        public IEnumerable<Finding> Evaluate(AnalyzerModel model)
+        {
+            var findings = new List<Finding>();
+            if (model?.FixtureStamp == null)
+                return findings; // non-fixture subject -> skip
+
+            FixtureStamp stamp = model.FixtureStamp.Value;
+            int codeGen = RecordingStore.CurrentRecordingSchemaGeneration;
+            if (stamp.SchemaGeneration == codeGen)
+                return findings; // fixture is current
+
+            string note = string.Equals(stamp.Provenance, "harvested", System.StringComparison.Ordinal)
+                ? "re-harvest-queue"
+                : "re-run-M-A4-regeneration";
+
+            if (model.Recordings != null)
+            {
+                foreach (Recording rec in model.Recordings)
+                {
+                    if (rec == null || string.IsNullOrEmpty(rec.RecordingId))
+                        continue;
+                    findings.Add(new Finding(
+                        RuleIdConst,
+                        VerdictLevel.StaleFixture,
+                        rec.RecordingId,
+                        -1,
+                        Inv("FIXTURE stale-fixture recording={0} stampGen={1} codeGen={2} provenance={3} action={4}",
+                            rec.RecordingId, stamp.SchemaGeneration, codeGen, stamp.Provenance ?? "synthetic", note),
+                        "RecordingStore.CurrentRecordingSchemaGeneration"));
+                }
+            }
+
+            return findings;
+        }
+
+        private static string Inv(string format, params object[] args) =>
+            string.Format(CultureInfo.InvariantCulture, format, args);
+    }
+}

--- a/Source/Parsek.Tests/Analyzer/Rules/FixtureStampRuleTests.cs
+++ b/Source/Parsek.Tests/Analyzer/Rules/FixtureStampRuleTests.cs
@@ -1,0 +1,85 @@
+using System.Collections.Generic;
+using System.Linq;
+using Parsek;
+using Xunit;
+
+namespace Parsek.Tests.Analyzer.Rules
+{
+    // Fixture-generation stamp check. Pure in-memory model (the stamp side of the
+    // loader parse is covered separately in the loader tests). Each test names the
+    // regression it guards.
+    public class FixtureStampRuleTests
+    {
+        private static AnalyzerModel ModelWith(FixtureStamp? stamp, params string[] recordingIds)
+        {
+            return new AnalyzerModel
+            {
+                SaveName = "fixstamp",
+                FixtureStamp = stamp,
+                Recordings = recordingIds
+                    .Select(id => new Recording { RecordingId = id })
+                    .ToList<Recording>(),
+            };
+        }
+
+        private static List<Finding> Run(AnalyzerModel model)
+        {
+            return new FixtureStampRule().Evaluate(model).ToList();
+        }
+
+        // Guards: a stamp at the current generation -> zero findings. Fails if a
+        // current fixture corpus is wrongly reported stale.
+        [Fact]
+        public void CurrentGenerationStamp_NoFindings()
+        {
+            var stamp = new FixtureStamp(RecordingStore.CurrentRecordingSchemaGeneration, "synthetic");
+            Assert.Empty(Run(ModelWith(stamp, "r0", "r1")));
+        }
+
+        // Guards (edge case 22): a stamp at a stale generation -> STALE-FIXTURE for
+        // EVERY recording, distinct from FAIL, and the run reads red-but-distinct.
+        // Fails if a stale corpus reads as a code bug (FAIL) or silently passes.
+        [Fact]
+        public void StaleGenerationStamp_StaleFixturePerRecording()
+        {
+            int staleGen = RecordingStore.CurrentRecordingSchemaGeneration - 1;
+            var stamp = new FixtureStamp(staleGen, "synthetic");
+            AnalyzerModel model = ModelWith(stamp, "r0", "r1");
+
+            List<Finding> findings = Run(model);
+
+            Assert.Equal(2, findings.Count);
+            Assert.All(findings, f =>
+            {
+                Assert.Equal(VerdictLevel.StaleFixture, f.Level);
+                Assert.Contains("stale-fixture", f.Message);
+            });
+
+            // Through the full pipeline: red via StaleFixture, not Fail.
+            AnalysisReport report = Analyzer.Evaluate(model, new List<IRecordingInvariant> { new FixtureStampRule() });
+            Assert.Equal(2, report.Counts.StaleFixture);
+            Assert.Equal(0, report.Counts.Fail);
+            Assert.True(report.IsRed);
+        }
+
+        // Guards: a harvested stamp carries the re-harvest-queue note (harvested
+        // fixtures cannot be script-regenerated). Fails if the action note is wrong.
+        [Fact]
+        public void HarvestedStaleStamp_CarriesReHarvestNote()
+        {
+            var stamp = new FixtureStamp(RecordingStore.CurrentRecordingSchemaGeneration - 1, "harvested");
+            List<Finding> findings = Run(ModelWith(stamp, "r0"));
+
+            Finding f = Assert.Single(findings);
+            Assert.Contains("action=re-harvest-queue", f.Message);
+        }
+
+        // Guards: a non-fixture subject (no stamp) skips the check entirely. Fails
+        // if an unstamped harness / triage save is wrongly flagged stale.
+        [Fact]
+        public void Unstamped_NoFindings()
+        {
+            Assert.Empty(Run(ModelWith(null, "r0", "r1")));
+        }
+    }
+}

--- a/Source/Parsek.Tests/Analyzer/Rules/Inv10CodecRoundtrip.cs
+++ b/Source/Parsek.Tests/Analyzer/Rules/Inv10CodecRoundtrip.cs
@@ -1,0 +1,275 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using Parsek;
+
+namespace Parsek.Tests.Analyzer.Rules
+{
+    // INV10 codec round-trips (design doc "The invariant rules" INV10, edge
+    // case 25).
+    //
+    // For each loaded recording, re-serialize and re-deserialize at the CODEC
+    // seams and assert structural equality, so a codec that silently drops a field
+    // on save or load is caught:
+    //   - RecordingTreeRecordCodec.SaveRecordingInto -> LoadRecordingFrom
+    //     (in-memory ConfigNode; run on a DeepClone so the model recording is not
+    //     mutated by SaveRecordingInto's generation stamp);
+    //   - RecordingManifestCodec serialize/deserialize (in-memory ConfigNode);
+    //   - TrajectorySidecarBinary Write/Read (to a scratch temp file, NEVER the
+    //     analyzed save).
+    // A non-round-tripping field -> FAIL naming the field. Comparison is NaN-aware
+    // (a stable NaN round-trips equal, edge case 25) and null/empty-string aware.
+    // Any codec exception is contained as a WARN, never propagated, so the
+    // core-purity contract (no rule throws over an in-memory model) holds.
+    internal sealed class Inv10CodecRoundtrip : IRecordingInvariant
+    {
+        internal const string RuleIdConst = "INV10-CODEC-ROUNDTRIP";
+
+        public string RuleId => RuleIdConst;
+
+        public string CitedContract =>
+            "RecordingTreeRecordCodec.SaveRecordingInto / RecordingManifestCodec / TrajectorySidecarBinary";
+
+        public IEnumerable<Finding> Evaluate(AnalyzerModel model)
+        {
+            var findings = new List<Finding>();
+            if (model?.Recordings == null)
+                return findings;
+
+            foreach (Recording rec in model.Recordings)
+            {
+                if (rec == null || string.IsNullOrEmpty(rec.RecordingId))
+                    continue;
+
+                TreeRecordRoundTrip(rec, findings);
+                ManifestRoundTrip(rec, findings);
+                TrajectoryRoundTrip(rec, findings);
+            }
+
+            return findings;
+        }
+
+        // --- RecordingTreeRecordCodec ---
+
+        private static void TreeRecordRoundTrip(Recording rec, List<Finding> findings)
+        {
+            try
+            {
+                // SaveRecordingInto stamps the current generation onto its argument;
+                // operate on a clone so the model recording is untouched.
+                Recording clone = Recording.DeepClone(rec);
+                var node = new ConfigNode("RECORDING");
+                RecordingTreeRecordCodec.SaveRecordingInto(node, clone);
+                var rec2 = new Recording();
+                RecordingTreeRecordCodec.LoadRecordingFrom(node, rec2);
+
+                CompareString(rec.RecordingId, "RecordingId", rec.RecordingId, rec2.RecordingId, findings);
+                CompareString(rec.RecordingId, "ChainId", rec.ChainId, rec2.ChainId, findings);
+                CompareString(rec.RecordingId, "ParentRecordingId", rec.ParentRecordingId, rec2.ParentRecordingId, findings);
+                CompareString(rec.RecordingId, "ParentAnchorRecordingId", rec.ParentAnchorRecordingId, rec2.ParentAnchorRecordingId, findings);
+                CompareString(rec.RecordingId, "SupersedeTargetId", rec.SupersedeTargetId, rec2.SupersedeTargetId, findings);
+                CompareInt(rec.RecordingId, "ChainIndex", rec.ChainIndex, rec2.ChainIndex, findings);
+                CompareInt(rec.RecordingId, "ChainBranch", rec.ChainBranch, rec2.ChainBranch, findings);
+            }
+            catch (Exception ex)
+            {
+                findings.Add(Warn(rec.RecordingId,
+                    Inv("INV10 codec-threw recording={0} seam=tree-record ex={1}", rec.RecordingId, ex.GetType().Name)));
+            }
+        }
+
+        // --- RecordingManifestCodec ---
+
+        private static void ManifestRoundTrip(Recording rec, List<Finding> findings)
+        {
+            bool hasStart = rec.StartResources != null && rec.StartResources.Count > 0;
+            bool hasEnd = rec.EndResources != null && rec.EndResources.Count > 0;
+            if (!hasStart && !hasEnd)
+                return;
+
+            try
+            {
+                var scratch = new ConfigNode("SCRATCH");
+                RecordingManifestCodec.SerializeResourceManifest(scratch, rec);
+                var rec2 = new Recording { RecordingId = rec.RecordingId };
+                RecordingManifestCodec.DeserializeResourceManifest(scratch, rec2);
+
+                CompareManifest(rec.RecordingId, "StartResources", rec.StartResources, rec2.StartResources, findings);
+                CompareManifest(rec.RecordingId, "EndResources", rec.EndResources, rec2.EndResources, findings);
+            }
+            catch (Exception ex)
+            {
+                findings.Add(Warn(rec.RecordingId,
+                    Inv("INV10 codec-threw recording={0} seam=manifest ex={1}", rec.RecordingId, ex.GetType().Name)));
+            }
+        }
+
+        // --- TrajectorySidecarBinary ---
+
+        private static void TrajectoryRoundTrip(Recording rec, List<Finding> findings)
+        {
+            string tmp = Path.Combine(Path.GetTempPath(),
+                "parsek-inv10-" + Guid.NewGuid().ToString("N") + ".prec");
+            try
+            {
+                TrajectorySidecarBinary.Write(tmp, rec, sidecarEpoch: 1);
+                if (!TrajectorySidecarBinary.TryProbe(tmp, out TrajectorySidecarProbe probe) || !probe.Supported)
+                {
+                    findings.Add(Warn(rec.RecordingId,
+                        Inv("INV10 codec-threw recording={0} seam=trajectory-probe reason={1}",
+                            rec.RecordingId, probe.FailureReason ?? "unsupported")));
+                    return;
+                }
+                var rec2 = new Recording();
+                TrajectorySidecarBinary.Read(tmp, rec2, probe);
+
+                ComparePoints(rec.RecordingId, "Points", rec.Points, rec2.Points, findings);
+                CompareOrbitSegments(rec.RecordingId, rec.OrbitSegments, rec2.OrbitSegments, findings);
+                ComparePartEvents(rec.RecordingId, rec.PartEvents, rec2.PartEvents, findings);
+            }
+            catch (Exception ex)
+            {
+                findings.Add(Warn(rec.RecordingId,
+                    Inv("INV10 codec-threw recording={0} seam=trajectory ex={1}", rec.RecordingId, ex.GetType().Name)));
+            }
+            finally
+            {
+                try { if (File.Exists(tmp)) File.Delete(tmp); } catch { }
+            }
+        }
+
+        // --- comparison helpers ---
+
+        private static void ComparePoints(
+            string recId, string field, List<TrajectoryPoint> a, List<TrajectoryPoint> b, List<Finding> findings)
+        {
+            int ca = a?.Count ?? 0;
+            int cb = b?.Count ?? 0;
+            if (ca != cb)
+            {
+                findings.Add(Fail(recId, Inv("INV10 roundtrip recording={0} field={1} error=count a={2} b={3}", recId, field, ca, cb)));
+                return;
+            }
+            for (int i = 0; i < ca; i++)
+            {
+                TrajectoryPoint pa = a[i];
+                TrajectoryPoint pb = b[i];
+                if (!DoubleEqual(pa.ut, pb.ut)
+                    || !DoubleEqual(pa.latitude, pb.latitude)
+                    || !DoubleEqual(pa.longitude, pb.longitude)
+                    || !DoubleEqual(pa.altitude, pb.altitude))
+                {
+                    findings.Add(Fail(recId, Inv("INV10 roundtrip recording={0} field={1} error=point-drift at={2}", recId, field, i)));
+                    return;
+                }
+            }
+        }
+
+        private static void CompareOrbitSegments(
+            string recId, List<OrbitSegment> a, List<OrbitSegment> b, List<Finding> findings)
+        {
+            int ca = a?.Count ?? 0;
+            int cb = b?.Count ?? 0;
+            if (ca != cb)
+            {
+                findings.Add(Fail(recId, Inv("INV10 roundtrip recording={0} field=OrbitSegments error=count a={1} b={2}", recId, ca, cb)));
+                return;
+            }
+            for (int i = 0; i < ca; i++)
+            {
+                OrbitSegment sa = a[i];
+                OrbitSegment sb = b[i];
+                if (!DoubleEqual(sa.startUT, sb.startUT)
+                    || !DoubleEqual(sa.endUT, sb.endUT)
+                    || !DoubleEqual(sa.semiMajorAxis, sb.semiMajorAxis)
+                    || !DoubleEqual(sa.eccentricity, sb.eccentricity)
+                    || !DoubleEqual(sa.inclination, sb.inclination))
+                {
+                    findings.Add(Fail(recId, Inv("INV10 roundtrip recording={0} field=OrbitSegments error=segment-drift at={1}", recId, i)));
+                    return;
+                }
+            }
+        }
+
+        private static void ComparePartEvents(
+            string recId, List<PartEvent> a, List<PartEvent> b, List<Finding> findings)
+        {
+            int ca = a?.Count ?? 0;
+            int cb = b?.Count ?? 0;
+            if (ca != cb)
+            {
+                findings.Add(Fail(recId, Inv("INV10 roundtrip recording={0} field=PartEvents error=count a={1} b={2}", recId, ca, cb)));
+                return;
+            }
+            for (int i = 0; i < ca; i++)
+            {
+                if (a[i].partPersistentId != b[i].partPersistentId
+                    || a[i].eventType != b[i].eventType
+                    || !DoubleEqual(a[i].ut, b[i].ut))
+                {
+                    findings.Add(Fail(recId, Inv("INV10 roundtrip recording={0} field=PartEvents error=event-drift at={1}", recId, i)));
+                    return;
+                }
+            }
+        }
+
+        private static void CompareManifest(
+            string recId, string field,
+            Dictionary<string, ResourceAmount> a, Dictionary<string, ResourceAmount> b, List<Finding> findings)
+        {
+            var keys = new HashSet<string>(StringComparer.Ordinal);
+            if (a != null) foreach (string k in a.Keys) keys.Add(k);
+            if (b != null) foreach (string k in b.Keys) keys.Add(k);
+
+            foreach (string key in keys)
+            {
+                ResourceAmount ra = default(ResourceAmount);
+                ResourceAmount rb = default(ResourceAmount);
+                bool inA = a != null && a.TryGetValue(key, out ra);
+                bool inB = b != null && b.TryGetValue(key, out rb);
+                if (inA != inB || !DoubleEqual(ra.amount, rb.amount) || !DoubleEqual(ra.maxAmount, rb.maxAmount))
+                {
+                    findings.Add(Fail(recId,
+                        Inv("INV10 roundtrip recording={0} field={1} error=resource-drift resource='{2}'", recId, field, key)));
+                }
+            }
+        }
+
+        private static void CompareString(string recId, string field, string a, string b, List<Finding> findings)
+        {
+            if (!string.Equals(a ?? "", b ?? "", StringComparison.Ordinal))
+                findings.Add(Fail(recId, Inv("INV10 roundtrip recording={0} field={1} error=drift a='{2}' b='{3}'", recId, field, a ?? "", b ?? "")));
+        }
+
+        private static void CompareInt(string recId, string field, int a, int b, List<Finding> findings)
+        {
+            if (a != b)
+                findings.Add(Fail(recId, Inv("INV10 roundtrip recording={0} field={1} error=drift a={2} b={3}", recId, field, a, b)));
+        }
+
+        private static Finding Fail(string recId, string message) =>
+            new Finding(RuleIdConst, VerdictLevel.Fail, recId, -1, message, "RecordingTreeRecordCodec.SaveRecordingInto");
+
+        private static Finding Warn(string recId, string message) =>
+            new Finding(RuleIdConst, VerdictLevel.Warn, recId, -1, message, "RecordingTreeRecordCodec.SaveRecordingInto");
+
+        private static bool DoubleEqual(double x, double y)
+        {
+            if (double.IsNaN(x) && double.IsNaN(y))
+                return true;
+            return x.Equals(y);
+        }
+
+        private static string Inv(string format, params object[] args)
+        {
+            var ic = CultureInfo.InvariantCulture;
+            for (int i = 0; i < args.Length; i++)
+            {
+                if (args[i] is double d)
+                    args[i] = d.ToString("R", ic);
+            }
+            return string.Format(ic, format, args);
+        }
+    }
+}

--- a/Source/Parsek.Tests/Analyzer/Rules/Inv10CodecRoundtripTests.cs
+++ b/Source/Parsek.Tests/Analyzer/Rules/Inv10CodecRoundtripTests.cs
@@ -1,0 +1,118 @@
+using System.Collections.Generic;
+using System.Linq;
+using Parsek;
+using Xunit;
+
+namespace Parsek.Tests.Analyzer.Rules
+{
+    // INV10 codec round-trips. The trajectory seam writes to a scratch temp file
+    // (never a save); the tree-record and manifest seams round-trip through
+    // in-memory ConfigNodes. Each test names the regression it guards.
+    public class Inv10CodecRoundtripTests
+    {
+        private static AnalyzerModel ModelWith(params Recording[] recs)
+        {
+            return new AnalyzerModel { SaveName = "inv10", Recordings = recs.ToList() };
+        }
+
+        private static List<Finding> Run(AnalyzerModel model)
+        {
+            return new Inv10CodecRoundtrip().Evaluate(model).ToList();
+        }
+
+        private static TrajectoryPoint P(double ut, double lat, double lon, double alt) =>
+            new TrajectoryPoint { ut = ut, latitude = lat, longitude = lon, altitude = alt, bodyName = "Kerbin" };
+
+        // Guards: a fully-populated recording (chain metadata, flat Points,
+        // OrbitSegments, PartEvents, resource manifest) round-trips at every codec
+        // seam -> zero INV10 FAIL. Fails if a codec silently drops a field on save
+        // or load.
+        [Fact]
+        public void PopulatedRecording_RoundTrips_NoFail()
+        {
+            var rec = new Recording
+            {
+                RecordingId = "ok0",
+                ChainId = "chain-a",
+                ChainIndex = 2,
+                ChainBranch = 1,
+                ParentRecordingId = "parent0",
+                Points = new List<TrajectoryPoint> { P(100, 0, 0, 1000), P(110, 0.01, 0.02, 1500) },
+                OrbitSegments = new List<OrbitSegment>
+                {
+                    new OrbitSegment
+                    {
+                        startUT = 120, endUT = 200, semiMajorAxis = 700000, eccentricity = 0.01,
+                        inclination = 5, bodyName = "Kerbin", isPredicted = false,
+                    },
+                },
+                PartEvents = new List<PartEvent>
+                {
+                    new PartEvent { ut = 105, partPersistentId = 100000, eventType = PartEventType.Decoupled, partName = "decoupler" },
+                },
+                StartResources = new Dictionary<string, ResourceAmount>
+                {
+                    ["LiquidFuel"] = new ResourceAmount { amount = 100.0, maxAmount = 100.0 },
+                },
+                EndResources = new Dictionary<string, ResourceAmount>
+                {
+                    ["LiquidFuel"] = new ResourceAmount { amount = 5.0, maxAmount = 100.0 },
+                },
+            };
+
+            List<Finding> findings = Run(ModelWith(rec));
+
+            Assert.DoesNotContain(findings, f => f.Level == VerdictLevel.Fail);
+            Assert.DoesNotContain(findings, f => f.Level == VerdictLevel.Warn);
+        }
+
+        // Guards: a manifest resource the codec drops on round-trip (empty-name
+        // entry) -> INV10 FAIL naming the resource field. Fails if the round-trip
+        // comparison is too shallow to notice the drift.
+        [Fact]
+        public void ManifestFieldDrift_FailsNamingField()
+        {
+            var rec = new Recording
+            {
+                RecordingId = "bad0",
+                StartResources = new Dictionary<string, ResourceAmount>
+                {
+                    ["LiquidFuel"] = new ResourceAmount { amount = 100.0, maxAmount = 100.0 },
+                    [""] = new ResourceAmount { amount = 3.0, maxAmount = 3.0 },
+                },
+            };
+
+            List<Finding> findings = Run(ModelWith(rec));
+
+            Assert.Contains(findings, f =>
+                f.RuleId == Inv10CodecRoundtrip.RuleIdConst
+                && f.Level == VerdictLevel.Fail
+                && f.Message.Contains("field=StartResources")
+                && f.Message.Contains("resource-drift"));
+        }
+
+        // Guards (edge case 25): an OrbitSegment carrying a NaN element round-trips
+        // equal under NaN-aware equality -> no FAIL. Fails if naive == flags a
+        // stable NaN, producing permanent noise on predicted-tail segments.
+        [Fact]
+        public void NaNOrbitElement_RoundTripsEqual_NoFail()
+        {
+            var rec = new Recording
+            {
+                RecordingId = "nan0",
+                OrbitSegments = new List<OrbitSegment>
+                {
+                    new OrbitSegment
+                    {
+                        startUT = 0, endUT = 10, semiMajorAxis = double.NaN, eccentricity = 0.0,
+                        inclination = 0, bodyName = "Kerbin", isPredicted = false,
+                    },
+                },
+            };
+
+            List<Finding> findings = Run(ModelWith(rec));
+
+            Assert.DoesNotContain(findings, f => f.Level == VerdictLevel.Fail);
+        }
+    }
+}

--- a/Source/Parsek.Tests/Analyzer/Rules/Inv1UtMonotonic.cs
+++ b/Source/Parsek.Tests/Analyzer/Rules/Inv1UtMonotonic.cs
@@ -44,7 +44,23 @@ namespace Parsek.Tests.Analyzer.Rules
                 {
                     TrackSection s = rec.TrackSections[i];
 
-                    if (s.startUT > s.endUT)
+                    // NaN section bound (double.IsNaN): a NaN startUT/endUT makes
+                    // section dispatch and the > comparison ill-defined (NaN > x is
+                    // always false, so the ordering check silently passes). Report
+                    // it explicitly as one finding; the ordering check below is
+                    // mutually exclusive because a NaN bound can never satisfy >.
+                    if (double.IsNaN(s.startUT) || double.IsNaN(s.endUT))
+                    {
+                        findings.Add(new Finding(
+                            RuleIdConst,
+                            VerdictLevel.Fail,
+                            rec.RecordingId,
+                            i,
+                            Inv("INV1 nan recording={0} seq=SectionSpan section={1} startUT={2} endUT={3}",
+                                rec.RecordingId, i, s.startUT, s.endUT),
+                            "TrackSection.startUT/endUT"));
+                    }
+                    else if (s.startUT > s.endUT)
                     {
                         findings.Add(new Finding(
                             RuleIdConst,
@@ -68,7 +84,31 @@ namespace Parsek.Tests.Analyzer.Rules
         private static void CheckPointSequence(
             Recording rec, string seqName, int sectionIndex, List<double> uts, List<Finding> findings)
         {
-            if (uts == null || uts.Count < 2)
+            if (uts == null)
+                return;
+
+            // NaN UT: a NaN sample UT breaks TrajectoryMath's binary-search sampler
+            // (every comparison against NaN is false, so the sort/search silently
+            // misbehaves) and never trips the strict back-step check below. Report
+            // the first NaN per sequence, same bounding style as the back-step
+            // reporting (one finding per sequence).
+            for (int i = 0; i < uts.Count; i++)
+            {
+                if (double.IsNaN(uts[i]))
+                {
+                    findings.Add(new Finding(
+                        RuleIdConst,
+                        VerdictLevel.Fail,
+                        rec.RecordingId,
+                        sectionIndex,
+                        Inv("INV1 nan recording={0} seq={1} section={2} at={3}",
+                            rec.RecordingId, seqName, sectionIndex, i),
+                        "TrajectoryPoint.ut"));
+                    return;
+                }
+            }
+
+            if (uts.Count < 2)
                 return;
 
             for (int i = 1; i < uts.Count; i++)

--- a/Source/Parsek.Tests/Analyzer/Rules/Inv1UtMonotonic.cs
+++ b/Source/Parsek.Tests/Analyzer/Rules/Inv1UtMonotonic.cs
@@ -1,0 +1,124 @@
+using System.Collections.Generic;
+using System.Globalization;
+
+namespace Parsek.Tests.Analyzer.Rules
+{
+    // INV1 UT monotonicity (design doc "The invariant rules", test plan INV1).
+    //
+    // TrajectoryMath's sampler binary-searches trajectory sequences by UT, which
+    // requires non-decreasing UT. This rule asserts:
+    //   - each TrackSection's frames / bodyFixedFrames UT sequence is non-decreasing,
+    //   - each TrackSection's checkpoints startUT sequence is non-decreasing,
+    //   - each TrackSection has startUT <= endUT,
+    //   - the flat Recording.Points UT sequence is non-decreasing.
+    //
+    // EQUAL UT is allowed: the recorder appends a structural-event snapshot at the
+    // exact UT of a dock/undock/EVA (TrajectoryPointFlags.StructuralEventSnapshot),
+    // so two adjacent samples legitimately share a UT. Only a STRICT back-step
+    // (uts[i] < uts[i-1]) is a violation -> FAIL. Pure over the model, no file.
+    internal sealed class Inv1UtMonotonic : IRecordingInvariant
+    {
+        internal const string RuleIdConst = "INV1-UT-MONOTONIC";
+
+        public string RuleId => RuleIdConst;
+
+        public string CitedContract => "TrajectoryPoint.ut / TrackSection.startUT/endUT";
+
+        public IEnumerable<Finding> Evaluate(AnalyzerModel model)
+        {
+            var findings = new List<Finding>();
+            if (model?.Recordings == null)
+                return findings;
+
+            foreach (Recording rec in model.Recordings)
+            {
+                if (rec == null)
+                    continue;
+
+                CheckPointSequence(rec, "Points", -1, PointUts(rec.Points), findings);
+
+                if (rec.TrackSections == null)
+                    continue;
+
+                for (int i = 0; i < rec.TrackSections.Count; i++)
+                {
+                    TrackSection s = rec.TrackSections[i];
+
+                    if (s.startUT > s.endUT)
+                    {
+                        findings.Add(new Finding(
+                            RuleIdConst,
+                            VerdictLevel.Fail,
+                            rec.RecordingId,
+                            i,
+                            Inv("INV1 backstep recording={0} seq=SectionSpan section={1} startUT={2} endUT={3}",
+                                rec.RecordingId, i, s.startUT, s.endUT),
+                            "TrackSection.startUT/endUT"));
+                    }
+
+                    CheckPointSequence(rec, "frames", i, PointUts(s.frames), findings);
+                    CheckPointSequence(rec, "bodyFixedFrames", i, PointUts(s.bodyFixedFrames), findings);
+                    CheckPointSequence(rec, "checkpoints", i, CheckpointUts(s.checkpoints), findings);
+                }
+            }
+
+            return findings;
+        }
+
+        private static void CheckPointSequence(
+            Recording rec, string seqName, int sectionIndex, List<double> uts, List<Finding> findings)
+        {
+            if (uts == null || uts.Count < 2)
+                return;
+
+            for (int i = 1; i < uts.Count; i++)
+            {
+                if (uts[i] < uts[i - 1])
+                {
+                    findings.Add(new Finding(
+                        RuleIdConst,
+                        VerdictLevel.Fail,
+                        rec.RecordingId,
+                        sectionIndex,
+                        Inv("INV1 backstep recording={0} seq={1} section={2} at={3} ut={4}->{5}",
+                            rec.RecordingId, seqName, sectionIndex, i, uts[i - 1], uts[i]),
+                        "TrajectoryPoint.ut"));
+                    // Report the first back-step per sequence only; one is enough
+                    // to flag the corrupt sidecar and keeps findings bounded.
+                    return;
+                }
+            }
+        }
+
+        private static List<double> PointUts(List<TrajectoryPoint> pts)
+        {
+            if (pts == null)
+                return null;
+            var uts = new List<double>(pts.Count);
+            foreach (TrajectoryPoint p in pts)
+                uts.Add(p.ut);
+            return uts;
+        }
+
+        private static List<double> CheckpointUts(List<OrbitSegment> segs)
+        {
+            if (segs == null)
+                return null;
+            var uts = new List<double>(segs.Count);
+            foreach (OrbitSegment s in segs)
+                uts.Add(s.startUT);
+            return uts;
+        }
+
+        private static string Inv(string format, params object[] args)
+        {
+            var ic = CultureInfo.InvariantCulture;
+            for (int i = 0; i < args.Length; i++)
+            {
+                if (args[i] is double d)
+                    args[i] = d.ToString("R", ic);
+            }
+            return string.Format(ic, format, args);
+        }
+    }
+}

--- a/Source/Parsek.Tests/Analyzer/Rules/Inv1UtMonotonicTests.cs
+++ b/Source/Parsek.Tests/Analyzer/Rules/Inv1UtMonotonicTests.cs
@@ -120,6 +120,52 @@ namespace Parsek.Tests.Analyzer.Rules
                 f.Level == VerdictLevel.Fail && f.Message.Contains("seq=SectionSpan"));
         }
 
+        // Guards: a NaN point UT -> FAIL. A NaN never trips the strict back-step
+        // check (NaN < x is always false), so without an explicit IsNaN check a
+        // NaN-poisoned sidecar would analyze GREEN and then break TrajectoryMath's
+        // binary-search sampler at playback.
+        [Fact]
+        public void NaNPointUt_Fails()
+        {
+            var rec = new Recording
+            {
+                RecordingId = "rec-nan-pt",
+                Points = new List<TrajectoryPoint> { P(0), P(double.NaN), P(2) },
+                TrackSections = new List<TrackSection>(),
+            };
+
+            List<Finding> findings = Run(rec);
+
+            Finding fail = Assert.Single(findings);
+            Assert.Equal(Inv1UtMonotonic.RuleIdConst, fail.RuleId);
+            Assert.Equal(VerdictLevel.Fail, fail.Level);
+            Assert.Contains("nan", fail.Message);
+            Assert.Contains("seq=Points", fail.Message);
+        }
+
+        // Guards: a NaN section startUT -> FAIL. NaN > endUT is always false, so the
+        // ordering check silently passes; the explicit IsNaN branch reports it.
+        [Fact]
+        public void NaNSectionStartUt_Fails()
+        {
+            var rec = new Recording
+            {
+                RecordingId = "rec-nan-span",
+                Points = new List<TrajectoryPoint>(),
+                TrackSections = new List<TrackSection>
+                {
+                    Section(double.NaN, 10, 0, 5),
+                },
+            };
+
+            List<Finding> findings = Run(rec);
+
+            Assert.Contains(findings, f =>
+                f.Level == VerdictLevel.Fail
+                && f.Message.Contains("nan")
+                && f.Message.Contains("seq=SectionSpan"));
+        }
+
         // Guards: a back-stepping checkpoint startUT sequence -> FAIL. Fails if
         // orbital-checkpoint sections are not covered.
         [Fact]

--- a/Source/Parsek.Tests/Analyzer/Rules/Inv1UtMonotonicTests.cs
+++ b/Source/Parsek.Tests/Analyzer/Rules/Inv1UtMonotonicTests.cs
@@ -1,0 +1,153 @@
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace Parsek.Tests.Analyzer.Rules
+{
+    // INV1 UT monotonicity. Pure in-memory AnalyzerModel fixtures (no loader,
+    // no disk), each test names the regression it guards.
+    public class Inv1UtMonotonicTests
+    {
+        private static TrajectoryPoint P(double ut)
+        {
+            return new TrajectoryPoint { ut = ut, bodyName = "Kerbin" };
+        }
+
+        private static TrackSection Section(double startUT, double endUT, params double[] frameUts)
+        {
+            return new TrackSection
+            {
+                referenceFrame = ReferenceFrame.Absolute,
+                startUT = startUT,
+                endUT = endUT,
+                frames = frameUts.Select(P).ToList(),
+                checkpoints = new List<OrbitSegment>(),
+            };
+        }
+
+        private static List<Finding> Run(Recording rec)
+        {
+            var model = new AnalyzerModel
+            {
+                SaveName = "inv1",
+                Recordings = new List<Recording> { rec },
+            };
+            return new Inv1UtMonotonic().Evaluate(model).ToList();
+        }
+
+        // Guards: a monotonic recording with an EQUAL-UT structural-event snapshot
+        // (two adjacent samples share a UT) -> zero findings. Fails if the check
+        // has an off-by-one that flags equal UT as a back-step, which would
+        // false-FAIL every dock/undock snapshot.
+        [Fact]
+        public void MonotonicWithEqualUtSnapshot_NoFindings()
+        {
+            var rec = new Recording
+            {
+                RecordingId = "rec-ok",
+                Points = new List<TrajectoryPoint> { P(0), P(1), P(1), P(2) },
+                TrackSections = new List<TrackSection>
+                {
+                    Section(0, 2, 0, 1, 1, 2),
+                },
+            };
+
+            Assert.Empty(Run(rec));
+        }
+
+        // Guards: a back-stepping UT in the flat Points list -> FAIL. Fails if a
+        // regression makes the rule accept descending UT, letting a corrupt
+        // sidecar through that breaks TrajectoryMath's binary-search sampling.
+        [Fact]
+        public void BackSteppingPoints_Fails()
+        {
+            var rec = new Recording
+            {
+                RecordingId = "rec-back",
+                Points = new List<TrajectoryPoint> { P(0), P(5), P(3) },
+                TrackSections = new List<TrackSection>(),
+            };
+
+            List<Finding> findings = Run(rec);
+
+            Finding fail = Assert.Single(findings);
+            Assert.Equal(Inv1UtMonotonic.RuleIdConst, fail.RuleId);
+            Assert.Equal(VerdictLevel.Fail, fail.Level);
+            Assert.Contains("seq=Points", fail.Message);
+        }
+
+        // Guards: a back-stepping UT inside a TrackSection's frames -> FAIL, cited
+        // to the offending section index. Fails if section frames are not checked.
+        [Fact]
+        public void BackSteppingSectionFrames_Fails()
+        {
+            var rec = new Recording
+            {
+                RecordingId = "rec-sec",
+                Points = new List<TrajectoryPoint>(),
+                TrackSections = new List<TrackSection>
+                {
+                    Section(0, 10, 0, 4, 2),
+                },
+            };
+
+            List<Finding> findings = Run(rec);
+
+            Finding fail = Assert.Single(findings);
+            Assert.Equal(VerdictLevel.Fail, fail.Level);
+            Assert.Contains("seq=frames", fail.Message);
+            Assert.Equal(0, fail.SectionIndex);
+        }
+
+        // Guards: a section whose startUT > endUT -> FAIL. Fails if the span
+        // ordering check is dropped (an inverted span breaks section dispatch).
+        [Fact]
+        public void SectionStartAfterEnd_Fails()
+        {
+            var rec = new Recording
+            {
+                RecordingId = "rec-span",
+                Points = new List<TrajectoryPoint>(),
+                TrackSections = new List<TrackSection>
+                {
+                    Section(20, 10, 20, 10),
+                },
+            };
+
+            List<Finding> findings = Run(rec);
+
+            Assert.Contains(findings, f =>
+                f.Level == VerdictLevel.Fail && f.Message.Contains("seq=SectionSpan"));
+        }
+
+        // Guards: a back-stepping checkpoint startUT sequence -> FAIL. Fails if
+        // orbital-checkpoint sections are not covered.
+        [Fact]
+        public void BackSteppingCheckpoints_Fails()
+        {
+            var section = new TrackSection
+            {
+                referenceFrame = ReferenceFrame.OrbitalCheckpoint,
+                startUT = 0,
+                endUT = 100,
+                frames = new List<TrajectoryPoint>(),
+                checkpoints = new List<OrbitSegment>
+                {
+                    new OrbitSegment { startUT = 40, endUT = 80, bodyName = "Kerbin" },
+                    new OrbitSegment { startUT = 30, endUT = 60, bodyName = "Kerbin" },
+                },
+            };
+            var rec = new Recording
+            {
+                RecordingId = "rec-cp",
+                Points = new List<TrajectoryPoint>(),
+                TrackSections = new List<TrackSection> { section },
+            };
+
+            List<Finding> findings = Run(rec);
+
+            Assert.Contains(findings, f =>
+                f.Level == VerdictLevel.Fail && f.Message.Contains("seq=checkpoints"));
+        }
+    }
+}

--- a/Source/Parsek.Tests/Analyzer/Rules/Inv2NoDoubleCover.cs
+++ b/Source/Parsek.Tests/Analyzer/Rules/Inv2NoDoubleCover.cs
@@ -1,0 +1,193 @@
+using System.Collections.Generic;
+using System.Globalization;
+
+namespace Parsek.Tests.Analyzer.Rules
+{
+    // INV2 no double-cover (design doc "The invariant rules", edge cases 7 + 8).
+    //
+    // Within one recording, the TrackSection [startUT,endUT] spans partition the
+    // recorded timeline into DISJOINT producer runs (RecordingOptimizer splits at
+    // env/body boundaries so each producer owns a distinct UT run). Two sections
+    // that overlap in INTERIOR UT mean an ambiguous playback position at the
+    // overlapping UT -> FAIL. Gaps are LEGITIMATE (on-rails BG spans emit no
+    // TrackSections, TrackSection.boundaryDiscontinuityMeters models seams); an
+    // uncovered gap NOT bridged by an OrbitSegment is a soft WARN, never a FAIL.
+    //
+    // Pure over the loaded model: reuses the exact UT arithmetic the sampler and
+    // optimizer assume, touches no file.
+    internal sealed class Inv2NoDoubleCover : IRecordingInvariant
+    {
+        internal const string OverlapRuleId = "INV2-NO-DOUBLE-COVER";
+        internal const string UncoveredRuleId = "INV2-UNCOVERED-SPAN";
+
+        public string RuleId => OverlapRuleId;
+
+        // The disjoint-producer contract (sections are non-overlapping producers,
+        // gaps modeled by boundaryDiscontinuityMeters / the on-rails no-section
+        // contract) that this rule checks.
+        public string CitedContract =>
+            "RecordingOptimizer.IsSplittableEnvOrBodyBoundary / TrackSection.boundaryDiscontinuityMeters";
+
+        public IEnumerable<Finding> Evaluate(AnalyzerModel model)
+        {
+            var findings = new List<Finding>();
+            if (model?.Recordings == null)
+                return findings;
+
+            foreach (Recording rec in model.Recordings)
+            {
+                if (rec?.TrackSections == null || rec.TrackSections.Count < 2)
+                    continue;
+
+                EvaluateRecording(rec, findings);
+            }
+
+            return findings;
+        }
+
+        private static void EvaluateRecording(Recording rec, List<Finding> findings)
+        {
+            // Pair each section with its original index so findings cite the real
+            // section position, then order by span start (ties by end) so a single
+            // running-max pass detects overlap AND containment.
+            var ordered = new List<(int Index, double Start, double End)>(rec.TrackSections.Count);
+            for (int i = 0; i < rec.TrackSections.Count; i++)
+            {
+                TrackSection s = rec.TrackSections[i];
+                ordered.Add((i, s.startUT, s.endUT));
+            }
+
+            ordered.Sort((a, b) =>
+            {
+                int c = a.Start.CompareTo(b.Start);
+                return c != 0 ? c : a.End.CompareTo(b.End);
+            });
+
+            List<(double Start, double End)> orbitCover = BuildMergedOrbitCoverage(rec);
+
+            // Running-max sweep: coverEnd is the furthest UT covered so far, and
+            // coverIdx/coverEnd's owning section is the one an overlap is reported
+            // against.
+            int coverIdx = ordered[0].Index;
+            double coverStart = ordered[0].Start;
+            double coverEnd = ordered[0].End;
+
+            for (int k = 1; k < ordered.Count; k++)
+            {
+                (int Index, double Start, double End) s = ordered[k];
+
+                if (s.Start < coverEnd)
+                {
+                    // Interior overlap: the new section starts before the covered
+                    // run ends. Double-covered UT -> ambiguous playback -> FAIL.
+                    findings.Add(new Finding(
+                        OverlapRuleId,
+                        VerdictLevel.Fail,
+                        rec.RecordingId,
+                        s.Index,
+                        Inv("INV2 overlap recording={0} a=[{1},{2}] b=[{3},{4}]",
+                            rec.RecordingId, coverStart, coverEnd, s.Start, s.End),
+                        "RecordingOptimizer.IsSplittableEnvOrBodyBoundary"));
+                }
+                else if (s.Start > coverEnd)
+                {
+                    // Genuine gap. Legitimate unless nothing (section or orbit
+                    // coast) bridges it -> soft WARN, never FAIL.
+                    bool bridged = IntervalCovered(orbitCover, coverEnd, s.Start);
+                    if (!bridged)
+                    {
+                        findings.Add(new Finding(
+                            UncoveredRuleId,
+                            VerdictLevel.Warn,
+                            rec.RecordingId,
+                            s.Index,
+                            Inv("INV2 uncovered recording={0} span=[{1},{2}] orbitBridged=False",
+                                rec.RecordingId, coverEnd, s.Start),
+                            "TrackSection.boundaryDiscontinuityMeters"));
+                    }
+                }
+                // else s.Start == coverEnd: sections touch exactly, no finding.
+
+                if (s.End > coverEnd)
+                {
+                    coverEnd = s.End;
+                    coverStart = s.Start;
+                    coverIdx = s.Index;
+                }
+            }
+
+            // Suppress the unused-warning without changing behavior; coverIdx is
+            // retained for readability of the running-cover triple.
+            _ = coverIdx;
+        }
+
+        /// <summary>
+        /// Merges the recording's OrbitSegment spans into a sorted list of
+        /// non-overlapping [start,end] intervals so a gap can be tested for
+        /// coast-bridging coverage in one pass.
+        /// </summary>
+        private static List<(double Start, double End)> BuildMergedOrbitCoverage(Recording rec)
+        {
+            var merged = new List<(double Start, double End)>();
+            if (rec.OrbitSegments == null || rec.OrbitSegments.Count == 0)
+                return merged;
+
+            var spans = new List<(double Start, double End)>(rec.OrbitSegments.Count);
+            foreach (OrbitSegment seg in rec.OrbitSegments)
+            {
+                if (seg.endUT >= seg.startUT)
+                    spans.Add((seg.startUT, seg.endUT));
+            }
+            if (spans.Count == 0)
+                return merged;
+
+            spans.Sort((a, b) => a.Start.CompareTo(b.Start));
+
+            double curStart = spans[0].Start;
+            double curEnd = spans[0].End;
+            for (int i = 1; i < spans.Count; i++)
+            {
+                if (spans[i].Start <= curEnd)
+                {
+                    if (spans[i].End > curEnd)
+                        curEnd = spans[i].End;
+                }
+                else
+                {
+                    merged.Add((curStart, curEnd));
+                    curStart = spans[i].Start;
+                    curEnd = spans[i].End;
+                }
+            }
+            merged.Add((curStart, curEnd));
+            return merged;
+        }
+
+        /// <summary>
+        /// True when [gapStart,gapEnd] lies wholly inside one merged orbit interval.
+        /// </summary>
+        private static bool IntervalCovered(
+            List<(double Start, double End)> merged, double gapStart, double gapEnd)
+        {
+            if (merged == null)
+                return false;
+            for (int i = 0; i < merged.Count; i++)
+            {
+                if (merged[i].Start <= gapStart && merged[i].End >= gapEnd)
+                    return true;
+            }
+            return false;
+        }
+
+        private static string Inv(string format, params object[] args)
+        {
+            var ic = CultureInfo.InvariantCulture;
+            for (int i = 0; i < args.Length; i++)
+            {
+                if (args[i] is double d)
+                    args[i] = d.ToString("R", ic);
+            }
+            return string.Format(ic, format, args);
+        }
+    }
+}

--- a/Source/Parsek.Tests/Analyzer/Rules/Inv2NoDoubleCoverTests.cs
+++ b/Source/Parsek.Tests/Analyzer/Rules/Inv2NoDoubleCoverTests.cs
@@ -1,0 +1,156 @@
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace Parsek.Tests.Analyzer.Rules
+{
+    // INV2 no double-cover. Each test names the regression it guards.
+    // Pure in-memory AnalyzerModel fixtures (no loader, no disk), so no shared
+    // static state and no [Collection("Sequential")] is needed.
+    public class Inv2NoDoubleCoverTests
+    {
+        private static TrackSection Section(double startUT, double endUT)
+        {
+            return new TrackSection
+            {
+                environment = SegmentEnvironment.ExoBallistic,
+                referenceFrame = ReferenceFrame.Absolute,
+                source = TrackSectionSource.Active,
+                startUT = startUT,
+                endUT = endUT,
+                frames = new List<TrajectoryPoint>(),
+                checkpoints = new List<OrbitSegment>(),
+            };
+        }
+
+        private static AnalyzerModel ModelWith(Recording rec)
+        {
+            return new AnalyzerModel
+            {
+                SaveName = "inv2",
+                Recordings = new List<Recording> { rec },
+            };
+        }
+
+        private static List<Finding> Run(Recording rec)
+        {
+            return new Inv2NoDoubleCover().Evaluate(ModelWith(rec)).ToList();
+        }
+
+        // Guards: an orbit-bridged gap between two authored sections is legitimate
+        // and emits NO finding. A regression that reverted to a "no gaps allowed"
+        // rule would false-alarm on every BG on-rails span that a coast bridges.
+        [Fact]
+        public void OrbitBridgedGap_NoFinding()
+        {
+            var rec = new Recording
+            {
+                RecordingId = "rec-bridged",
+                TrackSections = new List<TrackSection>
+                {
+                    Section(0, 100),
+                    Section(200, 300),
+                },
+                OrbitSegments = new List<OrbitSegment>
+                {
+                    new OrbitSegment { startUT = 100, endUT = 200, bodyName = "Kerbin" },
+                },
+            };
+
+            List<Finding> findings = Run(rec);
+
+            Assert.Empty(findings);
+        }
+
+        // Guards: two sections overlapping in interior UT ([100,200] and [150,250])
+        // -> FAIL. A regression where the overlap detector misses interior overlap
+        // would let double-covered (ambiguous playback position) UT through.
+        [Fact]
+        public void InteriorOverlap_Fails()
+        {
+            var rec = new Recording
+            {
+                RecordingId = "rec-overlap",
+                TrackSections = new List<TrackSection>
+                {
+                    Section(100, 200),
+                    Section(150, 250),
+                },
+            };
+
+            List<Finding> findings = Run(rec);
+
+            Finding fail = Assert.Single(findings);
+            Assert.Equal(Inv2NoDoubleCover.OverlapRuleId, fail.RuleId);
+            Assert.Equal(VerdictLevel.Fail, fail.Level);
+            Assert.Equal("rec-overlap", fail.Target);
+        }
+
+        // Guards: containment (a section fully inside another) is also interior
+        // overlap and must FAIL. The running-max sweep, not a naive
+        // adjacent-pair check, is what catches this.
+        [Fact]
+        public void ContainedSection_Fails()
+        {
+            var rec = new Recording
+            {
+                RecordingId = "rec-contained",
+                TrackSections = new List<TrackSection>
+                {
+                    Section(0, 500),
+                    Section(100, 200),
+                },
+            };
+
+            List<Finding> findings = Run(rec);
+
+            Assert.Contains(findings, f =>
+                f.RuleId == Inv2NoDoubleCover.OverlapRuleId && f.Level == VerdictLevel.Fail);
+        }
+
+        // Guards: an uncovered gap with no bridging OrbitSegment -> WARN
+        // (INV2-UNCOVERED-SPAN), never FAIL. A regression escalating this to FAIL
+        // would red-flag every legitimate on-rails BG gap.
+        [Fact]
+        public void UncoveredGap_Warns_NotFails()
+        {
+            var rec = new Recording
+            {
+                RecordingId = "rec-gap",
+                TrackSections = new List<TrackSection>
+                {
+                    Section(0, 100),
+                    Section(200, 300),
+                },
+            };
+
+            List<Finding> findings = Run(rec);
+
+            Finding warn = Assert.Single(findings);
+            Assert.Equal(Inv2NoDoubleCover.UncoveredRuleId, warn.RuleId);
+            Assert.Equal(VerdictLevel.Warn, warn.Level);
+            Assert.DoesNotContain(findings, f => f.Level == VerdictLevel.Fail);
+        }
+
+        // Guards: sections that touch exactly at a UT boundary (a.end == b.start)
+        // are NOT an overlap and NOT a gap. A regression using a non-strict
+        // comparison would false-FAIL every adjacent optimizer split.
+        [Fact]
+        public void TouchingSections_NoFinding()
+        {
+            var rec = new Recording
+            {
+                RecordingId = "rec-touch",
+                TrackSections = new List<TrackSection>
+                {
+                    Section(0, 100),
+                    Section(100, 200),
+                },
+            };
+
+            List<Finding> findings = Run(rec);
+
+            Assert.Empty(findings);
+        }
+    }
+}

--- a/Source/Parsek.Tests/Analyzer/Rules/Inv3RelativeContract.cs
+++ b/Source/Parsek.Tests/Analyzer/Rules/Inv3RelativeContract.cs
@@ -1,0 +1,140 @@
+using System.Collections.Generic;
+using System.Globalization;
+
+namespace Parsek.Tests.Analyzer.Rules
+{
+    // INV3 RELATIVE contract (design doc "The invariant rules", edge cases 5 + 6).
+    //
+    // The documented production hazard: in a ReferenceFrame.Relative TrackSection
+    // the frames' latitude/longitude/altitude fields carry anchor-local METRE
+    // offsets, NOT body-fixed lat/lon. Values routinely fall outside [-90,90] /
+    // [-180,180]. A naive reader that range-checks (or, worse, resolves them
+    // through body.GetWorldSurfacePosition) commits the exact bug this rule
+    // exists to catch. Therefore INV3:
+    //   - NEVER range-checks a RELATIVE section's frame lat/lon (metre offsets),
+    //   - requires a RELATIVE section to carry an anchor: anchorRecordingId
+    //     (non-loop) OR anchorVesselId != 0 (loop); neither -> FAIL,
+    //   - range-checks only ABSOLUTE section frames, out-of-range -> WARN
+    //     (INV3-ABSOLUTE-RANGE, not FAIL until KSP longitude normalization is
+    //     cited),
+    //   - skips OrbitalCheckpoint sections (no lat/lon frame surface).
+    //
+    // Pure over the model. Dispatches strictly on TrackSection.referenceFrame, the
+    // same discriminator TrajectoryMath.ComputeRelativeLocalOffset keys on, so the
+    // analyzer reads the offset contract, not the lat/lon reader.
+    internal sealed class Inv3RelativeContract : IRecordingInvariant
+    {
+        internal const string RelativeRuleId = "INV3-RELATIVE-CONTRACT";
+        internal const string AbsoluteRangeRuleId = "INV3-ABSOLUTE-RANGE";
+
+        public string RuleId => RelativeRuleId;
+
+        public string CitedContract =>
+            "TrackSection.referenceFrame / TrajectoryMath.ComputeRelativeLocalOffset";
+
+        public IEnumerable<Finding> Evaluate(AnalyzerModel model)
+        {
+            var findings = new List<Finding>();
+            if (model?.Recordings == null)
+                return findings;
+
+            foreach (Recording rec in model.Recordings)
+            {
+                if (rec?.TrackSections == null)
+                    continue;
+
+                for (int i = 0; i < rec.TrackSections.Count; i++)
+                {
+                    TrackSection s = rec.TrackSections[i];
+                    switch (s.referenceFrame)
+                    {
+                        case ReferenceFrame.Relative:
+                            EvaluateRelative(rec, i, s, findings);
+                            break;
+                        case ReferenceFrame.Absolute:
+                            EvaluateAbsolute(rec, i, s, findings);
+                            break;
+                        // OrbitalCheckpoint: no lat/lon frame surface; skip.
+                    }
+                }
+            }
+
+            return findings;
+        }
+
+        private static void EvaluateRelative(
+            Recording rec, int sectionIndex, TrackSection s, List<Finding> findings)
+        {
+            bool hasRecordingAnchor = !string.IsNullOrEmpty(s.anchorRecordingId);
+            bool hasVesselAnchor = s.anchorVesselId != 0;
+
+            if (!hasRecordingAnchor && !hasVesselAnchor)
+            {
+                findings.Add(new Finding(
+                    RelativeRuleId,
+                    VerdictLevel.Fail,
+                    rec.RecordingId,
+                    sectionIndex,
+                    Inv("INV3 relative recording={0}#{1} anchorRec=none anchorVessel=0 error=no-anchor",
+                        rec.RecordingId, sectionIndex),
+                    "TrackSection.referenceFrame"));
+                return;
+            }
+
+            // Deliberately NO lat/lon range check here: the frame fields are
+            // anchor-local metre offsets by contract. Emit a Verbose trace so a
+            // reviewer can confirm the analyzer dispatched through the offset
+            // contract rather than the lat/lon reader.
+            string offsetSample = "none";
+            if (s.frames != null && s.frames.Count > 0)
+            {
+                TrajectoryPoint f = s.frames[0];
+                offsetSample = Inv("{0},{1},{2}", f.latitude, f.longitude, f.altitude);
+            }
+            ParsekLog.Verbose("Analyzer",
+                Inv("INV3 relative recording={0}#{1} anchorRec={2} anchorVessel={3} offsetSample={4}",
+                    rec.RecordingId, sectionIndex,
+                    hasRecordingAnchor ? s.anchorRecordingId : "none",
+                    s.anchorVesselId, offsetSample));
+        }
+
+        private static void EvaluateAbsolute(
+            Recording rec, int sectionIndex, TrackSection s, List<Finding> findings)
+        {
+            if (s.frames == null)
+                return;
+
+            for (int i = 0; i < s.frames.Count; i++)
+            {
+                TrajectoryPoint f = s.frames[i];
+                bool latBad = f.latitude < -90.0 || f.latitude > 90.0;
+                bool lonBad = f.longitude < -180.0 || f.longitude > 180.0;
+                if (latBad || lonBad)
+                {
+                    findings.Add(new Finding(
+                        AbsoluteRangeRuleId,
+                        VerdictLevel.Warn,
+                        rec.RecordingId,
+                        sectionIndex,
+                        Inv("INV3 absolute-range recording={0}#{1} frame={2} lat={3} lon={4}",
+                            rec.RecordingId, sectionIndex, i, f.latitude, f.longitude),
+                        "TrackSection.referenceFrame"));
+                    // One WARN per section is enough to flag the corrupt Absolute
+                    // frame; keeps findings bounded.
+                    return;
+                }
+            }
+        }
+
+        private static string Inv(string format, params object[] args)
+        {
+            var ic = CultureInfo.InvariantCulture;
+            for (int i = 0; i < args.Length; i++)
+            {
+                if (args[i] is double d)
+                    args[i] = d.ToString("R", ic);
+            }
+            return string.Format(ic, format, args);
+        }
+    }
+}

--- a/Source/Parsek.Tests/Analyzer/Rules/Inv3RelativeContractTests.cs
+++ b/Source/Parsek.Tests/Analyzer/Rules/Inv3RelativeContractTests.cs
@@ -1,0 +1,172 @@
+using System.Collections.Generic;
+using System.Linq;
+using Parsek.Tests.Generators;
+using Xunit;
+
+namespace Parsek.Tests.Analyzer.Rules
+{
+    // INV3 RELATIVE contract. Fixtures via DebrisFrameContractRecordingFixture +
+    // TestBodyRegistry (plan section: INV3 fixture strategy). Body resolution is
+    // injected as TestBodyRegistry.CreateBody, which builds an in-memory body
+    // without mutating FlightGlobals statics, so no [Collection("Sequential")] is
+    // needed. Each test names the regression it guards.
+    public class Inv3RelativeContractTests
+    {
+        private static AnalyzerModel ModelWith(params Recording[] recs)
+        {
+            return new AnalyzerModel
+            {
+                SaveName = "inv3",
+                Recordings = recs.ToList(),
+                BodyResolver = name => TestBodyRegistry.CreateBody(name),
+            };
+        }
+
+        private static List<Finding> Run(AnalyzerModel model)
+        {
+            return new Inv3RelativeContract().Evaluate(model).ToList();
+        }
+
+        // Guards (the documented RELATIVE-misread bug): a parent-anchored debris
+        // fixture whose RELATIVE frames carry out-of-range values (metre offsets,
+        // > 90 / > 180) with a valid anchorRecordingId -> zero INV3 findings.
+        // Fails if the rule reads the offset fields as body-fixed lat/lon and
+        // false-alarms, which is the exact production hazard INV3 exists to catch.
+        [Fact]
+        public void RelativeMetreOffsets_WithAnchor_NotFlagged()
+        {
+            var rec = new Recording
+            {
+                RecordingId = "rec-rel",
+                TrackSections = new List<TrackSection>
+                {
+                    new TrackSection
+                    {
+                        referenceFrame = ReferenceFrame.Relative,
+                        startUT = 0,
+                        endUT = 10,
+                        anchorRecordingId = "parent-rec",
+                        frames = new List<TrajectoryPoint>
+                        {
+                            // Anchor-local metre offsets, deliberately out of any
+                            // lat/lon range. Must NOT be flagged.
+                            new TrajectoryPoint { ut = 0, latitude = 5000.0, longitude = -8000.0, altitude = 320.0, bodyName = "Kerbin" },
+                            new TrajectoryPoint { ut = 10, latitude = 5200.0, longitude = -8100.0, altitude = 340.0, bodyName = "Kerbin" },
+                        },
+                    },
+                },
+            };
+
+            Assert.Empty(Run(ModelWith(rec)));
+        }
+
+        // Guards: a real parent-anchored debris fixture (loop-anchored parent
+        // variant: parent RELATIVE via anchorVesselId, debris RELATIVE via
+        // anchorRecordingId) -> zero INV3 findings. Fails if either anchor form is
+        // rejected or the RELATIVE frames are range-checked.
+        [Fact]
+        public void DebrisFrameContractFixture_LoopAnchored_Clean()
+        {
+            DebrisFrameContractRecordingFixture.Fixture fx =
+                DebrisFrameContractRecordingFixture.Create(loopAnchoredParent: true);
+
+            List<Finding> findings = Run(ModelWith(fx.Parent, fx.Debris));
+
+            Assert.Empty(findings);
+        }
+
+        // Guards: a RELATIVE section with NEITHER anchorRecordingId NOR
+        // anchorVesselId -> FAIL. Fails if an unanchored relative section passes,
+        // which would make offset resolution silently unresolvable at playback.
+        [Fact]
+        public void RelativeWithNoAnchor_Fails()
+        {
+            var rec = new Recording
+            {
+                RecordingId = "rec-noanchor",
+                TrackSections = new List<TrackSection>
+                {
+                    new TrackSection
+                    {
+                        referenceFrame = ReferenceFrame.Relative,
+                        startUT = 0,
+                        endUT = 10,
+                        anchorRecordingId = null,
+                        anchorVesselId = 0,
+                        frames = new List<TrajectoryPoint>
+                        {
+                            new TrajectoryPoint { ut = 0, latitude = 1.0, bodyName = "Kerbin" },
+                        },
+                    },
+                },
+            };
+
+            List<Finding> findings = Run(ModelWith(rec));
+
+            Finding fail = Assert.Single(findings);
+            Assert.Equal(Inv3RelativeContract.RelativeRuleId, fail.RuleId);
+            Assert.Equal(VerdictLevel.Fail, fail.Level);
+            Assert.Contains("error=no-anchor", fail.Message);
+        }
+
+        // Guards: an ABSOLUTE section with an out-of-range longitude (185) -> WARN
+        // (INV3-ABSOLUTE-RANGE), NOT FAIL. Fails if a corrupt absolute longitude
+        // is silently accepted, or if it is escalated to FAIL before KSP
+        // normalization is cited.
+        [Fact]
+        public void AbsoluteOutOfRange_Warns_NotFails()
+        {
+            var rec = new Recording
+            {
+                RecordingId = "rec-abs",
+                TrackSections = new List<TrackSection>
+                {
+                    new TrackSection
+                    {
+                        referenceFrame = ReferenceFrame.Absolute,
+                        startUT = 0,
+                        endUT = 10,
+                        frames = new List<TrajectoryPoint>
+                        {
+                            new TrajectoryPoint { ut = 0, latitude = 10.0, longitude = 185.0, bodyName = "Kerbin" },
+                        },
+                    },
+                },
+            };
+
+            List<Finding> findings = Run(ModelWith(rec));
+
+            Finding warn = Assert.Single(findings);
+            Assert.Equal(Inv3RelativeContract.AbsoluteRangeRuleId, warn.RuleId);
+            Assert.Equal(VerdictLevel.Warn, warn.Level);
+            Assert.DoesNotContain(findings, f => f.Level == VerdictLevel.Fail);
+        }
+
+        // Guards: an in-range ABSOLUTE section -> zero findings. Fails if the
+        // range bounds are wrong (e.g. lon capped at 90 instead of 180).
+        [Fact]
+        public void AbsoluteInRange_NoFindings()
+        {
+            var rec = new Recording
+            {
+                RecordingId = "rec-abs-ok",
+                TrackSections = new List<TrackSection>
+                {
+                    new TrackSection
+                    {
+                        referenceFrame = ReferenceFrame.Absolute,
+                        startUT = 0,
+                        endUT = 10,
+                        frames = new List<TrajectoryPoint>
+                        {
+                            new TrajectoryPoint { ut = 0, latitude = -89.0, longitude = 179.0, bodyName = "Kerbin" },
+                            new TrajectoryPoint { ut = 10, latitude = 45.0, longitude = -179.0, bodyName = "Kerbin" },
+                        },
+                    },
+                },
+            };
+
+            Assert.Empty(Run(ModelWith(rec)));
+        }
+    }
+}

--- a/Source/Parsek.Tests/Analyzer/Rules/Inv4PartEventPid.cs
+++ b/Source/Parsek.Tests/Analyzer/Rules/Inv4PartEventPid.cs
@@ -1,0 +1,135 @@
+using System.Collections.Generic;
+using System.Globalization;
+
+namespace Parsek.Tests.Analyzer.Rules
+{
+    // INV4 part-event PID resolution (design doc "The invariant rules" INV4,
+    // edge case 23).
+    //
+    // Every PartEvent's partPersistentId must resolve against the paired snapshot's
+    // part-PID set. The synthetic ghost builder assigns persistentId =
+    // 100000 + idx*1111 (VesselSnapshotBuilder.AddPart); this rule checks
+    // membership, not the formula, so it stays correct for real captured
+    // snapshots too. Part GameObjects are named by persistentId at playback
+    // (.claude/CLAUDE.md ghost-event <-> snapshot PID), so an event PID missing
+    // from the snapshot silently drops a part event at playback -> FAIL.
+    //
+    // The snapshot used is the ghost visual snapshot when present (the surface
+    // playback actually looks parts up against), otherwise the vessel snapshot.
+    // With NO snapshot at all: a destroyed / showcase recording -> INFO (cannot
+    // resolve, not a bug). With a snapshot that FAILED to load (edge case 23):
+    // INFO (unresolvable) + WARN (the snapshot load failed). Pure over the model;
+    // never touches a file and never NREs on a null snapshot.
+    internal sealed class Inv4PartEventPid : IRecordingInvariant
+    {
+        internal const string RuleIdConst = "INV4-PARTEVENT-PID";
+
+        public string RuleId => RuleIdConst;
+
+        public string CitedContract =>
+            "VesselSnapshotBuilder.AddPart / ghost-event snapshot PID lookup";
+
+        public IEnumerable<Finding> Evaluate(AnalyzerModel model)
+        {
+            var findings = new List<Finding>();
+            if (model?.Recordings == null)
+                return findings;
+
+            foreach (Recording rec in model.Recordings)
+            {
+                if (rec == null || string.IsNullOrEmpty(rec.RecordingId))
+                    continue;
+                if (rec.PartEvents == null || rec.PartEvents.Count == 0)
+                    continue;
+
+                ConfigNode snapshot = rec.GhostVisualSnapshot ?? rec.VesselSnapshot;
+
+                if (snapshot == null)
+                {
+                    bool loadFailed =
+                        rec.VesselSnapshotHydrationFailed
+                        || SnapshotLoadFaulted(model, rec.RecordingId);
+
+                    findings.Add(new Finding(
+                        RuleIdConst,
+                        VerdictLevel.Info,
+                        rec.RecordingId,
+                        -1,
+                        Inv("INV4 no-snapshot recording={0} partEvents={1} loadFailed={2}",
+                            rec.RecordingId, rec.PartEvents.Count, loadFailed ? "True" : "False"),
+                        "VesselSnapshotBuilder.AddPart"));
+
+                    if (loadFailed)
+                    {
+                        findings.Add(new Finding(
+                            RuleIdConst,
+                            VerdictLevel.Warn,
+                            rec.RecordingId,
+                            -1,
+                            Inv("INV4 snapshot-load-failed recording={0}", rec.RecordingId),
+                            "VesselSnapshotBuilder.AddPart"));
+                    }
+                    continue;
+                }
+
+                HashSet<uint> pidSet = ExtractPartPids(snapshot);
+
+                var reported = new HashSet<uint>();
+                foreach (PartEvent ev in rec.PartEvents)
+                {
+                    if (pidSet.Contains(ev.partPersistentId))
+                        continue;
+                    if (!reported.Add(ev.partPersistentId))
+                        continue; // one FAIL per unresolvable PID keeps findings bounded
+                    findings.Add(new Finding(
+                        RuleIdConst,
+                        VerdictLevel.Fail,
+                        rec.RecordingId,
+                        -1,
+                        Inv("INV4 unresolved-pid recording={0} pid={1} event={2}",
+                            rec.RecordingId, ev.partPersistentId, ev.eventType),
+                        "VesselSnapshotBuilder.AddPart"));
+                }
+            }
+
+            return findings;
+        }
+
+        private static bool SnapshotLoadFaulted(AnalyzerModel model, string recordingId)
+        {
+            if (model.LoadFaults == null)
+                return false;
+            foreach (LoadFault f in model.LoadFaults)
+            {
+                if (f.FileKind == "snapshot" && f.RecordingId == recordingId)
+                    return true;
+            }
+            return false;
+        }
+
+        private static HashSet<uint> ExtractPartPids(ConfigNode snapshot)
+        {
+            var pids = new HashSet<uint>();
+            if (snapshot == null)
+                return pids;
+
+            // KSP VESSEL snapshots carry a flat list of PART children, each with a
+            // "persistentId" value. Read that value as the part PID set.
+            foreach (ConfigNode part in snapshot.GetNodes("PART"))
+            {
+                string pidStr = part.GetValue("persistentId");
+                if (!string.IsNullOrEmpty(pidStr)
+                    && uint.TryParse(pidStr, NumberStyles.Integer, CultureInfo.InvariantCulture, out uint pid))
+                {
+                    pids.Add(pid);
+                }
+            }
+            return pids;
+        }
+
+        private static string Inv(string format, params object[] args)
+        {
+            return string.Format(CultureInfo.InvariantCulture, format, args);
+        }
+    }
+}

--- a/Source/Parsek.Tests/Analyzer/Rules/Inv4PartEventPidTests.cs
+++ b/Source/Parsek.Tests/Analyzer/Rules/Inv4PartEventPidTests.cs
@@ -1,0 +1,147 @@
+using System.Collections.Generic;
+using System.Linq;
+using Parsek;
+using Parsek.Tests.Generators;
+using Xunit;
+
+namespace Parsek.Tests.Analyzer.Rules
+{
+    // INV4 part-event PID resolution. Fixtures build a real VESSEL snapshot via
+    // VesselSnapshotBuilder (parts get pid = 100000 + idx*1111) and attach
+    // PartEvents directly. Pure in-memory model; each test names the regression.
+    public class Inv4PartEventPidTests
+    {
+        private static AnalyzerModel ModelWith(
+            IEnumerable<Recording> recs, IEnumerable<LoadFault> loadFaults = null)
+        {
+            return new AnalyzerModel
+            {
+                SaveName = "inv4",
+                Recordings = recs.ToList(),
+                LoadFaults = (loadFaults ?? Enumerable.Empty<LoadFault>()).ToList(),
+            };
+        }
+
+        private static List<Finding> Run(AnalyzerModel model)
+        {
+            return new Inv4PartEventPid().Evaluate(model).ToList();
+        }
+
+        // The three-part FleaRocket assigns part pids 100000, 101111, 102222.
+        private static ConfigNode FleaSnapshot() =>
+            VesselSnapshotBuilder.FleaRocket("Flea", "Jeb", pid: 5001).Build();
+
+        // Guards: events whose PIDs are members of the snapshot part set produce
+        // zero FAIL. Fails if the membership check rejects valid 100000+idx*1111
+        // PIDs (would false-alarm on every synthetic ghost).
+        [Fact]
+        public void EventsMatchingSnapshotParts_NoFail()
+        {
+            var rec = new Recording
+            {
+                RecordingId = "ok0",
+                VesselSnapshot = FleaSnapshot(),
+                PartEvents = new List<PartEvent>
+                {
+                    new PartEvent { partPersistentId = 100000, eventType = PartEventType.EngineIgnited },
+                    new PartEvent { partPersistentId = 101111, eventType = PartEventType.Decoupled },
+                    new PartEvent { partPersistentId = 102222, eventType = PartEventType.ParachuteDeployed },
+                },
+            };
+
+            Assert.Empty(Run(ModelWith(new[] { rec })));
+        }
+
+        // Guards: an event PID absent from the snapshot -> FAIL. Fails if an
+        // unresolvable PID passes, silently dropping a part event at playback.
+        [Fact]
+        public void EventPidAbsentFromSnapshot_Fails()
+        {
+            var rec = new Recording
+            {
+                RecordingId = "bad0",
+                VesselSnapshot = FleaSnapshot(),
+                PartEvents = new List<PartEvent>
+                {
+                    new PartEvent { partPersistentId = 999999, eventType = PartEventType.Decoupled },
+                },
+            };
+
+            List<Finding> findings = Run(ModelWith(new[] { rec }));
+
+            Finding fail = Assert.Single(findings);
+            Assert.Equal(Inv4PartEventPid.RuleIdConst, fail.RuleId);
+            Assert.Equal(VerdictLevel.Fail, fail.Level);
+            Assert.Contains("pid=999999", fail.Message);
+        }
+
+        // Guards: a resolvable event resolves against the ghost visual snapshot when
+        // present (the surface playback looks parts up against). Fails if only the
+        // vessel snapshot is consulted and the ghost snapshot's parts are ignored.
+        [Fact]
+        public void PrefersGhostVisualSnapshot()
+        {
+            var rec = new Recording
+            {
+                RecordingId = "ghost0",
+                // Vessel snapshot has DIFFERENT parts; the ghost snapshot is the FleaRocket.
+                VesselSnapshot = VesselSnapshotBuilder.ProbeShip("Probe", pid: 42).Build(),
+                GhostVisualSnapshot = FleaSnapshot(),
+                PartEvents = new List<PartEvent>
+                {
+                    new PartEvent { partPersistentId = 101111, eventType = PartEventType.Decoupled },
+                },
+            };
+
+            Assert.Empty(Run(ModelWith(new[] { rec })));
+        }
+
+        // Guards: a recording with events but no snapshot (destroyed / showcase) ->
+        // INFO, never FAIL/WARN. Fails if a missing snapshot NREs the rule or is
+        // treated as a hard failure.
+        [Fact]
+        public void NoSnapshot_InfoOnly_NoCrash()
+        {
+            var rec = new Recording
+            {
+                RecordingId = "nosnap0",
+                PartEvents = new List<PartEvent>
+                {
+                    new PartEvent { partPersistentId = 100000, eventType = PartEventType.Decoupled },
+                },
+            };
+
+            List<Finding> findings = Run(ModelWith(new[] { rec }));
+
+            Finding info = Assert.Single(findings);
+            Assert.Equal(VerdictLevel.Info, info.Level);
+            Assert.Contains("no-snapshot", info.Message);
+            Assert.DoesNotContain(findings, f => f.Level == VerdictLevel.Fail || f.Level == VerdictLevel.Warn);
+        }
+
+        // Guards (edge case 23): a snapshot that failed to load -> INFO (unresolvable)
+        // + WARN (snapshot load failed), never a FAIL and never a crash. Fails if a
+        // load-failed snapshot NREs or is treated identically to a genuinely absent
+        // one.
+        [Fact]
+        public void SnapshotLoadFailed_InfoPlusWarn()
+        {
+            var rec = new Recording
+            {
+                RecordingId = "loadfail0",
+                PartEvents = new List<PartEvent>
+                {
+                    new PartEvent { partPersistentId = 100000, eventType = PartEventType.Decoupled },
+                },
+            };
+
+            List<Finding> findings = Run(ModelWith(
+                new[] { rec },
+                new[] { new LoadFault("p", "snapshot", "snapshot-load-failed", "loadfail0") }));
+
+            Assert.Contains(findings, f => f.Level == VerdictLevel.Info && f.Message.Contains("loadFailed=True"));
+            Assert.Contains(findings, f => f.Level == VerdictLevel.Warn && f.Message.Contains("snapshot-load-failed"));
+            Assert.DoesNotContain(findings, f => f.Level == VerdictLevel.Fail);
+        }
+    }
+}

--- a/Source/Parsek.Tests/Analyzer/Rules/Inv5SchemaGate.cs
+++ b/Source/Parsek.Tests/Analyzer/Rules/Inv5SchemaGate.cs
@@ -1,0 +1,177 @@
+using System.Collections.Generic;
+using System.Globalization;
+
+namespace Parsek.Tests.Analyzer.Rules
+{
+    // INV5 schema gate (design doc "The invariant rules" INV5, edge cases 1-4, 20, 22).
+    //
+    // Pure over the model. The loader (SaveDirectoryLoader, tasks 1.1/1.2) has
+    // already done all file I/O: it parsed each RECORDING's metadata generation
+    // via RecordingTreeRecordCodec.LoadRecordingFrom, captured each trajectory
+    // sidecar's probed (generation, formatVersion) into model.SidecarSchema
+    // (correction C2), and recorded every unloadable sidecar as a
+    // LoadFault{FileKind="trajectory"} carrying the exact production reason
+    // string. INV5 reads only that already-loaded model and emits:
+    //
+    //   - metadata gate FAIL: a recording whose (formatVersion, schemaGeneration)
+    //     fails RecordingStore.IsRecordingSchemaCompatible, with the exact reason
+    //     (generation-missing / generation-older / generation-newer /
+    //     format-version-mismatch). Re-running the production gate reproduces the
+    //     reason even after LoadRecordingFrom parks a rejected recording at
+    //     RecordingFormatVersion == -1, because the gate checks the generation
+    //     first (preserved) and a -1 format still yields format-version-mismatch.
+    //   - generation-mismatch FAIL: metadata passes the gate but the paired
+    //     trajectory sidecar reported a different generation (edge case 4).
+    //   - trajectory LoadFault FAIL: truncated / text-format / pre-reset-magic
+    //     sidecars (edge cases 1-3), surfaced with the production reason string so
+    //     a triage grep matches KSP.log.
+    //   - orphan-sidecar WARN: a SidecarSchema key with no matching recording is a
+    //     stray .prec the tree no longer references (edge case 20).
+    //   - generations inventory INFO: emitted only when informative (more than the
+    //     single current generation is present), so a homogeneous current-gen save
+    //     stays finding-free (the established clean-data-is-green convention the
+    //     Phase-2 rules and InvariantRegistryTests pin).
+    internal sealed class Inv5SchemaGate : IRecordingInvariant
+    {
+        internal const string SchemaGateRuleId = "INV5-SCHEMA-GATE";
+        internal const string OrphanSidecarRuleId = "INV5-ORPHAN-SIDECAR";
+        internal const string GenerationsRuleId = "INV5-GENERATIONS";
+
+        public string RuleId => SchemaGateRuleId;
+
+        public string CitedContract =>
+            "RecordingStore.IsRecordingSchemaCompatible / RecordingStore.CurrentRecordingSchemaGeneration";
+
+        public IEnumerable<Finding> Evaluate(AnalyzerModel model)
+        {
+            var findings = new List<Finding>();
+            if (model == null)
+                return findings;
+
+            var recIds = new HashSet<string>(System.StringComparer.Ordinal);
+            var faultedTrajectoryIds = new HashSet<string>(System.StringComparer.Ordinal);
+            if (model.LoadFaults != null)
+            {
+                foreach (LoadFault f in model.LoadFaults)
+                {
+                    if (f.FileKind == "trajectory" && !string.IsNullOrEmpty(f.RecordingId))
+                        faultedTrajectoryIds.Add(f.RecordingId);
+                }
+            }
+
+            var distinctGenerations = new HashSet<int>();
+
+            if (model.Recordings != null)
+            {
+                foreach (Recording rec in model.Recordings)
+                {
+                    if (rec == null || string.IsNullOrEmpty(rec.RecordingId))
+                        continue;
+                    recIds.Add(rec.RecordingId);
+                    distinctGenerations.Add(rec.RecordingSchemaGeneration);
+
+                    int sidecarGen = -1;
+                    bool hasSidecar =
+                        model.SidecarSchema != null
+                        && model.SidecarSchema.TryGetValue(rec.RecordingId, out var s);
+                    if (hasSidecar)
+                        sidecarGen = model.SidecarSchema[rec.RecordingId].Generation;
+
+                    if (!RecordingStore.IsRecordingSchemaCompatible(
+                            rec.RecordingFormatVersion,
+                            rec.RecordingSchemaGeneration,
+                            out string reason))
+                    {
+                        findings.Add(new Finding(
+                            SchemaGateRuleId,
+                            VerdictLevel.Fail,
+                            rec.RecordingId,
+                            -1,
+                            Inv("INV5 reject recording={0} reason={1} metadataGen={2} sidecarGen={3}",
+                                rec.RecordingId, reason, rec.RecordingSchemaGeneration, sidecarGen),
+                            "RecordingStore.IsRecordingSchemaCompatible"));
+                        continue;
+                    }
+
+                    // Metadata passed the gate: flag a sidecar whose probed generation
+                    // disagrees. Skipped when the sidecar itself failed to load (a
+                    // trajectory LoadFault already reports the sidecar problem below).
+                    if (hasSidecar
+                        && sidecarGen != rec.RecordingSchemaGeneration
+                        && !faultedTrajectoryIds.Contains(rec.RecordingId))
+                    {
+                        findings.Add(new Finding(
+                            SchemaGateRuleId,
+                            VerdictLevel.Fail,
+                            rec.RecordingId,
+                            -1,
+                            Inv("INV5 reject recording={0} reason=generation-mismatch metadataGen={1} sidecarGen={2}",
+                                rec.RecordingId, rec.RecordingSchemaGeneration, sidecarGen),
+                            "RecordingStore.IsRecordingSchemaCompatible"));
+                    }
+                }
+            }
+
+            // Unloadable trajectory sidecars (truncated / text / pre-reset magic).
+            if (model.LoadFaults != null)
+            {
+                foreach (LoadFault f in model.LoadFaults)
+                {
+                    if (f.FileKind != "trajectory")
+                        continue;
+                    findings.Add(new Finding(
+                        SchemaGateRuleId,
+                        VerdictLevel.Fail,
+                        f.RecordingId ?? "<trajectory>",
+                        -1,
+                        Inv("INV5 reject recording={0} reason={1} kind=load-fault",
+                            f.RecordingId ?? "<trajectory>", f.Reason ?? "unknown"),
+                        "RecordingStore.IsRecordingSchemaCompatible"));
+                }
+            }
+
+            // Orphan sidecars: a SidecarSchema key with no matching tree recording.
+            if (model.SidecarSchema != null)
+            {
+                foreach (KeyValuePair<string, (int Generation, int FormatVersion)> kv in model.SidecarSchema)
+                {
+                    if (recIds.Contains(kv.Key))
+                        continue;
+                    findings.Add(new Finding(
+                        OrphanSidecarRuleId,
+                        VerdictLevel.Warn,
+                        kv.Key,
+                        -1,
+                        Inv("INV5 orphan-sidecar recording={0} sidecarGen={1}", kv.Key, kv.Value.Generation),
+                        "RecordingStore.IsRecordingSchemaCompatible"));
+                }
+            }
+
+            // Generations inventory, informative only (a homogeneous current-gen
+            // save stays finding-free).
+            if (distinctGenerations.Count > 0
+                && (distinctGenerations.Count > 1
+                    || !distinctGenerations.Contains(RecordingStore.CurrentRecordingSchemaGeneration)))
+            {
+                var sorted = new List<int>(distinctGenerations);
+                sorted.Sort();
+                findings.Add(new Finding(
+                    GenerationsRuleId,
+                    VerdictLevel.Info,
+                    model.SaveName ?? "<save>",
+                    -1,
+                    Inv("INV5 generations={0} current={1}",
+                        string.Join(",", sorted.ConvertAll(g => g.ToString(CultureInfo.InvariantCulture))),
+                        RecordingStore.CurrentRecordingSchemaGeneration),
+                    "RecordingStore.CurrentRecordingSchemaGeneration"));
+            }
+
+            return findings;
+        }
+
+        private static string Inv(string format, params object[] args)
+        {
+            return string.Format(CultureInfo.InvariantCulture, format, args);
+        }
+    }
+}

--- a/Source/Parsek.Tests/Analyzer/Rules/Inv5SchemaGateTests.cs
+++ b/Source/Parsek.Tests/Analyzer/Rules/Inv5SchemaGateTests.cs
@@ -1,0 +1,175 @@
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace Parsek.Tests.Analyzer.Rules
+{
+    // INV5 schema gate. All fixtures are pure in-memory AnalyzerModels (plan
+    // fixture strategy: INV5-metadata is pure-model; the sidecar / orphan /
+    // load-fault side-tables the rule reads are populated directly here, which
+    // exercises the pure rule without the loader). Each test names the regression
+    // it guards.
+    public class Inv5SchemaGateTests
+    {
+        private static AnalyzerModel ModelWith(
+            IEnumerable<Recording> recordings = null,
+            IReadOnlyDictionary<string, (int, int)> sidecarSchema = null,
+            IEnumerable<LoadFault> loadFaults = null)
+        {
+            return new AnalyzerModel
+            {
+                SaveName = "inv5",
+                Recordings = (recordings ?? Enumerable.Empty<Recording>()).ToList(),
+                SidecarSchema = sidecarSchema != null
+                    ? sidecarSchema.ToDictionary(k => k.Key, v => v.Value)
+                    : new Dictionary<string, (int, int)>(),
+                LoadFaults = (loadFaults ?? Enumerable.Empty<LoadFault>()).ToList(),
+            };
+        }
+
+        private static List<Finding> Run(AnalyzerModel model)
+        {
+            return new Inv5SchemaGate().Evaluate(model).ToList();
+        }
+
+        private static Recording Rec(string id, int generation, int formatVersion = 1)
+        {
+            return new Recording
+            {
+                RecordingId = id,
+                RecordingSchemaGeneration = generation,
+                RecordingFormatVersion = formatVersion,
+            };
+        }
+
+        // Guards: a current-generation recording (gen 4, format 1) produces zero
+        // INV5 findings. Fails if the gate rejects valid current data.
+        [Fact]
+        public void CurrentGeneration_NoFindings()
+        {
+            var model = ModelWith(new[]
+            {
+                Rec("ok0", RecordingStore.CurrentRecordingSchemaGeneration,
+                    RecordingStore.CurrentRecordingFormatVersion),
+            });
+
+            Assert.Empty(Run(model));
+        }
+
+        // Guards: each metadata gate reason maps to the exact production reason
+        // string, so a triage grep matches KSP.log. Fails if the analyzer's reasons
+        // drift from RecordingStore.IsRecordingSchemaCompatible.
+        [Theory]
+        [InlineData(0, 1, "generation-missing")]
+        [InlineData(3, 1, "generation-older")]
+        [InlineData(5, 1, "generation-newer")]
+        [InlineData(4, 2, "format-version-mismatch")]
+        public void MetadataGate_EachReason_Fails(int generation, int formatVersion, string reason)
+        {
+            var model = ModelWith(new[] { Rec("bad0", generation, formatVersion) });
+
+            List<Finding> findings = Run(model);
+
+            Assert.Contains(findings, f =>
+                f.RuleId == Inv5SchemaGate.SchemaGateRuleId
+                && f.Level == VerdictLevel.Fail
+                && f.Target == "bad0"
+                && f.Message.Contains("reason=" + reason));
+        }
+
+        // Guards (edge case 4): metadata passes the gate but the paired sidecar
+        // reports a different generation -> generation-mismatch FAIL. Fails if a
+        // drifted sidecar schema silently passes.
+        [Fact]
+        public void SidecarGenerationDisagreement_Fails()
+        {
+            var model = ModelWith(
+                new[] { Rec("rec0", 4, 1) },
+                new Dictionary<string, (int, int)> { ["rec0"] = (3, 1) });
+
+            List<Finding> findings = Run(model);
+
+            Assert.Contains(findings, f =>
+                f.RuleId == Inv5SchemaGate.SchemaGateRuleId
+                && f.Level == VerdictLevel.Fail
+                && f.Target == "rec0"
+                && f.Message.Contains("reason=generation-mismatch")
+                && f.Message.Contains("sidecarGen=3"));
+        }
+
+        // Guards (edge case 20): a SidecarSchema key with no matching tree recording
+        // is a stray .prec -> WARN, not FAIL. Fails if orphan sidecars are ignored
+        // or escalated to FAIL.
+        [Fact]
+        public void OrphanSidecar_Warns()
+        {
+            var model = ModelWith(
+                new[] { Rec("ref0", 4, 1) },
+                new Dictionary<string, (int, int)>
+                {
+                    ["ref0"] = (4, 1),
+                    ["orphan0"] = (4, 1),
+                });
+
+            List<Finding> findings = Run(model);
+
+            Finding warn = Assert.Single(findings, f => f.RuleId == Inv5SchemaGate.OrphanSidecarRuleId);
+            Assert.Equal(VerdictLevel.Warn, warn.Level);
+            Assert.Equal("orphan0", warn.Target);
+            Assert.DoesNotContain(findings, f => f.Level == VerdictLevel.Fail);
+        }
+
+        // Guards (edge cases 1-3): a trajectory LoadFault (truncated / text /
+        // pre-reset) surfaces as a FAIL carrying the exact production reason string.
+        // Fails if malformed sidecars are dropped instead of reported.
+        [Fact]
+        public void TrajectoryLoadFault_FailsWithReason()
+        {
+            var model = ModelWith(
+                loadFaults: new[]
+                {
+                    new LoadFault("p", "trajectory", "text-sidecar-unsupported", "text0"),
+                });
+
+            List<Finding> findings = Run(model);
+
+            Assert.Contains(findings, f =>
+                f.RuleId == Inv5SchemaGate.SchemaGateRuleId
+                && f.Level == VerdictLevel.Fail
+                && f.Target == "text0"
+                && f.Message.Contains("reason=text-sidecar-unsupported"));
+        }
+
+        // Guards: a sidecar that both load-faulted AND disagrees on generation is
+        // reported once (via the load fault), not double-counted with a spurious
+        // generation-mismatch. Fails if the two paths both fire for one bad sidecar.
+        [Fact]
+        public void SidecarLoadFault_DoesNotAlsoEmitGenerationMismatch()
+        {
+            var model = ModelWith(
+                new[] { Rec("t0", 4, 1) },
+                new Dictionary<string, (int, int)> { ["t0"] = (3, 1) },
+                new[] { new LoadFault("p", "trajectory", "magic-mismatch", "t0") });
+
+            List<Finding> findings = Run(model);
+
+            Assert.DoesNotContain(findings, f => f.Message.Contains("reason=generation-mismatch"));
+            Assert.Contains(findings, f => f.Message.Contains("reason=magic-mismatch"));
+        }
+
+        // Guards: the generations inventory INFO fires only when a non-current
+        // generation is present (informative), keeping a homogeneous current-gen
+        // save finding-free. Fails if the inventory INFO leaks onto clean data.
+        [Fact]
+        public void GenerationsInventory_InfoOnlyWhenNonCurrentPresent()
+        {
+            var clean = ModelWith(new[] { Rec("ok0", 4, 1) });
+            Assert.DoesNotContain(Run(clean), f => f.RuleId == Inv5SchemaGate.GenerationsRuleId);
+
+            var mixed = ModelWith(new[] { Rec("ok0", 4, 1), Rec("old0", 3, 1) });
+            Finding info = Assert.Single(Run(mixed), f => f.RuleId == Inv5SchemaGate.GenerationsRuleId);
+            Assert.Equal(VerdictLevel.Info, info.Level);
+            Assert.Contains("generations=3,4", info.Message);
+        }
+    }
+}

--- a/Source/Parsek.Tests/Analyzer/Rules/Inv6ResourceManifest.cs
+++ b/Source/Parsek.Tests/Analyzer/Rules/Inv6ResourceManifest.cs
@@ -1,0 +1,165 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using Parsek;
+
+namespace Parsek.Tests.Analyzer.Rules
+{
+    // INV6 resource manifest consistency (design doc "The invariant rules" INV6,
+    // edge case 9).
+    //
+    // Where a resource manifest is present, it must round-trip through
+    // RecordingManifestCodec.SerializeResourceManifest / DeserializeResourceManifest
+    // (into a scratch in-memory ConfigNode, no file I/O) and its per-resource
+    // deltas (ResourceManifest.ComputeResourceDelta) must survive the round-trip
+    // unchanged. A resource that changes or vanishes across the round-trip -> FAIL
+    // naming the resource.
+    //
+    // Manifests are OPTIONAL: a recording with no manifest (a Gloops / showcase
+    // ghost, or any recording that carried none) produces NO finding. The design
+    // describes the absent case as "INFO, not a finding"; this rule takes the
+    // no-finding reading so a healthy save with manifest-less recordings stays
+    // finding-free (the clean-data-is-green convention the Phase-2 rules and
+    // InvariantRegistryTests pin). Pure over the model.
+    internal sealed class Inv6ResourceManifest : IRecordingInvariant
+    {
+        internal const string RuleIdConst = "INV6-RESOURCE-MANIFEST";
+
+        public string RuleId => RuleIdConst;
+
+        public string CitedContract =>
+            "RecordingManifestCodec.SerializeResourceManifest / ResourceManifest.ComputeResourceDelta";
+
+        public IEnumerable<Finding> Evaluate(AnalyzerModel model)
+        {
+            var findings = new List<Finding>();
+            if (model?.Recordings == null)
+                return findings;
+
+            foreach (Recording rec in model.Recordings)
+            {
+                if (rec == null || string.IsNullOrEmpty(rec.RecordingId))
+                    continue;
+
+                bool hasStart = rec.StartResources != null && rec.StartResources.Count > 0;
+                bool hasEnd = rec.EndResources != null && rec.EndResources.Count > 0;
+                if (!hasStart && !hasEnd)
+                    continue; // manifest optional -> no finding
+
+                // Round-trip the manifest through the codec into a scratch node.
+                var scratch = new ConfigNode("SCRATCH");
+                RecordingManifestCodec.SerializeResourceManifest(scratch, rec);
+                var rec2 = new Recording { RecordingId = rec.RecordingId };
+                RecordingManifestCodec.DeserializeResourceManifest(scratch, rec2);
+
+                CompareDictionaries(rec.RecordingId, "start",
+                    rec.StartResources, rec2.StartResources, findings);
+                CompareDictionaries(rec.RecordingId, "end",
+                    rec.EndResources, rec2.EndResources, findings);
+
+                // Delta consistency: the per-resource delta must be identical before
+                // and after the round-trip (ComputeResourceDelta is the production
+                // consumer of the manifest).
+                Dictionary<string, double> before =
+                    ResourceManifest.ComputeResourceDelta(rec.StartResources, rec.EndResources);
+                Dictionary<string, double> after =
+                    ResourceManifest.ComputeResourceDelta(rec2.StartResources, rec2.EndResources);
+                CompareDeltas(rec.RecordingId, before, after, findings);
+            }
+
+            return findings;
+        }
+
+        private static void CompareDictionaries(
+            string recId, string which,
+            Dictionary<string, ResourceAmount> a,
+            Dictionary<string, ResourceAmount> b,
+            List<Finding> findings)
+        {
+            var keys = new HashSet<string>(StringComparer.Ordinal);
+            if (a != null) foreach (string k in a.Keys) keys.Add(k);
+            if (b != null) foreach (string k in b.Keys) keys.Add(k);
+
+            foreach (string key in keys)
+            {
+                ResourceAmount ra = default(ResourceAmount);
+                ResourceAmount rb = default(ResourceAmount);
+                bool inA = a != null && a.TryGetValue(key, out ra);
+                bool inB = b != null && b.TryGetValue(key, out rb);
+
+                if (inA != inB)
+                {
+                    findings.Add(Fail(recId,
+                        Inv("INV6 manifest recording={0} field={1} resource='{2}' error=present-mismatch inA={3} inB={4}",
+                            recId, which, key, inA ? "True" : "False", inB ? "True" : "False")));
+                    continue;
+                }
+                if (!inA)
+                    continue;
+
+                if (!DoubleEqual(ra.amount, rb.amount) || !DoubleEqual(ra.maxAmount, rb.maxAmount))
+                {
+                    findings.Add(Fail(recId,
+                        Inv("INV6 manifest recording={0} field={1} resource='{2}' error=value-drift a={3}/{4} b={5}/{6}",
+                            recId, which, key, ra.amount, ra.maxAmount, rb.amount, rb.maxAmount)));
+                }
+            }
+        }
+
+        private static void CompareDeltas(
+            string recId,
+            Dictionary<string, double> before,
+            Dictionary<string, double> after,
+            List<Finding> findings)
+        {
+            if (before == null && after == null)
+                return;
+
+            var keys = new HashSet<string>(StringComparer.Ordinal);
+            if (before != null) foreach (string k in before.Keys) keys.Add(k);
+            if (after != null) foreach (string k in after.Keys) keys.Add(k);
+
+            foreach (string key in keys)
+            {
+                double db = 0.0;
+                double da = 0.0;
+                bool inB = before != null && before.TryGetValue(key, out db);
+                bool inA = after != null && after.TryGetValue(key, out da);
+
+                if (inB != inA || !DoubleEqual(db, da))
+                {
+                    findings.Add(Fail(recId,
+                        Inv("INV6 manifest recording={0} field=delta resource='{1}' error=delta-drift before={2} after={3}",
+                            recId, key, inB ? db.ToString("R", CultureInfo.InvariantCulture) : "<absent>",
+                            inA ? da.ToString("R", CultureInfo.InvariantCulture) : "<absent>")));
+                }
+            }
+        }
+
+        private static Finding Fail(string recId, string message)
+        {
+            return new Finding(RuleIdConst, VerdictLevel.Fail, recId, -1, message,
+                "RecordingManifestCodec.SerializeResourceManifest");
+        }
+
+        // NaN-aware: two NaNs are treated equal (a stable NaN round-trip is not a
+        // failure); otherwise bitwise-exact equality after the lossless "R" codec.
+        private static bool DoubleEqual(double x, double y)
+        {
+            if (double.IsNaN(x) && double.IsNaN(y))
+                return true;
+            return x.Equals(y);
+        }
+
+        private static string Inv(string format, params object[] args)
+        {
+            var ic = CultureInfo.InvariantCulture;
+            for (int i = 0; i < args.Length; i++)
+            {
+                if (args[i] is double d)
+                    args[i] = d.ToString("R", ic);
+            }
+            return string.Format(ic, format, args);
+        }
+    }
+}

--- a/Source/Parsek.Tests/Analyzer/Rules/Inv6ResourceManifestTests.cs
+++ b/Source/Parsek.Tests/Analyzer/Rules/Inv6ResourceManifestTests.cs
@@ -1,0 +1,82 @@
+using System.Collections.Generic;
+using System.Linq;
+using Parsek;
+using Xunit;
+
+namespace Parsek.Tests.Analyzer.Rules
+{
+    // INV6 resource manifest consistency. Pure in-memory model; the manifest
+    // round-trips through the codec into a scratch ConfigNode (no file). Each test
+    // names the regression it guards.
+    public class Inv6ResourceManifestTests
+    {
+        private static AnalyzerModel ModelWith(params Recording[] recs)
+        {
+            return new AnalyzerModel { SaveName = "inv6", Recordings = recs.ToList() };
+        }
+
+        private static List<Finding> Run(AnalyzerModel model)
+        {
+            return new Inv6ResourceManifest().Evaluate(model).ToList();
+        }
+
+        // Guards: a well-formed manifest round-trips -> zero INV6 findings. Fails if
+        // a valid manifest is flagged (codec / comparison over-strict).
+        [Fact]
+        public void ManifestPresent_RoundTrips_NoFindings()
+        {
+            var rec = new Recording
+            {
+                RecordingId = "ok0",
+                StartResources = new Dictionary<string, ResourceAmount>
+                {
+                    ["LiquidFuel"] = new ResourceAmount { amount = 100.0, maxAmount = 100.0 },
+                    ["Oxidizer"] = new ResourceAmount { amount = 122.0, maxAmount = 122.0 },
+                },
+                EndResources = new Dictionary<string, ResourceAmount>
+                {
+                    ["LiquidFuel"] = new ResourceAmount { amount = 5.0, maxAmount = 100.0 },
+                    ["Oxidizer"] = new ResourceAmount { amount = 6.0, maxAmount = 122.0 },
+                },
+            };
+
+            Assert.Empty(Run(ModelWith(rec)));
+        }
+
+        // Guards (edge case 9): a recording with no manifest (Gloops / showcase) ->
+        // zero findings. Fails if the rule wrongly requires manifests on ghost-only
+        // recordings.
+        [Fact]
+        public void ManifestAbsent_NoFindings()
+        {
+            var rec = new Recording { RecordingId = "nomanifest0" };
+            Assert.Empty(Run(ModelWith(rec)));
+        }
+
+        // Guards: a manifest whose round-trip loses a resource (an empty-name entry
+        // the codec drops on deserialize) -> INV6 FAIL naming the resource. Fails if
+        // the round-trip comparison is too shallow to notice a dropped resource.
+        [Fact]
+        public void ManifestRoundTripDropsResource_Fails()
+        {
+            var rec = new Recording
+            {
+                RecordingId = "bad0",
+                StartResources = new Dictionary<string, ResourceAmount>
+                {
+                    ["LiquidFuel"] = new ResourceAmount { amount = 100.0, maxAmount = 100.0 },
+                    // Empty-name resource: SerializeResourceManifest writes name="",
+                    // DeserializeResourceManifest skips empty names -> the key vanishes.
+                    [""] = new ResourceAmount { amount = 3.0, maxAmount = 3.0 },
+                },
+            };
+
+            List<Finding> findings = Run(ModelWith(rec));
+
+            Assert.Contains(findings, f =>
+                f.RuleId == Inv6ResourceManifest.RuleIdConst
+                && f.Level == VerdictLevel.Fail
+                && f.Target == "bad0");
+        }
+    }
+}

--- a/Source/Parsek.Tests/Analyzer/Rules/Inv7TreeTopology.cs
+++ b/Source/Parsek.Tests/Analyzer/Rules/Inv7TreeTopology.cs
@@ -1,0 +1,276 @@
+using System.Collections.Generic;
+using System.Globalization;
+
+namespace Parsek.Tests.Analyzer.Rules
+{
+    // INV7 tree topology (design doc "The invariant rules", edge cases 10-14).
+    //
+    // Runs over the RAW model (never the ERS/ELS visibility-filtered set - a
+    // superseded recording that ERS drops is still a row whose links this rule
+    // must resolve). Three families:
+    //
+    //   1. Dangling links (FAIL). Every non-null ParentRecordingId,
+    //      TrackSection.anchorRecordingId, ParentAnchorRecordingId,
+    //      Recording.SupersedeTargetId, and tombstone RetiringRecordingId must
+    //      resolve to a recording present in the model.
+    //   2. Cycles (FAIL). The parent-edge graph and the supersede (Old->New)
+    //      graph must be acyclic; the walk terminates via a per-walk visited set
+    //      so a corrupt A.parent=B / B.parent=A pair cannot loop forever.
+    //   3. Chain contiguity (FAIL / INFO). ChainIndex runs are contiguous PER
+    //      (ChainId, ChainBranch). A missing index is FAIL unless the chain
+    //      carries a supersede boundary (a HEAD/TIP re-fly split), in which case
+    //      it is an expected INFO. The exemption reuses the EXACT predicate the
+    //      optimizer's re-merge guard uses (EffectiveState.IsSupersededByRelation,
+    //      the load-bearing defense in RecordingOptimizer.CanAutoMerge), so INV7
+    //      and the optimizer agree on what a supersede boundary is.
+    internal sealed class Inv7TreeTopology : IRecordingInvariant
+    {
+        internal const string RuleIdConst = "INV7-TREE-TOPOLOGY";
+
+        public string RuleId => RuleIdConst;
+
+        public string CitedContract =>
+            "Recording.ChainId/ChainIndex/ChainBranch / RecordingOptimizer.CanAutoMerge / EffectiveState.IsSupersededByRelation";
+
+        public IEnumerable<Finding> Evaluate(AnalyzerModel model)
+        {
+            var findings = new List<Finding>();
+            if (model?.Recordings == null)
+                return findings;
+
+            var idSet = new HashSet<string>(System.StringComparer.Ordinal);
+            var byId = new Dictionary<string, Recording>(System.StringComparer.Ordinal);
+            foreach (Recording rec in model.Recordings)
+            {
+                if (rec == null || string.IsNullOrEmpty(rec.RecordingId))
+                    continue;
+                idSet.Add(rec.RecordingId);
+                byId[rec.RecordingId] = rec;
+            }
+
+            CheckDanglingLinks(model, idSet, findings);
+            CheckParentCycles(model, idSet, byId, findings);
+            CheckSupersedeCycles(model, findings);
+            CheckChainContiguity(model, findings);
+
+            return findings;
+        }
+
+        // --- Family 1: dangling links ---
+
+        private static void CheckDanglingLinks(
+            AnalyzerModel model, HashSet<string> idSet, List<Finding> findings)
+        {
+            foreach (Recording rec in model.Recordings)
+            {
+                if (rec == null || string.IsNullOrEmpty(rec.RecordingId))
+                    continue;
+
+                MaybeDangling(rec.RecordingId, -1, "ParentRecordingId", rec.ParentRecordingId, idSet, findings);
+                MaybeDangling(rec.RecordingId, -1, "ParentAnchorRecordingId", rec.ParentAnchorRecordingId, idSet, findings);
+                MaybeDangling(rec.RecordingId, -1, "SupersedeTargetId", rec.SupersedeTargetId, idSet, findings);
+
+                if (rec.TrackSections != null)
+                {
+                    for (int i = 0; i < rec.TrackSections.Count; i++)
+                    {
+                        MaybeDangling(rec.RecordingId, i, "anchorRecordingId",
+                            rec.TrackSections[i].anchorRecordingId, idSet, findings);
+                    }
+                }
+            }
+
+            if (model.Tombstones != null)
+            {
+                foreach (LedgerTombstone t in model.Tombstones)
+                {
+                    if (t == null || string.IsNullOrEmpty(t.RetiringRecordingId))
+                        continue;
+                    if (!idSet.Contains(t.RetiringRecordingId))
+                    {
+                        string target = t.TombstoneId ?? "<tombstone>";
+                        findings.Add(new Finding(
+                            RuleIdConst,
+                            VerdictLevel.Fail,
+                            target,
+                            -1,
+                            Inv("INV7 badlink recording={0} field=RetiringRecordingId target={1} kind=dangling",
+                                target, t.RetiringRecordingId),
+                            "EffectiveState.IsSupersededByRelation"));
+                    }
+                }
+            }
+        }
+
+        private static void MaybeDangling(
+            string recId, int sectionIndex, string field, string value,
+            HashSet<string> idSet, List<Finding> findings)
+        {
+            if (string.IsNullOrEmpty(value))
+                return;
+            if (idSet.Contains(value))
+                return;
+            findings.Add(new Finding(
+                RuleIdConst,
+                VerdictLevel.Fail,
+                recId,
+                sectionIndex,
+                Inv("INV7 badlink recording={0} field={1} target={2} kind=dangling", recId, field, value),
+                "Recording.ChainId/ChainIndex/ChainBranch"));
+        }
+
+        // --- Family 2a: parent-graph cycles ---
+
+        private static void CheckParentCycles(
+            AnalyzerModel model, HashSet<string> idSet,
+            Dictionary<string, Recording> byId, List<Finding> findings)
+        {
+            var reported = new HashSet<string>(System.StringComparer.Ordinal);
+
+            foreach (Recording rec in model.Recordings)
+            {
+                if (rec == null || string.IsNullOrEmpty(rec.RecordingId))
+                    continue;
+                if (reported.Contains(rec.RecordingId))
+                    continue;
+
+                var path = new HashSet<string>(System.StringComparer.Ordinal);
+                string cur = rec.RecordingId;
+                while (cur != null && idSet.Contains(cur))
+                {
+                    if (path.Contains(cur))
+                    {
+                        // cur closes a loop -> cycle. Report once and mark the
+                        // whole visited path so other start nodes skip it.
+                        findings.Add(new Finding(
+                            RuleIdConst,
+                            VerdictLevel.Fail,
+                            cur,
+                            -1,
+                            Inv("INV7 badlink recording={0} field=ParentRecordingId target={0} kind=cycle", cur),
+                            "Recording.ChainId/ChainIndex/ChainBranch"));
+                        foreach (string p in path)
+                            reported.Add(p);
+                        reported.Add(cur);
+                        break;
+                    }
+                    path.Add(cur);
+                    byId.TryGetValue(cur, out Recording node);
+                    cur = node?.ParentRecordingId;
+                }
+            }
+        }
+
+        // --- Family 2b: supersede-graph cycles (Old -> New) ---
+
+        private static void CheckSupersedeCycles(AnalyzerModel model, List<Finding> findings)
+        {
+            if (model.SupersedeRelations == null || model.SupersedeRelations.Count == 0)
+                return;
+
+            var next = new Dictionary<string, string>(System.StringComparer.Ordinal);
+            foreach (RecordingSupersedeRelation rel in model.SupersedeRelations)
+            {
+                if (rel == null || string.IsNullOrEmpty(rel.OldRecordingId) || string.IsNullOrEmpty(rel.NewRecordingId))
+                    continue;
+                if (!next.ContainsKey(rel.OldRecordingId))
+                    next[rel.OldRecordingId] = rel.NewRecordingId;
+            }
+
+            var reported = new HashSet<string>(System.StringComparer.Ordinal);
+            foreach (string start in next.Keys)
+            {
+                if (reported.Contains(start))
+                    continue;
+                var path = new HashSet<string>(System.StringComparer.Ordinal);
+                string cur = start;
+                while (cur != null && next.ContainsKey(cur))
+                {
+                    if (path.Contains(cur))
+                    {
+                        findings.Add(new Finding(
+                            RuleIdConst,
+                            VerdictLevel.Fail,
+                            cur,
+                            -1,
+                            Inv("INV7 badlink recording={0} field=SupersedeRelation target={0} kind=cycle", cur),
+                            "EffectiveState.IsSupersededByRelation"));
+                        foreach (string p in path)
+                            reported.Add(p);
+                        reported.Add(cur);
+                        break;
+                    }
+                    path.Add(cur);
+                    cur = next[cur];
+                }
+            }
+        }
+
+        // --- Family 3: chain contiguity per (ChainId, ChainBranch) ---
+
+        private static void CheckChainContiguity(AnalyzerModel model, List<Finding> findings)
+        {
+            // Group chained recordings by (ChainId, ChainBranch).
+            var groups = new Dictionary<(string, int), List<int>>();
+            // Track, per ChainId, whether the chain carries a supersede boundary:
+            // reuse the optimizer's own re-merge guard predicate so INV7 and
+            // RecordingOptimizer.CanAutoMerge agree on what a boundary is.
+            var chainHasSupersede = new Dictionary<string, bool>(System.StringComparer.Ordinal);
+
+            foreach (Recording rec in model.Recordings)
+            {
+                if (rec == null || string.IsNullOrEmpty(rec.ChainId))
+                    continue;
+
+                if (!chainHasSupersede.TryGetValue(rec.ChainId, out bool already) || !already)
+                {
+                    bool superseded = EffectiveState.IsSupersededByRelation(rec, model.SupersedeRelations);
+                    chainHasSupersede[rec.ChainId] = already || superseded;
+                }
+
+                if (rec.ChainIndex < 0)
+                    continue;
+
+                var key = (rec.ChainId, rec.ChainBranch);
+                if (!groups.TryGetValue(key, out List<int> indices))
+                {
+                    indices = new List<int>();
+                    groups[key] = indices;
+                }
+                indices.Add(rec.ChainIndex);
+            }
+
+            foreach (KeyValuePair<(string ChainId, int Branch), List<int>> g in groups)
+            {
+                List<int> indices = g.Value;
+                indices.Sort();
+
+                int min = indices[0];
+                int max = indices[indices.Count - 1];
+                var present = new HashSet<int>(indices);
+
+                bool exempt = chainHasSupersede.TryGetValue(g.Key.ChainId, out bool v) && v;
+
+                for (int n = min + 1; n < max; n++)
+                {
+                    if (present.Contains(n))
+                        continue;
+
+                    findings.Add(new Finding(
+                        RuleIdConst,
+                        exempt ? VerdictLevel.Info : VerdictLevel.Fail,
+                        g.Key.ChainId,
+                        -1,
+                        Inv("INV7 chaingap chainId={0} branch={1} missingIndex={2} supersedeExempt={3}",
+                            g.Key.ChainId, g.Key.Branch, n, exempt ? "True" : "False"),
+                        "Recording.ChainId/ChainIndex/ChainBranch"));
+                }
+            }
+        }
+
+        private static string Inv(string format, params object[] args)
+        {
+            return string.Format(CultureInfo.InvariantCulture, format, args);
+        }
+    }
+}

--- a/Source/Parsek.Tests/Analyzer/Rules/Inv7TreeTopology.cs
+++ b/Source/Parsek.Tests/Analyzer/Rules/Inv7TreeTopology.cs
@@ -100,6 +100,39 @@ namespace Parsek.Tests.Analyzer.Rules
                     }
                 }
             }
+
+            // Supersede-relation endpoints. A row whose OldRecordingId or
+            // NewRecordingId is absent from the model is a one-sided orphan. This is
+            // WARN (not FAIL), matching production LoadTimeSweep's warn-log severity:
+            // the forward supersede walk terminates cleanly on a missing endpoint, so
+            // it is a maintenance signal rather than a broken invariant.
+            if (model.SupersedeRelations != null)
+            {
+                foreach (RecordingSupersedeRelation rel in model.SupersedeRelations)
+                {
+                    if (rel == null)
+                        continue;
+                    string relTarget = rel.RelationId ?? "<supersede>";
+                    MaybeOrphanSupersede(relTarget, "OldRecordingId", rel.OldRecordingId, idSet, findings);
+                    MaybeOrphanSupersede(relTarget, "NewRecordingId", rel.NewRecordingId, idSet, findings);
+                }
+            }
+        }
+
+        private static void MaybeOrphanSupersede(
+            string relTarget, string field, string value,
+            HashSet<string> idSet, List<Finding> findings)
+        {
+            if (string.IsNullOrEmpty(value) || idSet.Contains(value))
+                return;
+            findings.Add(new Finding(
+                RuleIdConst,
+                VerdictLevel.Warn,
+                relTarget,
+                -1,
+                Inv("INV7 badlink recording={0} field=SupersedeRelation.{1} target={2} kind=dangling",
+                    relTarget, field, value),
+                "EffectiveState.IsSupersededByRelation"));
         }
 
         private static void MaybeDangling(

--- a/Source/Parsek.Tests/Analyzer/Rules/Inv7TreeTopologyTests.cs
+++ b/Source/Parsek.Tests/Analyzer/Rules/Inv7TreeTopologyTests.cs
@@ -1,0 +1,213 @@
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace Parsek.Tests.Analyzer.Rules
+{
+    // INV7 tree topology. Hand-built in-memory AnalyzerModel lists (ScenarioWriter
+    // cannot emit supersede/tombstone rows, per plan correction C4). Pure over the
+    // model: no loader, no disk, no shared static state.
+    public class Inv7TreeTopologyTests
+    {
+        private static Recording Rec(string id, string chainId = null, int chainIndex = -1, int branch = 0)
+        {
+            return new Recording
+            {
+                RecordingId = id,
+                ChainId = chainId,
+                ChainIndex = chainIndex,
+                ChainBranch = branch,
+            };
+        }
+
+        private static List<Finding> Run(AnalyzerModel model)
+        {
+            return new Inv7TreeTopology().Evaluate(model).ToList();
+        }
+
+        // Guards: a valid multi-branch chain (branch 0 = 0,1,2; branch 2 = 0,1)
+        // with resolvable parent links -> zero FAIL. Fails if per-branch
+        // contiguity is not scoped and the combined index set is treated as one
+        // run (branch 2's indices would look like "gaps" against branch 0).
+        [Fact]
+        public void ValidMultiBranchChain_NoFindings()
+        {
+            var model = new AnalyzerModel
+            {
+                SaveName = "inv7",
+                Recordings = new List<Recording>
+                {
+                    Rec("a", "chainX", 0, 0),
+                    Rec("b", "chainX", 1, 0),
+                    Rec("c", "chainX", 2, 0),
+                    Rec("d", "chainX", 0, 2),
+                    Rec("e", "chainX", 1, 2),
+                },
+            };
+            // parent links that resolve
+            model.Recordings[1].ParentRecordingId = "a";
+            model.Recordings[2].ParentRecordingId = "b";
+
+            Assert.Empty(Run(model));
+        }
+
+        // Guards: a Recording.SupersedeTargetId pointing at an id absent from the
+        // model -> FAIL (dangling). Fails if dangling supersede links pass, which
+        // would break re-fly visibility resolution.
+        [Fact]
+        public void DanglingSupersedeTargetId_Fails()
+        {
+            var rec = Rec("a");
+            rec.SupersedeTargetId = "ghost-missing";
+            var model = new AnalyzerModel
+            {
+                SaveName = "inv7",
+                Recordings = new List<Recording> { rec },
+            };
+
+            List<Finding> findings = Run(model);
+
+            Assert.Contains(findings, f =>
+                f.RuleId == Inv7TreeTopology.RuleIdConst
+                && f.Level == VerdictLevel.Fail
+                && f.Message.Contains("kind=dangling")
+                && f.Message.Contains("ghost-missing"));
+        }
+
+        // Guards: a dangling tombstone RetiringRecordingId -> FAIL. Fails if
+        // tombstone recording links are not validated against the model.
+        [Fact]
+        public void DanglingTombstoneRetiringRecordingId_Fails()
+        {
+            var model = new AnalyzerModel
+            {
+                SaveName = "inv7",
+                Recordings = new List<Recording> { Rec("a") },
+                Tombstones = new List<LedgerTombstone>
+                {
+                    new LedgerTombstone
+                    {
+                        TombstoneId = "tomb_1",
+                        ActionId = "act_1",
+                        RetiringRecordingId = "nope",
+                    },
+                },
+            };
+
+            List<Finding> findings = Run(model);
+
+            Assert.Contains(findings, f =>
+                f.Level == VerdictLevel.Fail
+                && f.Message.Contains("field=RetiringRecordingId")
+                && f.Message.Contains("kind=dangling"));
+        }
+
+        // Guards: a two-node parent cycle (a.parent=b, b.parent=a) -> FAIL AND the
+        // walk terminates (the test itself would hang on an infinite loop). Fails
+        // if the visited-set cycle guard regresses.
+        [Fact]
+        public void TwoNodeParentCycle_Fails_AndTerminates()
+        {
+            var a = Rec("a");
+            var b = Rec("b");
+            a.ParentRecordingId = "b";
+            b.ParentRecordingId = "a";
+            var model = new AnalyzerModel
+            {
+                SaveName = "inv7",
+                Recordings = new List<Recording> { a, b },
+            };
+
+            List<Finding> findings = Run(model);
+
+            Assert.Contains(findings, f =>
+                f.RuleId == Inv7TreeTopology.RuleIdConst
+                && f.Level == VerdictLevel.Fail
+                && f.Message.Contains("kind=cycle"));
+        }
+
+        // Guards: a ChainIndex gap AT a supersede boundary (HEAD/TIP re-fly split)
+        // -> INFO, not FAIL. The chain carries a supersede relation whose old side
+        // is a chain member, so the missing index is explained. Fails if the
+        // supersede-boundary exemption regresses and false-alarms on every
+        // re-flown tree.
+        [Fact]
+        public void ChainGapAtSupersedeBoundary_IsInfo()
+        {
+            // Chain X branch 0 has indices 0,1,3 (2 was split into HEAD/TIP).
+            var model = new AnalyzerModel
+            {
+                SaveName = "inv7",
+                Recordings = new List<Recording>
+                {
+                    Rec("a", "chainX", 0, 0),
+                    Rec("b", "chainX", 1, 0),
+                    Rec("tip", "chainX", 3, 0),
+                },
+                SupersedeRelations = new List<RecordingSupersedeRelation>
+                {
+                    new RecordingSupersedeRelation
+                    {
+                        RelationId = "rsr_1",
+                        OldRecordingId = "b",   // a chain member is superseded
+                        NewRecordingId = "tip",
+                        UT = 100.0,
+                    },
+                },
+            };
+
+            List<Finding> findings = Run(model);
+
+            Finding gap = Assert.Single(findings, f => f.Message.Contains("chaingap"));
+            Assert.Equal(VerdictLevel.Info, gap.Level);
+            Assert.Contains("missingIndex=2", gap.Message);
+            Assert.Contains("supersedeExempt=True", gap.Message);
+        }
+
+        // Guards: a ChainIndex gap NOT explained by any supersede row -> FAIL.
+        // Fails if the rule treats every chain gap as exempt.
+        [Fact]
+        public void ChainGapWithoutSupersede_Fails()
+        {
+            var model = new AnalyzerModel
+            {
+                SaveName = "inv7",
+                Recordings = new List<Recording>
+                {
+                    Rec("a", "chainY", 0, 0),
+                    Rec("b", "chainY", 1, 0),
+                    Rec("c", "chainY", 3, 0),
+                },
+            };
+
+            List<Finding> findings = Run(model);
+
+            Finding gap = Assert.Single(findings, f => f.Message.Contains("chaingap"));
+            Assert.Equal(VerdictLevel.Fail, gap.Level);
+            Assert.Contains("missingIndex=2", gap.Message);
+            Assert.Contains("supersedeExempt=False", gap.Message);
+        }
+
+        // Guards: parallel ghost-only continuations (ChainBranch=2) with their own
+        // contiguous index run pass even when the combined index set across
+        // branches looks gapped. Fails if contiguity is not scoped per
+        // (ChainId, ChainBranch).
+        [Fact]
+        public void ParallelBranchContiguousRuns_NoFindings()
+        {
+            var model = new AnalyzerModel
+            {
+                SaveName = "inv7",
+                Recordings = new List<Recording>
+                {
+                    Rec("a", "chainZ", 0, 0),
+                    Rec("b", "chainZ", 1, 0),
+                    Rec("d", "chainZ", 0, 2),
+                    Rec("e", "chainZ", 1, 2),
+                },
+            };
+
+            Assert.Empty(Run(model).Where(f => f.Message.Contains("chaingap")));
+        }
+    }
+}

--- a/Source/Parsek.Tests/Analyzer/Rules/Inv7TreeTopologyTests.cs
+++ b/Source/Parsek.Tests/Analyzer/Rules/Inv7TreeTopologyTests.cs
@@ -102,6 +102,69 @@ namespace Parsek.Tests.Analyzer.Rules
                 && f.Message.Contains("kind=dangling"));
         }
 
+        // Guards: a supersede row whose OldRecordingId is absent from the model ->
+        // WARN (not FAIL), matching production LoadTimeSweep's orphan-supersede
+        // warn-log severity. Fails if a one-sided orphan supersede row goes
+        // unreported, or is wrongly escalated to FAIL.
+        [Fact]
+        public void OrphanSupersedeOldRecordingId_Warns()
+        {
+            var model = new AnalyzerModel
+            {
+                SaveName = "inv7",
+                Recordings = new List<Recording> { Rec("present") },
+                SupersedeRelations = new List<RecordingSupersedeRelation>
+                {
+                    new RecordingSupersedeRelation
+                    {
+                        RelationId = "rsr_old",
+                        OldRecordingId = "gone",       // absent from the model
+                        NewRecordingId = "present",
+                        UT = 10.0,
+                    },
+                },
+            };
+
+            List<Finding> findings = Run(model);
+
+            Finding warn = Assert.Single(findings);
+            Assert.Equal(Inv7TreeTopology.RuleIdConst, warn.RuleId);
+            Assert.Equal(VerdictLevel.Warn, warn.Level);
+            Assert.Equal("rsr_old", warn.Target);
+            Assert.Contains("field=SupersedeRelation.OldRecordingId", warn.Message);
+            Assert.Contains("target=gone", warn.Message);
+        }
+
+        // Guards: a supersede row whose NewRecordingId is absent from the model ->
+        // WARN. Fails if only the Old endpoint is validated (the New endpoint is the
+        // superseding recording; a missing one is an equally real orphan).
+        [Fact]
+        public void OrphanSupersedeNewRecordingId_Warns()
+        {
+            var model = new AnalyzerModel
+            {
+                SaveName = "inv7",
+                Recordings = new List<Recording> { Rec("present") },
+                SupersedeRelations = new List<RecordingSupersedeRelation>
+                {
+                    new RecordingSupersedeRelation
+                    {
+                        RelationId = "rsr_new",
+                        OldRecordingId = "present",
+                        NewRecordingId = "gone",       // absent from the model
+                        UT = 10.0,
+                    },
+                },
+            };
+
+            List<Finding> findings = Run(model);
+
+            Finding warn = Assert.Single(findings);
+            Assert.Equal(VerdictLevel.Warn, warn.Level);
+            Assert.Contains("field=SupersedeRelation.NewRecordingId", warn.Message);
+            Assert.Contains("target=gone", warn.Message);
+        }
+
         // Guards: a two-node parent cycle (a.parent=b, b.parent=a) -> FAIL AND the
         // walk terminates (the test itself would hang on an infinite loop). Fails
         // if the visited-set cycle guard regresses.

--- a/Source/Parsek.Tests/Analyzer/Rules/Inv7bAnnotationStale.cs
+++ b/Source/Parsek.Tests/Analyzer/Rules/Inv7bAnnotationStale.cs
@@ -1,0 +1,98 @@
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using Parsek;
+
+namespace Parsek.Tests.Analyzer.Rules
+{
+    // INV7b annotation staleness (design doc "The invariant rules" INV7b, edge
+    // case 15).
+    //
+    // A .pann pipeline-annotation sidecar is a DERIVED smoothing cache, not
+    // authored data (rendering design 17.3.1). Where one exists, its recorded
+    // source epoch (PannotationsSidecarBinary.TryProbe -> SourceSidecarEpoch) must
+    // not be older than the paired .prec's current epoch
+    // (TrajectorySidecarBinary.TryProbe -> SidecarEpoch): an older annotation was
+    // built against a superseded trajectory and would render a ghost from a stale
+    // cache -> WARN. A .pann with no paired .prec is an orphan cache -> WARN.
+    //
+    // File-scoped: this rule probes the two sidecars directly, so it reads
+    // model.SaveDirectory (the plan makes INV7b a loader-scoped rule). When
+    // SaveDirectory is null (a purely in-memory model / the core-purity test), it
+    // no-ops without touching a file. It never throws (probe failures are contained).
+    internal sealed class Inv7bAnnotationStale : IRecordingInvariant
+    {
+        internal const string RuleIdConst = "INV7B-ANNOTATION-STALE";
+
+        public string RuleId => RuleIdConst;
+
+        public string CitedContract =>
+            "PannotationsSidecarBinary.TryProbe / RecordingPaths.BuildAnnotationsRelativePath";
+
+        public IEnumerable<Finding> Evaluate(AnalyzerModel model)
+        {
+            var findings = new List<Finding>();
+            if (model == null || string.IsNullOrEmpty(model.SaveDirectory))
+                return findings;
+
+            string recordingsDir = Path.Combine(model.SaveDirectory, "Parsek", "Recordings");
+            if (!Directory.Exists(recordingsDir))
+                return findings;
+
+            string[] pannFiles;
+            try
+            {
+                pannFiles = Directory.GetFiles(recordingsDir, "*.pann");
+            }
+            catch
+            {
+                return findings;
+            }
+
+            foreach (string pannFile in pannFiles)
+            {
+                string id = Path.GetFileNameWithoutExtension(pannFile);
+                if (string.IsNullOrEmpty(id))
+                    continue;
+
+                if (!PannotationsSidecarBinary.TryProbe(pannFile, out PannotationsSidecarProbe pannProbe))
+                {
+                    // A .pann we cannot probe is a corrupt derived cache; surface it
+                    // as stale/regenerable, not a hard failure.
+                    findings.Add(Warn(id, -1,
+                        Inv("INV7b annotation recording={0} error=probe-failed reason={1}",
+                            id, pannProbe.FailureReason ?? "unknown")));
+                    continue;
+                }
+
+                string precPath = Path.Combine(model.SaveDirectory, RecordingPaths.BuildTrajectoryRelativePath(id));
+                if (!File.Exists(precPath))
+                {
+                    findings.Add(Warn(id, -1,
+                        Inv("INV7b annotation recording={0} error=orphan pannEpoch={1}",
+                            id, pannProbe.SourceSidecarEpoch)));
+                    continue;
+                }
+
+                if (!TrajectorySidecarBinary.TryProbe(precPath, out TrajectorySidecarProbe precProbe))
+                    continue; // the .prec problem is INV5's to report, not INV7b's.
+
+                if (pannProbe.SourceSidecarEpoch < precProbe.SidecarEpoch)
+                {
+                    findings.Add(Warn(id, -1,
+                        Inv("INV7b annotation recording={0} error=stale pannEpoch={1} precEpoch={2}",
+                            id, pannProbe.SourceSidecarEpoch, precProbe.SidecarEpoch)));
+                }
+            }
+
+            return findings;
+        }
+
+        private static Finding Warn(string target, int sectionIndex, string message) =>
+            new Finding(RuleIdConst, VerdictLevel.Warn, target, sectionIndex, message,
+                "PannotationsSidecarBinary.TryProbe");
+
+        private static string Inv(string format, params object[] args) =>
+            string.Format(CultureInfo.InvariantCulture, format, args);
+    }
+}

--- a/Source/Parsek.Tests/Analyzer/Rules/Inv7bAnnotationStaleTests.cs
+++ b/Source/Parsek.Tests/Analyzer/Rules/Inv7bAnnotationStaleTests.cs
@@ -1,0 +1,148 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Parsek;
+using Parsek.Tests.Generators;
+using Xunit;
+
+namespace Parsek.Tests.Analyzer.Rules
+{
+    // INV7b annotation staleness. Loader-scoped: writes real .prec sidecars via
+    // ScenarioWriter, then writes .pann sidecars via PannotationsSidecarBinary at a
+    // chosen source epoch and runs the rule over the loaded model. Sequential
+    // because the loader / probes touch RecordingStore statics. Each test names the
+    // regression it guards.
+    [Collection("Sequential")]
+    public class Inv7bAnnotationStaleTests : IDisposable
+    {
+        private readonly string tempDir;
+        private readonly bool prevSuppress;
+
+        public Inv7bAnnotationStaleTests()
+        {
+            prevSuppress = RecordingStore.SuppressLogging;
+            RecordingStore.SuppressLogging = false;
+            RecordingStore.ResetForTesting();
+            ParsekLog.SuppressLogging = true;
+
+            tempDir = Path.Combine(Path.GetTempPath(),
+                "parsek-analyzer-inv7b-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(tempDir);
+        }
+
+        public void Dispose()
+        {
+            RecordingStore.ResetForTesting();
+            RecordingStore.SuppressLogging = prevSuppress;
+            ParsekLog.SuppressLogging = true;
+            if (Directory.Exists(tempDir))
+            {
+                try { Directory.Delete(tempDir, true); }
+                catch { }
+            }
+        }
+
+        private static void WriteSave(string saveDir, ScenarioWriter writer)
+        {
+            string scenarioText = writer.SerializeConfigNode(writer.BuildScenarioNode(), "SCENARIO", 1);
+            string save =
+                "GAME\n{\n\tFLIGHTSTATE\n\t{\n\t\tversion = 1.12.5\n\t}\n" + scenarioText + "}\n";
+            File.WriteAllText(Path.Combine(saveDir, "persistent.sfs"), save);
+        }
+
+        private string BuildSaveWithPrec(string id)
+        {
+            string saveDir = Path.Combine(tempDir, id);
+            Directory.CreateDirectory(saveDir);
+            var writer = new ScenarioWriter().WithV3Format().AddRecordingAsTree(
+                new RecordingBuilder("Ann Craft").WithRecordingId(id)
+                    .AddPoint(100, 0, 0, 1000).AddPoint(110, 0.01, 0.02, 1500));
+            WriteSave(saveDir, writer);
+            writer.WriteSidecarFiles(saveDir);
+            return saveDir;
+        }
+
+        private static int PrecEpoch(string saveDir, string id)
+        {
+            string precPath = Path.Combine(saveDir, RecordingPaths.BuildTrajectoryRelativePath(id));
+            Assert.True(TrajectorySidecarBinary.TryProbe(precPath, out TrajectorySidecarProbe probe));
+            return probe.SidecarEpoch;
+        }
+
+        private static void WritePann(string saveDir, string id, int sourceEpoch)
+        {
+            string pannPath = Path.Combine(saveDir, RecordingPaths.BuildAnnotationsRelativePath(id));
+            PannotationsSidecarBinary.Write(
+                pannPath,
+                id,
+                sourceEpoch,
+                RecordingStore.CurrentRecordingFormatVersion,
+                new byte[32],
+                new List<KeyValuePair<int, Parsek.Rendering.SmoothingSpline>>());
+        }
+
+        private static List<Finding> Run(string saveDir)
+        {
+            AnalyzerModel model = SaveDirectoryLoader.Load(saveDir, name => null);
+            return new Inv7bAnnotationStale().Evaluate(model).ToList();
+        }
+
+        // Guards: a .pann whose SourceSidecarEpoch matches the paired .prec -> zero
+        // INV7b findings. Fails if fresh annotations are flagged stale.
+        [Fact]
+        public void FreshAnnotation_NoFindings()
+        {
+            string saveDir = BuildSaveWithPrec("fresh0");
+            WritePann(saveDir, "fresh0", PrecEpoch(saveDir, "fresh0"));
+
+            Assert.Empty(Run(saveDir));
+        }
+
+        // Guards (edge case 15): a .pann whose SourceSidecarEpoch is behind the
+        // paired .prec's current epoch -> WARN. Fails if a stale smoothing cache
+        // passes, rendering a ghost from outdated annotations.
+        [Fact]
+        public void StaleAnnotation_Warns()
+        {
+            string saveDir = BuildSaveWithPrec("stale0");
+            WritePann(saveDir, "stale0", PrecEpoch(saveDir, "stale0") - 1);
+
+            List<Finding> findings = Run(saveDir);
+
+            Finding warn = Assert.Single(findings);
+            Assert.Equal(Inv7bAnnotationStale.RuleIdConst, warn.RuleId);
+            Assert.Equal(VerdictLevel.Warn, warn.Level);
+            Assert.Contains("error=stale", warn.Message);
+        }
+
+        // Guards (edge case 15): a .pann with no paired .prec is an orphan cache ->
+        // WARN. Fails if orphan annotations pass silently.
+        [Fact]
+        public void OrphanAnnotation_Warns()
+        {
+            string saveDir = Path.Combine(tempDir, "orphan");
+            Directory.CreateDirectory(saveDir);
+            Directory.CreateDirectory(Path.Combine(saveDir, "Parsek", "Recordings"));
+            File.WriteAllText(Path.Combine(saveDir, "persistent.sfs"),
+                "GAME\n{\n\tFLIGHTSTATE\n\t{\n\t\tversion = 1.12.5\n\t}\n}\n");
+            WritePann(saveDir, "orphan0", 3);
+
+            List<Finding> findings = Run(saveDir);
+
+            Finding warn = Assert.Single(findings);
+            Assert.Equal(VerdictLevel.Warn, warn.Level);
+            Assert.Contains("error=orphan", warn.Message);
+        }
+
+        // Guards (core-purity): a null SaveDirectory (in-memory model) -> zero
+        // findings, no file access. Fails if INV7b reaches for files without a save
+        // dir, blocking the H5 in-game reuse.
+        [Fact]
+        public void NullSaveDirectory_NoFindings()
+        {
+            var model = new AnalyzerModel { SaveName = "mem" };
+            Assert.Empty(new Inv7bAnnotationStale().Evaluate(model).ToList());
+        }
+    }
+}

--- a/Source/Parsek.Tests/Analyzer/Rules/Inv8Ledger.cs
+++ b/Source/Parsek.Tests/Analyzer/Rules/Inv8Ledger.cs
@@ -146,6 +146,15 @@ namespace Parsek.Tests.Analyzer.Rules
                 Inv("INV8 els raw={0} tombstoned={1} els={2}",
                     rawActionIds.Count, tombstonedIds.Count, elsCount));
 
+            // Single-report policy (mirrors INV5's tested faulted-trajectory skip):
+            // when the ledger file itself failed to load, the RAW action list is
+            // incomplete or empty, so every tombstone would look dangling. That is
+            // not an ELS inconsistency -- it is a load failure the LOADER-FAULT rule
+            // already reports as the authoritative finding. Skip the per-tombstone
+            // dangling check so the corrupt ledger is reported exactly once.
+            if (HasLedgerFault(model))
+                return;
+
             if (model.Tombstones == null)
                 return;
 
@@ -164,6 +173,16 @@ namespace Parsek.Tests.Analyzer.Rules
                         t.TombstoneId ?? "<none>", t.ActionId),
                     "EffectiveState.ComputeELS"));
             }
+        }
+
+        private static bool HasLedgerFault(AnalyzerModel model)
+        {
+            if (model.LoadFaults == null)
+                return false;
+            foreach (LoadFault f in model.LoadFaults)
+                if (f.FileKind == "ledger")
+                    return true;
+            return false;
         }
 
         private static string Inv(string format, params object[] args) =>

--- a/Source/Parsek.Tests/Analyzer/Rules/Inv8Ledger.cs
+++ b/Source/Parsek.Tests/Analyzer/Rules/Inv8Ledger.cs
@@ -1,0 +1,101 @@
+using System.Collections.Generic;
+using System.Globalization;
+using Parsek;
+
+namespace Parsek.Tests.Analyzer.Rules
+{
+    // INV8 ledger (design doc "The invariant rules" INV8, edge cases 16-18, 17b).
+    //
+    // Two parts, distinct severities. Pure over the model; the loader materialized
+    // the RAW, unfiltered Ledger.Actions (correction C1) and the tombstone rows so
+    // this rule can reconstruct the ELS filter itself.
+    //
+    // Part (a) -- ELS internal consistency (FAIL, every save). The rule computes
+    // the ELS filter internally from model.Ledger (raw actions) minus any action
+    // whose ActionId is tombstoned (the ELS definition cited in EffectiveState.cs;
+    // it NEVER calls the static EffectiveState.ComputeELS, which reads process
+    // statics -- correction C3). Because the input is the RAW list, the check is
+    // non-vacuous: every tombstone's target ActionId must resolve against the raw
+    // actions, and a tombstone pointing at an id absent from them is a real
+    // dangling reference -> FAIL. Runs for career and non-career saves alike.
+    //
+    // Part (b) -- career-diff reconstruction (WARN, career only). See the 5.2
+    // continuation below.
+    internal sealed class Inv8Ledger : IRecordingInvariant
+    {
+        internal const string RuleIdConst = "INV8-LEDGER";
+
+        public string RuleId => RuleIdConst;
+
+        public string CitedContract =>
+            "EffectiveState.ComputeELS (ELS definition) / CareerSaveParser.Parse / LedgerGroundTruthDiff.Compare";
+
+        public IEnumerable<Finding> Evaluate(AnalyzerModel model)
+        {
+            var findings = new List<Finding>();
+            if (model == null)
+                return findings;
+
+            EvaluateEls(model, findings);
+            return findings;
+        }
+
+        // --- Part (a): ELS internal consistency (RAW model, every save) ---
+
+        private static void EvaluateEls(AnalyzerModel model, List<Finding> findings)
+        {
+            var rawActionIds = new HashSet<string>(System.StringComparer.Ordinal);
+            if (model.Ledger != null)
+            {
+                foreach (GameAction a in model.Ledger)
+                {
+                    if (a != null && !string.IsNullOrEmpty(a.ActionId))
+                        rawActionIds.Add(a.ActionId);
+                }
+            }
+
+            // Compute the ELS filter internally (raw actions minus tombstoned ids).
+            // Not consumed by the dangling check itself -- it is the ELS definition
+            // made explicit so this rule and EffectiveState.ComputeELS agree on the
+            // filter without the analyzer touching the process-static computation.
+            var tombstonedIds = new HashSet<string>(System.StringComparer.Ordinal);
+            if (model.Tombstones != null)
+            {
+                foreach (LedgerTombstone t in model.Tombstones)
+                {
+                    if (t != null && !string.IsNullOrEmpty(t.ActionId))
+                        tombstonedIds.Add(t.ActionId);
+                }
+            }
+            int elsCount = 0;
+            foreach (string id in rawActionIds)
+                if (!tombstonedIds.Contains(id))
+                    elsCount++;
+            ParsekLog.Verbose("Analyzer",
+                Inv("INV8 els raw={0} tombstoned={1} els={2}",
+                    rawActionIds.Count, tombstonedIds.Count, elsCount));
+
+            if (model.Tombstones == null)
+                return;
+
+            foreach (LedgerTombstone t in model.Tombstones)
+            {
+                if (t == null || string.IsNullOrEmpty(t.ActionId))
+                    continue;
+                if (rawActionIds.Contains(t.ActionId))
+                    continue;
+                findings.Add(new Finding(
+                    RuleIdConst,
+                    VerdictLevel.Fail,
+                    t.TombstoneId ?? "<tombstone>",
+                    -1,
+                    Inv("INV8 dangling-tombstone tombstone={0} actionId={1} kind=els-inconsistency",
+                        t.TombstoneId ?? "<none>", t.ActionId),
+                    "EffectiveState.ComputeELS"));
+            }
+        }
+
+        private static string Inv(string format, params object[] args) =>
+            string.Format(CultureInfo.InvariantCulture, format, args);
+    }
+}

--- a/Source/Parsek.Tests/Analyzer/Rules/Inv8Ledger.cs
+++ b/Source/Parsek.Tests/Analyzer/Rules/Inv8Ledger.cs
@@ -19,16 +19,43 @@ namespace Parsek.Tests.Analyzer.Rules
     // actions, and a tombstone pointing at an id absent from them is a real
     // dangling reference -> FAIL. Runs for career and non-career saves alike.
     //
-    // Part (b) -- career-diff reconstruction (WARN, career only). See the 5.2
-    // continuation below.
+    // Part (b) -- career-diff reconstruction (WARN, career only). The rule diffs a
+    // headless ledger reconstruction against the parsed career totals via
+    // LedgerGroundTruthDiff.Compare with a hardcoded stock facility-max-levels map
+    // (the live-KSP injection has no offline equivalent). ANY divergence -> WARN,
+    // NEVER FAIL offline: the FAIL-severity career diff is the in-game H5 path
+    // (module M-A3), where the LedgerGroundTruthHarness reconstructs against a live
+    // quicksave. In v1 no headless reconstruction is built (correction C5, the
+    // recalc seam is deferred), so a career save with no injected reconstruction
+    // reports reconstruction-not-available INFO. A non-career save skips part (b)
+    // entirely (silent: the career diff carries no information on a Sandbox save,
+    // and staying finding-free preserves the clean-data-is-green convention).
     internal sealed class Inv8Ledger : IRecordingInvariant
     {
         internal const string RuleIdConst = "INV8-LEDGER";
+        internal const string CareerDiffRuleId = "INV8-CAREER-DIFF";
 
         public string RuleId => RuleIdConst;
 
         public string CitedContract =>
             "EffectiveState.ComputeELS (ELS definition) / CareerSaveParser.Parse / LedgerGroundTruthDiff.Compare";
+
+        // Hardcoded stock facility-max-levels (0-based max index; stock facilities
+        // are 3-tier -> 2), standing in for the live-KSP injection the in-game path
+        // uses. Keys match the display facility ids CareerSaveParser records.
+        private static readonly IReadOnlyDictionary<string, int> StockFacilityMaxLevels =
+            new Dictionary<string, int>(System.StringComparer.Ordinal)
+            {
+                ["SpaceCenter/LaunchPad"] = 2,
+                ["SpaceCenter/Runway"] = 2,
+                ["SpaceCenter/VehicleAssemblyBuilding"] = 2,
+                ["SpaceCenter/SpaceplaneHangar"] = 2,
+                ["SpaceCenter/TrackingStation"] = 2,
+                ["SpaceCenter/AstronautComplex"] = 2,
+                ["SpaceCenter/MissionControl"] = 2,
+                ["SpaceCenter/AdministrationFacility"] = 2,
+                ["SpaceCenter/ResearchAndDevelopment"] = 2,
+            };
 
         public IEnumerable<Finding> Evaluate(AnalyzerModel model)
         {
@@ -37,7 +64,51 @@ namespace Parsek.Tests.Analyzer.Rules
                 return findings;
 
             EvaluateEls(model, findings);
+            EvaluateCareerDiff(model, findings);
             return findings;
+        }
+
+        // --- Part (b): career-diff reconstruction (WARN, career only) ---
+
+        private static void EvaluateCareerDiff(AnalyzerModel model, List<Finding> findings)
+        {
+            // Non-career -> skip (silent). Part (b) has nothing to compare on a
+            // Sandbox / Science save.
+            if (model.CareerSave == null)
+                return;
+
+            if (model.LedgerReconstruction == null)
+            {
+                // No headless reconstruction available offline (correction C5).
+                findings.Add(new Finding(
+                    CareerDiffRuleId,
+                    VerdictLevel.Info,
+                    model.SaveName ?? "<save>",
+                    -1,
+                    "INV8 career-diff reconstruction-not-available (headless recalc deferred)",
+                    "LedgerGroundTruthDiff.Compare"));
+                return;
+            }
+
+            LedgerDivergenceReport report = LedgerGroundTruthDiff.Compare(
+                model.CareerSave,
+                model.LedgerReconstruction,
+                FacetTolerances.Default,
+                StockFacilityMaxLevels);
+
+            if (report == null || report.All.Count == 0)
+                return; // clean reconstruction -> no finding
+
+            // ANY divergence (hard or report-only) -> WARN offline, never FAIL.
+            int hard = report.HardFailures(LedgerGroundTruthDiff.StrictPerIdentityForTesting).Count;
+            findings.Add(new Finding(
+                CareerDiffRuleId,
+                VerdictLevel.Warn,
+                model.SaveName ?? "<save>",
+                -1,
+                Inv("INV8 career-diff divergences={0} hard={1} reportOnly={2}",
+                    report.All.Count, hard, report.All.Count - hard),
+                "LedgerGroundTruthDiff.Compare"));
         }
 
         // --- Part (a): ELS internal consistency (RAW model, every save) ---

--- a/Source/Parsek.Tests/Analyzer/Rules/Inv8LedgerCareerDiffTests.cs
+++ b/Source/Parsek.Tests/Analyzer/Rules/Inv8LedgerCareerDiffTests.cs
@@ -1,0 +1,84 @@
+using System.Collections.Generic;
+using System.Linq;
+using Parsek;
+using Xunit;
+
+namespace Parsek.Tests.Analyzer.Rules
+{
+    // INV8 part (b): career-diff reconstruction. Pure in-memory fixtures build a
+    // CareerSaveSnapshot and (where a reconstruction is injected) a
+    // LedgerReconstructionSnapshot directly. Each test names the regression.
+    public class Inv8LedgerCareerDiffTests
+    {
+        private static AnalyzerModel ModelWith(
+            CareerSaveSnapshot career, LedgerReconstructionSnapshot recon)
+        {
+            return new AnalyzerModel
+            {
+                SaveName = "inv8-career",
+                CareerSave = career,
+                LedgerReconstruction = recon,
+            };
+        }
+
+        private static List<Finding> Run(AnalyzerModel model)
+        {
+            return new Inv8Ledger().Evaluate(model).ToList();
+        }
+
+        private static CareerSaveSnapshot Career(double funds) =>
+            new CareerSaveSnapshot { Parsed = true, HasFunds = true, Funds = funds };
+
+        private static LedgerReconstructionSnapshot Recon(double funds) =>
+            new LedgerReconstructionSnapshot { HasFunds = true, Funds = funds };
+
+        // Guards: a career reconstruction that matches the parsed totals -> zero
+        // INV8 career-diff findings. Fails if the LedgerGroundTruthDiff wiring is
+        // wrong and a matching reconstruction diverges.
+        [Fact]
+        public void MatchingReconstruction_NoCareerDiffFinding()
+        {
+            List<Finding> findings = Run(ModelWith(Career(1000.0), Recon(1000.0)));
+
+            Assert.DoesNotContain(findings, f => f.RuleId == Inv8Ledger.CareerDiffRuleId);
+        }
+
+        // Guards (edge case 16): a funds divergence beyond tolerance -> WARN, NEVER
+        // FAIL offline (the FAIL-severity career diff is the in-game H5 path). Fails
+        // if the offline analyzer promotes a career-diff divergence to FAIL.
+        [Fact]
+        public void FundsDivergence_Warns_NeverFails()
+        {
+            List<Finding> findings = Run(ModelWith(Career(1000.0), Recon(500.0)));
+
+            Finding warn = Assert.Single(findings, f => f.RuleId == Inv8Ledger.CareerDiffRuleId);
+            Assert.Equal(VerdictLevel.Warn, warn.Level);
+            Assert.Contains("divergences=", warn.Message);
+            Assert.DoesNotContain(findings, f => f.Level == VerdictLevel.Fail);
+        }
+
+        // Guards (correction C5): a career save with no injected reconstruction ->
+        // INFO reconstruction-not-available, never FAIL/WARN. Fails if the offline
+        // rule fabricates a reconstruction or hard-fails on the deferred seam.
+        [Fact]
+        public void CareerNoReconstruction_InfoReconstructionNotAvailable()
+        {
+            List<Finding> findings = Run(ModelWith(Career(1000.0), null));
+
+            Finding info = Assert.Single(findings, f => f.RuleId == Inv8Ledger.CareerDiffRuleId);
+            Assert.Equal(VerdictLevel.Info, info.Level);
+            Assert.Contains("reconstruction-not-available", info.Message);
+        }
+
+        // Guards (edge case 18): a non-career save skips part (b) entirely -> no
+        // career-diff finding. Fails if the ledger rule crashes or fabricates a
+        // career-diff finding on a null CareerSaveSnapshot.
+        [Fact]
+        public void NonCareer_NoCareerDiffFinding()
+        {
+            List<Finding> findings = Run(ModelWith(null, null));
+
+            Assert.DoesNotContain(findings, f => f.RuleId == Inv8Ledger.CareerDiffRuleId);
+        }
+    }
+}

--- a/Source/Parsek.Tests/Analyzer/Rules/Inv8LedgerElsTests.cs
+++ b/Source/Parsek.Tests/Analyzer/Rules/Inv8LedgerElsTests.cs
@@ -1,0 +1,94 @@
+using System.Collections.Generic;
+using System.Linq;
+using Parsek;
+using Xunit;
+
+namespace Parsek.Tests.Analyzer.Rules
+{
+    // INV8 part (a): ELS internal consistency over the RAW model. Pure in-memory
+    // fixtures (ScenarioWriter cannot emit tombstone rows, correction C4). Each
+    // test names the regression it guards.
+    public class Inv8LedgerElsTests
+    {
+        private static AnalyzerModel ModelWith(
+            IEnumerable<GameAction> ledger,
+            IEnumerable<LedgerTombstone> tombstones,
+            bool career = false)
+        {
+            return new AnalyzerModel
+            {
+                SaveName = "inv8-els",
+                Ledger = (ledger ?? Enumerable.Empty<GameAction>()).ToList(),
+                Tombstones = (tombstones ?? Enumerable.Empty<LedgerTombstone>()).ToList(),
+                CareerSave = career ? new CareerSaveSnapshot { Parsed = true, HasFunds = true } : null,
+            };
+        }
+
+        private static List<Finding> Run(AnalyzerModel model)
+        {
+            return new Inv8Ledger().Evaluate(model).ToList();
+        }
+
+        private static GameAction Act(string id) => new GameAction { ActionId = id };
+
+        private static LedgerTombstone Tomb(string tombId, string actionId) =>
+            new LedgerTombstone { TombstoneId = tombId, ActionId = actionId, RetiringRecordingId = "r" };
+
+        // Guards: a tombstone whose target ActionId IS present in the raw ledger ->
+        // zero INV8 findings, proving the check runs against the RAW (unfiltered)
+        // action list so a resolving tombstone is accepted. Fails if the model were
+        // fed a pre-filtered ELS list (the tombstoned action would be gone and the
+        // check would false-alarm or go vacuous).
+        [Fact]
+        public void ResolvingTombstone_OverRawLedger_NoFindings()
+        {
+            var model = ModelWith(
+                new[] { Act("act_1"), Act("act_2") },
+                new[] { Tomb("t1", "act_1") });
+
+            Assert.Empty(Run(model));
+        }
+
+        // Guards (edge case 17b): a tombstone whose target ActionId is absent from
+        // the raw ledger -> FAIL. Fails if a dangling tombstone passes (the
+        // regression a pre-filtered ELS list would hide by construction).
+        [Fact]
+        public void DanglingTombstone_Fails()
+        {
+            var model = ModelWith(
+                new[] { Act("act_1") },
+                new[] { Tomb("t-bad", "act_missing") });
+
+            List<Finding> findings = Run(model);
+
+            Finding fail = Assert.Single(findings);
+            Assert.Equal(Inv8Ledger.RuleIdConst, fail.RuleId);
+            Assert.Equal(VerdictLevel.Fail, fail.Level);
+            Assert.Equal("t-bad", fail.Target);
+            Assert.Contains("actionId=act_missing", fail.Message);
+        }
+
+        // Guards (edge case 18): part (a) runs for a non-career save too - a
+        // dangling tombstone on a Sandbox model still FAILs. Fails if the ledger
+        // rule short-circuits on a null CareerSaveSnapshot.
+        [Fact]
+        public void NonCareer_ElsConsistency_StillRuns()
+        {
+            var model = ModelWith(
+                new[] { Act("act_1") },
+                new[] { Tomb("t-bad", "act_missing") },
+                career: false);
+
+            Assert.Contains(Run(model), f =>
+                f.Level == VerdictLevel.Fail && f.Message.Contains("els-inconsistency"));
+        }
+
+        // Guards: no tombstones -> zero findings, and the rule does not throw on an
+        // empty / null ledger. Fails if the ELS reconstruction NREs on empty input.
+        [Fact]
+        public void EmptyLedgerAndTombstones_NoFindings_NoThrow()
+        {
+            Assert.Empty(Run(ModelWith(null, null)));
+        }
+    }
+}

--- a/Source/Parsek.Tests/Analyzer/Rules/Inv8LedgerElsTests.cs
+++ b/Source/Parsek.Tests/Analyzer/Rules/Inv8LedgerElsTests.cs
@@ -83,6 +83,27 @@ namespace Parsek.Tests.Analyzer.Rules
                 f.Level == VerdictLevel.Fail && f.Message.Contains("els-inconsistency"));
         }
 
+        // Guards (single-report policy): when the ledger file failed to load
+        // (LoadFault{FileKind="ledger"}), the RAW action list is incomplete, so
+        // every tombstone would look dangling. INV8(a) must skip the per-tombstone
+        // dangling check and defer to the LOADER-FAULT finding, mirroring INV5's
+        // tested faulted-trajectory skip. Fails if INV8 double-reports a corrupt
+        // ledger as an ELS inconsistency.
+        [Fact]
+        public void LedgerLoadFault_SuppressesDanglingCheck()
+        {
+            var model = ModelWith(
+                Enumerable.Empty<GameAction>(),          // raw actions lost to the fault
+                new[] { Tomb("t-bad", "act_missing") }); // would dangle absent the guard
+            model.LoadFaults = new List<LoadFault>
+            {
+                new LoadFault("/save/Parsek/GameState/ledger.pgld", "ledger", "configNode-load-returned-null", null),
+            };
+
+            Assert.DoesNotContain(Run(model), f =>
+                f.RuleId == Inv8Ledger.RuleIdConst && f.Message.Contains("dangling-tombstone"));
+        }
+
         // Guards: no tombstones -> zero findings, and the rule does not throw on an
         // empty / null ledger. Fails if the ELS reconstruction NREs on empty input.
         [Fact]

--- a/Source/Parsek.Tests/Analyzer/Rules/Inv9RewindPoint.cs
+++ b/Source/Parsek.Tests/Analyzer/Rules/Inv9RewindPoint.cs
@@ -1,0 +1,145 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using Parsek;
+
+namespace Parsek.Tests.Analyzer.Rules
+{
+    // INV9 rewind-point + id validation (design doc "The invariant rules" INV9,
+    // edge case 19).
+    //
+    // Every recording id and every referenced RewindPoint id must pass
+    // RecordingPaths.ValidateRecordingId BEFORE any filesystem access, so a
+    // path-traversal id (../evil) is rejected by validation and never reaches the
+    // filesystem (a security regression if it did). A referenced RewindPoint's
+    // Parsek/RewindPoints/<id>.sfs must exist and parse as a ConfigNode, else
+    // FAIL; an RP quicksave on disk that no recording references -> WARN (orphan).
+    //
+    // File-scoped: existence / parse checks read model.SaveDirectory. Validation
+    // FAILs are emitted regardless of SaveDirectory (they touch no file); the
+    // existence / orphan checks no-op when SaveDirectory is null (a purely
+    // in-memory model / the core-purity test). Never throws.
+    internal sealed class Inv9RewindPoint : IRecordingInvariant
+    {
+        internal const string RuleIdConst = "INV9-REWINDPOINT";
+
+        public string RuleId => RuleIdConst;
+
+        public string CitedContract =>
+            "RecordingPaths.ValidateRecordingId / RecordingPaths.BuildRewindPointRelativePath";
+
+        public IEnumerable<Finding> Evaluate(AnalyzerModel model)
+        {
+            var findings = new List<Finding>();
+            if (model?.Recordings == null)
+                return findings;
+
+            var referencedRpIds = new HashSet<string>(StringComparer.Ordinal);
+
+            foreach (Recording rec in model.Recordings)
+            {
+                if (rec == null)
+                    continue;
+
+                // Every recording id must validate (traversal / invalid chars).
+                if (!string.IsNullOrEmpty(rec.RecordingId)
+                    && !RecordingPaths.ValidateRecordingId(rec.RecordingId, RecordingIdValidationLogContext.Test))
+                {
+                    findings.Add(Fail(rec.RecordingId, -1,
+                        Inv("INV9 badid recording={0} field=RecordingId", rec.RecordingId)));
+                }
+
+                string rpId = rec.RewindSaveFileName;
+                if (string.IsNullOrEmpty(rpId))
+                    continue;
+
+                // Validate the RewindPoint id BEFORE touching the filesystem.
+                if (!RecordingPaths.ValidateRecordingId(rpId, RecordingIdValidationLogContext.Test))
+                {
+                    findings.Add(Fail(rec.RecordingId ?? rpId, -1,
+                        Inv("INV9 badid recording={0} field=RewindSaveFileName rewindId={1}",
+                            rec.RecordingId ?? "<none>", rpId)));
+                    continue;
+                }
+                referencedRpIds.Add(rpId);
+
+                if (string.IsNullOrEmpty(model.SaveDirectory))
+                    continue;
+
+                string rel = RecordingPaths.BuildRewindPointRelativePath(rpId);
+                if (rel == null)
+                    continue; // validated above; defensive
+                string rpPath = Path.Combine(model.SaveDirectory, rel);
+
+                if (!File.Exists(rpPath))
+                {
+                    findings.Add(Fail(rec.RecordingId ?? rpId, -1,
+                        Inv("INV9 missing-rewindpoint recording={0} rewindId={1}",
+                            rec.RecordingId ?? "<none>", rpId)));
+                    continue;
+                }
+
+                if (!ParsesAsConfigNode(rpPath))
+                {
+                    findings.Add(Fail(rec.RecordingId ?? rpId, -1,
+                        Inv("INV9 unparsable-rewindpoint recording={0} rewindId={1}",
+                            rec.RecordingId ?? "<none>", rpId)));
+                }
+            }
+
+            InventoryOrphanRewindPoints(model, referencedRpIds, findings);
+            return findings;
+        }
+
+        private static void InventoryOrphanRewindPoints(
+            AnalyzerModel model, HashSet<string> referencedRpIds, List<Finding> findings)
+        {
+            if (string.IsNullOrEmpty(model.SaveDirectory))
+                return;
+
+            string rpDir = Path.Combine(model.SaveDirectory, RecordingPaths.RewindPointsSubdir);
+            if (!Directory.Exists(rpDir))
+                return;
+
+            string[] files;
+            try
+            {
+                files = Directory.GetFiles(rpDir, "*.sfs");
+            }
+            catch
+            {
+                return;
+            }
+
+            foreach (string file in files)
+            {
+                string id = Path.GetFileNameWithoutExtension(file);
+                if (string.IsNullOrEmpty(id) || referencedRpIds.Contains(id))
+                    continue;
+                findings.Add(new Finding(RuleIdConst, VerdictLevel.Warn, id, -1,
+                    Inv("INV9 orphan-rewindpoint rewindId={0}", id),
+                    "RecordingPaths.BuildRewindPointRelativePath"));
+            }
+        }
+
+        private static bool ParsesAsConfigNode(string path)
+        {
+            try
+            {
+                return ConfigNode.Load(path) != null;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        private static Finding Fail(string target, int sectionIndex, string message) =>
+            new Finding(RuleIdConst, VerdictLevel.Fail, target, sectionIndex, message,
+                "RecordingPaths.ValidateRecordingId");
+
+        private static string Inv(string format, params object[] args) =>
+            string.Format(CultureInfo.InvariantCulture, format, args);
+    }
+}

--- a/Source/Parsek.Tests/Analyzer/Rules/Inv9RewindPointTests.cs
+++ b/Source/Parsek.Tests/Analyzer/Rules/Inv9RewindPointTests.cs
@@ -1,0 +1,147 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Parsek;
+using Parsek.Tests.Generators;
+using Xunit;
+
+namespace Parsek.Tests.Analyzer.Rules
+{
+    // INV9 rewind-point + id validation. Loader-scoped fixtures write real
+    // RewindPoints/<id>.sfs quicksaves; the traversal-id case is pure in-memory to
+    // prove validation fires without a filesystem touch. Sequential because the
+    // loader touches RecordingStore statics. Each test names the regression.
+    [Collection("Sequential")]
+    public class Inv9RewindPointTests : IDisposable
+    {
+        private readonly string tempDir;
+        private readonly bool prevSuppress;
+
+        public Inv9RewindPointTests()
+        {
+            prevSuppress = RecordingStore.SuppressLogging;
+            RecordingStore.SuppressLogging = false;
+            RecordingStore.ResetForTesting();
+            ParsekLog.SuppressLogging = true;
+
+            tempDir = Path.Combine(Path.GetTempPath(),
+                "parsek-analyzer-inv9-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(tempDir);
+        }
+
+        public void Dispose()
+        {
+            RecordingStore.ResetForTesting();
+            RecordingStore.SuppressLogging = prevSuppress;
+            ParsekLog.SuppressLogging = true;
+            if (Directory.Exists(tempDir))
+            {
+                try { Directory.Delete(tempDir, true); }
+                catch { }
+            }
+        }
+
+        private static void WriteSave(string saveDir, ScenarioWriter writer)
+        {
+            string scenarioText = writer.SerializeConfigNode(writer.BuildScenarioNode(), "SCENARIO", 1);
+            string save =
+                "GAME\n{\n\tFLIGHTSTATE\n\t{\n\t\tversion = 1.12.5\n\t}\n" + scenarioText + "}\n";
+            File.WriteAllText(Path.Combine(saveDir, "persistent.sfs"), save);
+        }
+
+        private static void WriteRewindPoint(string saveDir, string rpId)
+        {
+            string dir = Path.Combine(saveDir, RecordingPaths.RewindPointsSubdir);
+            Directory.CreateDirectory(dir);
+            File.WriteAllText(Path.Combine(dir, rpId + ".sfs"),
+                "GAME\n{\n\tversion = 1.12.5\n}\n");
+        }
+
+        private string BuildSave(string name, RecordingBuilder builder)
+        {
+            string saveDir = Path.Combine(tempDir, name);
+            Directory.CreateDirectory(saveDir);
+            var writer = new ScenarioWriter().WithV3Format().AddRecordingAsTree(builder);
+            WriteSave(saveDir, writer);
+            writer.WriteSidecarFiles(saveDir);
+            return saveDir;
+        }
+
+        private static List<Finding> Run(string saveDir)
+        {
+            AnalyzerModel model = SaveDirectoryLoader.Load(saveDir, name => null);
+            return new Inv9RewindPoint().Evaluate(model).ToList();
+        }
+
+        // Guards: a valid RewindPoint id whose Parsek/RewindPoints/<id>.sfs exists
+        // and parses -> zero INV9 findings. Fails if a present, valid RP quicksave
+        // is flagged missing.
+        [Fact]
+        public void ValidRewindPoint_Present_NoFindings()
+        {
+            string saveDir = BuildSave("valid",
+                new RecordingBuilder("RP Craft").WithRecordingId("rp0")
+                    .AddPoint(100, 0, 0, 1000).WithRewindSave("rpfile0"));
+            WriteRewindPoint(saveDir, "rpfile0");
+
+            Assert.Empty(Run(saveDir));
+        }
+
+        // Guards (edge case 19): a RewindPoint id with a path-traversal sequence ->
+        // FAIL via ValidateRecordingId, emitted from a pure in-memory model whose
+        // SaveDirectory is a nonexistent path, so the escaped path is never touched.
+        // Fails if a traversal id reaches the filesystem (security regression).
+        [Fact]
+        public void TraversalRewindId_Fails_WithoutFsAccess()
+        {
+            var model = new AnalyzerModel
+            {
+                SaveName = "trav",
+                SaveDirectory = Path.Combine(tempDir, "does-not-exist"),
+                Recordings = new List<Recording>
+                {
+                    new Recording { RecordingId = "rec0", RewindSaveFileName = "../evil" },
+                },
+            };
+
+            List<Finding> findings = new Inv9RewindPoint().Evaluate(model).ToList();
+
+            Finding fail = Assert.Single(findings);
+            Assert.Equal(VerdictLevel.Fail, fail.Level);
+            Assert.Contains("badid", fail.Message);
+            Assert.Contains("../evil", fail.Message);
+        }
+
+        // Guards: a recording referencing an absent RP file -> FAIL. Fails if a
+        // dangling RewindPoint reference passes (re-fly would fail at load).
+        [Fact]
+        public void MissingRewindPoint_Fails()
+        {
+            string saveDir = BuildSave("missing",
+                new RecordingBuilder("RP Craft").WithRecordingId("rp1")
+                    .AddPoint(100, 0, 0, 1000).WithRewindSave("rpfile-missing"));
+
+            List<Finding> findings = Run(saveDir);
+
+            Finding fail = Assert.Single(findings, f => f.Level == VerdictLevel.Fail);
+            Assert.Contains("missing-rewindpoint", fail.Message);
+        }
+
+        // Guards: an RP quicksave on disk that no recording references -> WARN.
+        // Fails if orphan rewind points are ignored.
+        [Fact]
+        public void OrphanRewindPoint_Warns()
+        {
+            string saveDir = BuildSave("orphan",
+                new RecordingBuilder("RP Craft").WithRecordingId("rp2").AddPoint(100, 0, 0, 1000));
+            WriteRewindPoint(saveDir, "stray-rp");
+
+            List<Finding> findings = Run(saveDir);
+
+            Finding warn = Assert.Single(findings, f => f.Level == VerdictLevel.Warn);
+            Assert.Equal("stray-rp", warn.Target);
+            Assert.Contains("orphan-rewindpoint", warn.Message);
+        }
+    }
+}

--- a/Source/Parsek.Tests/Analyzer/Rules/LoadFaultRule.cs
+++ b/Source/Parsek.Tests/Analyzer/Rules/LoadFaultRule.cs
@@ -1,0 +1,77 @@
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+
+namespace Parsek.Tests.Analyzer.Rules
+{
+    // LOADER-FAULT rule (design doc "The invariant rules" / "The loader": a file
+    // that fails to parse IS a finding, never a crash).
+    //
+    // The loader (SaveDirectoryLoader.Load) records a LoadFault for every file it
+    // could not parse and keeps going. Trajectory (.prec) faults are owned by INV5
+    // and snapshot (_vessel/_ghost.craft) faults by INV4, which each surface them
+    // with their own recording-scoped context. Nothing, however, turned a corrupt
+    // persistent.sfs, a throwing RECORDING tree node, or an unparsable ledger.pgld
+    // into a report finding: those faults have no other rule, so a corrupt save
+    // analyzed GREEN. This rule closes that hole by emitting a FAIL for every
+    // LoadFault whose FileKind is one of {sfs, tree-node, ledger}, and deliberately
+    // ignores the trajectory/snapshot kinds so a fault is reported exactly once.
+    internal sealed class LoadFaultRule : IRecordingInvariant
+    {
+        internal const string RuleIdConst = "LOADER-FAULT";
+
+        // FileKinds this rule owns. trajectory -> INV5, snapshot -> INV4; excluded
+        // here so a single fault never produces two findings.
+        private static readonly HashSet<string> OwnedKinds =
+            new HashSet<string>(System.StringComparer.Ordinal)
+            {
+                "sfs",
+                "tree-node",
+                "ledger",
+            };
+
+        public string RuleId => RuleIdConst;
+
+        public string CitedContract => "SaveDirectoryLoader.Load / ConfigNode.Load";
+
+        public IEnumerable<Finding> Evaluate(AnalyzerModel model)
+        {
+            var findings = new List<Finding>();
+            if (model?.LoadFaults == null)
+                return findings;
+
+            foreach (LoadFault f in model.LoadFaults)
+            {
+                if (!OwnedKinds.Contains(f.FileKind))
+                    continue;
+
+                // Target is deterministic (never the machine-specific absolute
+                // path): the recording id when the fault carries one, else a
+                // kind token. The filename (not the directory) goes in the
+                // message so a triage grep can name the file without leaking the
+                // temp/save path into the report bytes.
+                string target = !string.IsNullOrEmpty(f.RecordingId)
+                    ? f.RecordingId
+                    : "<" + (f.FileKind ?? "unknown") + ">";
+                string file = string.IsNullOrEmpty(f.FilePath) ? "" : Path.GetFileName(f.FilePath);
+
+                findings.Add(new Finding(
+                    RuleIdConst,
+                    VerdictLevel.Fail,
+                    target,
+                    -1,
+                    Inv("LOADER-FAULT kind={0} recording={1} file={2} reason={3}",
+                        f.FileKind ?? "unknown",
+                        f.RecordingId ?? "<none>",
+                        file,
+                        f.Reason ?? "unknown"),
+                    "SaveDirectoryLoader.Load / ConfigNode.Load"));
+            }
+
+            return findings;
+        }
+
+        private static string Inv(string format, params object[] args) =>
+            string.Format(CultureInfo.InvariantCulture, format, args);
+    }
+}

--- a/Source/Parsek.Tests/Analyzer/Rules/LoadFaultRuleTests.cs
+++ b/Source/Parsek.Tests/Analyzer/Rules/LoadFaultRuleTests.cs
@@ -1,0 +1,114 @@
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace Parsek.Tests.Analyzer.Rules
+{
+    // LOADER-FAULT rule. Pure in-memory AnalyzerModel fixtures (no loader, no
+    // disk): the loader's job is only to POPULATE LoadFaults; this rule's job is to
+    // turn the owned kinds into FAIL findings. Each test names the regression it
+    // guards.
+    public class LoadFaultRuleTests
+    {
+        private static AnalyzerModel ModelWith(params LoadFault[] faults)
+        {
+            return new AnalyzerModel
+            {
+                SaveName = "loadfault",
+                LoadFaults = faults.ToList(),
+            };
+        }
+
+        private static List<Finding> Run(AnalyzerModel model)
+        {
+            return new LoadFaultRule().Evaluate(model).ToList();
+        }
+
+        // Guards the blocker: a corrupt persistent.sfs (the sfs LoadFault the loader
+        // records) becomes a FAIL, so a corrupt save no longer analyzes GREEN. Fails
+        // if the sfs kind is dropped and the report goes silent on a broken save.
+        [Fact]
+        public void SfsFault_Fails()
+        {
+            List<Finding> findings = Run(ModelWith(
+                new LoadFault("/save/persistent.sfs", "sfs", "unbalanced-braces", null)));
+
+            Finding fail = Assert.Single(findings);
+            Assert.Equal(LoadFaultRule.RuleIdConst, fail.RuleId);
+            Assert.Equal(VerdictLevel.Fail, fail.Level);
+            Assert.Contains("kind=sfs", fail.Message);
+            Assert.Contains("reason=unbalanced-braces", fail.Message);
+            // Deterministic: the machine-specific directory never leaks into the
+            // report; only the filename does.
+            Assert.DoesNotContain("/save/", fail.Message);
+            Assert.Contains("file=persistent.sfs", fail.Message);
+        }
+
+        // Guards: a throwing RECORDING tree node (tree-node LoadFault) becomes a
+        // FAIL carrying the recording id. Fails if a corrupt tree record is silently
+        // skipped with no finding.
+        [Fact]
+        public void TreeNodeFault_Fails()
+        {
+            List<Finding> findings = Run(ModelWith(
+                new LoadFault("/save/persistent.sfs", "tree-node", "FormatException: bad", "rec-7")));
+
+            Finding fail = Assert.Single(findings);
+            Assert.Equal(VerdictLevel.Fail, fail.Level);
+            Assert.Equal("rec-7", fail.Target);
+            Assert.Contains("kind=tree-node", fail.Message);
+            Assert.Contains("recording=rec-7", fail.Message);
+        }
+
+        // Guards: an unparsable ledger.pgld (ledger LoadFault) becomes a FAIL. Fails
+        // if a corrupt ledger analyzes GREEN.
+        [Fact]
+        public void LedgerFault_Fails()
+        {
+            List<Finding> findings = Run(ModelWith(
+                new LoadFault("/save/Parsek/GameState/ledger.pgld", "ledger", "configNode-load-returned-null", null)));
+
+            Finding fail = Assert.Single(findings);
+            Assert.Equal(VerdictLevel.Fail, fail.Level);
+            Assert.Equal("<ledger>", fail.Target);
+            Assert.Contains("kind=ledger", fail.Message);
+        }
+
+        // Guards single-report policy: trajectory and snapshot faults are owned by
+        // INV5 / INV4 respectively, so this rule must NOT double-report them. Fails
+        // if the owned-kind filter regresses and a .prec/.craft fault is counted
+        // twice.
+        [Fact]
+        public void TrajectoryAndSnapshotFaults_NotReported()
+        {
+            List<Finding> findings = Run(ModelWith(
+                new LoadFault("/save/Parsek/Recordings/r.prec", "trajectory", "truncated", "r"),
+                new LoadFault("/save/Parsek/Recordings/r_vessel.craft", "snapshot", "snapshot-load-failed", "r")));
+
+            Assert.Empty(findings);
+        }
+
+        // Guards: every owned fault produces its own FAIL (counts are not collapsed).
+        // Fails if the rule emits a single aggregate finding and loses per-file
+        // triage detail.
+        [Fact]
+        public void MultipleOwnedFaults_EachFails()
+        {
+            List<Finding> findings = Run(ModelWith(
+                new LoadFault("/save/persistent.sfs", "sfs", "unbalanced-braces", null),
+                new LoadFault("/save/Parsek/GameState/ledger.pgld", "ledger", "bad", null)));
+
+            Assert.Equal(2, findings.Count);
+            Assert.All(findings, f => Assert.Equal(VerdictLevel.Fail, f.Level));
+        }
+
+        // Guards: no faults / null list -> zero findings and no throw (clean saves
+        // stay GREEN and the rule survives the core-purity in-memory model).
+        [Fact]
+        public void NoFaults_NoFindings_NoThrow()
+        {
+            Assert.Empty(Run(ModelWith()));
+            Assert.Empty(new LoadFaultRule().Evaluate(new AnalyzerModel { SaveName = "empty" }));
+        }
+    }
+}

--- a/Source/Parsek.Tests/Analyzer/SaveDirectoryLoader.cs
+++ b/Source/Parsek.Tests/Analyzer/SaveDirectoryLoader.cs
@@ -20,6 +20,9 @@ namespace Parsek.Tests.Analyzer
             {
                 SaveName = ResolveSaveName(saveDir),
                 BodyResolver = bodyResolver,
+                // File-scoped rules (INV7b / INV9) probe sidecars the loader does not
+                // pre-materialize; they read this and no-op when it is null.
+                SaveDirectory = saveDir,
             };
 
             var recordings = new List<Recording>();

--- a/Source/Parsek.Tests/Analyzer/SaveDirectoryLoader.cs
+++ b/Source/Parsek.Tests/Analyzer/SaveDirectoryLoader.cs
@@ -1,0 +1,238 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace Parsek.Tests.Analyzer
+{
+    // The M-A1 loader: turns a save directory into a pure AnalyzerModel
+    // (design doc "The loader"). ALL file I/O lives here; a file that fails to
+    // parse becomes a LoadFault, never a crash. The invariant core downstream is
+    // pure over the produced model.
+    //
+    // Phase 1.1 loads the persistent.sfs ParsekScenario node: recording trees +
+    // recordings, ledger tombstones, and supersede relations. Phase 1.2 adds the
+    // sidecar hydration + probe capture; Phase 1.3 adds the ledger + career parse.
+    internal static class SaveDirectoryLoader
+    {
+        internal static AnalyzerModel Load(string saveDir, Func<string, CelestialBody> bodyResolver)
+        {
+            var model = new AnalyzerModel
+            {
+                SaveName = ResolveSaveName(saveDir),
+                BodyResolver = bodyResolver,
+            };
+
+            var recordings = new List<Recording>();
+            var trees = new List<RecordingTree>();
+            var tombstones = new List<LedgerTombstone>();
+            var supersedes = new List<RecordingSupersedeRelation>();
+            var loadFaults = new List<LoadFault>();
+
+            // Quiet the production sidecar/tree logging during load; the analyzer
+            // is not a KSP session and should not spam KSP-style lines.
+            bool prevSuppress = RecordingStore.SuppressLogging;
+            RecordingStore.SuppressLogging = true;
+            try
+            {
+                string sfsPath = string.IsNullOrEmpty(saveDir)
+                    ? null
+                    : Path.Combine(saveDir, "persistent.sfs");
+
+                ConfigNode root = TryLoadSfs(sfsPath, loadFaults);
+                if (root != null)
+                {
+                    ConfigNode gameNode = DescendToGameNode(root);
+                    ConfigNode scenario = FindParsekScenario(gameNode);
+                    if (scenario != null)
+                    {
+                        LoadTrees(scenario, sfsPath, trees, recordings, loadFaults);
+                        LoadStagingEntries(scenario, "RECORDING_SUPERSEDES",
+                            supersedes, RecordingSupersedeRelation.LoadFrom);
+                        LoadStagingEntries(scenario, "LEDGER_TOMBSTONES",
+                            tombstones, LedgerTombstone.LoadFrom);
+                    }
+                }
+            }
+            finally
+            {
+                RecordingStore.SuppressLogging = prevSuppress;
+            }
+
+            model.Recordings = recordings;
+            model.Trees = trees;
+            model.Tombstones = tombstones;
+            model.SupersedeRelations = supersedes;
+            model.LoadFaults = loadFaults;
+            return model;
+        }
+
+        private static string ResolveSaveName(string saveDir)
+        {
+            if (string.IsNullOrEmpty(saveDir))
+                return "";
+            // Directory name, robust to a trailing separator.
+            string trimmed = saveDir.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+            string name = Path.GetFileName(trimmed);
+            return string.IsNullOrEmpty(name) ? trimmed : name;
+        }
+
+        private static ConfigNode TryLoadSfs(string sfsPath, List<LoadFault> loadFaults)
+        {
+            if (string.IsNullOrEmpty(sfsPath) || !File.Exists(sfsPath))
+                return null; // No footprint; not a fault (a rule reports the empty save).
+
+            // Corruption pre-check: KSP's ConfigNode.Load parses unbalanced-brace
+            // content leniently and returns a partial node rather than failing, so a
+            // structural brace-balance check is the deterministic corruption signal
+            // (design edge case "corrupt .sfs (unbalanced braces)").
+            string text;
+            try
+            {
+                text = File.ReadAllText(sfsPath);
+            }
+            catch (Exception ex)
+            {
+                loadFaults.Add(new LoadFault(sfsPath, "sfs", ex.GetType().Name + ": " + ex.Message, null));
+                return null;
+            }
+
+            if (!BracesBalanced(text))
+            {
+                loadFaults.Add(new LoadFault(sfsPath, "sfs", "unbalanced-braces", null));
+                return null;
+            }
+
+            ConfigNode root;
+            try
+            {
+                root = ConfigNode.Load(sfsPath);
+            }
+            catch (Exception ex)
+            {
+                loadFaults.Add(new LoadFault(sfsPath, "sfs", ex.GetType().Name + ": " + ex.Message, null));
+                return null;
+            }
+
+            if (root == null)
+            {
+                loadFaults.Add(new LoadFault(sfsPath, "sfs", "configNode-load-returned-null", null));
+                return null;
+            }
+
+            // A non-empty file that parsed to a structurally empty node is corrupt.
+            if (root.values.Count == 0 && root.nodes.Count == 0 && text.Trim().Length > 0)
+            {
+                loadFaults.Add(new LoadFault(sfsPath, "sfs", "empty-or-unparseable-sfs", null));
+                return null;
+            }
+
+            return root;
+        }
+
+        private static bool BracesBalanced(string text)
+        {
+            if (string.IsNullOrEmpty(text))
+                return true;
+            int depth = 0;
+            for (int i = 0; i < text.Length; i++)
+            {
+                if (text[i] == '{')
+                {
+                    depth++;
+                }
+                else if (text[i] == '}')
+                {
+                    depth--;
+                    if (depth < 0)
+                        return false; // close before open
+                }
+            }
+            return depth == 0;
+        }
+
+        /// <summary>
+        /// Mirrors CareerSaveParser's root-vs-GAME descent: a KSP save's top node is
+        /// GAME, but ConfigNode.Load can return either the GAME node itself (its
+        /// FLIGHTSTATE/SCENARIO children are direct) or a wrapper.
+        /// </summary>
+        private static ConfigNode DescendToGameNode(ConfigNode root)
+        {
+            if (root.GetNode("FLIGHTSTATE") != null)
+                return root;
+            ConfigNode wrapped = root.GetNode("GAME");
+            return wrapped ?? root;
+        }
+
+        private static ConfigNode FindParsekScenario(ConfigNode gameNode)
+        {
+            foreach (ConfigNode scenario in gameNode.GetNodes("SCENARIO"))
+            {
+                if (string.Equals(scenario.GetValue("name"), "ParsekScenario", StringComparison.Ordinal))
+                    return scenario;
+            }
+            return null;
+        }
+
+        private static void LoadTrees(
+            ConfigNode scenario,
+            string sfsPath,
+            List<RecordingTree> trees,
+            List<Recording> recordings,
+            List<LoadFault> loadFaults)
+        {
+            foreach (ConfigNode treeNode in scenario.GetNodes("RECORDING_TREE"))
+            {
+                var tree = new RecordingTree
+                {
+                    Id = treeNode.GetValue("id") ?? "",
+                    TreeName = treeNode.GetValue("treeName") ?? "",
+                    RootRecordingId = treeNode.GetValue("rootRecordingId") ?? "",
+                    ActiveRecordingId = treeNode.GetValue("activeRecordingId"),
+                };
+
+                foreach (ConfigNode recNode in treeNode.GetNodes("RECORDING"))
+                {
+                    var rec = new Recording();
+                    try
+                    {
+                        RecordingTreeRecordCodec.LoadRecordingFrom(recNode, rec);
+                    }
+                    catch (Exception ex)
+                    {
+                        loadFaults.Add(new LoadFault(
+                            sfsPath, "tree-node",
+                            ex.GetType().Name + ": " + ex.Message,
+                            recNode.GetValue("recordingId")));
+                        continue;
+                    }
+
+                    // Include schema-incompatible recordings (LoadRecordingFrom leaves
+                    // RecordingFormatVersion == -1 but keeps the parsed id + generation)
+                    // so INV5 can flag them; the analyzer must SEE what the production
+                    // loader would reject, not silently drop it.
+                    if (string.IsNullOrEmpty(rec.RecordingId))
+                        continue;
+
+                    tree.Recordings[rec.RecordingId] = rec;
+                    rec.TreeId = tree.Id;
+                    recordings.Add(rec);
+                }
+
+                trees.Add(tree);
+            }
+        }
+
+        private static void LoadStagingEntries<T>(
+            ConfigNode scenario,
+            string containerNodeName,
+            List<T> target,
+            Func<ConfigNode, T> loadFrom)
+        {
+            foreach (ConfigNode container in scenario.GetNodes(containerNodeName))
+            {
+                foreach (ConfigNode entry in container.GetNodes("ENTRY"))
+                    target.Add(loadFrom(entry));
+            }
+        }
+    }
+}

--- a/Source/Parsek.Tests/Analyzer/SaveDirectoryLoader.cs
+++ b/Source/Parsek.Tests/Analyzer/SaveDirectoryLoader.cs
@@ -84,7 +84,35 @@ namespace Parsek.Tests.Analyzer
             model.Ledger = ledger;
             model.CareerSave = careerSave;
             model.LoadFaults = loadFaults;
+
+            LogLoadSummary(model, saveDir, loadFaults);
             return model;
+        }
+
+        /// <summary>
+        /// Diagnostic logging (design "Diagnostic Logging"): one per-subject summary
+        /// line at Verbose plus one Warn line per LoadFault. The per-fault Warn makes
+        /// the "a file that failed to parse is itself a finding" contract observable
+        /// in a run log. Emitted once at the end of a load (bounded: faults are few),
+        /// after RecordingStore.SuppressLogging is restored, so these analyzer-tagged
+        /// lines are not suppressed alongside the production sidecar logs.
+        /// </summary>
+        private static void LogLoadSummary(AnalyzerModel model, string saveDir, List<LoadFault> loadFaults)
+        {
+            ParsekLog.Verbose("Analyzer",
+                "load save='" + (model.SaveName ?? "") + "' path='" + (saveDir ?? "") + "'"
+                + " trees=" + model.Trees.Count
+                + " recordings=" + model.Recordings.Count
+                + " loadFaults=" + loadFaults.Count);
+
+            foreach (LoadFault f in loadFaults)
+            {
+                ParsekLog.Warn("Analyzer",
+                    "loadFault kind=" + (f.FileKind ?? "unknown")
+                    + " recording=" + (f.RecordingId ?? "<none>")
+                    + " path='" + (f.FilePath ?? "") + "'"
+                    + " reason=" + (f.Reason ?? "unknown"));
+            }
         }
 
         /// <summary>

--- a/Source/Parsek.Tests/Analyzer/SaveDirectoryLoader.cs
+++ b/Source/Parsek.Tests/Analyzer/SaveDirectoryLoader.cs
@@ -27,6 +27,7 @@ namespace Parsek.Tests.Analyzer
             var tombstones = new List<LedgerTombstone>();
             var supersedes = new List<RecordingSupersedeRelation>();
             var loadFaults = new List<LoadFault>();
+            var sidecarSchema = new Dictionary<string, (int, int)>(StringComparer.Ordinal);
 
             // Quiet the production sidecar/tree logging during load; the analyzer
             // is not a KSP session and should not spam KSP-style lines.
@@ -50,6 +51,7 @@ namespace Parsek.Tests.Analyzer
                             supersedes, RecordingSupersedeRelation.LoadFrom);
                         LoadStagingEntries(scenario, "LEDGER_TOMBSTONES",
                             tombstones, LedgerTombstone.LoadFrom);
+                        LoadSidecars(saveDir, recordings, sidecarSchema, loadFaults);
                     }
                 }
             }
@@ -62,6 +64,7 @@ namespace Parsek.Tests.Analyzer
             model.Trees = trees;
             model.Tombstones = tombstones;
             model.SupersedeRelations = supersedes;
+            model.SidecarSchema = sidecarSchema;
             model.LoadFaults = loadFaults;
             return model;
         }
@@ -232,6 +235,154 @@ namespace Parsek.Tests.Analyzer
             {
                 foreach (ConfigNode entry in container.GetNodes("ENTRY"))
                     target.Add(loadFrom(entry));
+            }
+        }
+
+        // --- Sidecar hydration + probe capture (task 1.2) ---
+
+        private static void LoadSidecars(
+            string saveDir,
+            List<Recording> recordings,
+            Dictionary<string, (int, int)> sidecarSchema,
+            List<LoadFault> loadFaults)
+        {
+            var recordingIds = new HashSet<string>(StringComparer.Ordinal);
+
+            foreach (Recording rec in recordings)
+            {
+                if (string.IsNullOrEmpty(rec.RecordingId))
+                    continue;
+                recordingIds.Add(rec.RecordingId);
+
+                // Reject a malformed id BEFORE touching the filesystem (path traversal,
+                // invalid filename chars). ValidateRecordingId is the production gate.
+                if (!RecordingPaths.ValidateRecordingId(rec.RecordingId, RecordingIdValidationLogContext.Test))
+                {
+                    loadFaults.Add(new LoadFault(null, "trajectory", "invalid-recording-id", rec.RecordingId));
+                    continue;
+                }
+
+                string precPath = Path.Combine(saveDir, RecordingPaths.BuildTrajectoryRelativePath(rec.RecordingId));
+                LoadTrajectorySidecar(precPath, rec, sidecarSchema, loadFaults);
+                LoadSnapshotSidecar(
+                    Path.Combine(saveDir, RecordingPaths.BuildVesselSnapshotRelativePath(rec.RecordingId)),
+                    rec.RecordingId, loadFaults, node => rec.VesselSnapshot = node);
+                LoadSnapshotSidecar(
+                    Path.Combine(saveDir, RecordingPaths.BuildGhostSnapshotRelativePath(rec.RecordingId)),
+                    rec.RecordingId, loadFaults, node => rec.GhostVisualSnapshot = node);
+            }
+
+            InventoryOrphanSidecars(saveDir, recordingIds, sidecarSchema);
+        }
+
+        private static void LoadTrajectorySidecar(
+            string precPath,
+            Recording rec,
+            Dictionary<string, (int, int)> sidecarSchema,
+            List<LoadFault> loadFaults)
+        {
+            // A genuinely absent trajectory sidecar is not a loader fault (the
+            // recording simply has none on disk); INV5 owns any presence policy.
+            if (!File.Exists(precPath))
+                return;
+
+            TrajectorySidecarProbe probe;
+            bool probed = RecordingStore.TryProbeTrajectorySidecar(precPath, out probe);
+            if (!probed)
+            {
+                // Header could not be read at all (e.g. truncated before the magic).
+                loadFaults.Add(new LoadFault(precPath, "trajectory",
+                    string.IsNullOrEmpty(probe.FailureReason) ? "probe-failed" : probe.FailureReason,
+                    rec.RecordingId));
+                return;
+            }
+
+            // C2: capture the sidecar's reported (generation, formatVersion) for INV5.
+            sidecarSchema[rec.RecordingId] = (probe.SchemaGeneration, probe.FormatVersion);
+
+            if (!probe.Supported)
+            {
+                loadFaults.Add(new LoadFault(precPath, "trajectory",
+                    string.IsNullOrEmpty(probe.FailureReason) ? "unsupported" : probe.FailureReason,
+                    rec.RecordingId));
+                return;
+            }
+
+            try
+            {
+                if (!RecordingStore.LoadTrajectorySidecarForTesting(precPath, rec))
+                {
+                    loadFaults.Add(new LoadFault(precPath, "trajectory",
+                        string.IsNullOrEmpty(probe.FailureReason) ? "load-failed" : probe.FailureReason,
+                        rec.RecordingId));
+                }
+            }
+            catch (Exception ex)
+            {
+                loadFaults.Add(new LoadFault(precPath, "trajectory",
+                    ex.GetType().Name + ": " + ex.Message, rec.RecordingId));
+            }
+        }
+
+        private static void LoadSnapshotSidecar(
+            string path,
+            string recordingId,
+            List<LoadFault> loadFaults,
+            Action<ConfigNode> assign)
+        {
+            if (!File.Exists(path))
+                return; // Snapshots are optional (destroyed / showcase recordings).
+
+            try
+            {
+                ConfigNode node;
+                if (RecordingStore.LoadSnapshotSidecarForTesting(path, out node) && node != null)
+                {
+                    assign(node);
+                    return;
+                }
+
+                string reason = "snapshot-load-failed";
+                SnapshotSidecarProbe probe;
+                if (RecordingStore.TryProbeSnapshotSidecar(path, out probe)
+                    && !string.IsNullOrEmpty(probe.FailureReason))
+                {
+                    reason = probe.FailureReason;
+                }
+                loadFaults.Add(new LoadFault(path, "snapshot", reason, recordingId));
+            }
+            catch (Exception ex)
+            {
+                loadFaults.Add(new LoadFault(path, "snapshot",
+                    ex.GetType().Name + ": " + ex.Message, recordingId));
+            }
+        }
+
+        /// <summary>
+        /// Inventories orphan trajectory sidecars: a <c>.prec</c> on disk that no tree
+        /// recording references. Captured into <paramref name="sidecarSchema"/> (a key
+        /// with no matching recording) so INV5 can flag it later, without a dedicated
+        /// model field.
+        /// </summary>
+        private static void InventoryOrphanSidecars(
+            string saveDir,
+            HashSet<string> recordingIds,
+            Dictionary<string, (int, int)> sidecarSchema)
+        {
+            string recordingsDir = Path.Combine(saveDir, "Parsek", "Recordings");
+            if (!Directory.Exists(recordingsDir))
+                return;
+
+            foreach (string precFile in Directory.GetFiles(recordingsDir, "*.prec"))
+            {
+                string id = Path.GetFileNameWithoutExtension(precFile);
+                if (string.IsNullOrEmpty(id) || recordingIds.Contains(id) || sidecarSchema.ContainsKey(id))
+                    continue;
+
+                TrajectorySidecarProbe probe;
+                sidecarSchema[id] = RecordingStore.TryProbeTrajectorySidecar(precFile, out probe)
+                    ? (probe.SchemaGeneration, probe.FormatVersion)
+                    : (0, 0);
             }
         }
     }

--- a/Source/Parsek.Tests/Analyzer/SaveDirectoryLoader.cs
+++ b/Source/Parsek.Tests/Analyzer/SaveDirectoryLoader.cs
@@ -28,6 +28,8 @@ namespace Parsek.Tests.Analyzer
             var supersedes = new List<RecordingSupersedeRelation>();
             var loadFaults = new List<LoadFault>();
             var sidecarSchema = new Dictionary<string, (int, int)>(StringComparer.Ordinal);
+            var ledger = new List<GameAction>();
+            CareerSaveSnapshot careerSave = null;
 
             // Quiet the production sidecar/tree logging during load; the analyzer
             // is not a KSP session and should not spam KSP-style lines.
@@ -53,7 +55,17 @@ namespace Parsek.Tests.Analyzer
                             tombstones, LedgerTombstone.LoadFrom);
                         LoadSidecars(saveDir, recordings, sidecarSchema, loadFaults);
                     }
+
+                    // Career parse (task 1.3): only kept when the save is career
+                    // (Funding present). Non-career -> null, no fault (INV8 owns any
+                    // career-availability finding).
+                    careerSave = ParseCareer(root);
                 }
+
+                // RAW ledger (correction C1): parsed directly from ledger.pgld,
+                // NEVER through Ledger.LoadFromFile, which mutates the process static
+                // Ledger.actions. Unfiltered: INV8 computes the ELS filter itself.
+                LoadLedger(saveDir, ledger, loadFaults);
             }
             finally
             {
@@ -65,6 +77,8 @@ namespace Parsek.Tests.Analyzer
             model.Tombstones = tombstones;
             model.SupersedeRelations = supersedes;
             model.SidecarSchema = sidecarSchema;
+            model.Ledger = ledger;
+            model.CareerSave = careerSave;
             model.LoadFaults = loadFaults;
             return model;
         }
@@ -384,6 +398,66 @@ namespace Parsek.Tests.Analyzer
                     ? (probe.SchemaGeneration, probe.FormatVersion)
                     : (0, 0);
             }
+        }
+
+        // --- Ledger + career parse (task 1.3) ---
+
+        /// <summary>
+        /// Parses <c>saves/&lt;save&gt;/Parsek/GameState/ledger.pgld</c> directly into
+        /// a RAW, unfiltered action list (correction C1). Deliberately does NOT call
+        /// <c>Ledger.LoadFromFile</c> (which mutates the process-static
+        /// <c>Ledger.actions</c>), keeping the loader pure and Sequential-safe.
+        /// </summary>
+        private static void LoadLedger(string saveDir, List<GameAction> ledger, List<LoadFault> loadFaults)
+        {
+            if (string.IsNullOrEmpty(saveDir))
+                return;
+
+            string ledgerPath = Path.Combine(saveDir, RecordingPaths.BuildLedgerRelativePath());
+            if (!File.Exists(ledgerPath))
+                return; // No ledger file == empty ledger; not a fault.
+
+            ConfigNode loaded;
+            try
+            {
+                loaded = ConfigNode.Load(ledgerPath);
+            }
+            catch (Exception ex)
+            {
+                loadFaults.Add(new LoadFault(ledgerPath, "ledger", ex.GetType().Name + ": " + ex.Message, null));
+                return;
+            }
+
+            if (loaded == null)
+            {
+                loadFaults.Add(new LoadFault(ledgerPath, "ledger", "configNode-load-returned-null", null));
+                return;
+            }
+
+            foreach (ConfigNode actionNode in loaded.GetNodes("GAME_ACTION"))
+            {
+                try
+                {
+                    ledger.Add(GameAction.DeserializeFrom(actionNode));
+                }
+                catch (Exception ex)
+                {
+                    loadFaults.Add(new LoadFault(ledgerPath, "ledger", ex.GetType().Name + ": " + ex.Message, null));
+                }
+            }
+        }
+
+        /// <summary>
+        /// Parses the career totals from the loaded save root, returning the snapshot
+        /// only when the save is career (Funding present). Non-career / unparsable ->
+        /// null, no fault (INV8 owns any career-availability finding).
+        /// </summary>
+        private static CareerSaveSnapshot ParseCareer(ConfigNode root)
+        {
+            CareerSaveSnapshot snapshot = CareerSaveParser.Parse(root);
+            if (snapshot != null && snapshot.Parsed && snapshot.HasFunds)
+                return snapshot;
+            return null;
         }
     }
 }

--- a/Source/Parsek.Tests/Analyzer/SaveDirectoryLoader.cs
+++ b/Source/Parsek.Tests/Analyzer/SaveDirectoryLoader.cs
@@ -75,6 +75,7 @@ namespace Parsek.Tests.Analyzer
                 RecordingStore.SuppressLogging = prevSuppress;
             }
 
+            model.FixtureStamp = ParseFixtureStamp(saveDir);
             model.Recordings = recordings;
             model.Trees = trees;
             model.Tombstones = tombstones;
@@ -84,6 +85,48 @@ namespace Parsek.Tests.Analyzer
             model.CareerSave = careerSave;
             model.LoadFaults = loadFaults;
             return model;
+        }
+
+        /// <summary>
+        /// Reads the fixture corpus provenance stamp from
+        /// <c>&lt;saveDir&gt;/fixture-generation.txt</c> (one line:
+        /// <c>generation=&lt;n&gt; provenance=&lt;synthetic|harvested&gt;</c>).
+        /// Returns null for a non-fixture subject (no file), which skips the
+        /// STALE-FIXTURE check entirely. Tolerant of ordering / whitespace; a
+        /// malformed / unreadable file yields null (unstamped) rather than a fault.
+        /// </summary>
+        private static FixtureStamp? ParseFixtureStamp(string saveDir)
+        {
+            if (string.IsNullOrEmpty(saveDir))
+                return null;
+            string path = Path.Combine(saveDir, "fixture-generation.txt");
+            if (!File.Exists(path))
+                return null;
+
+            string text;
+            try { text = File.ReadAllText(path); }
+            catch { return null; }
+
+            int generation = 0;
+            string provenance = null;
+            foreach (string token in text.Split(new[] { ' ', '\t', '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries))
+            {
+                int eq = token.IndexOf('=');
+                if (eq <= 0)
+                    continue;
+                string key = token.Substring(0, eq);
+                string value = token.Substring(eq + 1);
+                if (string.Equals(key, "generation", StringComparison.Ordinal))
+                    int.TryParse(value, System.Globalization.NumberStyles.Integer,
+                        System.Globalization.CultureInfo.InvariantCulture, out generation);
+                else if (string.Equals(key, "provenance", StringComparison.Ordinal))
+                    provenance = value;
+            }
+
+            // A file with neither field parsed is treated as unstamped.
+            if (generation == 0 && string.IsNullOrEmpty(provenance))
+                return null;
+            return new FixtureStamp(generation, provenance ?? "synthetic");
         }
 
         private static string ResolveSaveName(string saveDir)

--- a/Source/Parsek.Tests/Analyzer/SaveDirectoryLoaderLedgerTests.cs
+++ b/Source/Parsek.Tests/Analyzer/SaveDirectoryLoaderLedgerTests.cs
@@ -1,0 +1,132 @@
+using System;
+using System.IO;
+using System.Linq;
+using Parsek.Tests.Generators;
+using Xunit;
+
+namespace Parsek.Tests.Analyzer
+{
+    // Ledger + career parse tests (task 1.3). The ledger is loaded RAW (correction
+    // C1): directly from ledger.pgld, never through Ledger.LoadFromFile, so no
+    // process-static contamination. Sequential because Load toggles the
+    // RecordingStore.SuppressLogging static.
+    [Collection("Sequential")]
+    public class SaveDirectoryLoaderLedgerTests : IDisposable
+    {
+        private readonly string tempDir;
+        private readonly bool prevSuppress;
+
+        public SaveDirectoryLoaderLedgerTests()
+        {
+            prevSuppress = RecordingStore.SuppressLogging;
+            RecordingStore.SuppressLogging = false;
+            RecordingStore.ResetForTesting();
+            ParsekLog.SuppressLogging = true;
+
+            tempDir = Path.Combine(Path.GetTempPath(),
+                "parsek-analyzer-ledger-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(tempDir);
+        }
+
+        public void Dispose()
+        {
+            RecordingStore.ResetForTesting();
+            RecordingStore.SuppressLogging = prevSuppress;
+            ParsekLog.SuppressLogging = true;
+
+            if (Directory.Exists(tempDir))
+            {
+                try { Directory.Delete(tempDir, true); }
+                catch { }
+            }
+        }
+
+        private string NewSaveDir(string name)
+        {
+            string dir = Path.Combine(tempDir, name);
+            Directory.CreateDirectory(dir);
+            return dir;
+        }
+
+        private static CelestialBody NullResolver(string name) => null;
+
+        private static void WriteLedger(string saveDir, params string[] actionIds)
+        {
+            string dir = Path.Combine(saveDir, "Parsek", "GameState");
+            Directory.CreateDirectory(dir);
+
+            var root = new ConfigNode("LEDGER");
+            root.AddValue("version", "0");
+            root.AddValue("recordingSchemaGeneration",
+                RecordingStore.CurrentRecordingSchemaGeneration.ToString(
+                    System.Globalization.CultureInfo.InvariantCulture));
+            double ut = 10;
+            foreach (string id in actionIds)
+            {
+                ConfigNode n = root.AddNode("GAME_ACTION");
+                n.AddValue("actionId", id);
+                n.AddValue("type", "0");
+                n.AddValue("ut", ut.ToString(System.Globalization.CultureInfo.InvariantCulture));
+                ut += 10;
+            }
+            root.Save(Path.Combine(dir, "ledger.pgld"));
+        }
+
+        // Guards (C1): every GAME_ACTION loads RAW and verbatim, with no ELS
+        // pre-filtering. Fails if the loader dropped or reordered actions, which
+        // would make INV8's dangling-tombstone check vacuous.
+        [Fact]
+        public void LedgerFile_LoadsRawVerbatim()
+        {
+            string saveDir = NewSaveDir("ledger");
+            WriteLedger(saveDir, "act_1", "act_2", "act_3");
+
+            AnalyzerModel model = SaveDirectoryLoader.Load(saveDir, NullResolver);
+
+            Assert.Equal(3, model.Ledger.Count);
+            var ids = model.Ledger.Select(a => a.ActionId).ToList();
+            Assert.Equal(new[] { "act_1", "act_2", "act_3" }, ids);
+            Assert.DoesNotContain(model.LoadFaults, f => f.FileKind == "ledger");
+        }
+
+        // Guards: a non-career (Sandbox / Science) save leaves CareerSave null and
+        // records no career or ledger fault. Fails if the loader wrongly synthesizes
+        // a career snapshot or faults on the absence of one.
+        [Fact]
+        public void NonCareerSave_CareerNull_NoFault()
+        {
+            string saveDir = NewSaveDir("noncareer");
+            var writer = new ScenarioWriter().AddRecordingAsTree(
+                new RecordingBuilder("Sandbox Craft").WithRecordingId("sand0").AddPoint(100, 0, 0, 1000));
+            string scenarioText = writer.SerializeConfigNode(writer.BuildScenarioNode(), "SCENARIO", 1);
+            File.WriteAllText(Path.Combine(saveDir, "persistent.sfs"),
+                "GAME\n{\n\tFLIGHTSTATE\n\t{\n\t\tversion = 1.12.5\n\t}\n" + scenarioText + "}\n");
+
+            AnalyzerModel model = SaveDirectoryLoader.Load(saveDir, NullResolver);
+
+            Assert.Null(model.CareerSave);
+            Assert.DoesNotContain(model.LoadFaults, f => f.FileKind == "career");
+            Assert.DoesNotContain(model.LoadFaults, f => f.FileKind == "ledger");
+            Assert.Empty(model.Ledger);
+        }
+
+        // Guards: a save carrying a Funding SCENARIO is recognized as career and its
+        // parsed totals are surfaced on CareerSave (the HasFunds discriminator).
+        [Fact]
+        public void CareerSave_WhenFundingScenarioPresent_IsParsed()
+        {
+            string saveDir = NewSaveDir("career");
+            File.WriteAllText(Path.Combine(saveDir, "persistent.sfs"),
+                "GAME\n{\n" +
+                "\tSCENARIO\n\t{\n\t\tname = Funding\n\t\tfunds = 12345.5\n\t}\n" +
+                "\tFLIGHTSTATE\n\t{\n\t\tversion = 1.12.5\n\t}\n" +
+                "}\n");
+
+            AnalyzerModel model = SaveDirectoryLoader.Load(saveDir, NullResolver);
+
+            Assert.NotNull(model.CareerSave);
+            Assert.True(model.CareerSave.HasFunds);
+            Assert.Equal(12345.5, model.CareerSave.Funds);
+        }
+    }
+}

--- a/Source/Parsek.Tests/Analyzer/SaveDirectoryLoaderSidecarTests.cs
+++ b/Source/Parsek.Tests/Analyzer/SaveDirectoryLoaderSidecarTests.cs
@@ -1,0 +1,235 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using Parsek.Tests.Generators;
+using Xunit;
+
+namespace Parsek.Tests.Analyzer
+{
+    // Sidecar hydration + probe-capture tests (task 1.2). These write real .prec /
+    // _vessel.craft sidecars via ScenarioWriter, then corrupt them to prove the
+    // loader records a LoadFault (never crashes) and captures schema into
+    // SidecarSchema. Sequential because they touch RecordingStore statics.
+    [Collection("Sequential")]
+    public class SaveDirectoryLoaderSidecarTests : IDisposable
+    {
+        private readonly string tempDir;
+        private readonly bool prevSuppress;
+
+        public SaveDirectoryLoaderSidecarTests()
+        {
+            prevSuppress = RecordingStore.SuppressLogging;
+            RecordingStore.SuppressLogging = false;
+            RecordingStore.ResetForTesting();
+            ParsekLog.SuppressLogging = true;
+
+            tempDir = Path.Combine(Path.GetTempPath(),
+                "parsek-analyzer-sidecar-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(tempDir);
+        }
+
+        public void Dispose()
+        {
+            RecordingStore.ResetForTesting();
+            RecordingStore.SuppressLogging = prevSuppress;
+            ParsekLog.SuppressLogging = true;
+
+            if (Directory.Exists(tempDir))
+            {
+                try { Directory.Delete(tempDir, true); }
+                catch { }
+            }
+        }
+
+        private string NewSaveDir(string name)
+        {
+            string dir = Path.Combine(tempDir, name);
+            Directory.CreateDirectory(dir);
+            return dir;
+        }
+
+        private static void WriteSave(string saveDir, ScenarioWriter writer)
+        {
+            string scenarioText = writer.SerializeConfigNode(writer.BuildScenarioNode(), "SCENARIO", 1);
+            string save =
+                "GAME\n{\n" +
+                "\tFLIGHTSTATE\n\t{\n\t\tversion = 1.12.5\n\t}\n" +
+                scenarioText +
+                "}\n";
+            File.WriteAllText(Path.Combine(saveDir, "persistent.sfs"), save);
+        }
+
+        private static RecordingBuilder ValidBuilder(string id)
+        {
+            return new RecordingBuilder("Sidecar Craft")
+                .WithRecordingId(id)
+                .AddPoint(100, 0, 0, 1000)
+                .AddPoint(110, 0.01, 0.02, 1500)
+                .WithVesselSnapshot(VesselSnapshotBuilder.FleaRocket("Sidecar Craft", "Jeb", pid: 7001));
+        }
+
+        private static string PrecPath(string saveDir, string id) =>
+            Path.Combine(saveDir, "Parsek", "Recordings", id + ".prec");
+
+        private static string VesselPath(string saveDir, string id) =>
+            Path.Combine(saveDir, "Parsek", "Recordings", id + "_vessel.craft");
+
+        private static CelestialBody NullResolver(string name) => null;
+
+        // Guards: a valid current-generation sidecar set hydrates the trajectory into
+        // the recording and captures (generation=4, formatVersion=1) into
+        // SidecarSchema for INV5, with zero faults.
+        [Fact]
+        public void ValidSidecars_HydrateTrajectory_AndCaptureSchema()
+        {
+            string saveDir = NewSaveDir("valid");
+            var writer = new ScenarioWriter().WithV3Format().AddRecordingAsTree(ValidBuilder("valid0"));
+            WriteSave(saveDir, writer);
+            writer.WriteSidecarFiles(saveDir);
+
+            AnalyzerModel model = SaveDirectoryLoader.Load(saveDir, NullResolver);
+
+            Assert.Empty(model.LoadFaults);
+            Recording rec = model.Recordings.Single();
+            Assert.Equal(2, rec.Points.Count);
+            Assert.NotNull(rec.VesselSnapshot);
+            Assert.True(model.SidecarSchema.ContainsKey("valid0"));
+            Assert.Equal(RecordingStore.CurrentRecordingSchemaGeneration, model.SidecarSchema["valid0"].Generation);
+            Assert.Equal(RecordingStore.CurrentRecordingFormatVersion, model.SidecarSchema["valid0"].FormatVersion);
+        }
+
+        // Guards: a truncated .prec produces a trajectory LoadFault and no crash
+        // (design edge case 1). A crash instead of a finding is itself a bug.
+        [Fact]
+        public void TruncatedPrec_ProducesTrajectoryFault_NoCrash()
+        {
+            string saveDir = NewSaveDir("truncated");
+            var writer = new ScenarioWriter().WithV3Format().AddRecordingAsTree(ValidBuilder("trunc0"));
+            WriteSave(saveDir, writer);
+            writer.WriteSidecarFiles(saveDir);
+
+            string prec = PrecPath(saveDir, "trunc0");
+            byte[] bytes = File.ReadAllBytes(prec);
+            Array.Resize(ref bytes, 6); // keep the magic, drop the rest
+            File.WriteAllBytes(prec, bytes);
+
+            AnalyzerModel model = SaveDirectoryLoader.Load(saveDir, NullResolver);
+
+            Assert.Contains(model.LoadFaults, f => f.FileKind == "trajectory" && f.RecordingId == "trunc0");
+        }
+
+        // Guards: a text-format .prec (pre-v0-reset corpus) records the exact
+        // production reject reason (design edge case 2), so triage greps match KSP.log.
+        [Fact]
+        public void TextFormatPrec_ReasonTextSidecarUnsupported()
+        {
+            string saveDir = NewSaveDir("textprec");
+            var writer = new ScenarioWriter().WithV3Format().AddRecordingAsTree(ValidBuilder("text0"));
+            WriteSave(saveDir, writer);
+            writer.WriteSidecarFiles(saveDir);
+
+            var textNode = new ConfigNode("PARSEK_RECORDING");
+            textNode.AddValue("version",
+                RecordingStore.CurrentRecordingFormatVersion.ToString(CultureInfo.InvariantCulture));
+            textNode.AddValue("recordingId", "text0");
+            textNode.AddValue("sidecarEpoch", "1");
+            textNode.Save(PrecPath(saveDir, "text0"));
+
+            AnalyzerModel model = SaveDirectoryLoader.Load(saveDir, NullResolver);
+
+            Assert.Contains(model.LoadFaults, f =>
+                f.FileKind == "trajectory" &&
+                f.RecordingId == "text0" &&
+                f.Reason == "text-sidecar-unsupported");
+        }
+
+        // Guards: a pre-reset binary magic .prec records the pre-reset reject reason
+        // (design edge case 3).
+        [Fact]
+        public void PreResetMagicPrec_ProducesTrajectoryFault()
+        {
+            string saveDir = NewSaveDir("prereset");
+            var writer = new ScenarioWriter().WithV3Format().AddRecordingAsTree(ValidBuilder("pre0"));
+            WriteSave(saveDir, writer);
+            writer.WriteSidecarFiles(saveDir);
+
+            // "PRKB" pre-reset magic tag, then filler.
+            var bytes = new List<byte> { (byte)'P', (byte)'R', (byte)'K', (byte)'B' };
+            bytes.AddRange(new byte[] { 0, 0, 0, 1 });
+            File.WriteAllBytes(PrecPath(saveDir, "pre0"), bytes.ToArray());
+
+            AnalyzerModel model = SaveDirectoryLoader.Load(saveDir, NullResolver);
+
+            Assert.Contains(model.LoadFaults, f =>
+                f.FileKind == "trajectory" &&
+                f.RecordingId == "pre0" &&
+                f.Reason == "magic-mismatch");
+        }
+
+        // Guards: a corrupt vessel snapshot produces a snapshot LoadFault and leaves
+        // the recording's VesselSnapshot null (design edge case 23), never a crash.
+        [Fact]
+        public void CorruptSnapshot_ProducesSnapshotFault_NoCrash()
+        {
+            string saveDir = NewSaveDir("badsnapshot");
+            var writer = new ScenarioWriter().WithV3Format().AddRecordingAsTree(ValidBuilder("snap0"));
+            WriteSave(saveDir, writer);
+            writer.WriteSidecarFiles(saveDir);
+
+            string vessel = VesselPath(saveDir, "snap0");
+            byte[] bytes = File.ReadAllBytes(vessel);
+            Array.Resize(ref bytes, bytes.Length - 4); // truncate the deflate payload
+            File.WriteAllBytes(vessel, bytes);
+
+            AnalyzerModel model = SaveDirectoryLoader.Load(saveDir, NullResolver);
+
+            Assert.Contains(model.LoadFaults, f => f.FileKind == "snapshot" && f.RecordingId == "snap0");
+            Assert.Null(model.Recordings.Single().VesselSnapshot);
+        }
+
+        // Guards: a recording with no snapshot sidecar on disk is not a fault
+        // (snapshots are optional for destroyed / showcase recordings).
+        [Fact]
+        public void MissingSnapshot_IsNotAFault()
+        {
+            string saveDir = NewSaveDir("nosnapshot");
+            var noSnapshot = new RecordingBuilder("Trajectory Only")
+                .WithRecordingId("nosnap0")
+                .AddPoint(100, 0, 0, 1000)
+                .AddPoint(110, 0.01, 0.02, 1500);
+            var writer = new ScenarioWriter().WithV3Format().AddRecordingAsTree(noSnapshot);
+            WriteSave(saveDir, writer);
+            writer.WriteSidecarFiles(saveDir);
+
+            AnalyzerModel model = SaveDirectoryLoader.Load(saveDir, NullResolver);
+
+            Assert.DoesNotContain(model.LoadFaults, f => f.FileKind == "snapshot");
+        }
+
+        // Guards: an orphan .prec (no tree recording references it) is inventoried in
+        // SidecarSchema under an id absent from Recordings, so INV5 can flag it later.
+        [Fact]
+        public void OrphanSidecar_IsInventoriedInSidecarSchema()
+        {
+            string saveDir = NewSaveDir("orphan");
+
+            var referenced = new ScenarioWriter().WithV3Format().AddRecordingAsTree(ValidBuilder("ref0"));
+            WriteSave(saveDir, referenced);
+            referenced.WriteSidecarFiles(saveDir);
+
+            // A stray sidecar whose tree is never written into persistent.sfs.
+            var orphanWriter = new ScenarioWriter().WithV3Format().AddRecordingAsTree(ValidBuilder("orphan0"));
+            orphanWriter.WriteSidecarFiles(saveDir);
+
+            AnalyzerModel model = SaveDirectoryLoader.Load(saveDir, NullResolver);
+
+            var recordingIds = model.Recordings.Select(r => r.RecordingId).ToList();
+            Assert.Contains("ref0", recordingIds);
+            Assert.DoesNotContain("orphan0", recordingIds);
+            Assert.True(model.SidecarSchema.ContainsKey("orphan0"),
+                "orphan .prec must be inventoried in SidecarSchema");
+        }
+    }
+}

--- a/Source/Parsek.Tests/Analyzer/SaveDirectoryLoaderTests.cs
+++ b/Source/Parsek.Tests/Analyzer/SaveDirectoryLoaderTests.cs
@@ -151,6 +151,16 @@ namespace Parsek.Tests.Analyzer
             Assert.Empty(model.Trees);
             Assert.Empty(model.Tombstones);
             Assert.Empty(model.SupersedeRelations);
+
+            // Blocker regression: the sfs fault must reach the report as a red run,
+            // not analyze GREEN. Route through the full Evaluate pipeline (not just
+            // the model) so the LOADER-FAULT rule + verdict policy are exercised.
+            AnalysisReport report = Analyzer.Evaluate(model);
+            Assert.True(report.IsRed);
+            Assert.Contains(report.Findings, f =>
+                f.RuleId == Parsek.Tests.Analyzer.Rules.LoadFaultRule.RuleIdConst
+                && f.Level == VerdictLevel.Fail
+                && f.Message.Contains("kind=sfs"));
         }
 
         // Guards: a save with no Parsek footprint (a non-Parsek SCENARIO, or no sfs

--- a/Source/Parsek.Tests/Analyzer/SaveDirectoryLoaderTests.cs
+++ b/Source/Parsek.Tests/Analyzer/SaveDirectoryLoaderTests.cs
@@ -185,6 +185,30 @@ namespace Parsek.Tests.Analyzer
             Assert.Empty(model.Trees);
         }
 
+        // Guards: the loader parses a fixture-generation.txt stamp into
+        // model.FixtureStamp (order/whitespace tolerant); a save with no stamp file
+        // yields a null FixtureStamp (non-fixture subject -> STALE check skipped).
+        [Fact]
+        public void FixtureStamp_ParsedWhenPresent_NullWhenAbsent()
+        {
+            string stampedDir = NewSaveDir("stamped");
+            File.WriteAllText(Path.Combine(stampedDir, "persistent.sfs"),
+                "GAME\n{\n\tFLIGHTSTATE\n\t{\n\t\tversion = 1.12.5\n\t}\n}\n");
+            File.WriteAllText(Path.Combine(stampedDir, "fixture-generation.txt"),
+                "generation=3 provenance=harvested\n");
+
+            AnalyzerModel stamped = SaveDirectoryLoader.Load(stampedDir, NullResolver);
+            Assert.NotNull(stamped.FixtureStamp);
+            Assert.Equal(3, stamped.FixtureStamp.Value.SchemaGeneration);
+            Assert.Equal("harvested", stamped.FixtureStamp.Value.Provenance);
+
+            string plainDir = NewSaveDir("unstamped");
+            File.WriteAllText(Path.Combine(plainDir, "persistent.sfs"),
+                "GAME\n{\n\tFLIGHTSTATE\n\t{\n\t\tversion = 1.12.5\n\t}\n}\n");
+            AnalyzerModel plain = SaveDirectoryLoader.Load(plainDir, NullResolver);
+            Assert.Null(plain.FixtureStamp);
+        }
+
         // Guards: the loader restores RecordingStore.SuppressLogging to its prior
         // value even on the happy path, so it does not leak analyzer state into a
         // subsequent test or a live session.

--- a/Source/Parsek.Tests/Analyzer/SaveDirectoryLoaderTests.cs
+++ b/Source/Parsek.Tests/Analyzer/SaveDirectoryLoaderTests.cs
@@ -1,0 +1,208 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Parsek.Tests.Generators;
+using Xunit;
+
+namespace Parsek.Tests.Analyzer
+{
+    // Loader-scoped tests (design "Malformed-input robustness tests"). These touch
+    // the RecordingStore.SuppressLogging static during load, so the class is
+    // Sequential and restores the static in Dispose.
+    [Collection("Sequential")]
+    public class SaveDirectoryLoaderTests : IDisposable
+    {
+        private readonly string tempDir;
+        private readonly bool prevSuppress;
+
+        public SaveDirectoryLoaderTests()
+        {
+            prevSuppress = RecordingStore.SuppressLogging;
+            RecordingStore.SuppressLogging = false;
+            RecordingStore.ResetForTesting();
+            ParsekLog.SuppressLogging = true;
+
+            tempDir = Path.Combine(Path.GetTempPath(),
+                "parsek-analyzer-loader-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(tempDir);
+        }
+
+        public void Dispose()
+        {
+            RecordingStore.ResetForTesting();
+            RecordingStore.SuppressLogging = prevSuppress;
+            ParsekLog.SuppressLogging = true;
+
+            if (Directory.Exists(tempDir))
+            {
+                try { Directory.Delete(tempDir, true); }
+                catch { }
+            }
+        }
+
+        private string NewSaveDir(string name)
+        {
+            string dir = Path.Combine(tempDir, name);
+            Directory.CreateDirectory(dir);
+            return dir;
+        }
+
+        // Writes a persistent.sfs wrapping the writer's SCENARIO (optionally mutated
+        // to add supersede/tombstone ENTRY nodes ScenarioWriter cannot emit itself).
+        private static void WriteSave(string saveDir, ScenarioWriter writer, Action<ConfigNode> mutateScenario = null)
+        {
+            ConfigNode scenario = writer.BuildScenarioNode();
+            mutateScenario?.Invoke(scenario);
+            string scenarioText = writer.SerializeConfigNode(scenario, "SCENARIO", 1);
+            string save =
+                "GAME\n{\n" +
+                "\tFLIGHTSTATE\n\t{\n\t\tversion = 1.12.5\n\t}\n" +
+                scenarioText +
+                "}\n";
+            File.WriteAllText(Path.Combine(saveDir, "persistent.sfs"), save);
+        }
+
+        private static CelestialBody NullResolver(string name) => null;
+
+        // Guards: a synthetic ParsekScenario loads its trees + recordings +
+        // supersede rows + tombstones with the expected counts. Fails if the loader
+        // drops trees, miscounts recordings, or ignores the staging lists.
+        [Fact]
+        public void SyntheticSave_LoadsExpectedCounts()
+        {
+            string saveDir = NewSaveDir("synthetic");
+
+            var segs = new[]
+            {
+                new RecordingBuilder("Flea Chain").WithRecordingId("seg0")
+                    .AddPoint(100, 0, 0, 1000).WithChainId("c").WithChainIndex(0),
+                new RecordingBuilder("Flea Chain").WithRecordingId("seg1")
+                    .AddPoint(110, 0, 0, 1100).WithChainId("c").WithChainIndex(1)
+                    .WithParentRecordingId("seg0"),
+                new RecordingBuilder("Flea Chain").WithRecordingId("seg2")
+                    .AddPoint(120, 0, 0, 1200).WithChainId("c").WithChainIndex(2)
+                    .WithParentRecordingId("seg1"),
+            };
+
+            var writer = new ScenarioWriter().AddRecordingsAsTree(segs);
+
+            WriteSave(saveDir, writer, scenario =>
+            {
+                var sup = scenario.AddNode("RECORDING_SUPERSEDES");
+                new RecordingSupersedeRelation
+                {
+                    RelationId = "rsr_1",
+                    OldRecordingId = "seg1",
+                    NewRecordingId = "seg2",
+                    UT = 120,
+                }.SaveInto(sup);
+                new RecordingSupersedeRelation
+                {
+                    RelationId = "rsr_2",
+                    OldRecordingId = "seg0",
+                    NewRecordingId = "seg1",
+                    UT = 110,
+                }.SaveInto(sup);
+
+                var tomb = scenario.AddNode("LEDGER_TOMBSTONES");
+                new LedgerTombstone
+                {
+                    TombstoneId = "tomb_1",
+                    ActionId = "act_x",
+                    RetiringRecordingId = "seg2",
+                    UT = 120,
+                }.SaveInto(tomb);
+            });
+
+            AnalyzerModel model = SaveDirectoryLoader.Load(saveDir, NullResolver);
+
+            Assert.Empty(model.LoadFaults);
+            Assert.Single(model.Trees);
+            Assert.Equal(3, model.Recordings.Count);
+            Assert.Equal(2, model.SupersedeRelations.Count);
+            Assert.Single(model.Tombstones);
+
+            Assert.Equal("seg0", model.Trees[0].RootRecordingId);
+            var ids = new HashSet<string>();
+            foreach (Recording r in model.Recordings)
+                ids.Add(r.RecordingId);
+            Assert.Contains("seg0", ids);
+            Assert.Contains("seg1", ids);
+            Assert.Contains("seg2", ids);
+
+            Assert.Equal("act_x", model.Tombstones[0].ActionId);
+            Assert.Equal("synthetic", model.SaveName);
+        }
+
+        // Guards: a corrupt persistent.sfs yields exactly one sfs LoadFault and an
+        // empty model - triage must not crash on a malformed save.
+        [Fact]
+        public void CorruptSfs_ProducesSingleSfsFault_EmptyModel()
+        {
+            string saveDir = NewSaveDir("corrupt");
+            File.WriteAllText(Path.Combine(saveDir, "persistent.sfs"),
+                "GAME\n{\n\tSCENARIO\n\t{\n\t\tname = ParsekScenario\n{{{ broken unbalanced");
+
+            AnalyzerModel model = SaveDirectoryLoader.Load(saveDir, NullResolver);
+
+            Assert.Single(model.LoadFaults);
+            Assert.Equal("sfs", model.LoadFaults[0].FileKind);
+            Assert.Empty(model.Recordings);
+            Assert.Empty(model.Trees);
+            Assert.Empty(model.Tombstones);
+            Assert.Empty(model.SupersedeRelations);
+        }
+
+        // Guards: a save with no Parsek footprint (a non-Parsek SCENARIO, or no sfs
+        // at all) loads cleanly with zero faults and an empty model.
+        [Fact]
+        public void NonParsekSave_NoFaults_EmptyModel()
+        {
+            string saveDir = NewSaveDir("nonparsek");
+            File.WriteAllText(Path.Combine(saveDir, "persistent.sfs"),
+                "GAME\n{\n" +
+                "\tSCENARIO\n\t{\n\t\tname = SomeOther\n\t\tscene = 5\n\t}\n" +
+                "\tFLIGHTSTATE\n\t{\n\t\tversion = 1.12.5\n\t}\n" +
+                "}\n");
+
+            AnalyzerModel model = SaveDirectoryLoader.Load(saveDir, NullResolver);
+
+            Assert.Empty(model.LoadFaults);
+            Assert.Empty(model.Recordings);
+            Assert.Empty(model.Trees);
+            Assert.Empty(model.Tombstones);
+        }
+
+        [Fact]
+        public void MissingSfs_NoFaults_EmptyModel()
+        {
+            string saveDir = NewSaveDir("empty");
+
+            AnalyzerModel model = SaveDirectoryLoader.Load(saveDir, NullResolver);
+
+            Assert.Empty(model.LoadFaults);
+            Assert.Empty(model.Recordings);
+            Assert.Empty(model.Trees);
+        }
+
+        // Guards: the loader restores RecordingStore.SuppressLogging to its prior
+        // value even on the happy path, so it does not leak analyzer state into a
+        // subsequent test or a live session.
+        [Fact]
+        public void Load_RestoresSuppressLogging()
+        {
+            string saveDir = NewSaveDir("suppress");
+            var writer = new ScenarioWriter().AddRecordingAsTree(
+                new RecordingBuilder("Solo").WithRecordingId("solo0").AddPoint(100, 0, 0, 1000));
+            WriteSave(saveDir, writer);
+
+            RecordingStore.SuppressLogging = false;
+            SaveDirectoryLoader.Load(saveDir, NullResolver);
+            Assert.False(RecordingStore.SuppressLogging);
+
+            RecordingStore.SuppressLogging = true;
+            SaveDirectoryLoader.Load(saveDir, NullResolver);
+            Assert.True(RecordingStore.SuppressLogging);
+        }
+    }
+}

--- a/docs/dev/design-autotest-offline-analyzer.md
+++ b/docs/dev/design-autotest-offline-analyzer.md
@@ -298,14 +298,34 @@ does not spam KSP-style logs; the loader emits its own analyzer-tagged lines.
 
 ### The invariant rules
 
-Ten invariant families from plan section 7, plus 7b annotation staleness. Each
-is one `IRecordingInvariant` (or a small cluster sharing a `CitedContract`).
+Ten invariant families from plan section 7, plus 7b annotation staleness, plus
+the LOADER-FAULT rule that turns loader parse failures into findings. Each is one
+`IRecordingInvariant` (or a small cluster sharing a `CitedContract`).
 
+- **LOADER-FAULT** (`RuleId LOADER-FAULT`). A file the loader could not parse is
+  itself a finding, never a crash (design "The loader"). The loader records a
+  `LoadFault` per unparsable file and keeps going; this rule emits a FAIL for
+  every `LoadFault` whose `FileKind` is one of `{sfs, tree-node, ledger}`. Those
+  three kinds have no other owning rule, so before it existed a corrupt
+  `persistent.sfs`, a throwing RECORDING tree node, or an unparsable `ledger.pgld`
+  analyzed GREEN. The `trajectory` and `snapshot` kinds are deliberately EXCLUDED:
+  INV5 owns `.prec` faults and INV4 owns `_vessel/_ghost.craft` faults, each with
+  its own recording-scoped context, so a fault is reported exactly once. The
+  finding Target is the recording id when the fault carries one, else a
+  `<fileKind>` token; the message carries only the filename (not the absolute
+  path) so report bytes stay deterministic. CitedContract:
+  `SaveDirectoryLoader.Load` / `ConfigNode.Load`.
 - **INV1 UT monotonicity** (`RuleId INV1-UT-MONOTONIC`). Per `TrackSection`, the
   `frames` / `bodyFixedFrames` / `checkpoints` UT sequences are non-decreasing;
   the flat `Recording.Points` UT sequence is non-decreasing; per-section
-  `startUT <= endUT`. Violation = FAIL. CitedContract: `TrajectoryPoint.ut` +
-  `TrackSection.startUT/endUT` ordering assumed by `TrajectoryMath` sampling.
+  `startUT <= endUT`. Violation = FAIL. A NaN UT (any point UT, or a section
+  `startUT`/`endUT`) is also FAIL: `double.IsNaN` is checked explicitly because a
+  NaN never trips the strict back-step / ordering comparison (`NaN < x` and
+  `NaN > x` are both false), so a NaN-poisoned sidecar would otherwise analyze
+  GREEN and then break `TrajectoryMath`'s binary-search sampler at playback. One
+  NaN finding per sequence, same bounding style as the first-back-step reporting.
+  CitedContract: `TrajectoryPoint.ut` + `TrackSection.startUT/endUT` ordering
+  assumed by `TrajectoryMath` sampling.
 - **INV2 no double-cover** (`RuleId INV2-NO-DOUBLE-COVER`). No two sections'
   `[startUT,endUT]` spans overlap in interior UT. Gaps are allowed
   (on-rails BG spans emit no TrackSections;
@@ -334,13 +354,22 @@ is one `IRecordingInvariant` (or a small cluster sharing a `CitedContract`).
   (destroyed / showcase) -> INFO. CitedContract: `VesselSnapshotBuilder.AddPart`
   PID assignment + the ghost-event lookup contract (`.claude/CLAUDE.md` ghost
   event <-> snapshot PID).
-- **INV5 schema gate** (`RuleId INV5-SCHEMA-GATE`). Every recording +
-  trajectory sidecar passes `RecordingStore.IsRecordingSchemaCompatible`
-  (format 1, generation 4). A recording whose metadata and sidecar disagree, or
-  that fails the gate, -> FAIL with the exact reason string
-  (`generation-missing` / `generation-older` / `generation-newer` /
-  `format-version-mismatch`). The rule also inventories all generations seen as
-  INFO. CitedContract: `RecordingStore.IsRecordingSchemaCompatible`,
+- **INV5 schema gate** (`RuleId INV5-SCHEMA-GATE`, plus two sibling rule ids the
+  one rule emits under: `INV5-ORPHAN-SIDECAR` and `INV5-GENERATIONS`). Every
+  recording + trajectory sidecar passes
+  `RecordingStore.IsRecordingSchemaCompatible` (format 1, generation 4). A
+  recording whose metadata and sidecar disagree, or that fails the gate, -> FAIL
+  with the exact reason string (`generation-missing` / `generation-older` /
+  `generation-newer` / `format-version-mismatch`) under `INV5-SCHEMA-GATE`. A
+  `.prec` on disk with no matching tree recording -> WARN under
+  `INV5-ORPHAN-SIDECAR`. The generations inventory is emitted under
+  `INV5-GENERATIONS` and is CONDITIONAL-INFO: it fires only when informative
+  (more than one distinct generation is present, or the single generation present
+  is not the current one), so a homogeneous current-gen save stays finding-free
+  (the clean-data-is-green convention). The distinct rule ids let a triage grep /
+  the harness parser separate a hard schema reject (red) from an orphan (WARN) or
+  the inventory (INFO) without parsing the message body. CitedContract:
+  `RecordingStore.IsRecordingSchemaCompatible`,
   `RecordingStore.CurrentRecordingFormatVersion`,
   `RecordingStore.CurrentRecordingSchemaGeneration`.
 - **INV6 resource manifest consistency** (`RuleId INV6-RESOURCE-MANIFEST`).
@@ -363,9 +392,17 @@ is one `IRecordingInvariant` (or a small cluster sharing a `CitedContract`).
   (`ChainBranch > 0` = parallel ghost-only continuations, flight-recorder 9A.4)
   with a supersede-boundary exemption for HEAD/TIP splits. A dangling link or a
   cycle -> FAIL; a `(ChainId, ChainBranch)` index gap not explained by a
-  supersede boundary -> FAIL; a gap AT a supersede boundary -> INFO. CitedContract:
-  `Recording.ChainId/ChainIndex/ChainBranch` + `RecordingTreeSplitter` HEAD/TIP
-  split + `RecordingOptimizer.CanAutoMerge` supersede guard (verify against the
+  supersede boundary -> FAIL; a gap AT a supersede boundary -> INFO. The rule also
+  iterates `model.SupersedeRelations`: a row whose `OldRecordingId` or
+  `NewRecordingId` is absent from the model (a one-sided orphan) -> WARN, not FAIL.
+  This is WARN to match production `LoadTimeSweep`'s orphan-supersede warn-log
+  severity: the forward supersede walk terminates cleanly on a missing endpoint,
+  so it is a maintenance signal rather than a broken invariant (contrast the
+  `Recording.SupersedeTargetId` and tombstone `RetiringRecordingId` dangling
+  cases, which stay FAIL because they break visibility / retirement resolution).
+  CitedContract: `Recording.ChainId/ChainIndex/ChainBranch` +
+  `RecordingTreeSplitter` HEAD/TIP split + `RecordingOptimizer.CanAutoMerge`
+  supersede guard + `EffectiveState.IsSupersededByRelation` (verify against the
   optimizer's supersede guard before shipping, per plan section 7).
 - **INV7b annotation staleness** (`RuleId INV7B-ANNOTATION-STALE`). Where a
   `.pann` sidecar exists, its recorded source epoch matches the paired `.prec`
@@ -376,7 +413,10 @@ is one `IRecordingInvariant` (or a small cluster sharing a `CitedContract`).
   A `.pann` for a recording with no `.prec` -> WARN (orphan). CitedContract:
   `PannotationsSidecarBinary.TryProbe` (`SourceSidecarEpoch`) +
   `RecordingPaths.BuildAnnotationsRelativePath`.
-- **INV8 ledger** (`RuleId INV8-LEDGER`). Two parts, distinct severities.
+- **INV8 ledger** (`RuleId INV8-LEDGER` for part (a); part (b) emits under the
+  sibling id `INV8-CAREER-DIFF`). Two parts, distinct severities and distinct rule
+  ids so the harness can separate an ELS-consistency failure from a career-diff
+  observation.
   (a) ELS internal consistency, over the RAW model. The rule itself computes the
   ELS filter from `model.Ledger` (raw actions) plus `model.Tombstones` using the
   ELS definition cited in `EffectiveState.cs` (ELS = raw actions minus any action
@@ -384,7 +424,11 @@ is one `IRecordingInvariant` (or a small cluster sharing a `CitedContract`).
   `ActionId` resolves against the RAW action list. Because the input is the raw
   list, this check is non-vacuous: a tombstone pointing at an id absent from the
   raw actions is a real dangling reference. A dangling tombstone -> FAIL. This
-  part runs for every save (career or not).
+  part runs for every save (career or not). SINGLE-REPORT POLICY: when a
+  `LoadFault{FileKind="ledger"}` is present the RAW action list is incomplete, so
+  every tombstone would look dangling; part (a) then SKIPS the per-tombstone
+  dangling check and defers to the LOADER-FAULT finding (mirroring INV5's tested
+  faulted-trajectory skip), so a corrupt ledger is reported exactly once.
   (b) Career-diff reconstruction, career saves only, WARN severity in v1. When
   the save is career the rule reconstructs the ledger and diffs against the
   save's parsed career totals via `LedgerGroundTruthDiff.Compare`. Any divergence
@@ -400,9 +444,33 @@ is one `IRecordingInvariant` (or a small cluster sharing a `CitedContract`).
   belongs to the in-game H5 path, where the `LedgerGroundTruthHarness` seam
   already reconstructs against a live quicksave (module M-A3 / H5); there hard
   divergence (`report.HardFailures`) -> FAIL, report-only per-identity divergence
-  -> WARN. Non-career save -> INFO (part (b) skipped). CitedContract:
-  `EffectiveState.ComputeELS` (ELS definition) + `CareerSaveParser.Parse` +
-  `LedgerGroundTruthDiff.Compare` + `LedgerGroundTruthHarness` (in-game FAIL path).
+  -> WARN. A career save with no injected reconstruction reports
+  reconstruction-not-available INFO under `INV8-CAREER-DIFF`; a NON-CAREER save is
+  SILENT (no part-(b) finding at all, not INFO): the career diff carries no
+  information on a Sandbox / Science save, and staying finding-free preserves the
+  clean-data-is-green convention. CitedContract: `EffectiveState.ComputeELS` (ELS
+  definition) + `CareerSaveParser.Parse` + `LedgerGroundTruthDiff.Compare` +
+  `LedgerGroundTruthHarness` (in-game FAIL path).
+
+**Conditional-INFO policy (and its trade-off).** Three INFO sites are emitted
+ONLY when they carry information, deliberately preferring a finding-free clean
+report over an always-present inventory line:
+
+- an absent resource manifest (INV6) is SILENT (not even INFO) on the recording
+  kinds where a manifest is optional;
+- the INV5 generation inventory (`INV5-GENERATIONS`) fires only when more than the
+  single current generation is present;
+- the non-career INV8 part (b) is SILENT as described above.
+
+The trade-off: a clean current-gen save produces a byte-empty findings list,
+which is the clearest possible "all green" signal and keeps CI diffs quiet, but
+it means the report does NOT positively confirm "I looked at manifests /
+generations / the career diff and they were fine" -- absence of a finding is the
+only evidence the check ran. The per-subject loader summary line
+(`Analyzer: load save=... trees=n recordings=n loadFaults=n`) and the
+`subjectSchemaGeneration` report field carry the "the analyzer ran and saw N
+recordings at generation G" signal instead, so the silent-clean policy does not
+lose the run-happened evidence; it only moves it out of the findings list.
 - **INV9 rewind-point + id validation** (`RuleId INV9-REWINDPOINT`). Every
   `RewindPoint` id passes `RecordingPaths.ValidateRecordingId`, its
   `Parsek/RewindPoints/<id>.sfs` exists and parses as a ConfigNode, and every
@@ -516,8 +584,13 @@ Each: scenario -> expected behavior -> v1 or deferred.
     file the tree no longer references. Expected: WARN `INV5-ORPHAN-SIDECAR`
     (inventory), not FAIL. v1.
 21. **Empty save directory / no `ParsekScenario` node**. Scenario: a fresh save
-    or a non-Parsek save. Expected: one INFO
-    `Analyzer: no Parsek footprint`, zero FAIL, clean report. v1.
+    or a non-Parsek save. Expected: an EMPTY report -- zero findings of any level
+    (no synthetic "no Parsek footprint" INFO is emitted), zero FAIL, clean run.
+    The empty-findings state is itself the signal: the human-report header line
+    (`[Analyzer] save=... generation=0 FAIL=0 WARN=0 INFO=0 STALE=0`) and the
+    Verbose loader summary (`recordings=0 loadFaults=0`) carry the "analyzed, saw
+    nothing" evidence, consistent with the conditional-INFO / clean-data-is-green
+    policy (no findings-list line for a save that carries no Parsek data). v1.
 22. **Stale fixture corpus (generation bump landed, fixtures not regenerated)**.
     Scenario: corpus stamp gen 3, code gen 4. Expected: STALE-FIXTURE for every
     recording; CI red with the distinct STALE verdict, not FAIL (so the failure
@@ -740,12 +813,19 @@ and known-good builder output exposes wrong rules). Body resolution uses
 - **Text / pre-reset sidecar**: LoadFault with the exact production reason
   string, no crash. Fails if the analyzer diverges from the production reject
   path.
-- **Corrupt `.sfs` (unbalanced braces)**: single `sfs` LoadFault + empty model
-  + clean report, no crash. Fails if a malformed save takes down triage.
+- **Corrupt `.sfs` (unbalanced braces)**: single `sfs` LoadFault + empty model,
+  no crash, and the full Evaluate pipeline turns that fault into a `LOADER-FAULT`
+  FAIL so the report is RED (`IsRed`), not silently green. Fails if a malformed
+  save takes down triage, or if a corrupt sfs analyzes green.
+- **tree-node / ledger LoadFault**: a throwing RECORDING tree record or an
+  unparsable `ledger.pgld` each yield a `LOADER-FAULT` FAIL (red run). Fails if
+  either kind is dropped and analyzes green (the same blocker as the corrupt sfs).
 - **Missing snapshot for INV4**: INV4 downgrades to INFO + a snapshot-load WARN,
   no crash. Fails if a missing snapshot NREs the PID rule.
-- **Empty / non-Parsek save**: one INFO, zero FAIL, no crash. Fails if the
-  analyzer requires a Parsek footprint and errors on a vanilla save.
+- **Empty / non-Parsek save**: an EMPTY report (zero findings, zero FAIL), no
+  crash; the header zeros + loader summary carry the "analyzed, saw nothing"
+  signal (edge case 21). Fails if the analyzer requires a Parsek footprint and
+  errors on a vanilla save, or emits a spurious finding on a clean empty save.
 
 ### Report format stability tests
 
@@ -778,3 +858,44 @@ and known-good builder output exposes wrong rules). Body resolution uses
   implementations asserts a non-empty `CitedContract`. Fails if a new rule ships
   without naming the production member it checks, defeating the review gate that
   keeps wrong contracts out (plan section 7: "wrong contracts die in review").
+
+## Open Questions and Deferred Review NITs
+
+The INV8 part (b) headless-reconstruction seam is the one open question tracked
+inline (see the INV8 bullet's "OPEN QUESTION"): the offline career diff stays
+WARN-capped and reconstruction-not-available INFO until a Unity-free recalc seam
+plus a hardcoded facility-max-levels map are proven; the FAIL-severity variant
+lives on the in-game H5 path.
+
+The following smaller items were raised in review and CONSCIOUSLY DEFERRED (not
+fixed in this round). They are tracked here so they are not lost:
+
+- **Cycle-noise (INV7 parent/supersede cycles report one node, not the edge
+  set)**. A parent or supersede cycle emits a single FAIL at the node that closes
+  the loop and marks the whole visited path reported. That is enough to fail the
+  run and name a member, but the message does not enumerate the full cycle edge
+  set, so triage must walk the tree by hand to see every participant. Deferred:
+  the single finding is a correct red signal; richer cycle reporting is polish.
+- **Second out-edge supersede cycles**. `CheckSupersedeCycles` follows only the
+  FIRST `Old -> New` edge per node (`if (!next.ContainsKey(...)) next[old] = new`),
+  so a corrupt row set giving a node two distinct out-edges only has its first
+  edge walked; a cycle reachable exclusively through the second out-edge is not
+  detected. Deferred: the supersede graph is near-functional in practice (one
+  merge target per old id); multi-out-edge corruption is out of scope for v1.
+- **Double-report of an invalid recording id**. An id that fails
+  `ValidateRecordingId` can surface both as a loader `trajectory`
+  `invalid-recording-id` LoadFault (via INV5) and as an INV9 `badid` FAIL. Both
+  are FAIL and both are correct, but the same root cause is counted twice.
+  Deferred: over-reporting a real corruption is safe; de-duping across rules
+  needs a shared id-validity pass that is not worth the coupling yet.
+- **`BracesBalanced` value-brace false positive**. The corruption pre-check
+  counts every `{` / `}` in the raw sfs text, including braces that appear inside
+  a quoted / free-text VALUE (e.g. a vessel name or note containing a brace).
+  Such a value could tip the balance count and mis-flag a structurally valid save
+  as `unbalanced-braces`, or mask a real imbalance. Deferred: KSP sfs values
+  rarely carry literal braces and the check is a deterministic corruption signal
+  for the common case; a brace-aware tokenizer is a larger change.
+- **Numbered-sfs API**. The loader only reads `persistent.sfs`; the design's
+  "and any numbered `*.sfs` the caller names" (quicksaves / named saves) is not
+  wired to a parameter yet. Deferred: the harness and triage operate on
+  `persistent.sfs`; a caller-named-sfs overload lands when a run mode needs it.

--- a/scripts/analyze-recordings.ps1
+++ b/scripts/analyze-recordings.ps1
@@ -1,0 +1,79 @@
+# Offline recording analyzer CLI driver (module M-A1). Mirrors
+# validate-ksp-log.ps1: it resolves the target save directory, sets the env
+# vars the Manual analyzer test reads, drives that single xUnit test via
+# `dotnet test`, surfaces the two report files, and propagates the exit code.
+# This keeps ONE execution path (the xUnit host) for every run mode, so the
+# harness and a human get identical verdicts.
+#
+# Usage:
+#   scripts/analyze-recordings.ps1 -SaveDir <path-to-save-dir> [-ResultsDir <dir>] [-NoBuild]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$SaveDir,
+    [string]$ResultsDir,
+    [switch]$NoBuild
+)
+
+$ErrorActionPreference = "Stop"
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+
+# Resolve the save directory.
+try {
+    $resolvedSaveDir = (Resolve-Path $SaveDir -ErrorAction Stop).Path
+} catch {
+    Write-Error "Save directory not found: '$SaveDir'"
+    exit 1
+}
+if (-not (Test-Path $resolvedSaveDir -PathType Container)) {
+    Write-Error "Save path is not a directory: '$resolvedSaveDir'"
+    exit 1
+}
+
+# Results directory: explicit arg, else an 'analysis' folder beside the save.
+if ([string]::IsNullOrWhiteSpace($ResultsDir)) {
+    $ResultsDir = Join-Path $resolvedSaveDir "analysis"
+}
+if (-not (Test-Path $ResultsDir)) {
+    New-Item -ItemType Directory -Path $ResultsDir -Force | Out-Null
+}
+$resolvedResultsDir = (Resolve-Path $ResultsDir).Path
+
+# Hand the paths to the Manual analyzer test through the environment.
+$env:PARSEK_ANALYZER_SAVE = $resolvedSaveDir
+$env:PARSEK_ANALYZER_RESULTS = $resolvedResultsDir
+
+$testArgs = @(
+    "test",
+    (Join-Path $repoRoot "Source/Parsek.Tests/Parsek.Tests.csproj"),
+    "--filter", "FullyQualifiedName~OfflineAnalyzerTests.Manual_AnalyzeEnvSave_WritesReports",
+    "-v", "minimal"
+)
+if ($NoBuild) {
+    $testArgs += "--no-build"
+}
+
+Write-Host "Analyzing save '$resolvedSaveDir'"
+Write-Host "Writing reports to '$resolvedResultsDir'"
+dotnet @testArgs
+$testExit = $LASTEXITCODE
+
+# Surface the two report files (named after the save directory leaf).
+$saveName = Split-Path $resolvedSaveDir -Leaf
+$jsonPath = Join-Path $resolvedResultsDir "$saveName.analysis.json"
+$txtPath = Join-Path $resolvedResultsDir "$saveName.analysis.txt"
+
+if (Test-Path $jsonPath) {
+    Write-Host "Machine report: $jsonPath"
+} else {
+    Write-Host "Machine report was not written (expected: $jsonPath)"
+}
+if (Test-Path $txtPath) {
+    Write-Host "Human report:   $txtPath"
+}
+
+if ($testExit -ne 0) {
+    exit $testExit
+}
+
+Write-Host "Analyzer run complete."

--- a/scripts/analyze-recordings.ps1
+++ b/scripts/analyze-recordings.ps1
@@ -1,17 +1,21 @@
 # Offline recording analyzer CLI driver (module M-A1). Mirrors
 # validate-ksp-log.ps1: it resolves the target save directory, sets the env
 # vars the Manual analyzer test reads, drives that single xUnit test via
-# `dotnet test`, surfaces the two report files, and propagates the exit code.
-# This keeps ONE execution path (the xUnit host) for every run mode, so the
-# harness and a human get identical verdicts.
+# `dotnet test`, surfaces the two report files, echoes the human-report header
+# line, and propagates the exit code. This keeps ONE execution path (the xUnit
+# host) for every run mode, so the harness and a human get identical verdicts.
 #
 # Usage:
-#   scripts/analyze-recordings.ps1 -SaveDir <path-to-save-dir> [-ResultsDir <dir>] [-NoBuild]
+#   scripts/analyze-recordings.ps1 -SaveDir <path-to-save-dir> [-ResultsDir <dir>] [-NoBuild] [-FailOnRed]
+#
+# -FailOnRed exits nonzero when the report is red (any FAIL or any STALE), so a
+# harness / CI step can gate on the analyzer verdict without parsing JSON.
 param(
     [Parameter(Mandatory = $true)]
     [string]$SaveDir,
     [string]$ResultsDir,
-    [switch]$NoBuild
+    [switch]$NoBuild,
+    [switch]$FailOnRed
 )
 
 $ErrorActionPreference = "Stop"
@@ -39,24 +43,32 @@ if (-not (Test-Path $ResultsDir)) {
 }
 $resolvedResultsDir = (Resolve-Path $ResultsDir).Path
 
-# Hand the paths to the Manual analyzer test through the environment.
-$env:PARSEK_ANALYZER_SAVE = $resolvedSaveDir
-$env:PARSEK_ANALYZER_RESULTS = $resolvedResultsDir
+$testExit = 1
+try {
+    # Hand the paths to the Manual analyzer test through the environment.
+    $env:PARSEK_ANALYZER_SAVE = $resolvedSaveDir
+    $env:PARSEK_ANALYZER_RESULTS = $resolvedResultsDir
 
-$testArgs = @(
-    "test",
-    (Join-Path $repoRoot "Source/Parsek.Tests/Parsek.Tests.csproj"),
-    "--filter", "FullyQualifiedName~OfflineAnalyzerTests.Manual_AnalyzeEnvSave_WritesReports",
-    "-v", "minimal"
-)
-if ($NoBuild) {
-    $testArgs += "--no-build"
+    $testArgs = @(
+        "test",
+        (Join-Path $repoRoot "Source/Parsek.Tests/Parsek.Tests.csproj"),
+        "--filter", "FullyQualifiedName~OfflineAnalyzerTests.Manual_AnalyzeEnvSave_WritesReports",
+        "-v", "minimal"
+    )
+    if ($NoBuild) {
+        $testArgs += "--no-build"
+    }
+
+    Write-Host "Analyzing save '$resolvedSaveDir'"
+    Write-Host "Writing reports to '$resolvedResultsDir'"
+    dotnet @testArgs
+    $testExit = $LASTEXITCODE
 }
-
-Write-Host "Analyzing save '$resolvedSaveDir'"
-Write-Host "Writing reports to '$resolvedResultsDir'"
-dotnet @testArgs
-$testExit = $LASTEXITCODE
+finally {
+    # Never leak the analyzer env vars into the caller's session / a later run.
+    Remove-Item Env:\PARSEK_ANALYZER_SAVE -ErrorAction SilentlyContinue
+    Remove-Item Env:\PARSEK_ANALYZER_RESULTS -ErrorAction SilentlyContinue
+}
 
 # Surface the two report files (named after the save directory leaf).
 $saveName = Split-Path $resolvedSaveDir -Leaf
@@ -68,12 +80,33 @@ if (Test-Path $jsonPath) {
 } else {
     Write-Host "Machine report was not written (expected: $jsonPath)"
 }
+
+# Echo the human-report header line (the one-line verdict summary) so a caller
+# sees the counts without opening the file.
+$reportIsRed = $false
 if (Test-Path $txtPath) {
     Write-Host "Human report:   $txtPath"
+    $header = (Get-Content -LiteralPath $txtPath -TotalCount 1)
+    if ($header) {
+        Write-Host $header
+        # Red = any FAIL or any STALE (mirrors AnalysisReport.IsRed).
+        $failMatch = [regex]::Match($header, 'FAIL=(\d+)')
+        $staleMatch = [regex]::Match($header, 'STALE=(\d+)')
+        $failCount = if ($failMatch.Success) { [int]$failMatch.Groups[1].Value } else { 0 }
+        $staleCount = if ($staleMatch.Success) { [int]$staleMatch.Groups[1].Value } else { 0 }
+        if ($failCount -gt 0 -or $staleCount -gt 0) {
+            $reportIsRed = $true
+        }
+    }
 }
 
 if ($testExit -ne 0) {
     exit $testExit
+}
+
+if ($FailOnRed -and $reportIsRed) {
+    Write-Host "Analyzer verdict: RED (FailOnRed set) - exiting nonzero."
+    exit 2
 }
 
 Write-Host "Analyzer run complete."


### PR DESCRIPTION
## Summary

First implementation module of the automated-testing initiative (design doc: docs/dev/design-autotest-offline-analyzer.md, landed via #1299's branch which this PR stacks on).

An xUnit-hosted invariant analyzer that takes any save directory and validates every recording tree, sidecar set, ledger, and ParsekScenario node:

- **Framework**: pure invariant core (AnalyzerModel / IRecordingInvariant / Finding) with FAIL / WARN / INFO / STALE-FIXTURE verdicts, deterministic machine + human reports, CitedContract reflection gate (every rule must name its enforcing production code), core-purity gate (rules run over in-memory models, H5-ready for the future in-game category).
- **Loader**: never-crash save-directory loader (every parse failure is a FAIL finding via LOADER-FAULT - a truncated persistent.sfs analyzes RED); raw ledger via .pgld parse (no process-static mutation); sidecar probe capture.
- **12 rules**: UT monotonicity (incl. NaN), section no-double-cover, v6 RELATIVE frame contract (metre offsets never misread as lat/lon), part-event PID resolution, schema gate with exact production reason strings, resource manifest consistency, tree topology (per-(ChainId,ChainBranch) contiguity, supersede exemption via the same EffectiveState predicate the optimizer uses), annotation staleness, rewind-point integrity (path-traversal ids rejected before any fs access), ledger ELS consistency + WARN-capped career diff, codec round-trips, fixture generation stamps.
- **Entry points**: CI-floor test over synthetic corpora + Manual-trait mode over any save dir via PARSEK_ANALYZER_SAVE; scripts/analyze-recordings.ps1 driver with -FailOnRed.

## Review

Passed a clean-context adversarial review; all blockers/should-fixes applied (loader-fault findings, NaN handling, diagnostic logging, INV8 single-report policy, supersede-endpoint checks). Deferred NITs tracked in the design doc.

## Test plan

153 analyzer tests (every rule has positive + violating fixtures via RecordingBuilder/ScenarioWriter); full suite 17716 passed / 0 failed. No production source touched - all code in Source/Parsek.Tests/Analyzer/ + one script.