### PR TITLE
M-A2: ParsekTestCommands file-drop command seam

### DIFF
--- a/Source/Parsek.Tests/LockOwnershipTests.cs
+++ b/Source/Parsek.Tests/LockOwnershipTests.cs
@@ -1,0 +1,132 @@
+using Parsek.TestCommands;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    /// <summary>
+    /// Pure coverage for the lock-file grammar and ownership decision
+    /// (<see cref="LockFile"/>). Guards the single-session contract: two instances
+    /// must never both consume, a live foreign lock must not be stolen (pid liveness
+    /// beats a fresh t), and a crashed instance's lock must not wedge a fresh run (a
+    /// dead pid is reclaimed even if its t looked recent).
+    /// </summary>
+    public class LockOwnershipTests
+    {
+        private sealed class FakeProbe : IPidLivenessProbe
+        {
+            private readonly PidLiveness result;
+            public FakeProbe(PidLiveness result) { this.result = result; }
+            public PidLiveness Probe(int pid) => result;
+        }
+
+        // ----- Grammar round-trip -----
+
+        [Fact]
+        public void FormatParse_RoundTrips_WithSpacedRootPath()
+        {
+            string line = LockFile.FormatLockLine("7f3a", 48213, 17390510.101,
+                @"C:\Games\Kerbal Space Program");
+            Assert.True(LockFile.TryParseLockLine(line, out LockInfo info));
+            Assert.Equal("7f3a", info.Session);
+            Assert.Equal(48213, info.Pid);
+            Assert.Equal(@"C:\Games\Kerbal Space Program", info.Root); // spaces preserved
+        }
+
+        [Fact]
+        public void Format_UsesInvariantCulture_NoCommaInT()
+        {
+            string line = LockFile.FormatLockLine("s", 1, 17390510.101, "root");
+            // Only the escaped/root portion may contain arbitrary text; the numeric t
+            // field must not carry a locale comma.
+            Assert.Contains("t=17390510.101", line);
+        }
+
+        [Theory]
+        [InlineData("pid=1 t=2 root=x")]     // no session
+        [InlineData("session=s t=2 root=x")] // no pid
+        [InlineData("")]
+        public void TryParseLockLine_Missing_Fails(string line)
+        {
+            Assert.False(LockFile.TryParseLockLine(line, out _));
+        }
+
+        // ----- Ownership decisions -----
+
+        [Fact]
+        public void NoExistingLock_Acquires()
+        {
+            var decision = LockFile.DecideLockOwnership(
+                default, existingPresent: false, ownSession: "me", ownT: 100.0,
+                probe: new FakeProbe(PidLiveness.Alive));
+            Assert.Equal(LockOwnership.Acquire, decision);
+        }
+
+        [Fact]
+        public void OwnSessionLock_Reclaims()
+        {
+            var existing = new LockInfo { Ok = true, Session = "me", Pid = 42, T = 50.0 };
+            var decision = LockFile.DecideLockOwnership(
+                existing, existingPresent: true, ownSession: "me", ownT: 100.0,
+                probe: new FakeProbe(PidLiveness.Dead)); // probe irrelevant when it's ours
+            Assert.Equal(LockOwnership.Reclaim, decision);
+        }
+
+        [Fact]
+        public void ForeignLiveLock_StandsDown_EvenWithOlderT()
+        {
+            // pid liveness is primary: a live foreign lock is never stolen even though
+            // its t (10) looks older than ours (100).
+            var existing = new LockInfo { Ok = true, Session = "other", Pid = 999, T = 10.0 };
+            var decision = LockFile.DecideLockOwnership(
+                existing, existingPresent: true, ownSession: "me", ownT: 100.0,
+                probe: new FakeProbe(PidLiveness.Alive));
+            Assert.Equal(LockOwnership.StandDown, decision);
+        }
+
+        [Fact]
+        public void ForeignDeadLock_ReclaimsWithWarn_EvenWithRecentT()
+        {
+            // A crashed owner must not wedge a fresh run: reclaim even though its t
+            // (200) looks newer than ours (100).
+            var existing = new LockInfo { Ok = true, Session = "other", Pid = 999, T = 200.0 };
+            var decision = LockFile.DecideLockOwnership(
+                existing, existingPresent: true, ownSession: "me", ownT: 100.0,
+                probe: new FakeProbe(PidLiveness.Dead));
+            Assert.Equal(LockOwnership.ReclaimWithWarn, decision);
+        }
+
+        [Fact]
+        public void ForeignUnknownProbe_OlderOrEqualT_ReclaimsWithWarn()
+        {
+            // Cannot probe: last-resort t tie-break. Existing t (50) <= ours (100) ->
+            // treat as stale, reclaim.
+            var existing = new LockInfo { Ok = true, Session = "other", Pid = 999, T = 50.0 };
+            var decision = LockFile.DecideLockOwnership(
+                existing, existingPresent: true, ownSession: "me", ownT: 100.0,
+                probe: new FakeProbe(PidLiveness.Unknown));
+            Assert.Equal(LockOwnership.ReclaimWithWarn, decision);
+        }
+
+        [Fact]
+        public void ForeignUnknownProbe_NewerT_StandsDown()
+        {
+            // Existing t (300) newer than ours (100) -> defer to it.
+            var existing = new LockInfo { Ok = true, Session = "other", Pid = 999, T = 300.0 };
+            var decision = LockFile.DecideLockOwnership(
+                existing, existingPresent: true, ownSession: "me", ownT: 100.0,
+                probe: new FakeProbe(PidLiveness.Unknown));
+            Assert.Equal(LockOwnership.StandDown, decision);
+        }
+
+        [Fact]
+        public void ParseThenDecide_EndToEnd_ForeignLive_StandsDown()
+        {
+            string line = LockFile.FormatLockLine("other", 12345, 5.0, @"C:\KSP");
+            Assert.True(LockFile.TryParseLockLine(line, out LockInfo info));
+            var decision = LockFile.DecideLockOwnership(
+                info, existingPresent: true, ownSession: "mine", ownT: 500.0,
+                probe: new FakeProbe(PidLiveness.Alive));
+            Assert.Equal(LockOwnership.StandDown, decision);
+        }
+    }
+}

--- a/Source/Parsek.Tests/SettingWhitelistTests.cs
+++ b/Source/Parsek.Tests/SettingWhitelistTests.cs
@@ -1,0 +1,182 @@
+using System.Collections.Generic;
+using Parsek.TestCommands;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    /// <summary>
+    /// Pure coverage for the SetSetting whitelist (<see cref="SettingWhitelist"/>).
+    /// Guards three contracts: typed parse + range acceptance, the security boundary
+    /// (an arbitrary field name is rejected, never reflectively set), and the
+    /// persistence-route column (the 8 sidecar-tracked settings carry the exact
+    /// ParsekSettingsPersistence.Record* selector; the 8 GameParameters-only ones do
+    /// not). A regression in the route column writes a tracked setting only to the
+    /// live field, which ParsekScenario.OnLoad's ApplyTo would silently revert at the
+    /// next save load.
+    /// </summary>
+    public class SettingWhitelistTests
+    {
+        // ----- Accept + type/range -----
+
+        [Theory]
+        [InlineData("autoRecordOnLaunch", "true", true)]
+        [InlineData("autoRecordOnLaunch", "false", false)]
+        [InlineData("autoMerge", "true", true)]
+        [InlineData("verboseLogging", "false", false)]
+        [InlineData("ghostRenderTracing", "true", true)]
+        public void Accept_Bool(string name, string raw, bool expected)
+        {
+            var r = SettingWhitelist.TryApply(name, raw);
+            Assert.True(r.Accepted);
+            Assert.Equal(SettingValueType.Bool, r.Type);
+            Assert.Equal(expected, r.BoolValue);
+        }
+
+        [Theory]
+        [InlineData("samplingDensity", "0", 0)]
+        [InlineData("samplingDensity", "1", 1)]
+        [InlineData("samplingDensity", "2", 2)]
+        [InlineData("transitedBodyRotationModeIndex", "2", 2)]
+        public void Accept_Int_InRange(string name, string raw, int expected)
+        {
+            var r = SettingWhitelist.TryApply(name, raw);
+            Assert.True(r.Accepted);
+            Assert.Equal(SettingValueType.Int, r.Type);
+            Assert.Equal(expected, r.IntValue);
+        }
+
+        [Fact]
+        public void Accept_Float_InRange()
+        {
+            var r = SettingWhitelist.TryApply("ghostAudioVolume", "0.7");
+            Assert.True(r.Accepted);
+            Assert.Equal(SettingValueType.Float, r.Type);
+            Assert.True(System.Math.Abs(0.7f - r.FloatValue) < 1e-5f);
+        }
+
+        // ----- Reject: type / range / locale -----
+
+        [Theory]
+        [InlineData("samplingDensity", "5")]   // out of range 0..2
+        [InlineData("samplingDensity", "-1")]  // out of range
+        [InlineData("transitedBodyRotationModeIndex", "3")]
+        [InlineData("ghostAudioVolume", "1.5")] // out of range 0..1
+        [InlineData("ghostAudioVolume", "0,7")] // comma locale -> InvariantCulture rejects
+        [InlineData("autoMerge", "yes")]        // non-bool
+        [InlineData("samplingDensity", "abc")]  // non-int
+        public void Reject_ValueInvalid(string name, string raw)
+        {
+            var r = SettingWhitelist.TryApply(name, raw);
+            Assert.False(r.Accepted);
+            Assert.Equal("setting-value-invalid", r.RejectReason);
+        }
+
+        // ----- Security: arbitrary field never accepted -----
+
+        [Theory]
+        [InlineData("someOtherField")]
+        [InlineData("autoLoopIntervalSeconds")] // a real ParsekSettings field, but NOT whitelisted
+        [InlineData("")]
+        public void Reject_NonWhitelisted(string name)
+        {
+            var r = SettingWhitelist.TryApply(name, "true");
+            Assert.False(r.Accepted);
+            Assert.Equal("setting-not-whitelisted", r.RejectReason);
+            // The decision is pure data; there is no reflective set path to reach the field.
+            Assert.Null(r.RecordMethod);
+        }
+
+        // ----- Persistence route for all 16 -----
+
+        [Theory]
+        [InlineData("autoRecordOnLaunch")]
+        [InlineData("autoRecordOnEva")]
+        [InlineData("autoRecordOnFirstModificationAfterSwitch")]
+        [InlineData("autoMerge")]
+        [InlineData("verboseLogging")]
+        [InlineData("samplingDensity")]
+        [InlineData("ghostAudioVolume")]
+        [InlineData("transitedBodyRotationModeIndex")]
+        public void Route_GameParametersOnly_NoRecordMethod(string name)
+        {
+            var r = SettingWhitelist.TryApply(name, DefaultRawFor(name));
+            Assert.True(r.Accepted);
+            Assert.Equal(PersistenceRoute.GameParameters, r.Route);
+            Assert.Null(r.RecordMethod);
+        }
+
+        [Theory]
+        [InlineData("ghostRenderTracing", "RecordGhostRenderTracing")]
+        [InlineData("mapRenderTracing", "RecordMapRenderTracing")]
+        [InlineData("ledgerTracing", "RecordLedgerTracing")]
+        [InlineData("writeReadableSidecarMirrors", "RecordReadableSidecarMirrors")] // name asymmetry
+        [InlineData("autoBackupExistingSaves", "RecordAutoBackupExistingSaves")]
+        [InlineData("showCommittedFutureOverlays", "RecordShowCommittedFutureOverlays")]
+        [InlineData("blockCommittedActions", "RecordBlockCommittedActions")]
+        [InlineData("showRouteLines", "RecordShowRouteLines")]
+        public void Route_SidecarTracked_CarriesExactRecordMethod(string name, string expectedMethod)
+        {
+            var r = SettingWhitelist.TryApply(name, "true");
+            Assert.True(r.Accepted);
+            Assert.Equal(PersistenceRoute.GameParametersPlusSidecar, r.Route);
+            Assert.Equal(expectedMethod, r.RecordMethod);
+        }
+
+        [Fact]
+        public void Whitelist_HasExactly16Entries_8Tracked()
+        {
+            Assert.Equal(16, SettingWhitelist.WhitelistedNames.Count);
+
+            int tracked = 0;
+            foreach (string name in SettingWhitelist.WhitelistedNames)
+            {
+                var r = SettingWhitelist.TryApply(name, DefaultRawFor(name));
+                Assert.True(r.Accepted);
+                if (r.Route == PersistenceRoute.GameParametersPlusSidecar)
+                {
+                    tracked++;
+                    Assert.NotNull(r.RecordMethod);
+                }
+                else
+                {
+                    Assert.Null(r.RecordMethod);
+                }
+            }
+            Assert.Equal(8, tracked);
+        }
+
+        [Fact]
+        public void RecordMethodNames_MatchPersistenceMembers()
+        {
+            // The whitelist stores method-name strings; verify each names a real
+            // ParsekSettingsPersistence member (the applier calls it by name, so a
+            // typo here would silently no-op the sidecar write at runtime).
+            var persistenceType = typeof(ParsekSettingsPersistence);
+            foreach (string name in SettingWhitelist.WhitelistedNames)
+            {
+                var r = SettingWhitelist.TryApply(name, DefaultRawFor(name));
+                if (r.RecordMethod == null) continue;
+                var method = persistenceType.GetMethod(
+                    r.RecordMethod,
+                    System.Reflection.BindingFlags.Static
+                    | System.Reflection.BindingFlags.NonPublic
+                    | System.Reflection.BindingFlags.Public);
+                Assert.True(method != null, $"missing ParsekSettingsPersistence.{r.RecordMethod} for setting {name}");
+            }
+        }
+
+        private static string DefaultRawFor(string name)
+        {
+            switch (name)
+            {
+                case "samplingDensity":
+                case "transitedBodyRotationModeIndex":
+                    return "1";
+                case "ghostAudioVolume":
+                    return "0.5";
+                default:
+                    return "true";
+            }
+        }
+    }
+}

--- a/Source/Parsek.Tests/TestCommandChannelIoTests.cs
+++ b/Source/Parsek.Tests/TestCommandChannelIoTests.cs
@@ -1,0 +1,106 @@
+using System.Text;
+using Parsek.TestCommands;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    /// <summary>
+    /// Pure coverage for the channel-I/O decisions (<see cref="TestCommandChannelIo"/>):
+    /// the whole-line byte-offset advance rule and the bounded append-retry / backoff
+    /// policy. The raw FileStream work lives in the addon and is exercised in-game; these
+    /// are the parts of it that must be provably correct without Unity - a wrong offset
+    /// advance would re-read or drop a command line, and a wrong retry bound would either
+    /// spin forever or drop an ack.
+    /// </summary>
+    public class TestCommandChannelIoTests
+    {
+        // ----- Offset advance -----
+
+        [Fact]
+        public void WholeLineByteCount_AdvancesPastLastNewline_LeavingTornFragment()
+        {
+            byte[] buffer = Encoding.UTF8.GetBytes("id=1 cmd=A\nid=2 cmd=B\nid=3 cmd");
+            int whole = TestCommandChannelIo.WholeLineByteCount(buffer, buffer.Length);
+            // One past the SECOND '\n'; the "id=3 cmd" fragment is not consumed.
+            Assert.Equal("id=1 cmd=A\nid=2 cmd=B\n".Length, whole);
+        }
+
+        [Fact]
+        public void WholeLineByteCount_NoNewline_ConsumesNothing()
+        {
+            byte[] buffer = Encoding.UTF8.GetBytes("id=1 cmd=A");
+            Assert.Equal(0, TestCommandChannelIo.WholeLineByteCount(buffer, buffer.Length));
+        }
+
+        [Fact]
+        public void WholeLineByteCount_TrailingNewline_ConsumesAll()
+        {
+            byte[] buffer = Encoding.UTF8.GetBytes("id=1 cmd=A\n");
+            Assert.Equal(buffer.Length, TestCommandChannelIo.WholeLineByteCount(buffer, buffer.Length));
+        }
+
+        [Fact]
+        public void WholeLineByteCount_CountBoundsScan_IgnoresBytesBeyondCount()
+        {
+            // A newline lies beyond the reported read count; it must not be consumed.
+            byte[] buffer = Encoding.UTF8.GetBytes("id=1\nXXXX");
+            int reportedRead = 4; // "id=1" only; the '\n' at index 4 is beyond the read
+            Assert.Equal(0, TestCommandChannelIo.WholeLineByteCount(buffer, reportedRead));
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(-1)]
+        public void WholeLineByteCount_NonPositiveCount_IsZero(int count)
+        {
+            byte[] buffer = Encoding.UTF8.GetBytes("id=1 cmd=A\n");
+            Assert.Equal(0, TestCommandChannelIo.WholeLineByteCount(buffer, count));
+        }
+
+        [Fact]
+        public void WholeLineByteCount_NullBuffer_IsZero()
+        {
+            Assert.Equal(0, TestCommandChannelIo.WholeLineByteCount(null, 5));
+        }
+
+        [Fact]
+        public void WholeLineByteCount_Crlf_ConsumesThroughLf()
+        {
+            byte[] buffer = Encoding.UTF8.GetBytes("id=1 cmd=A\r\nid=2");
+            // Advance past the '\n' (CRLF included); "id=2" fragment left behind.
+            Assert.Equal("id=1 cmd=A\r\n".Length, TestCommandChannelIo.WholeLineByteCount(buffer, buffer.Length));
+        }
+
+        // ----- Retry / backoff -----
+
+        [Fact]
+        public void ShouldRetryAppend_RetriesUntilLastAttempt()
+        {
+            int max = TestCommandChannelIo.MaxAppendAttempts;
+            for (int attempt = 1; attempt < max; attempt++)
+                Assert.True(TestCommandChannelIo.ShouldRetryAppend(attempt, max));
+            // The final failure gives up (exhaustion leaves the id at EXECUTED).
+            Assert.False(TestCommandChannelIo.ShouldRetryAppend(max, max));
+        }
+
+        [Fact]
+        public void BackoffMillis_ScalesLinearly_AndFloorsAtOne()
+        {
+            Assert.Equal(TestCommandChannelIo.BaseBackoffMillis * 1, TestCommandChannelIo.BackoffMillis(1));
+            Assert.Equal(TestCommandChannelIo.BaseBackoffMillis * 3, TestCommandChannelIo.BackoffMillis(3));
+            // A non-positive attempt is treated as the first attempt (never a zero delay).
+            Assert.Equal(TestCommandChannelIo.BaseBackoffMillis, TestCommandChannelIo.BackoffMillis(0));
+        }
+
+        // ----- File-name constants (the fixed KSP-root channel) -----
+
+        [Fact]
+        public void ChannelFileNames_AreTheFixedContract()
+        {
+            Assert.Equal("parsek-test-commands.txt", TestCommandChannelIo.CommandFileName);
+            Assert.Equal("parsek-test-responses.txt", TestCommandChannelIo.ResponseFileName);
+            Assert.Equal("parsek-test-commands.journal", TestCommandChannelIo.JournalFileName);
+            Assert.Equal("parsek-test-commands.lock", TestCommandChannelIo.LockFileName);
+        }
+    }
+}

--- a/Source/Parsek.Tests/TestCommandCodecTests.cs
+++ b/Source/Parsek.Tests/TestCommandCodecTests.cs
@@ -1,0 +1,89 @@
+using Parsek.TestCommands;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    /// <summary>
+    /// Pure coverage for the ParsekTestCommands percent codec and token splitter
+    /// (<see cref="TestCommandProtocol"/>). Guards the wire-value contract: a
+    /// MissionMark label with spaces, a path with an '=', or a literal '%' must
+    /// survive a single encode/decode round-trip on one token. A regression here
+    /// splits a spaced value across tokens (breaks parsing) or corrupts a '%'.
+    /// </summary>
+    public class TestCommandCodecTests
+    {
+        [Theory]
+        [InlineData("mun landing start", "mun%20landing%20start")]
+        [InlineData("a=b", "a%3Db")]
+        [InlineData("50%", "50%25")]
+        [InlineData("plain", "plain")]
+        [InlineData("", "")]
+        public void Encode_SpecialChars_ProducesPercentForm(string literal, string encoded)
+        {
+            Assert.Equal(encoded, TestCommandProtocol.Encode(literal));
+        }
+
+        [Theory]
+        [InlineData("mun%20landing", "mun landing")]
+        [InlineData("a%3Db", "a=b")]
+        [InlineData("50%25", "50%")]
+        [InlineData("plain", "plain")]
+        public void Decode_PercentForm_ProducesLiteral(string encoded, string literal)
+        {
+            Assert.True(TestCommandProtocol.TryDecode(encoded, out string decoded));
+            Assert.Equal(literal, decoded);
+        }
+
+        [Theory]
+        [InlineData("mun landing start")]
+        [InlineData("a=b=c")]
+        [InlineData("100%")]
+        [InlineData("tab\tsep")]
+        [InlineData("percent%and=equals space")]
+        public void EncodeDecode_RoundTrips(string literal)
+        {
+            string encoded = TestCommandProtocol.Encode(literal);
+            Assert.True(TestCommandProtocol.TryDecode(encoded, out string back));
+            Assert.Equal(literal, back);
+        }
+
+        [Fact]
+        public void Encode_ControlChars_AreEscaped()
+        {
+            // Newline (0x0A) and DEL (0x7F) must not appear raw on a token.
+            string encoded = TestCommandProtocol.Encode("line\nend");
+            Assert.DoesNotContain("\n", encoded);
+            Assert.Contains("%0A", encoded);
+        }
+
+        [Theory]
+        [InlineData("%2")]     // truncated escape
+        [InlineData("%")]      // bare percent at end
+        [InlineData("ab%zz")]  // non-hex digits
+        [InlineData("x%g0")]   // one bad hex digit
+        public void Decode_MalformedEscape_Fails(string encoded)
+        {
+            Assert.False(TestCommandProtocol.TryDecode(encoded, out _));
+        }
+
+        [Theory]
+        [InlineData("id=0001", "id", "0001")]
+        [InlineData("name=mun%20landing", "name", "mun%20landing")]
+        [InlineData("k=a=b", "k", "a=b")] // split at FIRST '=', value keeps the rest
+        public void TrySplitToken_SplitsAtFirstEquals(string token, string key, string rawValue)
+        {
+            Assert.True(TestCommandProtocol.TrySplitToken(token, out string k, out string v));
+            Assert.Equal(key, k);
+            Assert.Equal(rawValue, v);
+        }
+
+        [Theory]
+        [InlineData("bareTokenNoEquals")]
+        [InlineData("=leadingEqualsEmptyKey")]
+        [InlineData("")]
+        public void TrySplitToken_Malformed_Fails(string token)
+        {
+            Assert.False(TestCommandProtocol.TrySplitToken(token, out _, out _));
+        }
+    }
+}

--- a/Source/Parsek.Tests/TestCommandCodecTests.cs
+++ b/Source/Parsek.Tests/TestCommandCodecTests.cs
@@ -67,6 +67,23 @@ namespace Parsek.Tests
         }
 
         [Theory]
+        // Non-ASCII strings are built with \u escapes to keep the test SOURCE pure ASCII:
+        // \u00fc = u-umlaut, \u4e2d\u6587 = CJK, \u00e9 = e-acute, \u2192 = a right-arrow.
+        [InlineData("M\u00fcn")]
+        [InlineData("\u4e2d\u6587")]
+        [InlineData("caf\u00e9")]
+        [InlineData("Mun \u2192 orbit")] // mixed ASCII + a non-ASCII arrow + a space
+        public void Encode_NonAscii_ProducesPureAsciiAndRoundTrips(string literal)
+        {
+            string encoded = TestCommandProtocol.Encode(literal);
+            // Every non-ASCII byte is percent-encoded, so the wire token is pure ASCII.
+            foreach (char c in encoded)
+                Assert.True(c < 0x80, $"encoded token must be pure ASCII, saw U+{(int)c:X4}");
+            Assert.True(TestCommandProtocol.TryDecode(encoded, out string back));
+            Assert.Equal(literal, back);
+        }
+
+        [Theory]
         [InlineData("id=0001", "id", "0001")]
         [InlineData("name=mun%20landing", "name", "mun%20landing")]
         [InlineData("k=a=b", "k", "a=b")] // split at FIRST '=', value keeps the rest

--- a/Source/Parsek.Tests/TestCommandDeferralBudgetTests.cs
+++ b/Source/Parsek.Tests/TestCommandDeferralBudgetTests.cs
@@ -1,0 +1,77 @@
+using Parsek.TestCommands;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    /// <summary>
+    /// Pure coverage for the deferral-budget model
+    /// (<see cref="DeferralBudget"/>). Guards that a never-satisfiable command
+    /// converts to TIMEOUT once past its per-verb budget and the pump advances,
+    /// rather than wedging the run forever. Also pins the per-verb budgets
+    /// (default 60s, LoadGame 300s, StartRecording scene-wait, RunTests scenario
+    /// budget with fallback).
+    /// </summary>
+    public class TestCommandDeferralBudgetTests
+    {
+        [Fact]
+        public void Default_Is60()
+        {
+            Assert.Equal(60.0, DeferralBudget.BudgetSeconds("MissionMark"));
+            Assert.Equal(60.0, DeferralBudget.BudgetSeconds("SetSetting"));
+        }
+
+        [Fact]
+        public void LoadGame_Is300()
+        {
+            Assert.Equal(300.0, DeferralBudget.BudgetSeconds("LoadGame"));
+        }
+
+        [Fact]
+        public void StartRecording_UsesSceneWaitBudget_GreaterThanDefault()
+        {
+            double budget = DeferralBudget.BudgetSeconds("StartRecording");
+            Assert.Equal(DeferralBudget.StartRecordingSceneWaitSeconds, budget);
+            Assert.True(budget > DeferralBudget.DefaultSeconds);
+        }
+
+        [Fact]
+        public void RunTests_UsesScenarioBudget_WhenProvided()
+        {
+            Assert.Equal(1200.0, DeferralBudget.BudgetSeconds("RunTests", 1200.0));
+        }
+
+        [Fact]
+        public void RunTests_FallsBack_WhenNoScenarioBudget()
+        {
+            Assert.Equal(DeferralBudget.RunTestsFallbackSeconds, DeferralBudget.BudgetSeconds("RunTests"));
+        }
+
+        [Fact]
+        public void ShouldTimeout_False_WithinBudget()
+        {
+            // First deferred at t=100, now t=140, budget 60 -> not yet.
+            Assert.False(DeferralBudget.ShouldTimeout(100.0, 140.0, 60.0));
+        }
+
+        [Fact]
+        public void ShouldTimeout_True_AtBudgetBoundary()
+        {
+            Assert.True(DeferralBudget.ShouldTimeout(100.0, 160.0, 60.0));
+        }
+
+        [Fact]
+        public void ShouldTimeout_True_PastBudget()
+        {
+            Assert.True(DeferralBudget.ShouldTimeout(100.0, 500.0, 60.0));
+        }
+
+        [Fact]
+        public void ShouldTimeout_Converts_OverLoadGameBudget()
+        {
+            // A LoadGame stuck deferring past 300s converts and advances.
+            double budget = DeferralBudget.BudgetSeconds("LoadGame");
+            Assert.False(DeferralBudget.ShouldTimeout(0.0, 299.0, budget));
+            Assert.True(DeferralBudget.ShouldTimeout(0.0, 301.0, budget));
+        }
+    }
+}

--- a/Source/Parsek.Tests/TestCommandDiagnosticsTests.cs
+++ b/Source/Parsek.Tests/TestCommandDiagnosticsTests.cs
@@ -1,0 +1,80 @@
+using System.Collections.Generic;
+using Parsek;
+using Parsek.TestCommands;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    /// <summary>
+    /// P6.1 log-assertion coverage for the per-command diagnostic lines. Every dispatch /
+    /// execution branch routes its log through <see cref="TestCommandDiagnostics"/>; these
+    /// tests pin the grep-able shapes (id + reason present) for the load-bearing lines
+    /// (receipt, dispatch branches, verdict, timeout, duplicate, reject) so a decision
+    /// branch is never silent and the shapes cannot drift under refactor. Uses the
+    /// RewindLoggingTests TestSink pattern.
+    /// </summary>
+    [Collection("Sequential")]
+    public class TestCommandDiagnosticsTests
+    {
+        private readonly List<string> lines = new List<string>();
+
+        public TestCommandDiagnosticsTests()
+        {
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.VerboseOverrideForTesting = true; // let Verbose lines through the sink
+            ParsekLog.TestSinkForTesting = l => lines.Add(l);
+        }
+
+        private void AssertLine(string level, string mustContain)
+            => Assert.Contains(lines, l => l.Contains(level) && l.Contains("[TestCommands]") && l.Contains(mustContain));
+
+        [Fact]
+        public void Receipt_LogsIdVerbArgs()
+        {
+            TestCommandDiagnostics.Receipt("0001", "SetSetting", 2);
+            AssertLine("[INFO]", "recv id=0001 cmd=SetSetting args=2");
+            ParsekLog.ResetTestOverrides();
+        }
+
+        [Fact]
+        public void DispatchBranches_EachEmitIdAndReason()
+        {
+            TestCommandDiagnostics.DispatchExecute("a1");
+            TestCommandDiagnostics.DispatchDefer("a2", "not-in-flight");
+            TestCommandDiagnostics.DispatchReject("a3", "InvokeRewind", "not-implemented-v1");
+            TestCommandDiagnostics.DispatchInterrupted("a4", JournalPhase.Claimed);
+
+            AssertLine("[INFO]", "dispatch id=a1 -> EXECUTE");
+            AssertLine("[INFO]", "dispatch id=a2 -> DEFER reason=not-in-flight");
+            AssertLine("[WARN]", "reject id=a3 cmd=InvokeRewind reason=not-implemented-v1");
+            AssertLine("[INFO]", "dispatch id=a4 -> INTERRUPTED (journal=Claimed)");
+            ParsekLog.ResetTestOverrides();
+        }
+
+        [Fact]
+        public void ExecVerdict_AndResponseAppended_Logged()
+        {
+            TestCommandDiagnostics.ExecVerdict("b1", "OK");
+            TestCommandDiagnostics.ResponseAppended("b1", "OK");
+            AssertLine("[INFO]", "exec id=b1 verdict=OK");
+            AssertLine("[VERBOSE]", "response appended id=b1 verdict=OK");
+            ParsekLog.ResetTestOverrides();
+        }
+
+        [Fact]
+        public void Timeout_LogsDeferredSeconds_InvariantCulture()
+        {
+            TestCommandDiagnostics.Timeout("c1", "StartRecording", 65.5, "not-in-flight");
+            AssertLine("[WARN]", "timeout id=c1 cmd=StartRecording deferred=65.5s reason=not-in-flight");
+            ParsekLog.ResetTestOverrides();
+        }
+
+        [Fact]
+        public void Duplicate_LogsIgnoredWarn()
+        {
+            TestCommandDiagnostics.Duplicate("d1");
+            AssertLine("[WARN]", "duplicate id=d1 ignored");
+            ParsekLog.ResetTestOverrides();
+        }
+    }
+}

--- a/Source/Parsek.Tests/TestCommandDispatchStateTests.cs
+++ b/Source/Parsek.Tests/TestCommandDispatchStateTests.cs
@@ -1,0 +1,86 @@
+using System.Collections.Generic;
+using Parsek.TestCommands;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    /// <summary>
+    /// Pure coverage for the dispatcher's static surface (P3.1): the per-verb
+    /// precondition table and the ITestCommandExecutor contract. Guards that every
+    /// implemented v1 verb has a precondition entry with the right scene requirement
+    /// (a missing/wrong entry would let a recorder verb execute outside FLIGHT) and
+    /// that the executor interface exposes exactly one method per v1 verb.
+    /// </summary>
+    public class TestCommandDispatchStateTests
+    {
+        /// <summary>Minimal fake executor used to prove the interface shape and that a
+        /// dispatched verb routes to exactly one method. Records the last call.</summary>
+        private sealed class FakeExecutor : ITestCommandExecutor
+        {
+            public readonly List<string> Calls = new List<string>();
+            public void SetSetting(ParsedCommand cmd) => Calls.Add("SetSetting");
+            public void StartRecording(ParsedCommand cmd) => Calls.Add("StartRecording");
+            public void StopRecording(ParsedCommand cmd) => Calls.Add("StopRecording");
+            public void CommitTree(ParsedCommand cmd) => Calls.Add("CommitTree");
+            public void DiscardTree(ParsedCommand cmd) => Calls.Add("DiscardTree");
+            public void RecordingState(ParsedCommand cmd) => Calls.Add("RecordingState");
+            public void RunTests(ParsedCommand cmd) => Calls.Add("RunTests");
+            public void LoadGame(ParsedCommand cmd) => Calls.Add("LoadGame");
+            public void MissionMark(ParsedCommand cmd) => Calls.Add("MissionMark");
+            public void FlushAndQuit(ParsedCommand cmd) => Calls.Add("FlushAndQuit");
+        }
+
+        [Fact]
+        public void PreconditionTable_CoversAllImplementedVerbs()
+        {
+            foreach (string verb in TestCommandVerbs.ImplementedVerbNames)
+            {
+                Assert.True(TestCommandDispatcher.PreconditionTable.ContainsKey(verb),
+                    $"no precondition entry for implemented verb {verb}");
+            }
+            Assert.Equal(TestCommandVerbs.ImplementedVerbNames.Count,
+                TestCommandDispatcher.PreconditionTable.Count);
+        }
+
+        // Expected requirement passed as a name string because the internal enum
+        // cannot appear in a public xUnit theory signature.
+        [Theory]
+        [InlineData("StartRecording", "RequiresFlight")]
+        [InlineData("StopRecording", "RequiresFlight")]
+        [InlineData("CommitTree", "RequiresFlight")]
+        [InlineData("DiscardTree", "RequiresFlight")]
+        [InlineData("SetSetting", "RequiresGameLoaded")]
+        [InlineData("RecordingState", "AnyScene")]
+        [InlineData("RunTests", "AnyScene")]
+        [InlineData("LoadGame", "AnyScene")]
+        [InlineData("MissionMark", "AnyScene")]
+        [InlineData("FlushAndQuit", "AnyScene")]
+        public void RequirementFor_MatchesTable(string verb, string expected)
+        {
+            Assert.Equal(expected, TestCommandDispatcher.RequirementFor(verb).ToString());
+        }
+
+        [Fact]
+        public void Executor_HasOneMethodPerImplementedVerb()
+        {
+            var fake = new FakeExecutor();
+            var cmd = new ParsedCommand();
+            fake.SetSetting(cmd);
+            fake.StartRecording(cmd);
+            fake.StopRecording(cmd);
+            fake.CommitTree(cmd);
+            fake.DiscardTree(cmd);
+            fake.RecordingState(cmd);
+            fake.RunTests(cmd);
+            fake.LoadGame(cmd);
+            fake.MissionMark(cmd);
+            fake.FlushAndQuit(cmd);
+
+            // One interface method per implemented v1 verb, no more, no less.
+            var interfaceMethods = typeof(ITestCommandExecutor).GetMethods();
+            Assert.Equal(TestCommandVerbs.ImplementedVerbNames.Count, interfaceMethods.Length);
+            foreach (string verb in TestCommandVerbs.ImplementedVerbNames)
+                Assert.Contains(fake.Calls, c => c == verb);
+        }
+    }
+}

--- a/Source/Parsek.Tests/TestCommandDispatchTests.cs
+++ b/Source/Parsek.Tests/TestCommandDispatchTests.cs
@@ -1,0 +1,218 @@
+using Parsek.TestCommands;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    /// <summary>
+    /// Pure coverage for the dispatch decision
+    /// (<see cref="TestCommandDispatcher.DecideDispatch"/>). This is the safety gate:
+    /// a command must never execute in an unsafe scene/state, LoadGame must never
+    /// silently discard an in-flight recording, and a leftover CLAIMED must resolve
+    /// to Interrupted (crash recovery) rather than re-execute. The matrix walks verb
+    /// x state cells and asserts Execute / Defer(reason) / Reject(reason) / Interrupted.
+    /// </summary>
+    public class TestCommandDispatchTests
+    {
+        private static ParsedCommand Cmd(string verb)
+            => TestCommandParser.ParseLine("id=1 cmd=" + verb, 1);
+
+        private static DispatchState Flight() => new DispatchState
+        {
+            Scene = TestCommandScene.Flight,
+            GameLoaded = true,
+            SettingsPresent = true,
+        };
+
+        private static DispatchState MainMenu() => new DispatchState
+        {
+            Scene = TestCommandScene.MainMenu,
+        };
+
+        // ----- Journal-phase crash recovery -----
+
+        [Fact]
+        public void JournalClaimed_Interrupted_EvenForExecutableVerb()
+        {
+            var st = Flight();
+            st.JournalPhase = JournalPhase.Claimed;
+            var r = TestCommandDispatcher.DecideDispatch(Cmd("StartRecording"), st);
+            Assert.Equal(DispatchDecision.Interrupted, r.Decision);
+        }
+
+        // ----- Parse / verb-class rejects -----
+
+        [Fact]
+        public void Malformed_Rejects_WithParseError()
+        {
+            var parsed = TestCommandParser.ParseLine("id=1 cmd=MissionMark garbage", 1);
+            var r = TestCommandDispatcher.DecideDispatch(parsed, Flight());
+            Assert.Equal(DispatchDecision.Reject, r.Decision);
+            Assert.Equal("malformed", r.Reason);
+        }
+
+        [Fact]
+        public void MissingId_Rejects_MissingId()
+        {
+            var parsed = TestCommandParser.ParseLine("cmd=MissionMark", 1);
+            var r = TestCommandDispatcher.DecideDispatch(parsed, Flight());
+            Assert.Equal(DispatchDecision.Reject, r.Decision);
+            Assert.Equal("missing-id", r.Reason);
+        }
+
+        [Fact]
+        public void ReservedVerb_Rejects_NotImplementedV1()
+        {
+            var r = TestCommandDispatcher.DecideDispatch(Cmd("InvokeRewind"), Flight());
+            Assert.Equal(DispatchDecision.Reject, r.Decision);
+            Assert.Equal("not-implemented-v1", r.Reason);
+        }
+
+        [Fact]
+        public void UnknownVerb_Rejects_UnknownCommand()
+        {
+            var r = TestCommandDispatcher.DecideDispatch(Cmd("Frobnicate"), Flight());
+            Assert.Equal(DispatchDecision.Reject, r.Decision);
+            Assert.Equal("unknown-command", r.Reason);
+        }
+
+        // ----- Safe-point gate -----
+
+        [Fact]
+        public void Transitioning_Defers_NotSafePoint()
+        {
+            var st = Flight();
+            st.Transitioning = true;
+            var r = TestCommandDispatcher.DecideDispatch(Cmd("MissionMark"), st);
+            Assert.Equal(DispatchDecision.Defer, r.Decision);
+            Assert.Equal("not-safe-point", r.Reason);
+        }
+
+        [Fact]
+        public void LoadingScene_Defers_NotSafePoint()
+        {
+            var st = new DispatchState { Scene = TestCommandScene.Loading };
+            var r = TestCommandDispatcher.DecideDispatch(Cmd("MissionMark"), st);
+            Assert.Equal(DispatchDecision.Defer, r.Decision);
+            Assert.Equal("not-safe-point", r.Reason);
+        }
+
+        [Fact]
+        public void SettleCounter_Defers_NotSafePoint()
+        {
+            var st = Flight();
+            st.SettleCounter = 2;
+            var r = TestCommandDispatcher.DecideDispatch(Cmd("MissionMark"), st);
+            Assert.Equal(DispatchDecision.Defer, r.Decision);
+            Assert.Equal("not-safe-point", r.Reason);
+        }
+
+        [Fact]
+        public void BatchRunning_Defers_BatchRunning()
+        {
+            var st = Flight();
+            st.BatchRunning = true;
+            var r = TestCommandDispatcher.DecideDispatch(Cmd("RunTests"), st);
+            Assert.Equal(DispatchDecision.Defer, r.Decision);
+            Assert.Equal("batch-running", r.Reason);
+        }
+
+        // ----- Per-verb scene precondition -----
+
+        [Theory]
+        [InlineData("StartRecording")]
+        [InlineData("StopRecording")]
+        [InlineData("CommitTree")]
+        [InlineData("DiscardTree")]
+        public void FlightVerb_OutsideFlight_Defers_NotInFlight(string verb)
+        {
+            var r = TestCommandDispatcher.DecideDispatch(Cmd(verb), MainMenu());
+            Assert.Equal(DispatchDecision.Defer, r.Decision);
+            Assert.Equal("not-in-flight", r.Reason);
+        }
+
+        [Theory]
+        [InlineData("StartRecording")]
+        [InlineData("StopRecording")]
+        [InlineData("DiscardTree")]
+        public void FlightVerb_InFlight_Executes(string verb)
+        {
+            var r = TestCommandDispatcher.DecideDispatch(Cmd(verb), Flight());
+            Assert.Equal(DispatchDecision.Execute, r.Decision);
+        }
+
+        [Fact]
+        public void CommitTree_InFlight_NoTree_StillExecutes_HandlerEmitsError()
+        {
+            // Dispatch only gates scene; the no-active-tree ERROR is the handler's
+            // job (C1), so CommitTree in FLIGHT executes even without a tree.
+            var st = Flight();
+            st.HasTree = false;
+            var r = TestCommandDispatcher.DecideDispatch(Cmd("CommitTree"), st);
+            Assert.Equal(DispatchDecision.Execute, r.Decision);
+        }
+
+        [Fact]
+        public void SetSetting_NoGame_Defers_GameNotLoaded()
+        {
+            var st = MainMenu(); // SettingsPresent = false
+            var r = TestCommandDispatcher.DecideDispatch(Cmd("SetSetting"), st);
+            Assert.Equal(DispatchDecision.Defer, r.Decision);
+            Assert.Equal("game-not-loaded", r.Reason);
+        }
+
+        [Fact]
+        public void SetSetting_GameLoaded_AnyScene_Executes()
+        {
+            var st = new DispatchState { Scene = TestCommandScene.SpaceCenter, GameLoaded = true, SettingsPresent = true };
+            var r = TestCommandDispatcher.DecideDispatch(Cmd("SetSetting"), st);
+            Assert.Equal(DispatchDecision.Execute, r.Decision);
+        }
+
+        [Theory]
+        [InlineData("RecordingState")]
+        [InlineData("MissionMark")]
+        [InlineData("FlushAndQuit")]
+        public void AnySceneVerb_ExecutesEvenAtTrackingStation(string verb)
+        {
+            var st = new DispatchState { Scene = TestCommandScene.TrackingStation };
+            var r = TestCommandDispatcher.DecideDispatch(Cmd(verb), st);
+            Assert.Equal(DispatchDecision.Execute, r.Decision);
+        }
+
+        [Fact]
+        public void RunTests_NoBatch_Executes()
+        {
+            var r = TestCommandDispatcher.DecideDispatch(Cmd("RunTests"), Flight());
+            Assert.Equal(DispatchDecision.Execute, r.Decision);
+        }
+
+        // ----- LoadGame boot channel + guards -----
+
+        [Fact]
+        public void LoadGame_AtMainMenu_NoRecorder_Executes()
+        {
+            var r = TestCommandDispatcher.DecideDispatch(Cmd("LoadGame"), MainMenu());
+            Assert.Equal(DispatchDecision.Execute, r.Decision);
+        }
+
+        [Fact]
+        public void LoadGame_LiveRecorder_Rejects_RecordingActive()
+        {
+            var st = Flight();
+            st.Recording = true;
+            var r = TestCommandDispatcher.DecideDispatch(Cmd("LoadGame"), st);
+            Assert.Equal(DispatchDecision.Reject, r.Decision);
+            Assert.Equal("recording-active", r.Reason);
+        }
+
+        [Fact]
+        public void LoadGame_LoadInFlight_Rejects_LoadInFlight()
+        {
+            var st = MainMenu();
+            st.LoadInFlight = true;
+            var r = TestCommandDispatcher.DecideDispatch(Cmd("LoadGame"), st);
+            Assert.Equal(DispatchDecision.Reject, r.Decision);
+            Assert.Equal("load-in-flight", r.Reason);
+        }
+    }
+}

--- a/Source/Parsek.Tests/TestCommandEnvGateTests.cs
+++ b/Source/Parsek.Tests/TestCommandEnvGateTests.cs
@@ -1,0 +1,46 @@
+using Parsek.TestCommands;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    /// <summary>
+    /// Pure coverage for the addon's fail-closed env gate
+    /// (<see cref="ParsekTestCommandAddon.IsArmed"/>). Only the literal <c>"1"</c> arms
+    /// the seam; every other value (unset / <c>"0"</c> / <c>"true"</c> / empty) stays
+    /// inert. Fails if the addon could consume commands without the exact gate, which
+    /// would ship the seam enabled by accident.
+    /// </summary>
+    public class TestCommandEnvGateTests
+    {
+        [Fact]
+        public void ExactlyOne_Arms()
+        {
+            Assert.True(ParsekTestCommandAddon.IsArmed("1"));
+        }
+
+        [Theory]
+        [InlineData(null)]   // env var unset
+        [InlineData("0")]
+        [InlineData("true")]
+        [InlineData("")]     // present but empty
+        [InlineData(" 1")]   // whitespace is not an exact match
+        [InlineData("1 ")]
+        [InlineData("01")]
+        [InlineData("yes")]
+        [InlineData("TRUE")]
+        public void AnythingElse_StaysInert(string envValue)
+        {
+            Assert.False(ParsekTestCommandAddon.IsArmed(envValue));
+        }
+
+        [Theory]
+        [InlineData(null, "unset")]
+        [InlineData("", "empty")]
+        [InlineData("0", "0")]
+        [InlineData("true", "true")]
+        public void FormatEnvForLog_RendersDistinctly(string envValue, string expected)
+        {
+            Assert.Equal(expected, ParsekTestCommandAddon.FormatEnvForLog(envValue));
+        }
+    }
+}

--- a/Source/Parsek.Tests/TestCommandExecutionTests.cs
+++ b/Source/Parsek.Tests/TestCommandExecutionTests.cs
@@ -1,0 +1,56 @@
+using Parsek.TestCommands;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    /// <summary>
+    /// Pure coverage for the execution-outcome decisions
+    /// (<see cref="TestCommandExecution"/>): an executor throw is contained as a terminal
+    /// ERROR (so the id completes and the pump advances rather than the whole seam wedging
+    /// on an unhandled throw), and only the two-phase pending sentinel holds the FIFO head.
+    /// </summary>
+    public class TestCommandExecutionTests
+    {
+        [Fact]
+        public void ExceptionTerminal_ProducesError_WithExceptionTypeName()
+        {
+            TestCommandExecution.ExceptionTerminal("InvalidOperationException",
+                out string verdict, out string msg);
+            Assert.Equal("ERROR", verdict);
+            Assert.Contains("InvalidOperationException", msg);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void ExceptionTerminal_NullOrEmptyType_StillError(string type)
+        {
+            TestCommandExecution.ExceptionTerminal(type, out string verdict, out string msg);
+            Assert.Equal("ERROR", verdict);
+            Assert.False(string.IsNullOrEmpty(msg));
+        }
+
+        [Fact]
+        public void ErrorVerdict_AdvancesQueue()
+        {
+            // The contained-exception ERROR is a real terminal verdict -> the pump advances.
+            Assert.True(TestCommandExecution.AdvancesQueue("ERROR"));
+        }
+
+        [Theory]
+        [InlineData("OK")]
+        [InlineData("REJECTED")]
+        [InlineData("TIMEOUT")]
+        [InlineData("INTERRUPTED")]
+        public void TerminalVerdicts_AdvanceQueue(string verdict)
+        {
+            Assert.True(TestCommandExecution.AdvancesQueue(verdict));
+        }
+
+        [Fact]
+        public void PendingVerdict_HoldsHead_DoesNotAdvance()
+        {
+            Assert.False(TestCommandExecution.AdvancesQueue(TestCommandExecution.PendingVerdict));
+        }
+    }
+}

--- a/Source/Parsek.Tests/TestCommandFlushAndQuitTests.cs
+++ b/Source/Parsek.Tests/TestCommandFlushAndQuitTests.cs
@@ -1,0 +1,37 @@
+using System.Collections.Generic;
+using System.Linq;
+using Parsek.TestCommands;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    /// <summary>
+    /// P5.8 coverage for the FlushAndQuit save gate + payload. A menu quit (no game
+    /// loaded) has nothing to save; a flight quit with a resolved save folder forces a
+    /// persistent save before quitting. Fails if the gate would attempt a save with no
+    /// game / no save folder, or if the saved payload key drifts.
+    /// </summary>
+    public class TestCommandFlushAndQuitTests
+    {
+        private static string Val(List<KeyValuePair<string, string>> p, string key)
+            => p.First(kv => kv.Key == key).Value;
+
+        [Theory]
+        [InlineData(true, true, true)]    // game loaded + save folder -> save
+        [InlineData(true, false, false)]  // game loaded but no save folder -> no save
+        [InlineData(false, true, false)]  // no game (menu) -> no save
+        [InlineData(false, false, false)] // no game, no folder -> no save
+        public void ShouldSave_OnlyWhenGameLoadedAndSaveFolderPresent(
+            bool gameLoaded, bool saveFolderPresent, bool expected)
+        {
+            Assert.Equal(expected, TestCommandFlushAndQuit.ShouldSave(gameLoaded, saveFolderPresent));
+        }
+
+        [Fact]
+        public void BuildPayload_ReflectsSavedFlag()
+        {
+            Assert.Equal("true", Val(TestCommandFlushAndQuit.BuildPayload(true), "saved"));
+            Assert.Equal("false", Val(TestCommandFlushAndQuit.BuildPayload(false), "saved"));
+        }
+    }
+}

--- a/Source/Parsek.Tests/TestCommandJournalTests.cs
+++ b/Source/Parsek.Tests/TestCommandJournalTests.cs
@@ -27,10 +27,33 @@ namespace Parsek.Tests
         [Fact]
         public void FormatExecuted_RoundTrips()
         {
-            string line = TestCommandJournal.FormatExecuted("0002", 2, 17390512.951);
+            string line = TestCommandJournal.FormatExecuted("0002", 2, 17390512.951, "OK", null, null);
             Assert.True(TestCommandJournal.TryParseLine(line, out JournalLine jl));
             Assert.Equal(JournalPhase.Executed, jl.Phase);
             Assert.Equal("0002", jl.Id);
+        }
+
+        [Fact]
+        public void FormatExecuted_CarriesVerdictPayloadMsg_RoundTrips()
+        {
+            var payload = new System.Collections.Generic.List<System.Collections.Generic.KeyValuePair<string, string>>
+            {
+                new System.Collections.Generic.KeyValuePair<string, string>("recordingId", "abc123"),
+                new System.Collections.Generic.KeyValuePair<string, string>("scene", "FLIGHT"),
+            };
+            // A msg with a space and '=' must survive the double-encode (payload token) and
+            // per-value encode round-trip.
+            string line = TestCommandJournal.FormatExecuted("0006", 6, 17390512.951, "OK", payload, "note with=eq");
+            Assert.True(TestCommandJournal.TryParseLine(line, out JournalLine jl));
+            Assert.Equal("OK", jl.Verdict);
+            Assert.Equal("note with=eq", jl.Msg);
+            Assert.NotNull(jl.Payload);
+            Assert.Equal(2, jl.Payload.Count);
+            Assert.Equal("recordingId", jl.Payload[0].Key);
+            Assert.Equal("abc123", jl.Payload[0].Value);
+            Assert.Equal("FLIGHT", jl.Payload[1].Value);
+            // The whole EXECUTED line stays a single-line, ASCII wire token (no raw newline).
+            Assert.DoesNotContain("\n", line);
         }
 
         [Fact]

--- a/Source/Parsek.Tests/TestCommandJournalTests.cs
+++ b/Source/Parsek.Tests/TestCommandJournalTests.cs
@@ -1,0 +1,92 @@
+using Parsek.TestCommands;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    /// <summary>
+    /// Pure coverage for the journal (WAL) line grammar
+    /// (<see cref="TestCommandJournal"/>) formatters, parse, and the torn-trailing-
+    /// line rule of the line splitter. A regression here corrupts the durable
+    /// at-most-once record or lets a half-written (never durably committed) trailing
+    /// line drive recovery.
+    /// </summary>
+    public class TestCommandJournalTests
+    {
+        [Fact]
+        public void FormatClaimed_RoundTripsThroughParser()
+        {
+            string line = TestCommandJournal.FormatClaimed("0002", 2, "StartRecording", "7f3a", 17390512.884);
+            Assert.True(TestCommandJournal.TryParseLine(line, out JournalLine jl));
+            Assert.Equal("0002", jl.Id);
+            Assert.Equal(JournalPhase.Claimed, jl.Phase);
+            Assert.Equal(2, jl.Seq);
+            Assert.Equal("StartRecording", jl.Verb);
+            Assert.Equal("7f3a", jl.Session);
+        }
+
+        [Fact]
+        public void FormatExecuted_RoundTrips()
+        {
+            string line = TestCommandJournal.FormatExecuted("0002", 2, 17390512.951);
+            Assert.True(TestCommandJournal.TryParseLine(line, out JournalLine jl));
+            Assert.Equal(JournalPhase.Executed, jl.Phase);
+            Assert.Equal("0002", jl.Id);
+        }
+
+        [Fact]
+        public void FormatDone_CarriesVerdict()
+        {
+            string line = TestCommandJournal.FormatDone("0002", 2, "OK", 17390512.960);
+            Assert.True(TestCommandJournal.TryParseLine(line, out JournalLine jl));
+            Assert.Equal(JournalPhase.Done, jl.Phase);
+            Assert.Equal("OK", jl.Verdict);
+        }
+
+        [Fact]
+        public void Format_UsesInvariantCulture_NoCommaInT()
+        {
+            string line = TestCommandJournal.FormatClaimed("1", 1, "LoadGame", "abc", 17390512.884);
+            Assert.DoesNotContain(",", line);
+        }
+
+        [Theory]
+        [InlineData("id=1 seq=2 verb=X t=3")]      // no phase
+        [InlineData("phase=CLAIMED seq=2")]         // no id
+        [InlineData("id=1 phase=BOGUS seq=2")]      // unknown phase
+        [InlineData("")]
+        public void TryParseLine_Malformed_Fails(string line)
+        {
+            Assert.False(TestCommandJournal.TryParseLine(line, out _));
+        }
+
+        [Fact]
+        public void SplitCompleteLines_DropsTornTrailingLine()
+        {
+            // Two whole lines + a torn third (no trailing \n).
+            string content =
+                "id=1 phase=CLAIMED seq=1 verb=X session=s t=1\n"
+                + "id=1 phase=EXECUTED seq=1 t=2\n"
+                + "id=1 phase=DONE seq=1 verd"; // torn, never committed
+            var lines = TestCommandJournal.SplitCompleteLines(content);
+            Assert.Equal(2, lines.Count);
+            Assert.Contains("phase=EXECUTED", lines[1]);
+        }
+
+        [Fact]
+        public void SplitCompleteLines_HandlesCrlf()
+        {
+            string content = "id=1 phase=CLAIMED seq=1 verb=X session=s t=1\r\n";
+            var lines = TestCommandJournal.SplitCompleteLines(content);
+            Assert.Single(lines);
+            Assert.True(TestCommandJournal.TryParseLine(lines[0], out JournalLine jl));
+            Assert.Equal(JournalPhase.Claimed, jl.Phase);
+        }
+
+        [Fact]
+        public void SplitCompleteLines_EmptyOrNull_ReturnsEmpty()
+        {
+            Assert.Empty(TestCommandJournal.SplitCompleteLines(null));
+            Assert.Empty(TestCommandJournal.SplitCompleteLines(""));
+        }
+    }
+}

--- a/Source/Parsek.Tests/TestCommandJournalTests.cs
+++ b/Source/Parsek.Tests/TestCommandJournalTests.cs
@@ -88,5 +88,33 @@ namespace Parsek.Tests
             Assert.Empty(TestCommandJournal.SplitCompleteLines(null));
             Assert.Empty(TestCommandJournal.SplitCompleteLines(""));
         }
+
+        // ----- In-memory phase-map mirror (defense-in-depth at-most-once) -----
+
+        [Fact]
+        public void MirrorPhaseIntoMap_RaisesPhase_KeepsHighest()
+        {
+            var map = new System.Collections.Generic.Dictionary<string, JournalPhase>();
+            TestCommandJournal.MirrorPhaseIntoMap(map, "0002", "CLAIMED");
+            Assert.Equal(JournalPhase.Claimed, map["0002"]);
+            TestCommandJournal.MirrorPhaseIntoMap(map, "0002", "EXECUTED");
+            Assert.Equal(JournalPhase.Executed, map["0002"]);
+            TestCommandJournal.MirrorPhaseIntoMap(map, "0002", "DONE");
+            Assert.Equal(JournalPhase.Done, map["0002"]);
+            // A lower phase after a higher one never regresses the map.
+            TestCommandJournal.MirrorPhaseIntoMap(map, "0002", "CLAIMED");
+            Assert.Equal(JournalPhase.Done, map["0002"]);
+        }
+
+        [Fact]
+        public void MirrorPhaseIntoMap_UnknownToken_OrNullId_IsNoOp()
+        {
+            var map = new System.Collections.Generic.Dictionary<string, JournalPhase>();
+            TestCommandJournal.MirrorPhaseIntoMap(map, "x", "BOGUS");
+            Assert.False(map.ContainsKey("x"));
+            TestCommandJournal.MirrorPhaseIntoMap(map, null, "CLAIMED");
+            Assert.Empty(map);
+            TestCommandJournal.MirrorPhaseIntoMap(null, "x", "CLAIMED"); // null map: no throw
+        }
     }
 }

--- a/Source/Parsek.Tests/TestCommandLoadGameTests.cs
+++ b/Source/Parsek.Tests/TestCommandLoadGameTests.cs
@@ -21,29 +21,39 @@ namespace Parsek.Tests
         public void Focusable_ValidGame_InRangeIdx()
         {
             Assert.True(TestCommandLoadGame.IsLoadedGameFocusable(
-                gamePresent: true, flightStatePresent: true, protoVesselsPresent: true,
+                gamePresent: true, compatible: true, flightStatePresent: true, protoVesselsPresent: true,
                 activeVesselIdx: 0, protoVesselCount: 3));
         }
 
         [Fact]
         public void NotFocusable_NullGame()
         {
-            Assert.False(TestCommandLoadGame.IsLoadedGameFocusable(false, false, false, 0, 0));
+            Assert.False(TestCommandLoadGame.IsLoadedGameFocusable(false, false, false, false, 0, 0));
+        }
+
+        [Fact]
+        public void NotFocusable_IncompatibleGame()
+        {
+            // A version-incompatible game (Game.compatible == false) is NOT focusable even
+            // though it parsed and has an in-range active vessel.
+            Assert.False(TestCommandLoadGame.IsLoadedGameFocusable(
+                gamePresent: true, compatible: false, flightStatePresent: true, protoVesselsPresent: true,
+                activeVesselIdx: 0, protoVesselCount: 3));
         }
 
         [Fact]
         public void NotFocusable_NullFlightState_OrProtoVessels()
         {
-            Assert.False(TestCommandLoadGame.IsLoadedGameFocusable(true, false, false, 0, 1));
-            Assert.False(TestCommandLoadGame.IsLoadedGameFocusable(true, true, false, 0, 1));
+            Assert.False(TestCommandLoadGame.IsLoadedGameFocusable(true, true, false, false, 0, 1));
+            Assert.False(TestCommandLoadGame.IsLoadedGameFocusable(true, true, true, false, 0, 1));
         }
 
         [Fact]
         public void NotFocusable_IdxOutOfRange()
         {
-            Assert.False(TestCommandLoadGame.IsLoadedGameFocusable(true, true, true, -1, 2));
-            Assert.False(TestCommandLoadGame.IsLoadedGameFocusable(true, true, true, 2, 2));
-            Assert.False(TestCommandLoadGame.IsLoadedGameFocusable(true, true, true, 5, 2));
+            Assert.False(TestCommandLoadGame.IsLoadedGameFocusable(true, true, true, true, -1, 2));
+            Assert.False(TestCommandLoadGame.IsLoadedGameFocusable(true, true, true, true, 2, 2));
+            Assert.False(TestCommandLoadGame.IsLoadedGameFocusable(true, true, true, true, 5, 2));
         }
 
         [Fact]

--- a/Source/Parsek.Tests/TestCommandLoadGameTests.cs
+++ b/Source/Parsek.Tests/TestCommandLoadGameTests.cs
@@ -1,0 +1,65 @@
+using System.Collections.Generic;
+using System.Linq;
+using Parsek.TestCommands;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    /// <summary>
+    /// P5.7 coverage for the LoadGame focusability decision + completion payload. A null
+    /// / incompatible game or an out-of-range active-vessel index must fail with
+    /// load-failed rather than sending FlightDriver.StartAndFocusVessel a bad index
+    /// (design edge case 27). Fails if a bad load is treated as focusable, or if the
+    /// completion payload keys drift.
+    /// </summary>
+    public class TestCommandLoadGameTests
+    {
+        private static string Val(List<KeyValuePair<string, string>> p, string key)
+            => p.First(kv => kv.Key == key).Value;
+
+        [Fact]
+        public void Focusable_ValidGame_InRangeIdx()
+        {
+            Assert.True(TestCommandLoadGame.IsLoadedGameFocusable(
+                gamePresent: true, flightStatePresent: true, protoVesselsPresent: true,
+                activeVesselIdx: 0, protoVesselCount: 3));
+        }
+
+        [Fact]
+        public void NotFocusable_NullGame()
+        {
+            Assert.False(TestCommandLoadGame.IsLoadedGameFocusable(false, false, false, 0, 0));
+        }
+
+        [Fact]
+        public void NotFocusable_NullFlightState_OrProtoVessels()
+        {
+            Assert.False(TestCommandLoadGame.IsLoadedGameFocusable(true, false, false, 0, 1));
+            Assert.False(TestCommandLoadGame.IsLoadedGameFocusable(true, true, false, 0, 1));
+        }
+
+        [Fact]
+        public void NotFocusable_IdxOutOfRange()
+        {
+            Assert.False(TestCommandLoadGame.IsLoadedGameFocusable(true, true, true, -1, 2));
+            Assert.False(TestCommandLoadGame.IsLoadedGameFocusable(true, true, true, 2, 2));
+            Assert.False(TestCommandLoadGame.IsLoadedGameFocusable(true, true, true, 5, 2));
+        }
+
+        [Fact]
+        public void CompletePayload_CarriesSceneAndSave()
+        {
+            var p = TestCommandLoadGame.BuildCompletePayload("FLIGHT", "DefaultCareer");
+            Assert.Equal("FLIGHT", Val(p, "scene"));
+            Assert.Equal("DefaultCareer", Val(p, "save"));
+            Assert.Equal(new[] { "scene", "save" }, p.Select(kv => kv.Key).ToArray());
+        }
+
+        [Fact]
+        public void CompletePayload_NullSave_EmptyString()
+        {
+            var p = TestCommandLoadGame.BuildCompletePayload("MAINMENU", null);
+            Assert.Equal(string.Empty, Val(p, "save"));
+        }
+    }
+}

--- a/Source/Parsek.Tests/TestCommandMissionMarkTests.cs
+++ b/Source/Parsek.Tests/TestCommandMissionMarkTests.cs
@@ -1,0 +1,60 @@
+using System.Collections.Generic;
+using Parsek;
+using Parsek.TestCommands;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    /// <summary>
+    /// P5.3 coverage for the MissionMark stable log line. The orchestrator greps
+    /// <c>MISSIONMARK label=&lt;label&gt; ut=&lt;ut&gt;</c> to correlate its own timeline
+    /// against the KSP session, so the message shape is a load-bearing contract. Both
+    /// the pure format and the actual ParsekLog.Info emission (tag + level) are asserted;
+    /// fails if the marker format drifts or the tag/level changes.
+    /// </summary>
+    [Collection("Sequential")]
+    public class TestCommandMissionMarkTests
+    {
+        public TestCommandMissionMarkTests() => ParsekLog.ResetTestOverrides();
+
+        [Fact]
+        public void FormatMarkMessage_WithUt_IsStable()
+        {
+            Assert.Equal("MISSIONMARK label=mun landing start ut=1234.5",
+                TestCommandMissionMark.FormatMarkMessage("mun landing start", 1234.5));
+        }
+
+        [Fact]
+        public void FormatMarkMessage_NoGame_RendersUtNone()
+        {
+            Assert.Equal("MISSIONMARK label=x ut=none",
+                TestCommandMissionMark.FormatMarkMessage("x", null));
+        }
+
+        [Fact]
+        public void FormatMarkMessage_NullLabel_EmptyLabel()
+        {
+            Assert.Equal("MISSIONMARK label= ut=none",
+                TestCommandMissionMark.FormatMarkMessage(null, null));
+        }
+
+        [Fact]
+        public void EmitMark_LogsTaggedInfoLine()
+        {
+            var lines = new List<string>();
+            ParsekLog.TestSinkForTesting = l => lines.Add(l);
+            try
+            {
+                TestCommandMissionMark.EmitMark("mun landing start", 1234.5);
+            }
+            finally
+            {
+                ParsekLog.ResetTestOverrides();
+            }
+
+            Assert.Contains(lines, l =>
+                l.Contains("[INFO]") && l.Contains("[TestCommands]")
+                && l.Contains("MISSIONMARK label=mun landing start ut=1234.5"));
+        }
+    }
+}

--- a/Source/Parsek.Tests/TestCommandParserTests.cs
+++ b/Source/Parsek.Tests/TestCommandParserTests.cs
@@ -126,6 +126,17 @@ namespace Parsek.Tests
             Assert.Equal("StopRecording", p.Verb);
         }
 
+        [Fact]
+        public void LeadingUtf8Bom_IsStripped_FirstCommandParses()
+        {
+            // N3: an editor / tooling can prepend a UTF-8 BOM (U+FEFF) to the file head; it
+            // must be stripped before tokenizing or the first command's id token fails.
+            var p = TestCommandParser.ParseLine("\uFEFFid=1 cmd=StopRecording", 1);
+            Assert.True(p.ParseOk);
+            Assert.Equal("1", p.Id);
+            Assert.Equal("StopRecording", p.Verb);
+        }
+
         // ----- F2: encoding-unsafe id / verb rejected at parse time -----
 
         [Fact]

--- a/Source/Parsek.Tests/TestCommandParserTests.cs
+++ b/Source/Parsek.Tests/TestCommandParserTests.cs
@@ -125,5 +125,57 @@ namespace Parsek.Tests
             Assert.True(p.ParseOk);
             Assert.Equal("StopRecording", p.Verb);
         }
+
+        // ----- F2: encoding-unsafe id / verb rejected at parse time -----
+
+        [Fact]
+        public void EncodedSpaceId_IsRejected_MalformedId()
+        {
+            // id=a%20b decodes to "a b"; a raw space in the id would journal-tokenize to "a"
+            // (a re-execution-after-restart hole), so it is rejected.
+            var p = TestCommandParser.ParseLine("id=a%20b cmd=MissionMark", 1);
+            Assert.False(p.ParseOk);
+            Assert.Equal("malformed-id", p.ParseError);
+        }
+
+        [Fact]
+        public void NewlineId_IsRejected_MalformedId()
+        {
+            // id=a%0Ab decodes to "a\nb"; a raw newline in the id would forge a journal line.
+            var p = TestCommandParser.ParseLine("id=a%0Ab cmd=MissionMark", 1);
+            Assert.False(p.ParseOk);
+            Assert.Equal("malformed-id", p.ParseError);
+        }
+
+        [Fact]
+        public void EncodingUnsafeVerb_IsRejected_MalformedVerb()
+        {
+            var p = TestCommandParser.ParseLine("id=1 cmd=Bad%0AVerb", 1);
+            Assert.False(p.ParseOk);
+            Assert.Equal("malformed-verb", p.ParseError);
+            Assert.Equal("1", p.Id); // id salvaged for correlation
+        }
+
+        [Theory]
+        [InlineData("0001")]
+        [InlineData("run-3.cmd-42")]
+        [InlineData("a1b2c3d4e5f6")]
+        public void AcceptedId_RoundTripsThroughJournalFormatters_ByteStable(string id)
+        {
+            // An accepted (encoding-stable) id embeds verbatim into every journal formatter
+            // and parses back unchanged -> no tokenization drift for the dedup key.
+            var p = TestCommandParser.ParseLine("id=" + id + " cmd=StopRecording", 1);
+            Assert.True(p.ParseOk);
+            Assert.Equal(id, p.Id);
+
+            string claimed = TestCommandJournal.FormatClaimed(id, 1, "StopRecording", "s", 1);
+            string executed = TestCommandJournal.FormatExecuted(id, 1, 2, "OK", null, null);
+            string done = TestCommandJournal.FormatDone(id, 1, "OK", 3);
+            foreach (string line in new[] { claimed, executed, done })
+            {
+                Assert.True(TestCommandJournal.TryParseLine(line, out JournalLine jl));
+                Assert.Equal(id, jl.Id);
+            }
+        }
     }
 }

--- a/Source/Parsek.Tests/TestCommandParserTests.cs
+++ b/Source/Parsek.Tests/TestCommandParserTests.cs
@@ -1,0 +1,129 @@
+using Parsek.TestCommands;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    /// <summary>
+    /// Pure coverage for the command-line envelope parser
+    /// (<see cref="TestCommandParser.ParseLine"/>). Guards the grammar: id first,
+    /// cmd second, args any order, unknown keys ignored, blank/# skipped, and each
+    /// malformed shape returning the correct reason. A regression here would accept
+    /// a malformed line and later execute it as a real command, or drop args.
+    /// </summary>
+    public class TestCommandParserTests
+    {
+        [Fact]
+        public void Valid_Line_PopulatesEnvelopeAndArgs()
+        {
+            var p = TestCommandParser.ParseLine("id=0001 cmd=SetSetting name=x value=false", 1);
+            Assert.True(p.ParseOk);
+            Assert.False(p.Ignored);
+            Assert.Equal("0001", p.Id);
+            Assert.Equal("SetSetting", p.Verb);
+            Assert.Equal("x", p.Args["name"]);
+            Assert.Equal("false", p.Args["value"]);
+        }
+
+        [Fact]
+        public void Valid_Line_DecodesPercentEncodedArg()
+        {
+            var p = TestCommandParser.ParseLine("id=7 cmd=MissionMark label=mun%20landing%20start", 1);
+            Assert.True(p.ParseOk);
+            Assert.Equal("mun landing start", p.Args["label"]);
+        }
+
+        [Fact]
+        public void Args_AnyOrder_AfterIdAndCmd()
+        {
+            var p = TestCommandParser.ParseLine("id=2 cmd=LoadGame name=persistent save=DefaultCareer", 1);
+            Assert.True(p.ParseOk);
+            Assert.Equal("DefaultCareer", p.Args["save"]);
+            Assert.Equal("persistent", p.Args["name"]);
+        }
+
+        [Fact]
+        public void UnknownKeys_AreKeptNotRejected()
+        {
+            // v= and any future phase-3 key are tolerated (forward compatibility).
+            var p = TestCommandParser.ParseLine("id=3 cmd=RecordingState v=1 futureKey=abc", 1);
+            Assert.True(p.ParseOk);
+            Assert.Equal("1", p.Args["v"]);
+            Assert.Equal("abc", p.Args["futureKey"]);
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("   ")]
+        [InlineData("\t")]
+        public void BlankLine_IsIgnored(string line)
+        {
+            var p = TestCommandParser.ParseLine(line, 5);
+            Assert.True(p.Ignored);
+            Assert.False(p.ParseOk);
+        }
+
+        [Fact]
+        public void CommentLine_IsIgnored()
+        {
+            var p = TestCommandParser.ParseLine("# this is a comment", 5);
+            Assert.True(p.Ignored);
+            Assert.False(p.ParseOk);
+        }
+
+        [Fact]
+        public void MissingId_FirstTokenNotId_ReturnsMissingId()
+        {
+            var p = TestCommandParser.ParseLine("cmd=StartRecording name=x", 4);
+            Assert.False(p.ParseOk);
+            Assert.False(p.Ignored);
+            Assert.Equal("missing-id", p.ParseError);
+            Assert.Null(p.Id);
+            Assert.Equal("line#4", TestCommandParser.FallbackId(p.LineNumber));
+        }
+
+        [Fact]
+        public void MissingCmd_SecondTokenNotCmd_ReturnsMissingCmdUnderRealId()
+        {
+            var p = TestCommandParser.ParseLine("id=0009 name=x", 1);
+            Assert.False(p.ParseOk);
+            Assert.Equal("missing-cmd", p.ParseError);
+            Assert.Equal("0009", p.Id); // id salvaged for correlation
+        }
+
+        [Fact]
+        public void BareToken_NoEquals_IsMalformed()
+        {
+            var p = TestCommandParser.ParseLine("id=1 cmd=MissionMark garbage", 1);
+            Assert.False(p.ParseOk);
+            Assert.Equal("malformed", p.ParseError);
+            Assert.Equal("1", p.Id); // id still salvaged
+        }
+
+        [Fact]
+        public void ValueWithRawSpace_SplitsIntoBareToken_IsMalformed()
+        {
+            // An un-encoded space splits "mun landing" into a second bare token.
+            var p = TestCommandParser.ParseLine("id=1 cmd=MissionMark label=mun landing", 1);
+            Assert.False(p.ParseOk);
+            Assert.Equal("malformed", p.ParseError);
+        }
+
+        [Fact]
+        public void GarbageFirstToken_NoUsableId_FallsBackToLineNumber()
+        {
+            var p = TestCommandParser.ParseLine("garbage", 12);
+            Assert.False(p.ParseOk);
+            Assert.Equal("malformed", p.ParseError);
+            Assert.Null(p.Id);
+            Assert.Equal("line#12", TestCommandParser.FallbackId(p.LineNumber));
+        }
+
+        [Fact]
+        public void TrailingNewline_IsStripped()
+        {
+            var p = TestCommandParser.ParseLine("id=1 cmd=StopRecording\n", 1);
+            Assert.True(p.ParseOk);
+            Assert.Equal("StopRecording", p.Verb);
+        }
+    }
+}

--- a/Source/Parsek.Tests/TestCommandRecordingStateTests.cs
+++ b/Source/Parsek.Tests/TestCommandRecordingStateTests.cs
@@ -1,0 +1,62 @@
+using System.Collections.Generic;
+using System.Linq;
+using Parsek.TestCommands;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    /// <summary>
+    /// P5.2 payload coverage for <see cref="TestCommandRecordingState.BuildPayload"/>.
+    /// RecordingState is read-only and valid in any scene; the load-bearing branch is
+    /// the no-flight-instance collapse (recording=false, empty tree, zero points) so a
+    /// menu / space-center RecordingState never reports a stale live recorder. Fails if
+    /// a field name drifts or the no-flight collapse leaks a stale tree/points value.
+    /// </summary>
+    public class TestCommandRecordingStateTests
+    {
+        private static string Val(List<KeyValuePair<string, string>> p, string key)
+            => p.First(kv => kv.Key == key).Value;
+
+        [Fact]
+        public void NoFlight_CollapsesToNotRecording_RegardlessOfOtherInputs()
+        {
+            var p = TestCommandRecordingState.BuildPayload(
+                hasFlight: false, isRecording: true, treeId: "abc", points: 99, sceneName: "MAINMENU");
+
+            Assert.Equal("false", Val(p, "recording"));
+            Assert.Equal(string.Empty, Val(p, "tree"));
+            Assert.Equal("0", Val(p, "points"));
+            Assert.Equal("MAINMENU", Val(p, "scene"));
+        }
+
+        [Fact]
+        public void Flight_Recording_ReportsSnapshotFields()
+        {
+            var p = TestCommandRecordingState.BuildPayload(
+                hasFlight: true, isRecording: true, treeId: "tree7", points: 812, sceneName: "FLIGHT");
+
+            Assert.Equal("true", Val(p, "recording"));
+            Assert.Equal("tree7", Val(p, "tree"));
+            Assert.Equal("812", Val(p, "points"));
+            Assert.Equal("FLIGHT", Val(p, "scene"));
+        }
+
+        [Fact]
+        public void Flight_NotRecording_NullTree_EmptyString()
+        {
+            var p = TestCommandRecordingState.BuildPayload(
+                hasFlight: true, isRecording: false, treeId: null, points: 0, sceneName: "FLIGHT");
+
+            Assert.Equal("false", Val(p, "recording"));
+            Assert.Equal(string.Empty, Val(p, "tree"));
+            Assert.Equal("0", Val(p, "points"));
+        }
+
+        [Fact]
+        public void Payload_HasExactlyTheFourContractKeys_InOrder()
+        {
+            var p = TestCommandRecordingState.BuildPayload(true, true, "t", 1, "FLIGHT");
+            Assert.Equal(new[] { "recording", "tree", "points", "scene" }, p.Select(kv => kv.Key).ToArray());
+        }
+    }
+}

--- a/Source/Parsek.Tests/TestCommandRecordingVerbsTests.cs
+++ b/Source/Parsek.Tests/TestCommandRecordingVerbsTests.cs
@@ -1,0 +1,61 @@
+using System.Collections.Generic;
+using System.Linq;
+using Parsek.TestCommands;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    /// <summary>
+    /// P5.4 / P5.5 payload coverage for the four recorder/tree verbs. The idempotency
+    /// flags (already / idle / nothing) are the signals the orchestrator uses to tell a
+    /// real action from a no-op, so their presence rules are pinned here. Fails if a
+    /// no-op flag leaks onto a real action (or vice versa) or a payload key drifts.
+    /// </summary>
+    public class TestCommandRecordingVerbsTests
+    {
+        private static bool Has(List<KeyValuePair<string, string>> p, string key)
+            => p.Any(kv => kv.Key == key);
+
+        private static string Val(List<KeyValuePair<string, string>> p, string key)
+            => p.First(kv => kv.Key == key).Value;
+
+        [Fact]
+        public void Start_FreshRecorder_NoAlreadyFlag()
+        {
+            var p = TestCommandRecordingVerbs.BuildStartPayload(alreadyLive: false, recordingId: "rec1");
+            Assert.Equal("rec1", Val(p, "recordingId"));
+            Assert.False(Has(p, "already"));
+        }
+
+        [Fact]
+        public void Start_AlreadyLive_CarriesAlreadyTrue()
+        {
+            var p = TestCommandRecordingVerbs.BuildStartPayload(alreadyLive: true, recordingId: "rec1");
+            Assert.Equal("rec1", Val(p, "recordingId"));
+            Assert.Equal("true", Val(p, "already"));
+        }
+
+        [Fact]
+        public void Start_NullRecordingId_EmptyString()
+        {
+            var p = TestCommandRecordingVerbs.BuildStartPayload(false, null);
+            Assert.Equal(string.Empty, Val(p, "recordingId"));
+        }
+
+        [Fact]
+        public void Stop_LiveRecorder_StoppedTrue_NoIdle()
+        {
+            var p = TestCommandRecordingVerbs.BuildStopPayload(wasLive: true);
+            Assert.Equal("true", Val(p, "stopped"));
+            Assert.False(Has(p, "idle"));
+        }
+
+        [Fact]
+        public void Stop_NoRecorder_StoppedFalse_IdleTrue()
+        {
+            var p = TestCommandRecordingVerbs.BuildStopPayload(wasLive: false);
+            Assert.Equal("false", Val(p, "stopped"));
+            Assert.Equal("true", Val(p, "idle"));
+        }
+    }
+}

--- a/Source/Parsek.Tests/TestCommandRecordingVerbsTests.cs
+++ b/Source/Parsek.Tests/TestCommandRecordingVerbsTests.cs
@@ -57,5 +57,28 @@ namespace Parsek.Tests
             Assert.Equal("false", Val(p, "stopped"));
             Assert.Equal("true", Val(p, "idle"));
         }
+
+        [Fact]
+        public void Commit_PayloadIsCommittedTrue()
+        {
+            var p = TestCommandRecordingVerbs.BuildCommitPayload();
+            Assert.Equal("true", Val(p, "committed"));
+        }
+
+        [Fact]
+        public void Discard_WithTree_DiscardedTrue()
+        {
+            var p = TestCommandRecordingVerbs.BuildDiscardPayload(hadTree: true);
+            Assert.Equal("true", Val(p, "discarded"));
+            Assert.False(Has(p, "nothing"));
+        }
+
+        [Fact]
+        public void Discard_NoTree_NothingTrue()
+        {
+            var p = TestCommandRecordingVerbs.BuildDiscardPayload(hadTree: false);
+            Assert.Equal("true", Val(p, "nothing"));
+            Assert.False(Has(p, "discarded"));
+        }
     }
 }

--- a/Source/Parsek.Tests/TestCommandRecoveryTests.cs
+++ b/Source/Parsek.Tests/TestCommandRecoveryTests.cs
@@ -1,0 +1,163 @@
+using System.Collections.Generic;
+using Parsek.TestCommands;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    /// <summary>
+    /// Pure coverage for the crash-recovery decision
+    /// (<see cref="TestCommandJournal.ReplayIntoPhaseMap"/> +
+    /// <see cref="TestCommandJournal.DecideRecovery"/>). This is the core
+    /// at-most-once guarantee: a non-idempotent command runs zero-or-one times,
+    /// never twice. The matrix covers every journal-replay cell including the
+    /// long-running LoadGame boot rows (CLAIMED never re-initiates, EXECUTED
+    /// rewrites, DONE skips), duplicate ids, and a torn trailing line.
+    /// </summary>
+    public class TestCommandRecoveryTests
+    {
+        // ----- Phase -> action, direct -----
+
+        [Fact]
+        public void FreshId_NoJournal_Executes()
+        {
+            Assert.Equal(RecoveryAction.Execute,
+                TestCommandJournal.DecideRecovery("x", JournalPhase.None));
+        }
+
+        [Fact]
+        public void Claimed_Interrupted_NoReExecute()
+        {
+            Assert.Equal(RecoveryAction.Interrupted,
+                TestCommandJournal.DecideRecovery("x", JournalPhase.Claimed));
+        }
+
+        [Fact]
+        public void Executed_RewritesResponse()
+        {
+            Assert.Equal(RecoveryAction.RewriteResponse,
+                TestCommandJournal.DecideRecovery("x", JournalPhase.Executed));
+        }
+
+        [Fact]
+        public void Done_Skips()
+        {
+            Assert.Equal(RecoveryAction.Skip,
+                TestCommandJournal.DecideRecovery("x", JournalPhase.Done));
+        }
+
+        // ----- Replay + decision, ordinary command -----
+
+        [Fact]
+        public void Replay_ClaimedOnly_DecidesInterrupted()
+        {
+            string content = TestCommandJournal.FormatClaimed("0002", 2, "StartRecording", "s", 1) + "\n";
+            var map = TestCommandJournal.ReplayIntoPhaseMap(content);
+            Assert.Equal(JournalPhase.Claimed, map["0002"]);
+            Assert.Equal(RecoveryAction.Interrupted, TestCommandJournal.DecideRecovery(map, "0002"));
+        }
+
+        [Fact]
+        public void Replay_ClaimedThenExecuted_DecidesRewrite()
+        {
+            string content =
+                TestCommandJournal.FormatClaimed("0002", 2, "StartRecording", "s", 1) + "\n"
+                + TestCommandJournal.FormatExecuted("0002", 2, 2) + "\n";
+            var map = TestCommandJournal.ReplayIntoPhaseMap(content);
+            Assert.Equal(JournalPhase.Executed, map["0002"]);
+            Assert.Equal(RecoveryAction.RewriteResponse, TestCommandJournal.DecideRecovery(map, "0002"));
+        }
+
+        [Fact]
+        public void Replay_FullLifecycle_DecidesSkip()
+        {
+            string content =
+                TestCommandJournal.FormatClaimed("0002", 2, "StartRecording", "s", 1) + "\n"
+                + TestCommandJournal.FormatExecuted("0002", 2, 2) + "\n"
+                + TestCommandJournal.FormatDone("0002", 2, "OK", 3) + "\n";
+            var map = TestCommandJournal.ReplayIntoPhaseMap(content);
+            Assert.Equal(JournalPhase.Done, map["0002"]);
+            Assert.Equal(RecoveryAction.Skip, TestCommandJournal.DecideRecovery(map, "0002"));
+        }
+
+        [Fact]
+        public void Replay_UnknownId_DecidesExecute()
+        {
+            var map = TestCommandJournal.ReplayIntoPhaseMap("");
+            Assert.Equal(RecoveryAction.Execute, TestCommandJournal.DecideRecovery(map, "never-seen"));
+        }
+
+        // ----- LoadGame rows (long-running boot channel) -----
+
+        [Fact]
+        public void LoadGame_Claimed_Interrupted_NeverReInitiate()
+        {
+            // Crashed mid-scene-load: journal at CLAIMED. Must NOT re-initiate the load.
+            string content = TestCommandJournal.FormatClaimed("0006", 6, "LoadGame", "s", 1) + "\n";
+            var map = TestCommandJournal.ReplayIntoPhaseMap(content);
+            Assert.Equal(RecoveryAction.Interrupted, TestCommandJournal.DecideRecovery(map, "0006"));
+        }
+
+        [Fact]
+        public void LoadGame_Executed_Rewrites()
+        {
+            string content =
+                TestCommandJournal.FormatClaimed("0006", 6, "LoadGame", "s", 1) + "\n"
+                + TestCommandJournal.FormatExecuted("0006", 6, 2) + "\n";
+            var map = TestCommandJournal.ReplayIntoPhaseMap(content);
+            Assert.Equal(RecoveryAction.RewriteResponse, TestCommandJournal.DecideRecovery(map, "0006"));
+        }
+
+        [Fact]
+        public void LoadGame_Done_Skips()
+        {
+            string content =
+                TestCommandJournal.FormatClaimed("0006", 6, "LoadGame", "s", 1) + "\n"
+                + TestCommandJournal.FormatExecuted("0006", 6, 2) + "\n"
+                + TestCommandJournal.FormatDone("0006", 6, "OK", 3) + "\n";
+            var map = TestCommandJournal.ReplayIntoPhaseMap(content);
+            Assert.Equal(RecoveryAction.Skip, TestCommandJournal.DecideRecovery(map, "0006"));
+        }
+
+        // ----- Duplicate id (crash-recovery rewrite): highest phase wins -----
+
+        [Fact]
+        public void DuplicateId_HighestPhaseWins()
+        {
+            // A DONE line followed by a stray earlier-phase line still resolves DONE.
+            string content =
+                TestCommandJournal.FormatExecuted("0002", 2, 2) + "\n"
+                + TestCommandJournal.FormatDone("0002", 2, "OK", 3) + "\n"
+                + TestCommandJournal.FormatClaimed("0002", 2, "StartRecording", "s", 4) + "\n";
+            var map = TestCommandJournal.ReplayIntoPhaseMap(content);
+            Assert.Equal(JournalPhase.Done, map["0002"]);
+        }
+
+        [Fact]
+        public void MultipleIds_TrackedIndependently()
+        {
+            string content =
+                TestCommandJournal.FormatClaimed("a", 1, "SetSetting", "s", 1) + "\n"
+                + TestCommandJournal.FormatExecuted("b", 2, 2) + "\n"
+                + TestCommandJournal.FormatDone("c", 3, "OK", 3) + "\n";
+            var map = TestCommandJournal.ReplayIntoPhaseMap(content);
+            Assert.Equal(RecoveryAction.Interrupted, TestCommandJournal.DecideRecovery(map, "a"));
+            Assert.Equal(RecoveryAction.RewriteResponse, TestCommandJournal.DecideRecovery(map, "b"));
+            Assert.Equal(RecoveryAction.Skip, TestCommandJournal.DecideRecovery(map, "c"));
+        }
+
+        // ----- Torn trailing line: never durably committed -----
+
+        [Fact]
+        public void TornTrailingExecuted_Ignored_StaysAtClaimed()
+        {
+            // The EXECUTED line was being appended when the process died (no \n),
+            // so replay must keep the id at CLAIMED -> Interrupted, not RewriteResponse.
+            string content =
+                TestCommandJournal.FormatClaimed("0002", 2, "StartRecording", "s", 1) + "\n"
+                + TestCommandJournal.FormatExecuted("0002", 2, 2); // torn: no trailing \n
+            var map = TestCommandJournal.ReplayIntoPhaseMap(content);
+            Assert.Equal(JournalPhase.Claimed, map["0002"]);
+            Assert.Equal(RecoveryAction.Interrupted, TestCommandJournal.DecideRecovery(map, "0002"));
+        }
+    }
+}

--- a/Source/Parsek.Tests/TestCommandRecoveryTests.cs
+++ b/Source/Parsek.Tests/TestCommandRecoveryTests.cs
@@ -61,7 +61,7 @@ namespace Parsek.Tests
         {
             string content =
                 TestCommandJournal.FormatClaimed("0002", 2, "StartRecording", "s", 1) + "\n"
-                + TestCommandJournal.FormatExecuted("0002", 2, 2) + "\n";
+                + TestCommandJournal.FormatExecuted("0002", 2, 2, "OK", null, null) + "\n";
             var map = TestCommandJournal.ReplayIntoPhaseMap(content);
             Assert.Equal(JournalPhase.Executed, map["0002"]);
             Assert.Equal(RecoveryAction.RewriteResponse, TestCommandJournal.DecideRecovery(map, "0002"));
@@ -72,7 +72,7 @@ namespace Parsek.Tests
         {
             string content =
                 TestCommandJournal.FormatClaimed("0002", 2, "StartRecording", "s", 1) + "\n"
-                + TestCommandJournal.FormatExecuted("0002", 2, 2) + "\n"
+                + TestCommandJournal.FormatExecuted("0002", 2, 2, "OK", null, null) + "\n"
                 + TestCommandJournal.FormatDone("0002", 2, "OK", 3) + "\n";
             var map = TestCommandJournal.ReplayIntoPhaseMap(content);
             Assert.Equal(JournalPhase.Done, map["0002"]);
@@ -102,7 +102,7 @@ namespace Parsek.Tests
         {
             string content =
                 TestCommandJournal.FormatClaimed("0006", 6, "LoadGame", "s", 1) + "\n"
-                + TestCommandJournal.FormatExecuted("0006", 6, 2) + "\n";
+                + TestCommandJournal.FormatExecuted("0006", 6, 2, "OK", null, null) + "\n";
             var map = TestCommandJournal.ReplayIntoPhaseMap(content);
             Assert.Equal(RecoveryAction.RewriteResponse, TestCommandJournal.DecideRecovery(map, "0006"));
         }
@@ -112,7 +112,7 @@ namespace Parsek.Tests
         {
             string content =
                 TestCommandJournal.FormatClaimed("0006", 6, "LoadGame", "s", 1) + "\n"
-                + TestCommandJournal.FormatExecuted("0006", 6, 2) + "\n"
+                + TestCommandJournal.FormatExecuted("0006", 6, 2, "OK", null, null) + "\n"
                 + TestCommandJournal.FormatDone("0006", 6, "OK", 3) + "\n";
             var map = TestCommandJournal.ReplayIntoPhaseMap(content);
             Assert.Equal(RecoveryAction.Skip, TestCommandJournal.DecideRecovery(map, "0006"));
@@ -125,7 +125,7 @@ namespace Parsek.Tests
         {
             // A DONE line followed by a stray earlier-phase line still resolves DONE.
             string content =
-                TestCommandJournal.FormatExecuted("0002", 2, 2) + "\n"
+                TestCommandJournal.FormatExecuted("0002", 2, 2, "OK", null, null) + "\n"
                 + TestCommandJournal.FormatDone("0002", 2, "OK", 3) + "\n"
                 + TestCommandJournal.FormatClaimed("0002", 2, "StartRecording", "s", 4) + "\n";
             var map = TestCommandJournal.ReplayIntoPhaseMap(content);
@@ -137,12 +137,63 @@ namespace Parsek.Tests
         {
             string content =
                 TestCommandJournal.FormatClaimed("a", 1, "SetSetting", "s", 1) + "\n"
-                + TestCommandJournal.FormatExecuted("b", 2, 2) + "\n"
+                + TestCommandJournal.FormatExecuted("b", 2, 2, "OK", null, null) + "\n"
                 + TestCommandJournal.FormatDone("c", 3, "OK", 3) + "\n";
             var map = TestCommandJournal.ReplayIntoPhaseMap(content);
             Assert.Equal(RecoveryAction.Interrupted, TestCommandJournal.DecideRecovery(map, "a"));
             Assert.Equal(RecoveryAction.RewriteResponse, TestCommandJournal.DecideRecovery(map, "b"));
             Assert.Equal(RecoveryAction.Skip, TestCommandJournal.DecideRecovery(map, "c"));
+        }
+
+        // ----- True RewriteResponse (Adjudication A): re-emit the original verdict -----
+
+        [Fact]
+        public void Executed_RewriteResponse_ReEmitsOriginalVerdictPayloadMsg()
+        {
+            // The EXECUTED line stores the original terminal outcome; a crash before DONE
+            // must rewrite THAT response, not a synthetic INTERRUPTED.
+            var payload = new List<KeyValuePair<string, string>>
+            {
+                new KeyValuePair<string, string>("recordingId", "abc123"),
+            };
+            string content =
+                TestCommandJournal.FormatClaimed("0002", 2, "StartRecording", "s", 1) + "\n"
+                + TestCommandJournal.FormatExecuted("0002", 2, 2, "OK", payload, null) + "\n";
+            var lines = TestCommandJournal.SplitCompleteLines(content);
+
+            Assert.Equal(RecoveryAction.RewriteResponse,
+                TestCommandJournal.DecideRecovery(TestCommandJournal.ReplayIntoPhaseMap(lines), "0002"));
+
+            Assert.True(TestCommandJournal.TryGetExecutedResponse(
+                lines, "0002", out string verdict, out var recovered, out string msg));
+            Assert.Equal("OK", verdict);
+            Assert.Null(msg); // stored empty msg normalizes back to null
+            Assert.NotNull(recovered);
+            Assert.Equal("recordingId", recovered[0].Key);
+            Assert.Equal("abc123", recovered[0].Value);
+        }
+
+        [Fact]
+        public void Executed_RewriteResponse_IsByteEquivalentToOriginalResponse()
+        {
+            // The rewritten response differs from the pre-crash one ONLY in seq/ut; the
+            // verdict + payload + msg reconstruct byte-for-byte. Holding seq + ut fixed here
+            // isolates that reconstruction.
+            var payload = new List<KeyValuePair<string, string>>
+            {
+                new KeyValuePair<string, string>("recordingId", "abc123"),
+            };
+            string original = TestCommandResponse.FormatResponseLine(
+                "0002", "StartRecording", "OK", 2, 1234.5, payload, null);
+
+            string content = TestCommandJournal.FormatExecuted("0002", 2, 2, "OK", payload, null) + "\n";
+            Assert.True(TestCommandJournal.TryGetExecutedResponse(
+                TestCommandJournal.SplitCompleteLines(content), "0002",
+                out string verdict, out var recovered, out string msg));
+            string rewritten = TestCommandResponse.FormatResponseLine(
+                "0002", "StartRecording", verdict, 2, 1234.5, recovered, msg);
+
+            Assert.Equal(original, rewritten);
         }
 
         // ----- Torn trailing line: never durably committed -----
@@ -154,7 +205,7 @@ namespace Parsek.Tests
             // so replay must keep the id at CLAIMED -> Interrupted, not RewriteResponse.
             string content =
                 TestCommandJournal.FormatClaimed("0002", 2, "StartRecording", "s", 1) + "\n"
-                + TestCommandJournal.FormatExecuted("0002", 2, 2); // torn: no trailing \n
+                + TestCommandJournal.FormatExecuted("0002", 2, 2, "OK", null, null); // torn: no trailing \n
             var map = TestCommandJournal.ReplayIntoPhaseMap(content);
             Assert.Equal(JournalPhase.Claimed, map["0002"]);
             Assert.Equal(RecoveryAction.Interrupted, TestCommandJournal.DecideRecovery(map, "0002"));

--- a/Source/Parsek.Tests/TestCommandResponseFormatTests.cs
+++ b/Source/Parsek.Tests/TestCommandResponseFormatTests.cs
@@ -1,0 +1,88 @@
+using System.Collections.Generic;
+using Parsek.TestCommands;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    /// <summary>
+    /// Pure coverage for the response-line formatter
+    /// (<see cref="TestCommandResponse.FormatResponseLine"/>). Guards the exact
+    /// grep-able shape (id/cmd/verdict/seq present, ut omitted with no game,
+    /// payload values percent-encoded, InvariantCulture floats). A regression here
+    /// drops a field or leaks a locale comma into ut, which the orchestrator
+    /// cannot parse.
+    /// </summary>
+    public class TestCommandResponseFormatTests
+    {
+        [Fact]
+        public void Format_WithGameLoaded_IncludesUtAndPayload()
+        {
+            string line = TestCommandResponse.FormatResponseLine(
+                "0002", "StartRecording", "OK", 2, 1234.5,
+                new[] { new KeyValuePair<string, string>("recordingId", "abc123") },
+                null);
+            Assert.Equal("id=0002 cmd=StartRecording verdict=OK seq=2 ut=1234.5 recordingId=abc123", line);
+        }
+
+        [Fact]
+        public void Format_NoGame_OmitsUt()
+        {
+            string line = TestCommandResponse.FormatResponseLine(
+                "0001", "SetSetting", "OK", 1, null,
+                new[] { new KeyValuePair<string, string>("name", "autoMerge") },
+                null);
+            Assert.DoesNotContain(" ut=", line);
+            Assert.StartsWith("id=0001 cmd=SetSetting verdict=OK seq=1 name=autoMerge", line);
+        }
+
+        [Fact]
+        public void Format_RejectMsg_IsPercentEncoded()
+        {
+            string line = TestCommandResponse.FormatResponseLine(
+                "0009", "SetSetting", "REJECTED", 9, null, null,
+                "setting-not-whitelisted name=foo");
+            // Space and '=' inside the msg must be escaped so the reader keeps it
+            // on one token.
+            Assert.Contains("msg=setting-not-whitelisted%20name%3Dfoo", line);
+        }
+
+        [Fact]
+        public void Format_FloatUt_UsesInvariantCulture()
+        {
+            string line = TestCommandResponse.FormatResponseLine(
+                "1", "RecordingState", "OK", 3, 1235.1, null, null);
+            Assert.Contains("ut=1235.1", line);
+            Assert.DoesNotContain(",", line); // no comma-locale decimal
+        }
+
+        [Fact]
+        public void Format_FieldOrder_IsIdCmdVerdictSeqUtPayloadMsg()
+        {
+            string line = TestCommandResponse.FormatResponseLine(
+                "5", "RunTests", "OK", 5, 1300.0,
+                new[]
+                {
+                    new KeyValuePair<string, string>("passed", "42"),
+                    new KeyValuePair<string, string>("failed", "0"),
+                },
+                "note");
+            int idIdx = line.IndexOf("id=");
+            int cmdIdx = line.IndexOf(" cmd=");
+            int verdictIdx = line.IndexOf(" verdict=");
+            int seqIdx = line.IndexOf(" seq=");
+            int utIdx = line.IndexOf(" ut=");
+            int passedIdx = line.IndexOf(" passed=");
+            int msgIdx = line.IndexOf(" msg=");
+            Assert.True(idIdx < cmdIdx && cmdIdx < verdictIdx && verdictIdx < seqIdx
+                        && seqIdx < utIdx && utIdx < passedIdx && passedIdx < msgIdx);
+        }
+
+        [Fact]
+        public void Format_NoTrailingNewline()
+        {
+            string line = TestCommandResponse.FormatResponseLine(
+                "1", "StopRecording", "OK", 1, null, null, null);
+            Assert.DoesNotContain("\n", line);
+        }
+    }
+}

--- a/Source/Parsek.Tests/TestCommandRunTestsTests.cs
+++ b/Source/Parsek.Tests/TestCommandRunTestsTests.cs
@@ -1,0 +1,42 @@
+using System.Collections.Generic;
+using System.Linq;
+using Parsek.TestCommands;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    /// <summary>
+    /// P5.6 coverage for the two-phase RunTests result payload. When the owned batch
+    /// finishes, the terminal response must carry passed/failed/skipped and the fixed
+    /// results file name the orchestrator tails. Fails if a count key drifts or the
+    /// results file name changes out from under the harness.
+    /// </summary>
+    public class TestCommandRunTestsTests
+    {
+        private static string Val(List<KeyValuePair<string, string>> p, string key)
+            => p.First(kv => kv.Key == key).Value;
+
+        [Fact]
+        public void BuildResultPayload_CarriesCountsAndResultsFile()
+        {
+            var p = TestCommandRunTests.BuildResultPayload(passed: 42, failed: 0, skipped: 3);
+            Assert.Equal("42", Val(p, "passed"));
+            Assert.Equal("0", Val(p, "failed"));
+            Assert.Equal("3", Val(p, "skipped"));
+            Assert.Equal("parsek-test-results.txt", Val(p, "results"));
+        }
+
+        [Fact]
+        public void BuildResultPayload_KeyOrderIsStable()
+        {
+            var p = TestCommandRunTests.BuildResultPayload(1, 2, 3);
+            Assert.Equal(new[] { "passed", "failed", "skipped", "results" }, p.Select(kv => kv.Key).ToArray());
+        }
+
+        [Fact]
+        public void ResultsFileName_IsTheDocumentedConstant()
+        {
+            Assert.Equal("parsek-test-results.txt", TestCommandRunTests.ResultsFileName);
+        }
+    }
+}

--- a/Source/Parsek.Tests/TestCommandSettingApplierTests.cs
+++ b/Source/Parsek.Tests/TestCommandSettingApplierTests.cs
@@ -1,0 +1,109 @@
+using System.Collections.Generic;
+using Parsek.TestCommands;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    /// <summary>
+    /// P5.1 route-dispatch coverage for <see cref="TestCommandSettingApplier.ApplySetting"/>.
+    /// The security-critical property the SetSetting design column adds is that the 8
+    /// sidecar-authoritative settings ALSO route through the matching
+    /// <c>ParsekSettingsPersistence.Record*</c> member, while the 8 GameParameters-only
+    /// settings do NOT. A tracked setting written only to the live field would be
+    /// silently reverted by <c>ParsekScenario.OnLoad</c>'s <c>ApplyTo</c> at the next
+    /// save load (the exact bug this column fixes). These tests drive the pure applier
+    /// with spy delegates so the routing decision is verified without a live Unity
+    /// <c>ParsekSettings</c>.
+    /// </summary>
+    public class TestCommandSettingApplierTests
+    {
+        // The 8 GameParameters-only names (Record* must NOT fire) and the 8 tracked names
+        // (Record* MUST fire with the exact member name), verified against the design
+        // whitelist table.
+        private static readonly Dictionary<string, string> Expected = new Dictionary<string, string>
+        {
+            ["autoRecordOnLaunch"] = null,
+            ["autoRecordOnEva"] = null,
+            ["autoRecordOnFirstModificationAfterSwitch"] = null,
+            ["autoMerge"] = null,
+            ["verboseLogging"] = null,
+            ["samplingDensity"] = null,
+            ["ghostAudioVolume"] = null,
+            ["transitedBodyRotationModeIndex"] = null,
+
+            ["ghostRenderTracing"] = "RecordGhostRenderTracing",
+            ["mapRenderTracing"] = "RecordMapRenderTracing",
+            ["ledgerTracing"] = "RecordLedgerTracing",
+            ["writeReadableSidecarMirrors"] = "RecordReadableSidecarMirrors",
+            ["autoBackupExistingSaves"] = "RecordAutoBackupExistingSaves",
+            ["showCommittedFutureOverlays"] = "RecordShowCommittedFutureOverlays",
+            ["blockCommittedActions"] = "RecordBlockCommittedActions",
+            ["showRouteLines"] = "RecordShowRouteLines",
+        };
+
+        private static string ValidValueFor(SettingValueType type)
+        {
+            switch (type)
+            {
+                case SettingValueType.Bool: return "true";
+                case SettingValueType.Int: return "1";
+                case SettingValueType.Float: return "0.5";
+                default: return "true";
+            }
+        }
+
+        [Fact]
+        public void ApplySetting_AlwaysSetsLiveField_AndRoutesRecordOnlyForTrackedNames()
+        {
+            foreach (KeyValuePair<string, string> kv in Expected)
+            {
+                string name = kv.Key;
+                string expectedRecord = kv.Value;
+
+                // Produce the accepted decision through the real whitelist so the route +
+                // Record* selector under test come from the production table, not the test.
+                SettingApplyResult first = SettingWhitelist.TryApply(name, "true");
+                if (!first.Accepted)
+                    first = SettingWhitelist.TryApply(name, ValidValueFor(first.Type));
+                Assert.True(first.Accepted, $"whitelist should accept a valid value for '{name}'");
+
+                int liveSets = 0;
+                var recordCalls = new List<string>();
+                TestCommandSettingApplier.ApplySetting(
+                    first,
+                    r => liveSets++,
+                    r => recordCalls.Add(r.RecordMethod));
+
+                Assert.Equal(1, liveSets); // live field ALWAYS set
+
+                if (expectedRecord == null)
+                {
+                    Assert.Equal(PersistenceRoute.GameParameters, first.Route);
+                    Assert.Empty(recordCalls); // GameParameters-only: never routes to Record*
+                }
+                else
+                {
+                    Assert.Equal(PersistenceRoute.GameParametersPlusSidecar, first.Route);
+                    Assert.Single(recordCalls);
+                    Assert.Equal(expectedRecord, recordCalls[0]); // exact member name
+                }
+            }
+        }
+
+        [Fact]
+        public void ApplySetting_TrackedName_RoutesSidecar_GameParamsName_DoesNot()
+        {
+            // Focused pair: one tracked, one untracked, spelling out the fix's contract.
+            SettingApplyResult tracked = SettingWhitelist.TryApply("mapRenderTracing", "true");
+            SettingApplyResult untracked = SettingWhitelist.TryApply("autoMerge", "true");
+
+            var trackedRecord = new List<string>();
+            TestCommandSettingApplier.ApplySetting(tracked, r => { }, r => trackedRecord.Add(r.RecordMethod));
+            Assert.Equal(new[] { "RecordMapRenderTracing" }, trackedRecord);
+
+            var untrackedRecord = new List<string>();
+            TestCommandSettingApplier.ApplySetting(untracked, r => { }, r => untrackedRecord.Add(r.RecordMethod));
+            Assert.Empty(untrackedRecord);
+        }
+    }
+}

--- a/Source/Parsek.Tests/TestCommandVerbTableTests.cs
+++ b/Source/Parsek.Tests/TestCommandVerbTableTests.cs
@@ -1,0 +1,70 @@
+using Parsek.TestCommands;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    /// <summary>
+    /// Pure coverage for the known-verb table (<see cref="TestCommandVerbs"/>).
+    /// Guards that v1 verbs classify Implemented, phase-3 names classify Reserved
+    /// (distinct so the orchestrator can probe capability), and anything else is
+    /// Unknown. A regression would let v1 silently execute or mis-bucket a future
+    /// command as a typo.
+    /// </summary>
+    public class TestCommandVerbTableTests
+    {
+        [Theory]
+        [InlineData("SetSetting")]
+        [InlineData("StartRecording")]
+        [InlineData("StopRecording")]
+        [InlineData("CommitTree")]
+        [InlineData("DiscardTree")]
+        [InlineData("RecordingState")]
+        [InlineData("RunTests")]
+        [InlineData("LoadGame")]
+        [InlineData("MissionMark")]
+        [InlineData("FlushAndQuit")]
+        public void ImplementedVerbs_ClassifyImplemented(string verb)
+        {
+            Assert.Equal(TestCommandVerbClass.Implemented, TestCommandVerbs.Classify(verb));
+        }
+
+        [Theory]
+        [InlineData("StartLoopPlayback")]
+        [InlineData("StopPlayback")]
+        [InlineData("EnterWatchMode")]
+        [InlineData("InvokeRewind")]
+        [InlineData("AnswerMergeDialog")]
+        [InlineData("KscAction")]
+        [InlineData("SealSlot")]
+        [InlineData("StashSlot")]
+        [InlineData("FlySlot")]
+        [InlineData("RouteCommand")]
+        [InlineData("MissionConfig")]
+        [InlineData("TimeJump")]
+        [InlineData("SimulateStockSwitchClick")]
+        [InlineData("CrashAfterJournalPhase")]
+        [InlineData("RunInvariantReport")]
+        public void ReservedVerbs_ClassifyReserved(string verb)
+        {
+            Assert.Equal(TestCommandVerbClass.Reserved, TestCommandVerbs.Classify(verb));
+        }
+
+        [Theory]
+        [InlineData("Frobnicate")]
+        [InlineData("setsetting")]  // case-sensitive: lowercase is not a match
+        [InlineData("SETSETTING")]
+        [InlineData("")]
+        [InlineData(null)]
+        public void UnknownVerbs_ClassifyUnknown(string verb)
+        {
+            Assert.Equal(TestCommandVerbClass.Unknown, TestCommandVerbs.Classify(verb));
+        }
+
+        [Fact]
+        public void Table_HasExpectedCounts()
+        {
+            Assert.Equal(10, TestCommandVerbs.ImplementedVerbNames.Count);
+            Assert.Equal(15, TestCommandVerbs.ReservedVerbNames.Count);
+        }
+    }
+}

--- a/Source/Parsek/InGameTests/LogContractTests.cs
+++ b/Source/Parsek/InGameTests/LogContractTests.cs
@@ -140,6 +140,35 @@ namespace Parsek.InGameTests
             ParsekLog.Verbose("TestRunner", $"SES-002: SessionStart format valid, utc={utcNow}");
         }
 
+        // --- MSN-001: MissionMark correlation marker format ---
+
+        [InGameTest(Category = "LogContracts",
+            Description = "MSN-001: MissionMark line uses 'MISSIONMARK label=<label> ut=<ut>' format")]
+        public static void MissionMarkFormatValid()
+        {
+            // The external orchestrator greps this exact shape to correlate its own
+            // timeline against the KSP session, so (like SES-002 for SessionStart) it gets
+            // a dedicated contract test. Every other [TestCommands] line is covered by the
+            // generic structure/level contracts (FMT-001 / FMT-002).
+            string withUt = Parsek.TestCommands.TestCommandMissionMark.FormatMarkMessage("mun landing start", 1234.5);
+            string noGame = Parsek.TestCommands.TestCommandMissionMark.FormatMarkMessage("x", null);
+
+            var pattern = new Regex(@"^MISSIONMARK label=.* ut=(\d+(\.\d+)?|none)$");
+            InGameAssert.IsTrue(pattern.IsMatch(withUt),
+                $"MSN-001: MissionMark format invalid: {withUt}");
+            InGameAssert.IsTrue(pattern.IsMatch(noGame),
+                $"MSN-001: MissionMark (no game) format invalid: {noGame}");
+
+            // Spell out the exact expected lines so a format drift is caught, not masked
+            // by a permissive regex.
+            InGameAssert.AreEqual("MISSIONMARK label=mun landing start ut=1234.5", withUt,
+                "MSN-001: unexpected MissionMark line");
+            InGameAssert.AreEqual("MISSIONMARK label=x ut=none", noGame,
+                "MSN-001: unexpected MissionMark (no game) line");
+
+            ParsekLog.Verbose("TestRunner", "MSN-001: MissionMark correlation marker format valid");
+        }
+
         // --- RAT-001: Suppressed count format ---
 
         [InGameTest(Category = "LogContracts",

--- a/Source/Parsek/InGameTests/TestCommandAddonTests.cs
+++ b/Source/Parsek/InGameTests/TestCommandAddonTests.cs
@@ -1,0 +1,105 @@
+using System;
+using Parsek.TestCommands;
+
+namespace Parsek.InGameTests
+{
+    /// <summary>
+    /// P6.2 in-game (live-KSP) tests for the ParsekTestCommands addon's Unity side.
+    ///
+    /// <para>Case (a) — env-gate inert-when-unarmed — is fully AUTOMATED: it runs in any
+    /// scene and proves the security gate (the addon's armed state matches the pure
+    /// <see cref="ParsekTestCommandAddon.IsArmed"/> predicate over the live env var) and,
+    /// when unarmed, that the addon never touched the channel files
+    /// (<c>StartupDoneForTesting == false</c>).</para>
+    ///
+    /// <para>Cases (b) and (c) are PENDING-OPERATOR: they cannot self-set-up inside the
+    /// in-game batch and therefore <see cref="InGameAssert.Skip"/> with a message naming
+    /// the required context (house rule: a FLIGHT/boot test that cannot size itself must
+    /// Skip, never assert against an assumed context). The reason they cannot run in the
+    /// batch is structural, not incidental: while an in-game test batch is running the
+    /// addon's pump is gated OFF (<c>Update</c> returns at the <c>IsBatchRunning</c>
+    /// gate), so no command written to the channel from inside a batch would ever be
+    /// consumed by the addon. The real end-to-end drive is performed by the EXTERNAL
+    /// Python orchestrator (M-A5) against a dedicated automation instance armed with
+    /// <c>PARSEK_TEST_COMMANDS=1</c>, not by an in-game test.</para>
+    ///
+    /// <para>PENDING-OPERATOR RUNBOOK (external, one dedicated automation KSP instance):
+    /// <list type="number">
+    /// <item><description>Launch KSP with the environment variable
+    /// <c>PARSEK_TEST_COMMANDS=1</c> set (fail-closed: any other value stays inert).</description></item>
+    /// <item><description>(b) FLIGHT round-trip: with a flight loaded, append to
+    /// <c>&lt;KSP-root&gt;/parsek-test-commands.txt</c> the lines
+    /// <c>id=1 cmd=StartRecording</c>, <c>id=2 cmd=RecordingState</c>,
+    /// <c>id=3 cmd=CommitTree</c>, <c>id=4 cmd=RecordingState</c>; tail
+    /// <c>parsek-test-responses.txt</c> and assert verdict=OK for each, that id=2 reports
+    /// <c>recording=true</c> with a non-empty <c>tree</c>, that id=3 reports
+    /// <c>committed=true</c>, and that id=4 reports <c>recording=false</c>.</description></item>
+    /// <item><description>(c) Cold-boot: from the MAIN MENU (no save loaded) append
+    /// <c>id=1 cmd=LoadGame save=&lt;SaveFolder&gt; name=persistent</c> then
+    /// <c>id=2 cmd=RecordingState</c>; assert id=1 verdict=OK with <c>scene=FLIGHT</c> and
+    /// the echoed <c>save</c>, and id=2 verdict=OK reporting the loaded scene.</description></item>
+    /// </list>
+    /// The addon's at-most-once journal (<c>parsek-test-commands.journal</c>) and lock
+    /// (<c>parsek-test-commands.lock</c>) also live at the KSP root.</para>
+    /// </summary>
+    public static class TestCommandAddonTests
+    {
+        private const string EnvVarName = "PARSEK_TEST_COMMANDS";
+
+        // (a) AUTOMATED: the shipped default (env unset / not "1") must be provably inert.
+        [InGameTest(Category = "TestCommands",
+            Description = "TC-A: env-gate honored; when unarmed the addon touches no channel files")]
+        public static void EnvGateHonored_InertWhenUnarmed()
+        {
+            ParsekTestCommandAddon addon = ParsekTestCommandAddon.Instance;
+            InGameAssert.IsNotNull(addon,
+                "ParsekTestCommandAddon.Instance should exist (KSPAddon Startup.Instantly)");
+
+            string env = Environment.GetEnvironmentVariable(EnvVarName);
+            bool expectedArmed = ParsekTestCommandAddon.IsArmed(env);
+
+            InGameAssert.AreEqual(expectedArmed, addon.IsArmedForTesting,
+                $"TC-A: armed state must match the pure IsArmed gate for env='{env ?? "unset"}'");
+
+            if (!expectedArmed)
+            {
+                // The security-critical inert proof: TryStartup (the only file-touching
+                // startup) runs solely behind the armed gate, so an unarmed addon never
+                // resolves channel paths or writes the lock/journal.
+                InGameAssert.IsFalse(addon.StartupDoneForTesting,
+                    "TC-A: unarmed addon must perform no channel file access (startup must not run)");
+            }
+
+            ParsekLog.Verbose("TestRunner",
+                $"TC-A: env-gate honored armed={addon.IsArmedForTesting} startupDone={addon.StartupDoneForTesting} (env='{env ?? "unset"}')");
+        }
+
+        // (b) PENDING-OPERATOR: the FLIGHT StartRecording -> RecordingState -> CommitTree
+        // -> RecordingState round-trip must be driven by the external orchestrator; the
+        // addon pump is gated off during an in-game batch, so this cannot self-run here.
+        [InGameTest(Category = "TestCommands", Scene = GameScenes.FLIGHT,
+            Description = "TC-B: FLIGHT channel round-trip (external orchestrator; PENDING-OPERATOR)")]
+        public static void FlightChannelRoundTrip_PendingOperator()
+        {
+            InGameAssert.Skip(
+                "TC-B PENDING-OPERATOR: the StartRecording->RecordingState->CommitTree->RecordingState "
+                + "round-trip via the file channel must be driven by the external orchestrator against an "
+                + "instance armed with PARSEK_TEST_COMMANDS=1. It cannot self-run in an in-game batch "
+                + "because the addon pump is gated off while a batch runs (IsBatchRunning). See the "
+                + "PENDING-OPERATOR RUNBOOK in TestCommandAddonTests.");
+        }
+
+        // (c) PENDING-OPERATOR: the cold-boot LoadGame (from MAINMENU) -> RecordingState
+        // boot channel must be driven by the external orchestrator at process start.
+        [InGameTest(Category = "TestCommands", Scene = GameScenes.MAINMENU,
+            Description = "TC-C: cold-boot LoadGame->RecordingState (external orchestrator; PENDING-OPERATOR)")]
+        public static void ColdBootLoadGame_PendingOperator()
+        {
+            InGameAssert.Skip(
+                "TC-C PENDING-OPERATOR: the cold-boot LoadGame->RecordingState boot channel must be driven "
+                + "by the external orchestrator at process start (PARSEK_TEST_COMMANDS=1), issuing LoadGame "
+                + "as the first command from the main menu. It cannot self-run in an in-game batch. See the "
+                + "PENDING-OPERATOR RUNBOOK in TestCommandAddonTests.");
+        }
+    }
+}

--- a/Source/Parsek/InGameTests/TestCommandAddonTests.cs
+++ b/Source/Parsek/InGameTests/TestCommandAddonTests.cs
@@ -45,6 +45,18 @@ namespace Parsek.InGameTests
     /// <c>id=2 cmd=RecordingState</c>; assert id=1 verdict=OK with <c>scene=FLIGHT</c> and
     /// the echoed <c>save</c>, and id=2 verdict=OK reporting the loaded scene.</description></item>
     /// </list>
+    /// Operator notes:
+    /// <list type="bullet">
+    /// <item><description>N6: a boot save used by (c) MUST contain an ACTIVE VESSEL - LoadGame
+    /// resolves the save's <c>flightState.activeVesselIdx</c> and refuses (<c>load-failed</c>)
+    /// a save with no in-range active vessel, and <c>StartAndFocusVessel</c> needs one to land
+    /// in FLIGHT. A save parked at the Space Center with no active flight will not boot into
+    /// FLIGHT.</description></item>
+    /// <item><description>N7: ALWAYS send <c>CommitTree</c> or <c>DiscardTree</c> BEFORE a
+    /// <c>LoadGame</c> when a recorder may be live - LoadGame is Rejected
+    /// (<c>recording-active</c>) while a recorder is recording so it never silently discards an
+    /// in-flight recording. Sequence a clean commit/discard first (as in (b) before any (c)).</description></item>
+    /// </list>
     /// The addon's at-most-once journal (<c>parsek-test-commands.journal</c>) and lock
     /// (<c>parsek-test-commands.lock</c>) also live at the KSP root.</para>
     /// </summary>

--- a/Source/Parsek/InGameTests/TestCommandAddonTests.cs
+++ b/Source/Parsek/InGameTests/TestCommandAddonTests.cs
@@ -16,11 +16,17 @@ namespace Parsek.InGameTests
     /// in-game batch and therefore <see cref="InGameAssert.Skip"/> with a message naming
     /// the required context (house rule: a FLIGHT/boot test that cannot size itself must
     /// Skip, never assert against an assumed context). The reason they cannot run in the
-    /// batch is structural, not incidental: while an in-game test batch is running the
-    /// addon's pump is gated OFF (<c>Update</c> returns at the <c>IsBatchRunning</c>
-    /// gate), so no command written to the channel from inside a batch would ever be
-    /// consumed by the addon. The real end-to-end drive is performed by the EXTERNAL
-    /// Python orchestrator (M-A5) against a dedicated automation instance armed with
+    /// batch is structural, on two counts. FIRST and foremost is the ENV GATE: the addon
+    /// only arms when <c>PARSEK_TEST_COMMANDS=1</c>, and that value is read ONCE at process
+    /// start (<c>Awake</c>) and never re-read, so an in-game test - which runs long after
+    /// Awake, inside an already-launched process it cannot re-launch - can neither arm the
+    /// addon nor un-set the gate. An in-game test therefore has no way to reach a live pump
+    /// at all. SECOND (and only relevant once armed) is the BATCH GATE: while an in-game
+    /// test batch runs the pump is gated OFF (<c>Update</c> returns at the
+    /// <c>IsBatchRunning</c> gate, which post-F5 also covers the interactive Ctrl+Shift+T
+    /// runner), so a command written from inside a batch would not be consumed even in an
+    /// armed instance. The real end-to-end drive is performed by the EXTERNAL Python
+    /// orchestrator (M-A5) against a dedicated automation instance launched with
     /// <c>PARSEK_TEST_COMMANDS=1</c>, not by an in-game test.</para>
     ///
     /// <para>PENDING-OPERATOR RUNBOOK (external, one dedicated automation KSP instance):
@@ -84,8 +90,10 @@ namespace Parsek.InGameTests
             InGameAssert.Skip(
                 "TC-B PENDING-OPERATOR: the StartRecording->RecordingState->CommitTree->RecordingState "
                 + "round-trip via the file channel must be driven by the external orchestrator against an "
-                + "instance armed with PARSEK_TEST_COMMANDS=1. It cannot self-run in an in-game batch "
-                + "because the addon pump is gated off while a batch runs (IsBatchRunning). See the "
+                + "instance launched with PARSEK_TEST_COMMANDS=1. It cannot self-run in an in-game batch: "
+                + "the env gate is read once at process start so an in-game test can neither arm the addon "
+                + "nor reach a live pump, and even in an armed instance the pump is gated off while a batch "
+                + "runs (IsBatchRunning, which post-F5 also covers the Ctrl+Shift+T runner). See the "
                 + "PENDING-OPERATOR RUNBOOK in TestCommandAddonTests.");
         }
 
@@ -97,9 +105,11 @@ namespace Parsek.InGameTests
         {
             InGameAssert.Skip(
                 "TC-C PENDING-OPERATOR: the cold-boot LoadGame->RecordingState boot channel must be driven "
-                + "by the external orchestrator at process start (PARSEK_TEST_COMMANDS=1), issuing LoadGame "
-                + "as the first command from the main menu. It cannot self-run in an in-game batch. See the "
-                + "PENDING-OPERATOR RUNBOOK in TestCommandAddonTests.");
+                + "by the external orchestrator against an instance launched with PARSEK_TEST_COMMANDS=1, "
+                + "issuing LoadGame as the first command from the main menu. It cannot self-run in an in-game "
+                + "test: the env gate is read once at process start, so an in-game test can neither arm the "
+                + "addon nor re-launch the process, and the batch gate (post-F5) blocks the pump anyway. See "
+                + "the PENDING-OPERATOR RUNBOOK in TestCommandAddonTests.");
         }
     }
 }

--- a/Source/Parsek/InGameTests/TestRunnerShortcut.cs
+++ b/Source/Parsek/InGameTests/TestRunnerShortcut.cs
@@ -49,6 +49,16 @@ namespace Parsek.InGameTests
         /// instance alive. Used by in-game tests to verify bridge survival (#269).
         /// </summary>
         internal static TestRunnerShortcut Instance => instance;
+
+        /// <summary>
+        /// The interactive (Ctrl+Shift+T) test runner this shortcut owns, exposed so the
+        /// ParsekTestCommands addon's safe-point gate can OR its batch state into
+        /// <c>IsBatchRunning</c>: a command must never execute mid-batch even when the batch
+        /// was started from this UI rather than the addon's own <c>RunTests</c> runner. Null
+        /// until the window is first opened (the runner is lazily created in <c>OnGUI</c>).
+        /// </summary>
+        internal static InGameTestRunner ActiveRunnerForGating => instance != null ? instance.runner : null;
+
         internal bool HasOpaqueStyleForTesting => opaqueStyle != null;
         internal bool HasAllOpaqueStateBackgroundsForTesting => AreAllOpaqueStyleBackgroundsPresent(opaqueStyle);
         internal Texture2D OpaqueWindowBackgroundForTesting => opaqueStyle?.normal.background;

--- a/Source/Parsek/TestCommands/LockFile.cs
+++ b/Source/Parsek/TestCommands/LockFile.cs
@@ -1,0 +1,170 @@
+using System;
+using System.Globalization;
+
+namespace Parsek.TestCommands
+{
+    /// <summary>Tri-state liveness of a probed process id.</summary>
+    internal enum PidLiveness
+    {
+        /// <summary>The pid is a live process (and, where cheaply checkable, a KSP instance).</summary>
+        Alive,
+
+        /// <summary>The pid is not a live process (the previous owner crashed / exited).</summary>
+        Dead,
+
+        /// <summary>The pid could not be probed; fall back to the <c>t</c> tie-break.</summary>
+        Unknown,
+    }
+
+    /// <summary>
+    /// Seam for probing whether a lock's recorded pid is still alive. The real addon
+    /// implements this over <c>System.Diagnostics.Process</c>; tests inject a fake so
+    /// <see cref="LockFile.DecideLockOwnership"/> stays pure and deterministic.
+    /// </summary>
+    internal interface IPidLivenessProbe
+    {
+        PidLiveness Probe(int pid);
+    }
+
+    /// <summary>The ownership decision for a KSP-root automation lock.</summary>
+    internal enum LockOwnership
+    {
+        /// <summary>The lock is ours (session matches): reclaim it silently.</summary>
+        Reclaim,
+
+        /// <summary>A foreign lock with a LIVE pid: another instance owns the channel;
+        /// stand down (do not consume commands).</summary>
+        StandDown,
+
+        /// <summary>A foreign lock with a DEAD pid (previous owner crashed): reclaim,
+        /// logging a Warn.</summary>
+        ReclaimWithWarn,
+
+        /// <summary>No usable existing lock: acquire it.</summary>
+        Acquire,
+    }
+
+    /// <summary>Pure result of parsing a lock line.</summary>
+    internal struct LockInfo
+    {
+        public bool Ok;
+        public string Session;
+        public int Pid;
+        public double T;
+        public string Root;
+    }
+
+    /// <summary>
+    /// Pure lock-file grammar and ownership decision for the ParsekTestCommands seam
+    /// (M-A2). The lock detects two automation instances pointed at the same KSP root.
+    /// Ownership is decided by PID LIVENESS, not by <c>t</c>: <c>t</c> is written once
+    /// at startup and never refreshed, so a long-lived healthy instance would look
+    /// "stale" by <c>t</c> while a just-crashed one would look "fresh". <c>t</c> is a
+    /// last-resort tie-break only, used when a pid cannot be probed.
+    /// </summary>
+    internal static class LockFile
+    {
+        private const string RootKey = "root=";
+
+        /// <summary>
+        /// Formats the single lock line. <paramref name="root"/> is written last and
+        /// raw (it may contain spaces, e.g. "Kerbal Space Program"); the parser reads
+        /// it as the trailing remainder after <c>root=</c>.
+        /// </summary>
+        internal static string FormatLockLine(string session, int pid, double t, string root)
+        {
+            return "session=" + session
+                + " pid=" + pid.ToString(CultureInfo.InvariantCulture)
+                + " t=" + t.ToString("R", CultureInfo.InvariantCulture)
+                + " " + RootKey + (root ?? string.Empty);
+        }
+
+        /// <summary>
+        /// Parses a lock line. Requires <c>session</c> and a parseable <c>pid</c>;
+        /// <c>t</c> defaults to 0 when absent, and <c>root</c> is the raw trailing
+        /// remainder after <c>root=</c> (may contain spaces). Returns false (Ok=false)
+        /// when session or pid is missing.
+        /// </summary>
+        internal static bool TryParseLockLine(string line, out LockInfo info)
+        {
+            info = new LockInfo();
+            if (string.IsNullOrEmpty(line)) return false;
+
+            // Split off the root remainder first so a spaced path does not corrupt the
+            // whitespace tokenization of the leading fields.
+            string prefix = line;
+            int rootIdx = line.IndexOf(RootKey, StringComparison.Ordinal);
+            if (rootIdx >= 0)
+            {
+                info.Root = line.Substring(rootIdx + RootKey.Length);
+                prefix = line.Substring(0, rootIdx);
+            }
+
+            bool sawSession = false;
+            bool sawPid = false;
+            string[] tokens = prefix.Split(new[] { ' ', '\t' }, StringSplitOptions.RemoveEmptyEntries);
+            foreach (string token in tokens)
+            {
+                if (!TestCommandProtocol.TrySplitToken(token, out string key, out string value))
+                    continue;
+                switch (key)
+                {
+                    case "session":
+                        info.Session = value;
+                        sawSession = true;
+                        break;
+                    case "pid":
+                        if (int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out int pid))
+                        {
+                            info.Pid = pid;
+                            sawPid = true;
+                        }
+                        break;
+                    case "t":
+                        if (double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out double t))
+                            info.T = t;
+                        break;
+                }
+            }
+
+            if (!sawSession || !sawPid) return false;
+            info.Ok = true;
+            return true;
+        }
+
+        /// <summary>
+        /// Decides ownership of an existing lock. Order: no usable lock -> Acquire;
+        /// our own session -> Reclaim; otherwise probe the foreign pid -> Alive =
+        /// StandDown, Dead = ReclaimWithWarn, Unknown = the <c>t</c> tie-break (reclaim
+        /// with warn when the existing lock's t is not newer than ours, else stand
+        /// down). PID liveness is the primary signal; <c>t</c> is only the last resort.
+        /// </summary>
+        internal static LockOwnership DecideLockOwnership(
+            LockInfo existing,
+            bool existingPresent,
+            string ownSession,
+            double ownT,
+            IPidLivenessProbe probe)
+        {
+            if (!existingPresent || !existing.Ok)
+                return LockOwnership.Acquire;
+
+            if (existing.Session == ownSession)
+                return LockOwnership.Reclaim;
+
+            PidLiveness liveness = probe != null ? probe.Probe(existing.Pid) : PidLiveness.Unknown;
+            switch (liveness)
+            {
+                case PidLiveness.Alive:
+                    return LockOwnership.StandDown;
+                case PidLiveness.Dead:
+                    return LockOwnership.ReclaimWithWarn;
+                default:
+                    // Cannot probe the pid: last-resort t tie-break. A stale lock (t not
+                    // newer than ours) is reclaimed so a crashed owner does not wedge a
+                    // fresh run; a lock that looks newer than ours we defer to.
+                    return existing.T <= ownT ? LockOwnership.ReclaimWithWarn : LockOwnership.StandDown;
+            }
+        }
+    }
+}

--- a/Source/Parsek/TestCommands/ParsekTestCommandAddon.cs
+++ b/Source/Parsek/TestCommands/ParsekTestCommandAddon.cs
@@ -671,7 +671,7 @@ namespace Parsek.TestCommands
         void ITestCommandExecutor.RecordingState(ParsedCommand cmd) => RecordingStateImpl(cmd);
         void ITestCommandExecutor.RunTests(ParsedCommand cmd) => StubNotImplemented();
         void ITestCommandExecutor.LoadGame(ParsedCommand cmd) => StubNotImplemented();
-        void ITestCommandExecutor.MissionMark(ParsedCommand cmd) => StubNotImplemented();
+        void ITestCommandExecutor.MissionMark(ParsedCommand cmd) => MissionMarkImpl(cmd);
         void ITestCommandExecutor.FlushAndQuit(ParsedCommand cmd) => StubNotImplemented();
 
         private void InvokeExecutor(ParsedCommand cmd)
@@ -811,6 +811,15 @@ namespace Parsek.TestCommands
             ParsekLog.Info(Tag,
                 $"recordingstate recording={Bool(hasFlight && isRecording)} tree={(hasFlight ? (treeId ?? string.Empty) : string.Empty)} points={Int(hasFlight ? points : 0)} scene={sceneName}{(hasFlight ? string.Empty : " (no-flight-instance)")}");
             SetExecResult("OK", payload, null);
+        }
+
+        // ----- MissionMark (P5.3) -----
+        // Emits the stable MISSIONMARK correlation line (any scene) and echoes the label.
+        private void MissionMarkImpl(ParsedCommand cmd)
+        {
+            string label = ArgOrNull(cmd, "label") ?? string.Empty;
+            TestCommandMissionMark.EmitMark(label, CurrentUt());
+            SetExecResult("OK", Payload(Kv("label", label)), null);
         }
 
         private static string ReadLiveSettingForLog(string name)

--- a/Source/Parsek/TestCommands/ParsekTestCommandAddon.cs
+++ b/Source/Parsek/TestCommands/ParsekTestCommandAddon.cs
@@ -663,7 +663,7 @@ namespace Parsek.TestCommands
         // Explicit interface implementation: ParsedCommand is internal, so these cannot be
         // public members of the public MonoBehaviour. The pump dispatches via the interface
         // (InvokeExecutor casts this to ITestCommandExecutor).
-        void ITestCommandExecutor.SetSetting(ParsedCommand cmd) => StubNotImplemented();
+        void ITestCommandExecutor.SetSetting(ParsedCommand cmd) => SetSettingImpl(cmd);
         void ITestCommandExecutor.StartRecording(ParsedCommand cmd) => StubNotImplemented();
         void ITestCommandExecutor.StopRecording(ParsedCommand cmd) => StubNotImplemented();
         void ITestCommandExecutor.CommitTree(ParsedCommand cmd) => StubNotImplemented();
@@ -697,6 +697,120 @@ namespace Parsek.TestCommands
         }
 
         private void StubNotImplemented() => SetExecResult("ERROR", null, "stub");
+
+        // ----- Shared verb-body helpers (P5.x) -----
+
+        private static string ArgOrNull(ParsedCommand cmd, string key)
+            => cmd.Args != null && cmd.Args.TryGetValue(key, out string v) ? v : null;
+
+        private static KeyValuePair<string, string> Kv(string key, string value)
+            => new KeyValuePair<string, string>(key, value);
+
+        private static List<KeyValuePair<string, string>> Payload(params KeyValuePair<string, string>[] items)
+            => new List<KeyValuePair<string, string>>(items);
+
+        private static string Bool(bool b) => b ? "true" : "false";
+
+        private static string Int(int n) => n.ToString(CultureInfo.InvariantCulture);
+
+        // ----- SetSetting (P5.1) -----
+        // Applies a whitelisted setting through the pure whitelist decision + the pure
+        // route dispatcher. An unknown name or out-of-range value is REJECTED here (the
+        // side effect is journalled so a restart replay skips the id); the field is never
+        // touched on a reject. The security boundary is SettingWhitelist: there is no
+        // reflective set, only a switch over the exact known names.
+        private void SetSettingImpl(ParsedCommand cmd)
+        {
+            string name = ArgOrNull(cmd, "name");
+            string value = ArgOrNull(cmd, "value");
+
+            SettingApplyResult result = SettingWhitelist.TryApply(name, value);
+            if (!result.Accepted)
+            {
+                ParsekLog.Warn(Tag,
+                    $"setting rejected name={name ?? "(none)"} reason={(result.RejectReason == "setting-not-whitelisted" ? "not-whitelisted" : "value-invalid")} raw={value ?? "(none)"}");
+                SetExecResult("REJECTED", null, $"{result.RejectReason} name={name ?? string.Empty}");
+                return;
+            }
+
+            string oldValue = ReadLiveSettingForLog(result.Name);
+            TestCommandSettingApplier.ApplySetting(result, SetLiveSettingField, InvokeRecordMethod);
+            string newValue = ReadLiveSettingForLog(result.Name);
+
+            ParsekLog.Info(Tag, $"setting name={result.Name} old={oldValue} new={newValue}");
+            SetExecResult("OK", Payload(Kv("name", result.Name), Kv("value", value ?? string.Empty)), null);
+        }
+
+        // Sets the live ParsekSettings.Current field for the accepted whitelist name.
+        // Guarded by the RequiresGameLoaded precondition (SettingsPresent), but null-safe.
+        private void SetLiveSettingField(SettingApplyResult r)
+        {
+            ParsekSettings s = ParsekSettings.Current;
+            if (s == null) return;
+            switch (r.Name)
+            {
+                case "autoRecordOnLaunch": s.autoRecordOnLaunch = r.BoolValue; break;
+                case "autoRecordOnEva": s.autoRecordOnEva = r.BoolValue; break;
+                case "autoRecordOnFirstModificationAfterSwitch": s.autoRecordOnFirstModificationAfterSwitch = r.BoolValue; break;
+                case "autoMerge": s.autoMerge = r.BoolValue; break;
+                case "verboseLogging": s.verboseLogging = r.BoolValue; break;
+                case "samplingDensity": s.samplingDensity = r.IntValue; break;
+                case "ghostAudioVolume": s.ghostAudioVolume = r.FloatValue; break;
+                case "transitedBodyRotationModeIndex": s.transitedBodyRotationModeIndex = r.IntValue; break;
+                case "ghostRenderTracing": s.ghostRenderTracing = r.BoolValue; break;
+                case "mapRenderTracing": s.mapRenderTracing = r.BoolValue; break;
+                case "ledgerTracing": s.ledgerTracing = r.BoolValue; break;
+                case "writeReadableSidecarMirrors": s.writeReadableSidecarMirrors = r.BoolValue; break;
+                case "autoBackupExistingSaves": s.autoBackupExistingSaves = r.BoolValue; break;
+                case "showCommittedFutureOverlays": s.showCommittedFutureOverlays = r.BoolValue; break;
+                case "blockCommittedActions": s.blockCommittedActions = r.BoolValue; break;
+                case "showRouteLines": s.showRouteLines = r.BoolValue; break;
+            }
+        }
+
+        // Invokes the exact ParsekSettingsPersistence.Record* member for a
+        // sidecar-tracked setting (mirrors UI/SettingsWindowUI). All 8 tracked settings
+        // are bools, so every Record* takes r.BoolValue.
+        private void InvokeRecordMethod(SettingApplyResult r)
+        {
+            switch (r.RecordMethod)
+            {
+                case "RecordGhostRenderTracing": ParsekSettingsPersistence.RecordGhostRenderTracing(r.BoolValue); break;
+                case "RecordMapRenderTracing": ParsekSettingsPersistence.RecordMapRenderTracing(r.BoolValue); break;
+                case "RecordLedgerTracing": ParsekSettingsPersistence.RecordLedgerTracing(r.BoolValue); break;
+                case "RecordReadableSidecarMirrors": ParsekSettingsPersistence.RecordReadableSidecarMirrors(r.BoolValue); break;
+                case "RecordAutoBackupExistingSaves": ParsekSettingsPersistence.RecordAutoBackupExistingSaves(r.BoolValue); break;
+                case "RecordShowCommittedFutureOverlays": ParsekSettingsPersistence.RecordShowCommittedFutureOverlays(r.BoolValue); break;
+                case "RecordBlockCommittedActions": ParsekSettingsPersistence.RecordBlockCommittedActions(r.BoolValue); break;
+                case "RecordShowRouteLines": ParsekSettingsPersistence.RecordShowRouteLines(r.BoolValue); break;
+            }
+        }
+
+        private static string ReadLiveSettingForLog(string name)
+        {
+            ParsekSettings s = ParsekSettings.Current;
+            if (s == null) return "?";
+            switch (name)
+            {
+                case "autoRecordOnLaunch": return Bool(s.autoRecordOnLaunch);
+                case "autoRecordOnEva": return Bool(s.autoRecordOnEva);
+                case "autoRecordOnFirstModificationAfterSwitch": return Bool(s.autoRecordOnFirstModificationAfterSwitch);
+                case "autoMerge": return Bool(s.autoMerge);
+                case "verboseLogging": return Bool(s.verboseLogging);
+                case "samplingDensity": return Int(s.samplingDensity);
+                case "ghostAudioVolume": return s.ghostAudioVolume.ToString("R", CultureInfo.InvariantCulture);
+                case "transitedBodyRotationModeIndex": return Int(s.transitedBodyRotationModeIndex);
+                case "ghostRenderTracing": return Bool(s.ghostRenderTracing);
+                case "mapRenderTracing": return Bool(s.mapRenderTracing);
+                case "ledgerTracing": return Bool(s.ledgerTracing);
+                case "writeReadableSidecarMirrors": return Bool(s.writeReadableSidecarMirrors);
+                case "autoBackupExistingSaves": return Bool(s.autoBackupExistingSaves);
+                case "showCommittedFutureOverlays": return Bool(s.showCommittedFutureOverlays);
+                case "blockCommittedActions": return Bool(s.blockCommittedActions);
+                case "showRouteLines": return Bool(s.showRouteLines);
+                default: return "?";
+            }
+        }
 
         private void SetExecResult(string verdict, List<KeyValuePair<string, string>> payload, string msg)
         {

--- a/Source/Parsek/TestCommands/ParsekTestCommandAddon.cs
+++ b/Source/Parsek/TestCommands/ParsekTestCommandAddon.cs
@@ -1,0 +1,144 @@
+using System;
+using UnityEngine;
+
+namespace Parsek.TestCommands
+{
+    /// <summary>
+    /// The thin Unity host for the ParsekTestCommands seam (M-A2). A DDOL
+    /// <see cref="MonoBehaviour"/> that, ONLY when armed by the
+    /// <c>PARSEK_TEST_COMMANDS=1</c> environment variable, polls the KSP-root command
+    /// file, executes commands on the Unity main thread, and appends responses. The
+    /// parse / validate / dispatch / journal / lock logic all lives in the pure
+    /// <c>Parsek.TestCommands</c> core (xUnit-tested without Unity); this addon only
+    /// samples live state, performs file I/O, and calls those decisions. It mirrors
+    /// <see cref="Parsek.InGameTests.TestRunnerShortcut"/>'s lifecycle pattern
+    /// (Instantly + DontDestroyOnLoad + singleton guard + scene-scoped safe-point
+    /// gating).
+    ///
+    /// <para>Fail-closed and provably inert: the env var is read ONCE in
+    /// <see cref="Awake"/> (changing it requires a process restart), and when it is not
+    /// the literal <c>1</c> the addon takes NO file handles and does NO polling work -
+    /// <see cref="Update"/> returns immediately on the cached <see cref="armed"/> bool.
+    /// It is never shipped enabled and adds no Settings-UI toggle.</para>
+    /// </summary>
+    [KSPAddon(KSPAddon.Startup.Instantly, true)]
+    public class ParsekTestCommandAddon : MonoBehaviour
+    {
+        private const string Tag = "TestCommands";
+
+        /// <summary>The environment variable that arms the addon.</summary>
+        internal const string EnvVarName = "PARSEK_TEST_COMMANDS";
+
+        /// <summary>The ONLY value that arms it (exact match, fail-closed).</summary>
+        internal const string ArmValue = "1";
+
+        /// <summary>Frames to wait after a new scene loads before it is "settled" and the
+        /// pump may execute. Matches the scene-scoped-state pattern TestRunnerShortcut
+        /// uses for its input lock.</summary>
+        private const int SettleFrames = 2;
+
+        private static ParsekTestCommandAddon instance;
+
+        /// <summary>Singleton accessor - non-null after Awake while DDOL keeps the
+        /// instance alive. Used by in-game tests to assert inert-when-unarmed.</summary>
+        internal static ParsekTestCommandAddon Instance => instance;
+
+        // Cached ONCE in Awake from the env var; changing PARSEK_TEST_COMMANDS after
+        // process start has NO effect (documented: env change requires a KSP restart).
+        private bool armed;
+
+        // Scene-scoped safe-point gating. onGameSceneLoadRequested sets transitioning;
+        // onLevelWasLoaded seeds the settle counter for the new scene; Update drains it
+        // and clears transitioning at the settle boundary.
+        private bool sceneTransitioning;
+        private int settleCounter;
+
+        internal bool IsArmedForTesting => armed;
+        internal bool SceneTransitioningForTesting => sceneTransitioning;
+        internal int SettleCounterForTesting => settleCounter;
+
+        /// <summary>
+        /// Pure fail-closed env-gate predicate: ONLY the literal <c>"1"</c> arms the
+        /// addon. <c>null</c> (unset), <c>"0"</c>, <c>"true"</c>, and <c>""</c> all stay
+        /// inert. This is the security boundary that prevents the seam from ever shipping
+        /// enabled by accident.
+        /// </summary>
+        internal static bool IsArmed(string envValue) => envValue == ArmValue;
+
+        void Awake()
+        {
+            if (instance != null)
+            {
+                Destroy(gameObject);
+                return;
+            }
+            instance = this;
+            DontDestroyOnLoad(gameObject);
+
+            // Read ONCE. The env var is the entire arm gate; it is never re-read.
+            string envValue = Environment.GetEnvironmentVariable(EnvVarName);
+            armed = IsArmed(envValue);
+
+            if (armed)
+            {
+                ParsekLog.Info(Tag, "armed (PARSEK_TEST_COMMANDS=1)");
+                // Scene-scoped state only (no gameplay subscriptions), matching
+                // TestRunnerShortcut: the addon tracks scene transitions purely for its
+                // own safe-point gating.
+                GameEvents.onGameSceneLoadRequested.Add(OnSceneChangeRequested);
+                GameEvents.onLevelWasLoaded.Add(OnLevelWasLoaded);
+            }
+            else
+            {
+                ParsekLog.Verbose(Tag, $"inert: PARSEK_TEST_COMMANDS={FormatEnvForLog(envValue)}");
+            }
+        }
+
+        void Update()
+        {
+            // Provably inert when unarmed: no polling, no file access - return on the
+            // cached bool before any work.
+            if (!armed) return;
+
+            if (settleCounter > 0)
+            {
+                settleCounter--;
+                if (settleCounter == 0)
+                    sceneTransitioning = false;
+            }
+        }
+
+        void OnDestroy()
+        {
+            if (instance == this)
+            {
+                instance = null;
+                if (armed)
+                {
+                    GameEvents.onGameSceneLoadRequested.Remove(OnSceneChangeRequested);
+                    GameEvents.onLevelWasLoaded.Remove(OnLevelWasLoaded);
+                }
+            }
+        }
+
+        // A scene load has been requested: we are leaving the current scene. Gate the
+        // pump off until the new scene loads and settles.
+        private void OnSceneChangeRequested(GameScenes scene)
+        {
+            sceneTransitioning = true;
+            settleCounter = 0;
+        }
+
+        // The new scene is active: start the settle countdown. Transitioning clears when
+        // the counter drains (in Update), a couple of frames into the new scene.
+        private void OnLevelWasLoaded(GameScenes scene)
+        {
+            settleCounter = SettleFrames;
+        }
+
+        /// <summary>Human-readable rendering of the env value for the inert log line:
+        /// <c>unset</c> for null, <c>empty</c> for the empty string, else the raw value.</summary>
+        internal static string FormatEnvForLog(string envValue)
+            => envValue == null ? "unset" : (envValue.Length == 0 ? "empty" : envValue);
+    }
+}

--- a/Source/Parsek/TestCommands/ParsekTestCommandAddon.cs
+++ b/Source/Parsek/TestCommands/ParsekTestCommandAddon.cs
@@ -818,7 +818,7 @@ namespace Parsek.TestCommands
         void ITestCommandExecutor.RunTests(ParsedCommand cmd) => RunTestsImpl(cmd);
         void ITestCommandExecutor.LoadGame(ParsedCommand cmd) => LoadGameImpl(cmd);
         void ITestCommandExecutor.MissionMark(ParsedCommand cmd) => MissionMarkImpl(cmd);
-        void ITestCommandExecutor.FlushAndQuit(ParsedCommand cmd) => StubNotImplemented();
+        void ITestCommandExecutor.FlushAndQuit(ParsedCommand cmd) => FlushAndQuitImpl(cmd);
 
         private void InvokeExecutor(ParsedCommand cmd)
         {
@@ -991,6 +991,37 @@ namespace Parsek.TestCommands
 
             ParsekLog.Info(Tag, $"stoprecording stopped={Bool(wasLive)} idle={Bool(!wasLive)}");
             SetExecResult("OK", TestCommandRecordingVerbs.BuildStopPayload(wasLive), null);
+        }
+
+        // ----- FlushAndQuit (P5.8) -----
+        // If a game is loaded, force a "persistent"-slot save so committed data is durable,
+        // THEN schedule Application.Quit deferred one frame. The quit is scheduled by
+        // MaybeScheduleQuit only AFTER the response + journal DONE are written and flushed
+        // (WriteDoneAndAdvance), so a killed process never loses this command's ack.
+        // Deliberately NEVER auto-commits an in-flight recorder (a bare quit never did).
+        private void FlushAndQuitImpl(ParsedCommand cmd)
+        {
+            bool gameLoaded = HighLogic.CurrentGame != null;
+            bool saveFolderPresent = !string.IsNullOrEmpty(HighLogic.SaveFolder);
+            bool saved = false;
+
+            if (TestCommandFlushAndQuit.ShouldSave(gameLoaded, saveFolderPresent))
+            {
+                try
+                {
+                    string result = GamePersistence.SaveGame("persistent", HighLogic.SaveFolder, SaveMode.OVERWRITE);
+                    saved = !string.IsNullOrEmpty(result);
+                }
+                catch (Exception ex)
+                {
+                    ParsekLog.Warn(Tag, $"flushandquit save failed: {ex.Message}");
+                }
+            }
+
+            ParsekLog.Info(Tag, $"flushandquit: saved={Bool(saved)} game-loaded={Bool(gameLoaded)}; quitting");
+            pendingQuit = true;
+            quitId = cmd.Id;
+            SetExecResult("OK", TestCommandFlushAndQuit.BuildPayload(saved), null);
         }
 
         // ----- LoadGame (P5.7, two-phase boot channel, C2) -----

--- a/Source/Parsek/TestCommands/ParsekTestCommandAddon.cs
+++ b/Source/Parsek/TestCommands/ParsekTestCommandAddon.cs
@@ -463,12 +463,12 @@ namespace Parsek.TestCommands
             {
                 case DispatchDecision.Execute:
                     ResetDeferTracking();
-                    ParsekLog.Info(Tag, $"dispatch id={head.Id} -> EXECUTE");
+                    TestCommandDiagnostics.DispatchExecute(head.Id);
                     ExecuteHead(head); // owns its dequeue (terminal / pending-response)
                     break;
                 case DispatchDecision.Reject:
                     ResetDeferTracking();
-                    ParsekLog.Warn(Tag, $"reject id={head.Id} cmd={head.Verb} reason={result.Reason}");
+                    TestCommandDiagnostics.DispatchReject(head.Id, head.Verb, result.Reason);
                     WriteTerminalNoSideEffect(head, "REJECTED", result.Reason);
                     pending.Dequeue();
                     break;
@@ -504,12 +504,12 @@ namespace Parsek.TestCommands
 
                 if (processedIds.Contains(id) || queuedIds.Contains(id))
                 {
-                    ParsekLog.Warn(Tag, $"duplicate id={id} ignored");
+                    TestCommandDiagnostics.Duplicate(id);
                     continue;
                 }
 
                 int argCount = parsed.Args != null ? parsed.Args.Count : 0;
-                ParsekLog.Info(Tag, $"recv id={id} cmd={parsed.Verb ?? "?"} args={argCount}");
+                TestCommandDiagnostics.Receipt(id, parsed.Verb, argCount);
                 queuedIds.Add(id);
                 pending.Enqueue(parsed);
                 parsedCount++;
@@ -541,7 +541,7 @@ namespace Parsek.TestCommands
                 return;
             }
 
-            ParsekLog.Info(Tag, $"exec id={id} cmd={head.Verb} start");
+            TestCommandDiagnostics.ExecStart(id, head.Verb);
             ClearExecResult();
             InvokeExecutor(head);
             string verdict = execVerdict ?? "ERROR";
@@ -558,7 +558,7 @@ namespace Parsek.TestCommands
                 completionSeq = seq;
                 completionVerb = head.Verb;
                 completionStartedAt = WallClockSeconds();
-                ParsekLog.Info(Tag, $"exec id={id} verdict=PENDING (two-phase awaiting completion)");
+                TestCommandDiagnostics.ExecPending(id);
                 return;
             }
 
@@ -577,10 +577,11 @@ namespace Parsek.TestCommands
 
             string line = TestCommandResponse.FormatResponseLine(
                 id, verb, verdict, seq, CurrentUt(), payload, msg);
-            ParsekLog.Info(Tag, $"exec id={id} verdict={verdict}");
+            TestCommandDiagnostics.ExecVerdict(id, verdict);
 
             if (AppendResponse(line, id))
             {
+                TestCommandDiagnostics.ResponseAppended(id, verdict);
                 WriteDoneAndAdvance(id, seq, verdict);
             }
             else
@@ -650,8 +651,7 @@ namespace Parsek.TestCommands
                 double budget = DeferralBudget.BudgetSeconds(completionVerb);
                 if (DeferralBudget.ShouldTimeout(completionStartedAt, now, budget))
                 {
-                    ParsekLog.Warn(Tag,
-                        $"timeout id={completionId} cmd={completionVerb} deferred={(now - completionStartedAt).ToString("F1", CultureInfo.InvariantCulture)}s reason=awaiting-completion");
+                    TestCommandDiagnostics.Timeout(completionId, completionVerb, now - completionStartedAt, "awaiting-completion");
                     if (completionVerb == "LoadGame") loadInFlight = false;
                     string tid = completionId; long tseq = completionSeq; string tverb = completionVerb;
                     ClearTwoPhase();
@@ -710,7 +710,7 @@ namespace Parsek.TestCommands
         private void InterruptHead(ParsedCommand head)
         {
             string id = head.Id;
-            ParsekLog.Info(Tag, $"dispatch id={id} -> INTERRUPTED (journal=CLAIMED)");
+            TestCommandDiagnostics.DispatchInterrupted(id, JournalPhase.Claimed);
             long seq = NextSeq();
             string line = TestCommandResponse.FormatResponseLine(
                 id, head.Verb ?? string.Empty, "INTERRUPTED", seq, CurrentUt(), null, "interrupted-claimed");
@@ -741,20 +741,18 @@ namespace Parsek.TestCommands
             {
                 deferHeadId = head.Id;
                 deferStartedAtSeconds = now;
-                ParsekLog.Info(Tag, $"dispatch id={head.Id} -> DEFER reason={reason}");
+                TestCommandDiagnostics.DispatchDefer(head.Id, reason);
             }
             else
             {
-                ParsekLog.VerboseRateLimited(Tag, $"defer-{head.Id}",
-                    $"dispatch id={head.Id} -> DEFER reason={reason}", 5.0);
+                TestCommandDiagnostics.DispatchDeferRepeat(head.Id, reason);
             }
             lastDeferReason = reason;
 
             double budget = DeferralBudget.BudgetSeconds(head.Verb);
             if (DeferralBudget.ShouldTimeout(deferStartedAtSeconds, now, budget))
             {
-                ParsekLog.Warn(Tag,
-                    $"timeout id={head.Id} cmd={head.Verb} deferred={(now - deferStartedAtSeconds).ToString("F1", CultureInfo.InvariantCulture)}s reason={lastDeferReason}");
+                TestCommandDiagnostics.Timeout(head.Id, head.Verb, now - deferStartedAtSeconds, lastDeferReason);
                 WriteTerminalNoSideEffect(head, "TIMEOUT", lastDeferReason);
                 pending.Dequeue();
                 ResetDeferTracking();

--- a/Source/Parsek/TestCommands/ParsekTestCommandAddon.cs
+++ b/Source/Parsek/TestCommands/ParsekTestCommandAddon.cs
@@ -666,8 +666,8 @@ namespace Parsek.TestCommands
         void ITestCommandExecutor.SetSetting(ParsedCommand cmd) => SetSettingImpl(cmd);
         void ITestCommandExecutor.StartRecording(ParsedCommand cmd) => StartRecordingImpl(cmd);
         void ITestCommandExecutor.StopRecording(ParsedCommand cmd) => StopRecordingImpl(cmd);
-        void ITestCommandExecutor.CommitTree(ParsedCommand cmd) => StubNotImplemented();
-        void ITestCommandExecutor.DiscardTree(ParsedCommand cmd) => StubNotImplemented();
+        void ITestCommandExecutor.CommitTree(ParsedCommand cmd) => CommitTreeImpl(cmd);
+        void ITestCommandExecutor.DiscardTree(ParsedCommand cmd) => DiscardTreeImpl(cmd);
         void ITestCommandExecutor.RecordingState(ParsedCommand cmd) => RecordingStateImpl(cmd);
         void ITestCommandExecutor.RunTests(ParsedCommand cmd) => StubNotImplemented();
         void ITestCommandExecutor.LoadGame(ParsedCommand cmd) => StubNotImplemented();
@@ -845,6 +845,48 @@ namespace Parsek.TestCommands
 
             ParsekLog.Info(Tag, $"stoprecording stopped={Bool(wasLive)} idle={Bool(!wasLive)}");
             SetExecResult("OK", TestCommandRecordingVerbs.BuildStopPayload(wasLive), null);
+        }
+
+        // ----- CommitTree / DiscardTree (P5.5, C1) -----
+        // CommitTree pre-checks HasActiveTree: with no tree it is ERROR msg=no-active-tree
+        // (the production CommitTreeFlight guard is only a screen toast, so we mirror it
+        // here as a real terminal verdict). DiscardTree with no tree is an idempotent
+        // OK nothing=true; otherwise stop a live recorder then discard via the
+        // wrong-context entry point with test-command-specific strings.
+        private void CommitTreeImpl(ParsedCommand cmd)
+        {
+            ParsekFlight flight = ParsekFlight.Instance;
+            if (flight == null || !flight.HasActiveTree)
+            {
+                ParsekLog.Warn(Tag, "committree no-active-tree");
+                SetExecResult("ERROR", null, "no-active-tree");
+                return;
+            }
+
+            flight.CommitTreeFlight();
+            ParsekLog.Info(Tag, "committree committed=true");
+            SetExecResult("OK", TestCommandRecordingVerbs.BuildCommitPayload(), null);
+        }
+
+        private void DiscardTreeImpl(ParsedCommand cmd)
+        {
+            ParsekFlight flight = ParsekFlight.Instance;
+            if (flight == null || !flight.HasActiveTree)
+            {
+                ParsekLog.Info(Tag, "discardtree nothing=true");
+                SetExecResult("OK", TestCommandRecordingVerbs.BuildDiscardPayload(hadTree: false), null);
+                return;
+            }
+
+            if (ParsekFlight.HasLiveRecorderForTagging())
+                flight.StopRecording();
+            flight.AutoDiscardActiveTreeWithMessage(
+                reason: "test-command-discard",
+                screenMessage: "Recording discarded (test command)",
+                ledgerRecalcReason: "test-command-discard");
+
+            ParsekLog.Info(Tag, "discardtree discarded=true");
+            SetExecResult("OK", TestCommandRecordingVerbs.BuildDiscardPayload(hadTree: true), null);
         }
 
         // ----- MissionMark (P5.3) -----

--- a/Source/Parsek/TestCommands/ParsekTestCommandAddon.cs
+++ b/Source/Parsek/TestCommands/ParsekTestCommandAddon.cs
@@ -664,8 +664,8 @@ namespace Parsek.TestCommands
         // public members of the public MonoBehaviour. The pump dispatches via the interface
         // (InvokeExecutor casts this to ITestCommandExecutor).
         void ITestCommandExecutor.SetSetting(ParsedCommand cmd) => SetSettingImpl(cmd);
-        void ITestCommandExecutor.StartRecording(ParsedCommand cmd) => StubNotImplemented();
-        void ITestCommandExecutor.StopRecording(ParsedCommand cmd) => StubNotImplemented();
+        void ITestCommandExecutor.StartRecording(ParsedCommand cmd) => StartRecordingImpl(cmd);
+        void ITestCommandExecutor.StopRecording(ParsedCommand cmd) => StopRecordingImpl(cmd);
         void ITestCommandExecutor.CommitTree(ParsedCommand cmd) => StubNotImplemented();
         void ITestCommandExecutor.DiscardTree(ParsedCommand cmd) => StubNotImplemented();
         void ITestCommandExecutor.RecordingState(ParsedCommand cmd) => RecordingStateImpl(cmd);
@@ -811,6 +811,40 @@ namespace Parsek.TestCommands
             ParsekLog.Info(Tag,
                 $"recordingstate recording={Bool(hasFlight && isRecording)} tree={(hasFlight ? (treeId ?? string.Empty) : string.Empty)} points={Int(hasFlight ? points : 0)} scene={sceneName}{(hasFlight ? string.Empty : " (no-flight-instance)")}");
             SetExecResult("OK", payload, null);
+        }
+
+        // ----- StartRecording / StopRecording (P5.4, C1) -----
+        // Both underlying ParsekFlight methods return void, so the payload is derived
+        // from recorder-live state sampled around the call (C1). Dispatch guarantees
+        // FLIGHT, but the handlers are defensive against a null Instance.
+        private void StartRecordingImpl(ParsedCommand cmd)
+        {
+            bool alreadyLive = ParsekFlight.HasLiveRecorderForTagging();
+            ParsekFlight flight = ParsekFlight.Instance;
+            if (flight == null)
+            {
+                ParsekLog.Warn(Tag, "startrecording no-flight-instance");
+                SetExecResult("ERROR", null, "no-flight-instance");
+                return;
+            }
+
+            if (!alreadyLive)
+                flight.StartRecording();
+
+            string recordingId = ParsekFlight.GetActiveRecordingIdForTagging();
+            ParsekLog.Info(Tag, $"startrecording recordingId={recordingId} already={Bool(alreadyLive)}");
+            SetExecResult("OK", TestCommandRecordingVerbs.BuildStartPayload(alreadyLive, recordingId), null);
+        }
+
+        private void StopRecordingImpl(ParsedCommand cmd)
+        {
+            bool wasLive = ParsekFlight.HasLiveRecorderForTagging();
+            ParsekFlight flight = ParsekFlight.Instance;
+            if (wasLive && flight != null)
+                flight.StopRecording();
+
+            ParsekLog.Info(Tag, $"stoprecording stopped={Bool(wasLive)} idle={Bool(!wasLive)}");
+            SetExecResult("OK", TestCommandRecordingVerbs.BuildStopPayload(wasLive), null);
         }
 
         // ----- MissionMark (P5.3) -----

--- a/Source/Parsek/TestCommands/ParsekTestCommandAddon.cs
+++ b/Source/Parsek/TestCommands/ParsekTestCommandAddon.cs
@@ -668,7 +668,7 @@ namespace Parsek.TestCommands
         void ITestCommandExecutor.StopRecording(ParsedCommand cmd) => StubNotImplemented();
         void ITestCommandExecutor.CommitTree(ParsedCommand cmd) => StubNotImplemented();
         void ITestCommandExecutor.DiscardTree(ParsedCommand cmd) => StubNotImplemented();
-        void ITestCommandExecutor.RecordingState(ParsedCommand cmd) => StubNotImplemented();
+        void ITestCommandExecutor.RecordingState(ParsedCommand cmd) => RecordingStateImpl(cmd);
         void ITestCommandExecutor.RunTests(ParsedCommand cmd) => StubNotImplemented();
         void ITestCommandExecutor.LoadGame(ParsedCommand cmd) => StubNotImplemented();
         void ITestCommandExecutor.MissionMark(ParsedCommand cmd) => StubNotImplemented();
@@ -784,6 +784,33 @@ namespace Parsek.TestCommands
                 case "RecordBlockCommittedActions": ParsekSettingsPersistence.RecordBlockCommittedActions(r.BoolValue); break;
                 case "RecordShowRouteLines": ParsekSettingsPersistence.RecordShowRouteLines(r.BoolValue); break;
             }
+        }
+
+        // ----- RecordingState (P5.2) -----
+        // Read-only recorder/tree snapshot, valid in ANY scene. With no live
+        // ParsekFlight (any non-flight scene, or flight not yet ready) the recorder is
+        // definitionally not recording, so recording=false with empty tree / zero points.
+        private void RecordingStateImpl(ParsedCommand cmd)
+        {
+            string sceneName = HighLogic.LoadedScene.ToString();
+            ParsekFlight flight = ParsekFlight.Instance;
+            bool hasFlight = flight != null;
+            bool isRecording = false;
+            string treeId = null;
+            int points = 0;
+            if (hasFlight)
+            {
+                RecorderStateSnapshot snap = flight.CaptureRecorderState();
+                isRecording = snap.isRecording;
+                treeId = snap.treeId;
+                points = snap.bufferedPoints;
+            }
+
+            List<KeyValuePair<string, string>> payload =
+                TestCommandRecordingState.BuildPayload(hasFlight, isRecording, treeId, points, sceneName);
+            ParsekLog.Info(Tag,
+                $"recordingstate recording={Bool(hasFlight && isRecording)} tree={(hasFlight ? (treeId ?? string.Empty) : string.Empty)} points={Int(hasFlight ? points : 0)} scene={sceneName}{(hasFlight ? string.Empty : " (no-flight-instance)")}");
+            SetExecResult("OK", payload, null);
         }
 
         private static string ReadLiveSettingForLog(string name)

--- a/Source/Parsek/TestCommands/ParsekTestCommandAddon.cs
+++ b/Source/Parsek/TestCommands/ParsekTestCommandAddon.cs
@@ -287,15 +287,19 @@ namespace Parsek.TestCommands
                         break;
                     case RecoveryAction.RewriteResponse:
                         executed++;
-                        // Side effect ran but the response may not have landed and cannot
-                        // be reconstructed post-crash; re-ack with a distinct recovery msg
-                        // so the orchestrator (which treats the FIRST terminal line per id
-                        // as authoritative) is never left hanging.
-                        WriteRecoveryTerminal(id, verb, "INTERRUPTED", "recovered-executed");
+                        // Side effect ran; re-emit the ORIGINAL terminal response stored on the
+                        // EXECUTED line (true RewriteResponse) so the orchestrator sees the real
+                        // verdict/payload/msg, not a synthetic INTERRUPTED. A pre-enrichment /
+                        // torn EXECUTED line with no stored fields falls back to the old ack.
+                        if (TestCommandJournal.TryGetExecutedResponse(
+                                lines, id, out string exVerdict, out var exPayload, out string exMsg))
+                            WriteRecoveryTerminal(id, verb, exVerdict, exPayload, exMsg);
+                        else
+                            WriteRecoveryTerminal(id, verb, "INTERRUPTED", null, "recovered-executed");
                         break;
                     case RecoveryAction.Interrupted:
                         claimed++;
-                        WriteRecoveryTerminal(id, verb, "INTERRUPTED", "interrupted-claimed");
+                        WriteRecoveryTerminal(id, verb, "INTERRUPTED", null, "interrupted-claimed");
                         break;
                 }
                 processedIds.Add(id);
@@ -606,7 +610,9 @@ namespace Parsek.TestCommands
             string id, long seq, string verb, string verdict,
             List<KeyValuePair<string, string>> payload, string msg)
         {
-            WriteJournal(TestCommandJournal.FormatExecuted(id, seq, WallClockSeconds()), id, "EXECUTED");
+            WriteJournal(
+                TestCommandJournal.FormatExecuted(id, seq, WallClockSeconds(), verdict, payload, msg),
+                id, "EXECUTED");
 
             string line = TestCommandResponse.FormatResponseLine(
                 id, verb, verdict, seq, CurrentUt(), payload, msg);
@@ -730,7 +736,7 @@ namespace Parsek.TestCommands
             string verb = head.Verb ?? string.Empty;
             long seq = NextSeq();
             WriteJournal(TestCommandJournal.FormatClaimed(id, seq, verb, SessionId(), WallClockSeconds()), id, "CLAIMED");
-            WriteJournal(TestCommandJournal.FormatExecuted(id, seq, WallClockSeconds()), id, "EXECUTED");
+            WriteJournal(TestCommandJournal.FormatExecuted(id, seq, WallClockSeconds(), verdict, null, msg), id, "EXECUTED");
             string line = TestCommandResponse.FormatResponseLine(id, verb, verdict, seq, CurrentUt(), null, msg);
             AppendResponse(line, id);
             WriteJournal(TestCommandJournal.FormatDone(id, seq, verdict, WallClockSeconds()), id, "DONE");
@@ -753,12 +759,17 @@ namespace Parsek.TestCommands
         }
 
         // Startup crash-recovery terminal (from ReplayAndReconcile). No pending head to
-        // dequeue; just re-ack + DONE + processed-set seed happens in the caller.
-        private void WriteRecoveryTerminal(string id, string verb, string verdict, string msg)
+        // dequeue; just re-ack + DONE + processed-set seed happens in the caller. For the
+        // RewriteResponse (EXECUTED) case the ORIGINAL verdict/payload/msg are supplied so the
+        // rewritten line is byte-equivalent to the pre-crash response; the CLAIMED case keeps
+        // the synthetic interrupted-claimed ack.
+        private void WriteRecoveryTerminal(
+            string id, string verb, string verdict,
+            List<KeyValuePair<string, string>> payload, string msg)
         {
             long seq = NextSeq();
             string line = TestCommandResponse.FormatResponseLine(
-                id, verb ?? string.Empty, verdict, seq, CurrentUt(), null, msg);
+                id, verb ?? string.Empty, verdict, seq, CurrentUt(), payload, msg);
             AppendResponse(line, id);
             WriteJournal(TestCommandJournal.FormatDone(id, seq, verdict, WallClockSeconds()), id, "DONE");
         }

--- a/Source/Parsek/TestCommands/ParsekTestCommandAddon.cs
+++ b/Source/Parsek/TestCommands/ParsekTestCommandAddon.cs
@@ -5,6 +5,7 @@ using System.Globalization;
 using System.IO;
 using System.Text;
 using System.Threading;
+using Parsek.InGameTests;
 using UnityEngine;
 
 namespace Parsek.TestCommands
@@ -28,7 +29,7 @@ namespace Parsek.TestCommands
     /// It is never shipped enabled and adds no Settings-UI toggle.</para>
     /// </summary>
     [KSPAddon(KSPAddon.Startup.Instantly, true)]
-    public class ParsekTestCommandAddon : MonoBehaviour
+    public class ParsekTestCommandAddon : MonoBehaviour, ITestCommandExecutor
     {
         private const string Tag = "TestCommands";
 
@@ -73,6 +74,46 @@ namespace Parsek.TestCommands
         private string journalFilePath;
         private string lockFilePath;
         private long commandByteOffset;
+
+        // Pump state (P4.4). pending is the strict-FIFO command queue; queuedIds /
+        // processedIds dedup ids (in-flight vs already-terminal). journalPhases is the
+        // startup-replayed phase map (feeds DispatchState.JournalPhase). lineCounter is
+        // the absolute file line position for the line#<n> fallback id. responseSeq is
+        // the per-process monotonic response/journal counter.
+        private readonly Queue<ParsedCommand> pending = new Queue<ParsedCommand>();
+        private readonly HashSet<string> queuedIds = new HashSet<string>();
+        private readonly HashSet<string> processedIds = new HashSet<string>();
+        private Dictionary<string, JournalPhase> journalPhases = new Dictionary<string, JournalPhase>();
+        private int lineCounter;
+        private long responseSeq;
+        // Set true while a LoadGame is in flight (P5.7); read now by the LoadGame guard.
+        private bool loadInFlight = false;
+
+        // The in-game test runner the addon owns for RunTests (P5.6). Null until then;
+        // the batch-running safe-point gate reads it now so the pump never runs a command
+        // mid-batch once RunTests is wired.
+        private InGameTestRunner ownedRunner = null;
+
+        // Head deferral tracking: the id currently deferring at the FIFO head and when it
+        // began, so a never-satisfiable head converts to TIMEOUT once its budget expires.
+        private string deferHeadId;
+        private double deferStartedAtSeconds;
+        private string lastDeferReason;
+
+        // A terminal response whose append exhausted its retries on a prior frame. The
+        // side effect already ran and is journaled EXECUTED, so this is re-appended
+        // WITHOUT re-executing until it lands, then journaled DONE.
+        private bool headPendingResponse;
+        private string headPendingResponseLine;
+        private string headPendingResponseId;
+        private long headPendingResponseSeq;
+        private string headPendingResponseVerdict;
+
+        // Executor result carrier: the ITestCommandExecutor methods are void, so a verb
+        // handler stashes its verdict/payload/msg here and the pump reads them back.
+        private string execVerdict;
+        private List<KeyValuePair<string, string>> execPayload;
+        private string execMsg;
 
         internal bool IsArmedForTesting => armed;
         internal bool SceneTransitioningForTesting => sceneTransitioning;
@@ -134,13 +175,22 @@ namespace Parsek.TestCommands
                 if (settleCounter == 0)
                     sceneTransitioning = false;
             }
+
+            // Safe-point gate: never pump during LOADING, a scene transition / settle, or
+            // an in-game test batch. (DecideDispatch re-checks these from DispatchState;
+            // gating here avoids even reading the channel at an unsafe moment.)
+            if (HighLogic.LoadedScene == GameScenes.LOADING) return;
+            if (sceneTransitioning || settleCounter > 0) return;
+            if (IsBatchRunning()) return;
+
+            Pump();
         }
 
-        // ----- Startup: channel paths + lock (P4.3) -----
+        // ----- Startup: channel paths + lock + journal reconcile (P4.3 / P4.4) -----
 
-        // Runs ONCE on the first armed frame. Resolves the four KSP-root channel paths and
-        // decides lock ownership; the journal replay + reconcile and offset/processed-set
-        // seed are wired on top of this in P4.4.
+        // Runs ONCE on the first armed frame. Resolves the four KSP-root channel paths,
+        // decides lock ownership, then (if we own the channel) replays the journal and
+        // reconciles crash-recovery leftovers and seeds the processed-id set.
         private void TryStartup()
         {
             startupDone = true;
@@ -151,6 +201,67 @@ namespace Parsek.TestCommands
             lockFilePath = Path.Combine(root, TestCommandChannelIo.LockFileName);
 
             AcquireLock(root);
+            if (disabled) return;
+
+            ReplayAndReconcile();
+        }
+
+        // Replays the journal into a per-id phase map and applies each crash-recovery
+        // action (DecideRecovery): DONE ids skip, EXECUTED ids re-ack, CLAIMED ids get an
+        // INTERRUPTED terminal. Every journalled id is seeded into the processed set so a
+        // re-read of its command line is a no-op. The command-file byte offset stays 0:
+        // ids are deduped by the processed set, so a full rescan on the first poll is
+        // correct and only happens once (steady state uses the offset + processed set).
+        private void ReplayAndReconcile()
+        {
+            string content = null;
+            try
+            {
+                if (File.Exists(journalFilePath))
+                    content = File.ReadAllText(journalFilePath, Utf8NoBom);
+            }
+            catch (IOException ex)
+            {
+                ParsekLog.Warn(Tag, $"journal read failed: {ex.Message}");
+            }
+
+            List<string> lines = TestCommandJournal.SplitCompleteLines(content ?? string.Empty);
+            journalPhases = TestCommandJournal.ReplayIntoPhaseMap(lines);
+
+            // Capture the verb per id from CLAIMED lines for nicer recovery responses/logs.
+            var verbs = new Dictionary<string, string>();
+            foreach (string l in lines)
+                if (TestCommandJournal.TryParseLine(l, out JournalLine jl) && !string.IsNullOrEmpty(jl.Verb))
+                    verbs[jl.Id] = jl.Verb;
+
+            int done = 0, executed = 0, claimed = 0;
+            foreach (KeyValuePair<string, JournalPhase> kv in journalPhases)
+            {
+                string id = kv.Key;
+                verbs.TryGetValue(id, out string verb);
+                switch (TestCommandJournal.DecideRecovery(id, kv.Value))
+                {
+                    case RecoveryAction.Skip:
+                        done++;
+                        break;
+                    case RecoveryAction.RewriteResponse:
+                        executed++;
+                        // Side effect ran but the response may not have landed and cannot
+                        // be reconstructed post-crash; re-ack with a distinct recovery msg
+                        // so the orchestrator (which treats the FIRST terminal line per id
+                        // as authoritative) is never left hanging.
+                        WriteRecoveryTerminal(id, verb, "INTERRUPTED", "recovered-executed");
+                        break;
+                    case RecoveryAction.Interrupted:
+                        claimed++;
+                        WriteRecoveryTerminal(id, verb, "INTERRUPTED", "interrupted-claimed");
+                        break;
+                }
+                processedIds.Add(id);
+            }
+
+            ParsekLog.Info(Tag,
+                $"journal replay: {done} done, {executed} executed-not-done (rewriting response), {claimed} claimed-not-executed (INTERRUPTED)");
         }
 
         // ----- Lock acquire / inspect (P4.3) -----
@@ -290,6 +401,339 @@ namespace Parsek.TestCommands
                 }
             }
             return false;
+        }
+
+        // ----- The pump (P4.4) -----
+
+        // One poll: retry a stuck response, then read+enqueue new command lines, then make
+        // and act on a single strict-FIFO head decision. Runs only at a safe point.
+        private void Pump()
+        {
+            // Retry a terminal response append that exhausted its retries on a prior frame.
+            // The side effect already ran (journalled EXECUTED), so this never re-executes.
+            if (headPendingResponse)
+            {
+                if (!AppendResponse(headPendingResponseLine, headPendingResponseId))
+                    return; // still failing; try again next frame
+                WriteJournal(
+                    TestCommandJournal.FormatDone(headPendingResponseId, headPendingResponseSeq, headPendingResponseVerdict, WallClockSeconds()),
+                    headPendingResponseId, "DONE");
+                MarkProcessed(headPendingResponseId);
+                if (pending.Count > 0) pending.Dequeue();
+                headPendingResponse = false;
+                return;
+            }
+
+            ReadAndEnqueue();
+
+            if (pending.Count == 0) return;
+
+            ParsedCommand head = pending.Peek();
+            DispatchState state = BuildDispatchState(head);
+            DispatchResult result = TestCommandDispatcher.DecideDispatch(head, state);
+
+            switch (result.Decision)
+            {
+                case DispatchDecision.Execute:
+                    ResetDeferTracking();
+                    ParsekLog.Info(Tag, $"dispatch id={head.Id} -> EXECUTE");
+                    ExecuteHead(head); // owns its dequeue (terminal / pending-response)
+                    break;
+                case DispatchDecision.Reject:
+                    ResetDeferTracking();
+                    ParsekLog.Warn(Tag, $"reject id={head.Id} cmd={head.Verb} reason={result.Reason}");
+                    WriteTerminalNoSideEffect(head, "REJECTED", result.Reason);
+                    pending.Dequeue();
+                    break;
+                case DispatchDecision.Interrupted:
+                    ResetDeferTracking();
+                    InterruptHead(head);
+                    pending.Dequeue();
+                    break;
+                case DispatchDecision.Defer:
+                    HandleDefer(head, result.Reason); // dequeues only on TIMEOUT
+                    break;
+            }
+        }
+
+        // Read new whole lines and enqueue parseable, not-yet-terminal commands (skipping
+        // blank/comment lines and duplicate ids). Batch-counting per the house convention:
+        // one rate-limited poll summary rather than a line per read.
+        private void ReadAndEnqueue()
+        {
+            List<string> newLines = ReadNewCommandLines();
+            int readCount = newLines.Count;
+            int parsedCount = 0;
+
+            foreach (string raw in newLines)
+            {
+                lineCounter++;
+                ParsedCommand parsed = TestCommandParser.ParseLine(raw, lineCounter);
+                if (parsed.Ignored) continue; // blank / comment: no response
+
+                // Normalize the correlation id (real id, or line#<n> for a missing/garbage id).
+                string id = parsed.Id ?? TestCommandParser.FallbackId(lineCounter);
+                parsed.Id = id;
+
+                if (processedIds.Contains(id) || queuedIds.Contains(id))
+                {
+                    ParsekLog.Warn(Tag, $"duplicate id={id} ignored");
+                    continue;
+                }
+
+                int argCount = parsed.Args != null ? parsed.Args.Count : 0;
+                ParsekLog.Info(Tag, $"recv id={id} cmd={parsed.Verb ?? "?"} args={argCount}");
+                queuedIds.Add(id);
+                pending.Enqueue(parsed);
+                parsedCount++;
+            }
+
+            if (readCount > 0 || pending.Count > 0)
+            {
+                string headVerb = pending.Count > 0 ? (pending.Peek().Verb ?? "?") : "none";
+                ParsekLog.VerboseRateLimited(Tag, "poll",
+                    $"poll: read={readCount} lines, parsed={parsedCount}, deferred-head={headVerb}", 5.0);
+            }
+        }
+
+        // Execute the head verb: journal CLAIMED -> run the (stub) handler -> journal
+        // EXECUTED -> append the terminal response -> journal DONE -> advance. At-most-once:
+        // the side effect runs ONLY after CLAIMED durably lands, and a failed response
+        // append is cached for retry WITHOUT re-executing.
+        private void ExecuteHead(ParsedCommand head)
+        {
+            string id = head.Id;
+            long seq = NextSeq();
+
+            if (!WriteJournal(
+                TestCommandJournal.FormatClaimed(id, seq, head.Verb ?? string.Empty, SessionId(), WallClockSeconds()),
+                id, "CLAIMED"))
+            {
+                // Could not durably claim; do NOT run the side effect. Leave the head and
+                // retry next frame (no side effect has run, so at-most-once holds).
+                return;
+            }
+
+            ParsekLog.Info(Tag, $"exec id={id} cmd={head.Verb} start");
+            ClearExecResult();
+            InvokeExecutor(head);
+            string verdict = execVerdict ?? "ERROR";
+
+            WriteJournal(TestCommandJournal.FormatExecuted(id, seq, WallClockSeconds()), id, "EXECUTED");
+
+            string line = TestCommandResponse.FormatResponseLine(
+                id, head.Verb, verdict, seq, CurrentUt(), execPayload, execMsg);
+            ParsekLog.Info(Tag, $"exec id={id} verdict={verdict}");
+
+            if (AppendResponse(line, id))
+            {
+                WriteJournal(TestCommandJournal.FormatDone(id, seq, verdict, WallClockSeconds()), id, "DONE");
+                MarkProcessed(id);
+                pending.Dequeue();
+            }
+            else
+            {
+                // Append exhausted this frame: cache for retry, leave head un-dequeued,
+                // do NOT re-run the side effect (id stays journalled EXECUTED).
+                headPendingResponse = true;
+                headPendingResponseLine = line;
+                headPendingResponseId = id;
+                headPendingResponseSeq = seq;
+                headPendingResponseVerdict = verdict;
+            }
+        }
+
+        // A terminal outcome with NO side effect (REJECTED / TIMEOUT): journal
+        // CLAIMED+EXECUTED+DONE around the response so a restart replay skips the id.
+        private void WriteTerminalNoSideEffect(ParsedCommand head, string verdict, string msg)
+        {
+            string id = head.Id;
+            string verb = head.Verb ?? string.Empty;
+            long seq = NextSeq();
+            WriteJournal(TestCommandJournal.FormatClaimed(id, seq, verb, SessionId(), WallClockSeconds()), id, "CLAIMED");
+            WriteJournal(TestCommandJournal.FormatExecuted(id, seq, WallClockSeconds()), id, "EXECUTED");
+            string line = TestCommandResponse.FormatResponseLine(id, verb, verdict, seq, CurrentUt(), null, msg);
+            AppendResponse(line, id);
+            WriteJournal(TestCommandJournal.FormatDone(id, seq, verdict, WallClockSeconds()), id, "DONE");
+            MarkProcessed(id);
+        }
+
+        // Crash-recovery INTERRUPTED at the live head (journal CLAIMED for this id). Mostly
+        // defensive: such ids are usually seeded into the processed set at startup and
+        // filtered before reaching dispatch.
+        private void InterruptHead(ParsedCommand head)
+        {
+            string id = head.Id;
+            ParsekLog.Info(Tag, $"dispatch id={id} -> INTERRUPTED (journal=CLAIMED)");
+            long seq = NextSeq();
+            string line = TestCommandResponse.FormatResponseLine(
+                id, head.Verb ?? string.Empty, "INTERRUPTED", seq, CurrentUt(), null, "interrupted-claimed");
+            AppendResponse(line, id);
+            WriteJournal(TestCommandJournal.FormatDone(id, seq, "INTERRUPTED", WallClockSeconds()), id, "DONE");
+            MarkProcessed(id);
+        }
+
+        // Startup crash-recovery terminal (from ReplayAndReconcile). No pending head to
+        // dequeue; just re-ack + DONE + processed-set seed happens in the caller.
+        private void WriteRecoveryTerminal(string id, string verb, string verdict, string msg)
+        {
+            long seq = NextSeq();
+            string line = TestCommandResponse.FormatResponseLine(
+                id, verb ?? string.Empty, verdict, seq, CurrentUt(), null, msg);
+            AppendResponse(line, id);
+            WriteJournal(TestCommandJournal.FormatDone(id, seq, verdict, WallClockSeconds()), id, "DONE");
+        }
+
+        // Head deferral + per-command TIMEOUT conversion. The head tracks when it first
+        // began deferring; once (now - start) exceeds the verb's budget it converts to a
+        // TIMEOUT terminal (carrying the last defer reason) and the pump advances so a
+        // never-satisfiable command never wedges the run.
+        private void HandleDefer(ParsedCommand head, string reason)
+        {
+            double now = WallClockSeconds();
+            if (deferHeadId != head.Id)
+            {
+                deferHeadId = head.Id;
+                deferStartedAtSeconds = now;
+                ParsekLog.Info(Tag, $"dispatch id={head.Id} -> DEFER reason={reason}");
+            }
+            else
+            {
+                ParsekLog.VerboseRateLimited(Tag, $"defer-{head.Id}",
+                    $"dispatch id={head.Id} -> DEFER reason={reason}", 5.0);
+            }
+            lastDeferReason = reason;
+
+            double budget = DeferralBudget.BudgetSeconds(head.Verb);
+            if (DeferralBudget.ShouldTimeout(deferStartedAtSeconds, now, budget))
+            {
+                ParsekLog.Warn(Tag,
+                    $"timeout id={head.Id} cmd={head.Verb} deferred={(now - deferStartedAtSeconds).ToString("F1", CultureInfo.InvariantCulture)}s reason={lastDeferReason}");
+                WriteTerminalNoSideEffect(head, "TIMEOUT", lastDeferReason);
+                pending.Dequeue();
+                ResetDeferTracking();
+            }
+        }
+
+        private void ResetDeferTracking() => deferHeadId = null;
+
+        private DispatchState BuildDispatchState(ParsedCommand head)
+        {
+            JournalPhase phase = JournalPhase.None;
+            if (journalPhases != null && head.Id != null)
+                journalPhases.TryGetValue(head.Id, out phase);
+
+            ParsekFlight flight = ParsekFlight.Instance;
+            return new DispatchState
+            {
+                Scene = MapScene(HighLogic.LoadedScene),
+                GameLoaded = HighLogic.CurrentGame != null,
+                SettingsPresent = ParsekSettings.Current != null,
+                Recording = ParsekFlight.HasLiveRecorderForTagging(),
+                HasTree = flight != null && flight.HasActiveTree,
+                Transitioning = sceneTransitioning,
+                SettleCounter = settleCounter,
+                BatchRunning = IsBatchRunning(),
+                LoadInFlight = loadInFlight,
+                JournalPhase = phase,
+            };
+        }
+
+        private bool IsBatchRunning() => ownedRunner != null && ownedRunner.IsRunning;
+
+        private static TestCommandScene MapScene(GameScenes scene)
+        {
+            switch (scene)
+            {
+                case GameScenes.LOADING: return TestCommandScene.Loading;
+                case GameScenes.MAINMENU: return TestCommandScene.MainMenu;
+                case GameScenes.SPACECENTER: return TestCommandScene.SpaceCenter;
+                case GameScenes.EDITOR: return TestCommandScene.Editor;
+                case GameScenes.FLIGHT: return TestCommandScene.Flight;
+                case GameScenes.TRACKSTATION: return TestCommandScene.TrackingStation;
+                default: return TestCommandScene.Other;
+            }
+        }
+
+        // ----- Executor: all ten v1 verbs as NOT-IMPLEMENTED-YET stubs (P4.4) -----
+        // The addon implements ITestCommandExecutor; the real verb bodies replace these
+        // stubs one at a time in P5.x. Each stub reports an ERROR verdict with msg=stub so
+        // the pump's journal / response / at-most-once machinery is fully exercised now.
+
+        // Explicit interface implementation: ParsedCommand is internal, so these cannot be
+        // public members of the public MonoBehaviour. The pump dispatches via the interface
+        // (InvokeExecutor casts this to ITestCommandExecutor).
+        void ITestCommandExecutor.SetSetting(ParsedCommand cmd) => StubNotImplemented();
+        void ITestCommandExecutor.StartRecording(ParsedCommand cmd) => StubNotImplemented();
+        void ITestCommandExecutor.StopRecording(ParsedCommand cmd) => StubNotImplemented();
+        void ITestCommandExecutor.CommitTree(ParsedCommand cmd) => StubNotImplemented();
+        void ITestCommandExecutor.DiscardTree(ParsedCommand cmd) => StubNotImplemented();
+        void ITestCommandExecutor.RecordingState(ParsedCommand cmd) => StubNotImplemented();
+        void ITestCommandExecutor.RunTests(ParsedCommand cmd) => StubNotImplemented();
+        void ITestCommandExecutor.LoadGame(ParsedCommand cmd) => StubNotImplemented();
+        void ITestCommandExecutor.MissionMark(ParsedCommand cmd) => StubNotImplemented();
+        void ITestCommandExecutor.FlushAndQuit(ParsedCommand cmd) => StubNotImplemented();
+
+        private void InvokeExecutor(ParsedCommand cmd)
+        {
+            ITestCommandExecutor exec = this;
+            switch (cmd.Verb)
+            {
+                case "SetSetting": exec.SetSetting(cmd); break;
+                case "StartRecording": exec.StartRecording(cmd); break;
+                case "StopRecording": exec.StopRecording(cmd); break;
+                case "CommitTree": exec.CommitTree(cmd); break;
+                case "DiscardTree": exec.DiscardTree(cmd); break;
+                case "RecordingState": exec.RecordingState(cmd); break;
+                case "RunTests": exec.RunTests(cmd); break;
+                case "LoadGame": exec.LoadGame(cmd); break;
+                case "MissionMark": exec.MissionMark(cmd); break;
+                case "FlushAndQuit": exec.FlushAndQuit(cmd); break;
+                default:
+                    // Unreachable: DecideDispatch rejects unknown/reserved verbs before Execute.
+                    SetExecResult("ERROR", null, "unknown-command");
+                    break;
+            }
+        }
+
+        private void StubNotImplemented() => SetExecResult("ERROR", null, "stub");
+
+        private void SetExecResult(string verdict, List<KeyValuePair<string, string>> payload, string msg)
+        {
+            execVerdict = verdict;
+            execPayload = payload;
+            execMsg = msg;
+        }
+
+        private void ClearExecResult()
+        {
+            execVerdict = "ERROR";
+            execPayload = null;
+            execMsg = null;
+        }
+
+        private void MarkProcessed(string id)
+        {
+            processedIds.Add(id);
+            queuedIds.Remove(id);
+        }
+
+        private long NextSeq() => ++responseSeq;
+
+        private static string SessionId() => ParsekProcess.ProcessSessionId.ToString("N");
+
+        private static double? CurrentUt()
+        {
+            if (HighLogic.CurrentGame == null) return null;
+            try { return Planetarium.GetUniversalTime(); }
+            catch (Exception) { return null; }
+        }
+
+        private bool WriteJournal(string line, string id, string phase)
+        {
+            bool ok = AppendJournal(line, id);
+            if (ok) ParsekLog.Verbose(Tag, $"journal id={id} phase={phase}");
+            return ok;
         }
 
         // ----- Small impl helpers -----

--- a/Source/Parsek/TestCommands/ParsekTestCommandAddon.cs
+++ b/Source/Parsek/TestCommands/ParsekTestCommandAddon.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Text;
 using System.Threading;
 using Parsek.InGameTests;
+using Parsek.InGameTests.Helpers;
 using UnityEngine;
 
 namespace Parsek.TestCommands
@@ -635,7 +636,7 @@ namespace Parsek.TestCommands
                 if (HighLogic.CurrentGame != null)
                 {
                     string sceneName = HighLogic.LoadedScene.ToString();
-                    payload = Payload(Kv("scene", sceneName), Kv("save", loadGameSave ?? string.Empty));
+                    payload = TestCommandLoadGame.BuildCompletePayload(sceneName, loadGameSave);
                     verdict = "OK";
                     done = true;
                     loadInFlight = false;
@@ -815,7 +816,7 @@ namespace Parsek.TestCommands
         void ITestCommandExecutor.DiscardTree(ParsedCommand cmd) => DiscardTreeImpl(cmd);
         void ITestCommandExecutor.RecordingState(ParsedCommand cmd) => RecordingStateImpl(cmd);
         void ITestCommandExecutor.RunTests(ParsedCommand cmd) => RunTestsImpl(cmd);
-        void ITestCommandExecutor.LoadGame(ParsedCommand cmd) => StubNotImplemented();
+        void ITestCommandExecutor.LoadGame(ParsedCommand cmd) => LoadGameImpl(cmd);
         void ITestCommandExecutor.MissionMark(ParsedCommand cmd) => MissionMarkImpl(cmd);
         void ITestCommandExecutor.FlushAndQuit(ParsedCommand cmd) => StubNotImplemented();
 
@@ -990,6 +991,59 @@ namespace Parsek.TestCommands
 
             ParsekLog.Info(Tag, $"stoprecording stopped={Bool(wasLive)} idle={Bool(!wasLive)}");
             SetExecResult("OK", TestCommandRecordingVerbs.BuildStopPayload(wasLive), null);
+        }
+
+        // ----- LoadGame (P5.7, two-phase boot channel, C2) -----
+        // The boot channel: realises the .sfs into a KSP Game and focuses its active
+        // vessel via the same Assembly-CSharp-only sequence QuickloadResumeHelpers uses,
+        // INCLUDING FlightCameraReloadPin.Arm BEFORE StartAndFocusVessel (stock bug #4803
+        // guard). Dispatch already rejected recording-active / load-in-flight. A null /
+        // incompatible game or an out-of-range active-vessel index is a single-phase
+        // ERROR load-failed; a focusable game enters two-phase (PENDING), completing when
+        // the new scene settles with HighLogic.CurrentGame != null. save=<folder> maps to
+        // HighLogic.SaveFolder + the saveName param; name=<slot/file> maps to slotName.
+        private void LoadGameImpl(ParsedCommand cmd)
+        {
+            string save = ArgOrNull(cmd, "save");
+            string name = ArgOrNull(cmd, "name");
+            ParsekLog.Info(Tag,
+                $"loadgame start save={save ?? string.Empty} name={name ?? string.Empty} scene={HighLogic.LoadedScene}");
+
+            Game game;
+            try
+            {
+                if (!string.IsNullOrEmpty(save))
+                    HighLogic.SaveFolder = save;
+                game = GamePersistence.LoadGame(name, save, true, false);
+            }
+            catch (Exception ex)
+            {
+                ParsekLog.Error(Tag, $"loadgame failed save={save ?? string.Empty}: {ex.Message}");
+                SetExecResult("ERROR", null, "load-failed");
+                return;
+            }
+
+            bool focusable = TestCommandLoadGame.IsLoadedGameFocusable(
+                game != null,
+                game != null && game.flightState != null,
+                game != null && game.flightState != null && game.flightState.protoVessels != null,
+                game != null && game.flightState != null ? game.flightState.activeVesselIdx : -1,
+                game != null && game.flightState != null && game.flightState.protoVessels != null
+                    ? game.flightState.protoVessels.Count : 0);
+
+            if (!focusable)
+            {
+                ParsekLog.Error(Tag, $"loadgame failed save={save ?? string.Empty}: game null/incompatible");
+                SetExecResult("ERROR", null, "load-failed");
+                return;
+            }
+
+            int idx = game.flightState.activeVesselIdx;
+            FlightCameraReloadPin.Arm($"TestCommandLoadGame:{save}/{name}");
+            FlightDriver.StartAndFocusVessel(game, idx);
+            loadInFlight = true;
+            loadGameSave = save;
+            SetExecResult(PendingVerdict, null, null);
         }
 
         // ----- RunTests (P5.6, two-phase) -----

--- a/Source/Parsek/TestCommands/ParsekTestCommandAddon.cs
+++ b/Source/Parsek/TestCommands/ParsekTestCommandAddon.cs
@@ -95,7 +95,7 @@ namespace Parsek.TestCommands
         // at initiation but defers EXECUTED + the terminal response until TryCompleteTwoPhase
         // sees the operation settle (RunTests batch done / new game loaded). A crash between
         // CLAIMED and completion leaves the id at CLAIMED -> INTERRUPTED on restart.
-        private const string PendingVerdict = "__PENDING__";
+        private const string PendingVerdict = TestCommandExecution.PendingVerdict;
         private bool awaitingCompletion;
         private string completionId;
         private string completionVerb;
@@ -261,6 +261,10 @@ namespace Parsek.TestCommands
             {
                 ParsekLog.Warn(Tag, $"journal read failed: {ex.Message}");
             }
+            catch (UnauthorizedAccessException ex)
+            {
+                ParsekLog.Warn(Tag, $"journal read failed (access denied): {ex.Message}");
+            }
 
             List<string> lines = TestCommandJournal.SplitCompleteLines(content ?? string.Empty);
             journalPhases = TestCommandJournal.ReplayIntoPhaseMap(lines);
@@ -326,6 +330,10 @@ namespace Parsek.TestCommands
             {
                 ParsekLog.Warn(Tag, $"lock read failed: {ex.Message}");
             }
+            catch (UnauthorizedAccessException ex)
+            {
+                ParsekLog.Warn(Tag, $"lock read failed (access denied): {ex.Message}");
+            }
 
             string ownSession = ParsekProcess.ProcessSessionId.ToString("N");
             double ownT = WallClockSeconds();
@@ -355,6 +363,10 @@ namespace Parsek.TestCommands
             catch (IOException ex)
             {
                 ParsekLog.Warn(Tag, $"lock write failed: {ex.Message}");
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                ParsekLog.Warn(Tag, $"lock write failed (access denied): {ex.Message}");
             }
         }
 
@@ -549,7 +561,22 @@ namespace Parsek.TestCommands
 
             TestCommandDiagnostics.ExecStart(id, head.Verb);
             ClearExecResult();
-            InvokeExecutor(head);
+            try
+            {
+                InvokeExecutor(head);
+            }
+            catch (Exception ex)
+            {
+                // An executor threw: contain it as a terminal ERROR so the id completes and
+                // the pump advances instead of the whole seam wedging on an unhandled throw.
+                // The side effect already ran to the point of the throw and is journalled
+                // CLAIMED; converting to a terminal (EXECUTED + response + DONE) preserves
+                // at-most-once (a restart replay sees EXECUTED and never re-runs it).
+                TestCommandExecution.ExceptionTerminal(ex.GetType().Name, out string exVerdict, out string exMsg);
+                ParsekLog.Error(Tag, $"exec threw id={id} cmd={head.Verb}: {ex.GetType().Name}: {ex.Message}");
+                EmitExecutedTerminal(id, seq, head.Verb, exVerdict, null, exMsg);
+                return;
+            }
             string verdict = execVerdict ?? "ERROR";
 
             if (verdict == PendingVerdict)
@@ -1211,7 +1238,15 @@ namespace Parsek.TestCommands
         private bool WriteJournal(string line, string id, string phase)
         {
             bool ok = AppendJournal(line, id);
-            if (ok) ParsekLog.Verbose(Tag, $"journal id={id} phase={phase}");
+            if (ok)
+            {
+                ParsekLog.Verbose(Tag, $"journal id={id} phase={phase}");
+                // Defense-in-depth: mirror the durable write into the in-memory phase map so a
+                // same-process re-dispatch of this id never reads JournalPhase.None for an
+                // already-claimed command (the durable at-most-once record and the live map
+                // stay in lock-step without waiting for a restart replay).
+                TestCommandJournal.MirrorPhaseIntoMap(journalPhases, id, phase);
+            }
             return ok;
         }
 

--- a/Source/Parsek/TestCommands/ParsekTestCommandAddon.cs
+++ b/Source/Parsek/TestCommands/ParsekTestCommandAddon.cs
@@ -89,6 +89,25 @@ namespace Parsek.TestCommands
         // Set true while a LoadGame is in flight (P5.7); read now by the LoadGame guard.
         private bool loadInFlight = false;
 
+        // Two-phase verbs (RunTests P5.6 / LoadGame P5.7). The executor INITIATES the
+        // long-running side effect and returns PendingVerdict; the pump journals CLAIMED
+        // at initiation but defers EXECUTED + the terminal response until TryCompleteTwoPhase
+        // sees the operation settle (RunTests batch done / new game loaded). A crash between
+        // CLAIMED and completion leaves the id at CLAIMED -> INTERRUPTED on restart.
+        private const string PendingVerdict = "__PENDING__";
+        private bool awaitingCompletion;
+        private string completionId;
+        private string completionVerb;
+        private long completionSeq;
+        private double completionStartedAt;
+        private string loadGameSave;
+
+        // FlushAndQuit (P5.8): the response + journal DONE are written and flushed BEFORE
+        // Application.Quit, which is deferred one frame via a coroutine scheduled only
+        // after the DONE for the quit id lands.
+        private bool pendingQuit;
+        private string quitId;
+
         // The in-game test runner the addon owns for RunTests (P5.6). Null until then;
         // the batch-running safe-point gate reads it now so the pump never runs a command
         // mid-batch once RunTests is wired.
@@ -181,6 +200,17 @@ namespace Parsek.TestCommands
             // gating here avoids even reading the channel at an unsafe moment.)
             if (HighLogic.LoadedScene == GameScenes.LOADING) return;
             if (sceneTransitioning || settleCounter > 0) return;
+
+            // Two-phase completion (RunTests / LoadGame) is checked BEFORE the batch gate:
+            // RunTests must complete precisely when its owned batch stops running, which
+            // the IsBatchRunning early return below would otherwise mask. While a two-phase
+            // command awaits completion it holds the FIFO head, so no other command runs.
+            if (awaitingCompletion)
+            {
+                TryCompleteTwoPhase();
+                return;
+            }
+
             if (IsBatchRunning()) return;
 
             Pump();
@@ -415,12 +445,8 @@ namespace Parsek.TestCommands
             {
                 if (!AppendResponse(headPendingResponseLine, headPendingResponseId))
                     return; // still failing; try again next frame
-                WriteJournal(
-                    TestCommandJournal.FormatDone(headPendingResponseId, headPendingResponseSeq, headPendingResponseVerdict, WallClockSeconds()),
-                    headPendingResponseId, "DONE");
-                MarkProcessed(headPendingResponseId);
-                if (pending.Count > 0) pending.Dequeue();
                 headPendingResponse = false;
+                WriteDoneAndAdvance(headPendingResponseId, headPendingResponseSeq, headPendingResponseVerdict);
                 return;
             }
 
@@ -519,28 +545,147 @@ namespace Parsek.TestCommands
             InvokeExecutor(head);
             string verdict = execVerdict ?? "ERROR";
 
+            if (verdict == PendingVerdict)
+            {
+                // Two-phase (RunTests / LoadGame): the side effect was initiated; the
+                // terminal response + EXECUTED journal are deferred until the operation
+                // settles (TryCompleteTwoPhase). Journal stays at CLAIMED meanwhile, so a
+                // crash between here and completion reports INTERRUPTED on restart. Head
+                // stays in the queue (strict FIFO) so nothing else runs during the wait.
+                awaitingCompletion = true;
+                completionId = id;
+                completionSeq = seq;
+                completionVerb = head.Verb;
+                completionStartedAt = WallClockSeconds();
+                ParsekLog.Info(Tag, $"exec id={id} verdict=PENDING (two-phase awaiting completion)");
+                return;
+            }
+
+            EmitExecutedTerminal(id, seq, head.Verb, verdict, execPayload, execMsg);
+        }
+
+        // Shared single-phase terminal tail: journal EXECUTED, append the response, then
+        // (on a successful append) journal DONE + advance, else cache for a retry WITHOUT
+        // re-executing (id stays journalled EXECUTED). Used by ExecuteHead and by the
+        // two-phase completion.
+        private void EmitExecutedTerminal(
+            string id, long seq, string verb, string verdict,
+            List<KeyValuePair<string, string>> payload, string msg)
+        {
             WriteJournal(TestCommandJournal.FormatExecuted(id, seq, WallClockSeconds()), id, "EXECUTED");
 
             string line = TestCommandResponse.FormatResponseLine(
-                id, head.Verb, verdict, seq, CurrentUt(), execPayload, execMsg);
+                id, verb, verdict, seq, CurrentUt(), payload, msg);
             ParsekLog.Info(Tag, $"exec id={id} verdict={verdict}");
 
             if (AppendResponse(line, id))
             {
-                WriteJournal(TestCommandJournal.FormatDone(id, seq, verdict, WallClockSeconds()), id, "DONE");
-                MarkProcessed(id);
-                pending.Dequeue();
+                WriteDoneAndAdvance(id, seq, verdict);
             }
             else
             {
-                // Append exhausted this frame: cache for retry, leave head un-dequeued,
-                // do NOT re-run the side effect (id stays journalled EXECUTED).
                 headPendingResponse = true;
                 headPendingResponseLine = line;
                 headPendingResponseId = id;
                 headPendingResponseSeq = seq;
                 headPendingResponseVerdict = verdict;
             }
+        }
+
+        // Journal DONE, mark the id processed, advance the FIFO head, and (for
+        // FlushAndQuit) schedule the deferred quit now that the response + DONE are durable.
+        private void WriteDoneAndAdvance(string id, long seq, string verdict)
+        {
+            WriteJournal(TestCommandJournal.FormatDone(id, seq, verdict, WallClockSeconds()), id, "DONE");
+            MarkProcessed(id);
+            if (pending.Count > 0) pending.Dequeue();
+            MaybeScheduleQuit(id);
+        }
+
+        // ----- Two-phase completion (P5.6 RunTests / P5.7 LoadGame) -----
+
+        // Called each safe-point frame while a two-phase command awaits completion. When
+        // the operation has settled it builds the terminal payload, journals EXECUTED +
+        // response + DONE (advancing the head); otherwise it converts to TIMEOUT once the
+        // verb's budget expires so a never-settling operation cannot wedge the run.
+        private void TryCompleteTwoPhase()
+        {
+            double now = WallClockSeconds();
+            bool done = false;
+            string verdict = null;
+            List<KeyValuePair<string, string>> payload = null;
+            string msg = null;
+
+            if (completionVerb == "RunTests")
+            {
+                if (ownedRunner == null || !ownedRunner.IsRunning)
+                {
+                    int passed = ownedRunner != null ? ownedRunner.Passed : 0;
+                    int failed = ownedRunner != null ? ownedRunner.Failed : 0;
+                    int skipped = ownedRunner != null ? ownedRunner.Skipped : 0;
+                    payload = TestCommandRunTests.BuildResultPayload(passed, failed, skipped);
+                    verdict = "OK";
+                    done = true;
+                    ParsekLog.Info(Tag,
+                        $"runtests complete passed={passed} failed={failed} skipped={skipped} results={TestCommandRunTests.ResultsFileName}");
+                }
+            }
+            else if (completionVerb == "LoadGame")
+            {
+                if (HighLogic.CurrentGame != null)
+                {
+                    string sceneName = HighLogic.LoadedScene.ToString();
+                    payload = Payload(Kv("scene", sceneName), Kv("save", loadGameSave ?? string.Empty));
+                    verdict = "OK";
+                    done = true;
+                    loadInFlight = false;
+                    ParsekLog.Info(Tag,
+                        $"loadgame complete scene={sceneName} save={loadGameSave ?? string.Empty} game-loaded=true");
+                }
+            }
+
+            if (!done)
+            {
+                double budget = DeferralBudget.BudgetSeconds(completionVerb);
+                if (DeferralBudget.ShouldTimeout(completionStartedAt, now, budget))
+                {
+                    ParsekLog.Warn(Tag,
+                        $"timeout id={completionId} cmd={completionVerb} deferred={(now - completionStartedAt).ToString("F1", CultureInfo.InvariantCulture)}s reason=awaiting-completion");
+                    if (completionVerb == "LoadGame") loadInFlight = false;
+                    string tid = completionId; long tseq = completionSeq; string tverb = completionVerb;
+                    ClearTwoPhase();
+                    EmitExecutedTerminal(tid, tseq, tverb, "TIMEOUT", null, "awaiting-completion");
+                }
+                return;
+            }
+
+            string cid = completionId; long cseq = completionSeq; string cverb = completionVerb;
+            ClearTwoPhase();
+            EmitExecutedTerminal(cid, cseq, cverb, verdict, payload, msg);
+        }
+
+        private void ClearTwoPhase()
+        {
+            awaitingCompletion = false;
+            completionId = null;
+            completionVerb = null;
+        }
+
+        // Deferred one-frame quit for FlushAndQuit: scheduled only after the response +
+        // journal DONE are durable, so a killed process never loses the quit's ack.
+        private void MaybeScheduleQuit(string id)
+        {
+            if (!pendingQuit || id != quitId) return;
+            pendingQuit = false;
+            ParsekLog.Info(Tag, $"flushandquit: scheduling Application.Quit (deferred one frame) id={id}");
+            StartCoroutine(DeferredQuit());
+        }
+
+        private System.Collections.IEnumerator DeferredQuit()
+        {
+            yield return null;
+            ParsekLog.Info(Tag, "flushandquit: Application.Quit");
+            Application.Quit();
         }
 
         // A terminal outcome with NO side effect (REJECTED / TIMEOUT): journal
@@ -669,7 +814,7 @@ namespace Parsek.TestCommands
         void ITestCommandExecutor.CommitTree(ParsedCommand cmd) => CommitTreeImpl(cmd);
         void ITestCommandExecutor.DiscardTree(ParsedCommand cmd) => DiscardTreeImpl(cmd);
         void ITestCommandExecutor.RecordingState(ParsedCommand cmd) => RecordingStateImpl(cmd);
-        void ITestCommandExecutor.RunTests(ParsedCommand cmd) => StubNotImplemented();
+        void ITestCommandExecutor.RunTests(ParsedCommand cmd) => RunTestsImpl(cmd);
         void ITestCommandExecutor.LoadGame(ParsedCommand cmd) => StubNotImplemented();
         void ITestCommandExecutor.MissionMark(ParsedCommand cmd) => MissionMarkImpl(cmd);
         void ITestCommandExecutor.FlushAndQuit(ParsedCommand cmd) => StubNotImplemented();
@@ -845,6 +990,26 @@ namespace Parsek.TestCommands
 
             ParsekLog.Info(Tag, $"stoprecording stopped={Bool(wasLive)} idle={Bool(!wasLive)}");
             SetExecResult("OK", TestCommandRecordingVerbs.BuildStopPayload(wasLive), null);
+        }
+
+        // ----- RunTests (P5.6, two-phase) -----
+        // Owns an InGameTestRunner (the pump's IsBatchRunning gate reads it). Initiates
+        // RunAll() / RunCategory(category) and returns PendingVerdict; completion is
+        // deferred (TryCompleteTwoPhase) until the batch stops running, then reports
+        // passed/failed/skipped + the exported results filename.
+        private void RunTestsImpl(ParsedCommand cmd)
+        {
+            string category = ArgOrNull(cmd, "category");
+            if (ownedRunner == null)
+                ownedRunner = new InGameTestRunner(this);
+
+            if (string.IsNullOrEmpty(category))
+                ownedRunner.RunAll();
+            else
+                ownedRunner.RunCategory(category);
+
+            ParsekLog.Info(Tag, $"runtests start category={category ?? "all"}");
+            SetExecResult(PendingVerdict, null, null);
         }
 
         // ----- CommitTree / DiscardTree (P5.5, C1) -----

--- a/Source/Parsek/TestCommands/ParsekTestCommandAddon.cs
+++ b/Source/Parsek/TestCommands/ParsekTestCommandAddon.cs
@@ -805,10 +805,11 @@ namespace Parsek.TestCommands
             }
         }
 
-        // ----- Executor: all ten v1 verbs as NOT-IMPLEMENTED-YET stubs (P4.4) -----
-        // The addon implements ITestCommandExecutor; the real verb bodies replace these
-        // stubs one at a time in P5.x. Each stub reports an ERROR verdict with msg=stub so
-        // the pump's journal / response / at-most-once machinery is fully exercised now.
+        // ----- Executor: all ten v1 verbs (P5.1 - P5.8) -----
+        // The addon implements ITestCommandExecutor; each method delegates to its verb
+        // body (below). The bodies stash their verdict/payload/msg via SetExecResult (or
+        // the PENDING sentinel for the two-phase RunTests / LoadGame) and the pump reads
+        // them back to journal + append the terminal response.
 
         // Explicit interface implementation: ParsedCommand is internal, so these cannot be
         // public members of the public MonoBehaviour. The pump dispatches via the interface
@@ -845,8 +846,6 @@ namespace Parsek.TestCommands
                     break;
             }
         }
-
-        private void StubNotImplemented() => SetExecResult("ERROR", null, "stub");
 
         // ----- Shared verb-body helpers (P5.x) -----
 

--- a/Source/Parsek/TestCommands/ParsekTestCommandAddon.cs
+++ b/Source/Parsek/TestCommands/ParsekTestCommandAddon.cs
@@ -1018,6 +1018,17 @@ namespace Parsek.TestCommands
             if (!alreadyLive)
                 flight.StartRecording();
 
+            // F4: ParsekFlight.StartRecording is void and can REFUSE (vessel not ready /
+            // packed / a guard blocked it) without going live. Re-sample the recorder truth so
+            // a refusal reports ERROR msg=start-refused instead of a false OK. (A vessel-ready
+            // Defer is the cleaner long-term fix; tracked in the design doc's deferred list.)
+            if (!ParsekFlight.HasLiveRecorderForTagging())
+            {
+                ParsekLog.Warn(Tag, $"startrecording start-refused (recorder not live after StartRecording) already={Bool(alreadyLive)}");
+                SetExecResult("ERROR", null, "start-refused");
+                return;
+            }
+
             string recordingId = ParsekFlight.GetActiveRecordingIdForTagging();
             ParsekLog.Info(Tag, $"startrecording recordingId={recordingId} already={Bool(alreadyLive)}");
             SetExecResult("OK", TestCommandRecordingVerbs.BuildStartPayload(alreadyLive, recordingId), null);
@@ -1097,6 +1108,7 @@ namespace Parsek.TestCommands
 
             bool focusable = TestCommandLoadGame.IsLoadedGameFocusable(
                 game != null,
+                game != null && game.compatible,
                 game != null && game.flightState != null,
                 game != null && game.flightState != null && game.flightState.protoVessels != null,
                 game != null && game.flightState != null ? game.flightState.activeVesselIdx : -1,

--- a/Source/Parsek/TestCommands/ParsekTestCommandAddon.cs
+++ b/Source/Parsek/TestCommands/ParsekTestCommandAddon.cs
@@ -1,4 +1,10 @@
 using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+using System.Text;
+using System.Threading;
 using UnityEngine;
 
 namespace Parsek.TestCommands
@@ -53,9 +59,25 @@ namespace Parsek.TestCommands
         private bool sceneTransitioning;
         private int settleCounter;
 
+        // Channel state (P4.3). Paths resolve on the first armed frame; the lock decides
+        // whether this instance owns the channel (disabled == stood down behind a live
+        // foreign lock). commandByteOffset is the persistent read cursor over whole lines.
+        private static readonly Encoding Utf8NoBom = new UTF8Encoding(false);
+        private static readonly DateTime UnixEpoch = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        private readonly IPidLivenessProbe livenessProbe = new ProcessLivenessProbe();
+
+        private bool startupDone;
+        private bool disabled;
+        private string commandFilePath;
+        private string responseFilePath;
+        private string journalFilePath;
+        private string lockFilePath;
+        private long commandByteOffset;
+
         internal bool IsArmedForTesting => armed;
         internal bool SceneTransitioningForTesting => sceneTransitioning;
         internal int SettleCounterForTesting => settleCounter;
+        internal bool DisabledForTesting => disabled;
 
         /// <summary>
         /// Pure fail-closed env-gate predicate: ONLY the literal <c>"1"</c> arms the
@@ -100,11 +122,229 @@ namespace Parsek.TestCommands
             // cached bool before any work.
             if (!armed) return;
 
+            // First armed frame: resolve channel paths and acquire the lock. If we stood
+            // down behind a live foreign lock, disabled is set and we do no channel work.
+            if (!startupDone)
+                TryStartup();
+            if (disabled) return;
+
             if (settleCounter > 0)
             {
                 settleCounter--;
                 if (settleCounter == 0)
                     sceneTransitioning = false;
+            }
+        }
+
+        // ----- Startup: channel paths + lock (P4.3) -----
+
+        // Runs ONCE on the first armed frame. Resolves the four KSP-root channel paths and
+        // decides lock ownership; the journal replay + reconcile and offset/processed-set
+        // seed are wired on top of this in P4.4.
+        private void TryStartup()
+        {
+            startupDone = true;
+            string root = KspRootPath();
+            commandFilePath = Path.Combine(root, TestCommandChannelIo.CommandFileName);
+            responseFilePath = Path.Combine(root, TestCommandChannelIo.ResponseFileName);
+            journalFilePath = Path.Combine(root, TestCommandChannelIo.JournalFileName);
+            lockFilePath = Path.Combine(root, TestCommandChannelIo.LockFileName);
+
+            AcquireLock(root);
+        }
+
+        // ----- Lock acquire / inspect (P4.3) -----
+
+        // Reads any existing lock, decides ownership via the pure DecideLockOwnership with
+        // a real Process.GetProcessById liveness probe, and either stands down (live
+        // foreign owner) or writes our own lock line (acquire / reclaim / reclaim-crashed).
+        private void AcquireLock(string root)
+        {
+            LockInfo existing = default;
+            bool present = false;
+            try
+            {
+                if (File.Exists(lockFilePath))
+                {
+                    string content = File.ReadAllText(lockFilePath, Utf8NoBom);
+                    List<string> lines = TestCommandJournal.SplitCompleteLines(content);
+                    // The lock is a single line; tolerate a missing trailing newline by
+                    // falling back to the raw trimmed content.
+                    string lockLine = lines.Count > 0 ? lines[0] : content.Trim();
+                    present = LockFile.TryParseLockLine(lockLine, out existing);
+                }
+            }
+            catch (IOException ex)
+            {
+                ParsekLog.Warn(Tag, $"lock read failed: {ex.Message}");
+            }
+
+            string ownSession = ParsekProcess.ProcessSessionId.ToString("N");
+            double ownT = WallClockSeconds();
+            LockOwnership decision = LockFile.DecideLockOwnership(
+                existing, present, ownSession, ownT, livenessProbe);
+
+            if (decision == LockOwnership.StandDown)
+            {
+                disabled = true;
+                ParsekLog.Warn(Tag,
+                    $"standing down: foreign live lock session={existing.Session} pid={existing.Pid} (alive) t={existing.T.ToString("R", CultureInfo.InvariantCulture)}");
+                return;
+            }
+            if (decision == LockOwnership.ReclaimWithWarn)
+            {
+                ParsekLog.Warn(Tag,
+                    $"reclaimed crashed lock session={existing.Session} pid={existing.Pid} (dead) t={existing.T.ToString("R", CultureInfo.InvariantCulture)}");
+            }
+
+            int pid = CurrentProcessId();
+            string line = LockFile.FormatLockLine(ownSession, pid, ownT, root);
+            try
+            {
+                File.WriteAllText(lockFilePath, line + "\n", Utf8NoBom);
+                ParsekLog.Info(Tag, $"lock acquired session={ownSession} pid={pid}");
+            }
+            catch (IOException ex)
+            {
+                ParsekLog.Warn(Tag, $"lock write failed: {ex.Message}");
+            }
+        }
+
+        // ----- Command-file reads (P4.3) -----
+
+        // Reads whole new command lines appended since the persistent byte offset. Opens
+        // the file share-all (FileShare.ReadWrite) so the orchestrator can keep appending;
+        // advances the offset only over newline-terminated content (the pure
+        // WholeLineByteCount rule), leaving a torn trailing fragment for the next poll.
+        private List<string> ReadNewCommandLines()
+        {
+            var lines = new List<string>();
+            if (string.IsNullOrEmpty(commandFilePath) || !File.Exists(commandFilePath))
+                return lines;
+            try
+            {
+                using (var fs = new FileStream(
+                    commandFilePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
+                {
+                    long length = fs.Length;
+                    if (length <= commandByteOffset)
+                        return lines; // nothing new since the last poll
+                    fs.Seek(commandByteOffset, SeekOrigin.Begin);
+                    int toRead = checked((int)(length - commandByteOffset));
+                    byte[] buffer = new byte[toRead];
+                    int read = ReadFully(fs, buffer, toRead);
+                    int whole = TestCommandChannelIo.WholeLineByteCount(buffer, read);
+                    if (whole <= 0)
+                        return lines; // only a torn trailing fragment so far
+                    string chunk = Utf8NoBom.GetString(buffer, 0, whole);
+                    lines = TestCommandJournal.SplitCompleteLines(chunk);
+                    commandByteOffset += whole;
+                }
+            }
+            catch (IOException ex)
+            {
+                ParsekLog.Warn(Tag, $"command read failed offset={commandByteOffset}: {ex.Message}");
+            }
+            return lines;
+        }
+
+        // ----- Response / journal appends (P4.3) -----
+
+        private bool AppendResponse(string line, string id)
+            => TryAppendLine(responseFilePath, line, "response", id);
+
+        private bool AppendJournal(string line, string id)
+            => TryAppendLine(journalFilePath, line, "journal", id);
+
+        // Append one newline-terminated line with append+flush and bounded backoff retry.
+        // On exhaustion returns false WITHOUT throwing; the caller leaves the id at
+        // EXECUTED so the response is (re)written next frame / next restart, never
+        // re-executed.
+        private bool TryAppendLine(string path, string line, string kind, string id)
+        {
+            if (string.IsNullOrEmpty(path)) return false;
+            for (int attempt = 1; attempt <= TestCommandChannelIo.MaxAppendAttempts; attempt++)
+            {
+                try
+                {
+                    using (var fs = new FileStream(
+                        path, FileMode.Append, FileAccess.Write, FileShare.ReadWrite))
+                    using (var writer = new StreamWriter(fs, Utf8NoBom))
+                    {
+                        writer.Write(line);
+                        writer.Write('\n');
+                        writer.Flush();
+                    }
+                    return true;
+                }
+                catch (IOException ex)
+                {
+                    ParsekLog.Warn(Tag, $"{kind} append failed id={id} attempt={attempt}: {ex.Message}");
+                    if (!TestCommandChannelIo.ShouldRetryAppend(attempt, TestCommandChannelIo.MaxAppendAttempts))
+                    {
+                        ParsekLog.Error(Tag,
+                            $"{kind} append giving up this frame id={id}; will retry (journal=EXECUTED)");
+                        return false;
+                    }
+                    Thread.Sleep(TestCommandChannelIo.BackoffMillis(attempt));
+                }
+            }
+            return false;
+        }
+
+        // ----- Small impl helpers -----
+
+        private static string KspRootPath() => KSPUtil.ApplicationRootPath;
+
+        private static int CurrentProcessId()
+        {
+            try { return Process.GetCurrentProcess().Id; }
+            catch (Exception) { return 0; }
+        }
+
+        // Wall-clock seconds (Unix epoch, InvariantCulture on the wire) for lock/journal
+        // t. NOT a game clock: the lock outlives any single scene and must not depend on
+        // Planetarium being present.
+        private static double WallClockSeconds() => (DateTime.UtcNow - UnixEpoch).TotalSeconds;
+
+        private static int ReadFully(Stream s, byte[] buffer, int count)
+        {
+            int total = 0;
+            while (total < count)
+            {
+                int n = s.Read(buffer, total, count - total);
+                if (n <= 0) break;
+                total += n;
+            }
+            return total;
+        }
+
+        // Real pid-liveness probe over System.Diagnostics.Process (the seam the pure
+        // DecideLockOwnership consumes; tests inject a fake instead).
+        private sealed class ProcessLivenessProbe : IPidLivenessProbe
+        {
+            public PidLiveness Probe(int pid)
+            {
+                if (pid <= 0) return PidLiveness.Dead;
+                try
+                {
+                    using (Process proc = Process.GetProcessById(pid))
+                    {
+                        return proc.HasExited ? PidLiveness.Dead : PidLiveness.Alive;
+                    }
+                }
+                catch (ArgumentException)
+                {
+                    return PidLiveness.Dead; // no live process carries that id
+                }
+                catch (InvalidOperationException)
+                {
+                    return PidLiveness.Dead; // the process has already exited
+                }
+                catch (Exception)
+                {
+                    return PidLiveness.Unknown; // could not probe (e.g. access denied)
+                }
             }
         }
 

--- a/Source/Parsek/TestCommands/ParsekTestCommandAddon.cs
+++ b/Source/Parsek/TestCommands/ParsekTestCommandAddon.cs
@@ -121,13 +121,16 @@ namespace Parsek.TestCommands
         private string lastDeferReason;
 
         // A terminal response whose append exhausted its retries on a prior frame. The
-        // side effect already ran and is journaled EXECUTED, so this is re-appended
-        // WITHOUT re-executing until it lands, then journaled DONE.
+        // side effect already ran (or was a no-side-effect REJECTED/TIMEOUT/INTERRUPTED
+        // ack), so this is re-appended WITHOUT re-executing until it lands, then journaled
+        // DONE. headPendingResponseDequeues records whether landing advances the FIFO head
+        // (true for a queued head, false for a startup recovery ack with no queue entry).
         private bool headPendingResponse;
         private string headPendingResponseLine;
         private string headPendingResponseId;
         private long headPendingResponseSeq;
         private string headPendingResponseVerdict;
+        private bool headPendingResponseDequeues;
 
         // Executor result carrier: the ITestCommandExecutor methods are void, so a verb
         // handler stashes its verdict/payload/msg here and the pump reads them back.
@@ -463,13 +466,16 @@ namespace Parsek.TestCommands
         private void Pump()
         {
             // Retry a terminal response append that exhausted its retries on a prior frame.
-            // The side effect already ran (journalled EXECUTED), so this never re-executes.
+            // Covers EXECUTED single-phase acks AND the no-side-effect REJECTED/TIMEOUT/
+            // INTERRUPTED acks (F6): the side effect (if any) already ran, so this never
+            // re-executes. DONE is journaled only after the append finally lands.
             if (headPendingResponse)
             {
                 if (!AppendResponse(headPendingResponseLine, headPendingResponseId))
                     return; // still failing; try again next frame
                 headPendingResponse = false;
-                WriteDoneAndAdvance(headPendingResponseId, headPendingResponseSeq, headPendingResponseVerdict);
+                WriteDoneAndAdvance(headPendingResponseId, headPendingResponseSeq,
+                    headPendingResponseVerdict, headPendingResponseDequeues);
                 return;
             }
 
@@ -491,13 +497,14 @@ namespace Parsek.TestCommands
                 case DispatchDecision.Reject:
                     ResetDeferTracking();
                     TestCommandDiagnostics.DispatchReject(head.Id, head.Verb, result.Reason);
+                    // Dequeue is owned by the terminal completion (immediate, or deferred
+                    // via the headPendingResponse retry if the ack append fails) so a
+                    // REJECTED ack survives an append failure.
                     WriteTerminalNoSideEffect(head, "REJECTED", result.Reason);
-                    pending.Dequeue();
                     break;
                 case DispatchDecision.Interrupted:
                     ResetDeferTracking();
-                    InterruptHead(head);
-                    pending.Dequeue();
+                    InterruptHead(head); // owns its dequeue via the terminal completion
                     break;
                 case DispatchDecision.Defer:
                     HandleDefer(head, result.Reason); // dequeues only on TIMEOUT
@@ -578,7 +585,7 @@ namespace Parsek.TestCommands
                 // at-most-once (a restart replay sees EXECUTED and never re-runs it).
                 TestCommandExecution.ExceptionTerminal(ex.GetType().Name, out string exVerdict, out string exMsg);
                 ParsekLog.Error(Tag, $"exec threw id={id} cmd={head.Verb}: {ex.GetType().Name}: {ex.Message}");
-                EmitExecutedTerminal(id, seq, head.Verb, exVerdict, null, exMsg);
+                EmitExecutedTerminal(id, seq, head.Verb, exVerdict, null, exMsg, dequeueHead: true);
                 return;
             }
             string verdict = execVerdict ?? "ERROR";
@@ -599,16 +606,16 @@ namespace Parsek.TestCommands
                 return;
             }
 
-            EmitExecutedTerminal(id, seq, head.Verb, verdict, execPayload, execMsg);
+            EmitExecutedTerminal(id, seq, head.Verb, verdict, execPayload, execMsg, dequeueHead: true);
         }
 
-        // Shared single-phase terminal tail: journal EXECUTED, append the response, then
-        // (on a successful append) journal DONE + advance, else cache for a retry WITHOUT
-        // re-executing (id stays journalled EXECUTED). Used by ExecuteHead and by the
-        // two-phase completion.
+        // Shared single-phase terminal tail: journal EXECUTED, then append the response and
+        // journal DONE + advance (or cache for retry WITHOUT re-executing). Used by
+        // ExecuteHead, the exception-containment path, WriteTerminalNoSideEffect, and the
+        // two-phase completion. dequeueHead is true when the id holds the FIFO head.
         private void EmitExecutedTerminal(
             string id, long seq, string verb, string verdict,
-            List<KeyValuePair<string, string>> payload, string msg)
+            List<KeyValuePair<string, string>> payload, string msg, bool dequeueHead)
         {
             WriteJournal(
                 TestCommandJournal.FormatExecuted(id, seq, WallClockSeconds(), verdict, payload, msg),
@@ -617,29 +624,41 @@ namespace Parsek.TestCommands
             string line = TestCommandResponse.FormatResponseLine(
                 id, verb, verdict, seq, CurrentUt(), payload, msg);
             TestCommandDiagnostics.ExecVerdict(id, verdict);
+            FinishTerminalResponse(id, seq, verdict, line, dequeueHead);
+        }
 
-            if (AppendResponse(line, id))
+        // Append a terminal response line; on success journal DONE + advance, else cache it in
+        // the headPendingResponse slot so the Pump-top retry re-appends it (WITHOUT
+        // re-executing) and journals DONE only once it lands. dequeueHead controls whether a
+        // successful landing advances the FIFO head (false for a startup recovery ack that was
+        // never queued). This is the single ack-durability path for EVERY terminal outcome -
+        // executed, no-side-effect REJECTED/TIMEOUT, INTERRUPTED, and startup recovery (F6).
+        private void FinishTerminalResponse(
+            string id, long seq, string verdict, string responseLine, bool dequeueHead)
+        {
+            if (AppendResponse(responseLine, id))
             {
                 TestCommandDiagnostics.ResponseAppended(id, verdict);
-                WriteDoneAndAdvance(id, seq, verdict);
+                WriteDoneAndAdvance(id, seq, verdict, dequeueHead);
             }
             else
             {
                 headPendingResponse = true;
-                headPendingResponseLine = line;
+                headPendingResponseLine = responseLine;
                 headPendingResponseId = id;
                 headPendingResponseSeq = seq;
                 headPendingResponseVerdict = verdict;
+                headPendingResponseDequeues = dequeueHead;
             }
         }
 
-        // Journal DONE, mark the id processed, advance the FIFO head, and (for
-        // FlushAndQuit) schedule the deferred quit now that the response + DONE are durable.
-        private void WriteDoneAndAdvance(string id, long seq, string verdict)
+        // Journal DONE, mark the id processed, advance the FIFO head (when it owns it), and
+        // (for FlushAndQuit) schedule the deferred quit now that the response + DONE are durable.
+        private void WriteDoneAndAdvance(string id, long seq, string verdict, bool dequeueHead)
         {
             WriteJournal(TestCommandJournal.FormatDone(id, seq, verdict, WallClockSeconds()), id, "DONE");
             MarkProcessed(id);
-            if (pending.Count > 0) pending.Dequeue();
+            if (dequeueHead && pending.Count > 0) pending.Dequeue();
             MaybeScheduleQuit(id);
         }
 
@@ -694,14 +713,14 @@ namespace Parsek.TestCommands
                     if (completionVerb == "LoadGame") loadInFlight = false;
                     string tid = completionId; long tseq = completionSeq; string tverb = completionVerb;
                     ClearTwoPhase();
-                    EmitExecutedTerminal(tid, tseq, tverb, "TIMEOUT", null, "awaiting-completion");
+                    EmitExecutedTerminal(tid, tseq, tverb, "TIMEOUT", null, "awaiting-completion", dequeueHead: true);
                 }
                 return;
             }
 
             string cid = completionId; long cseq = completionSeq; string cverb = completionVerb;
             ClearTwoPhase();
-            EmitExecutedTerminal(cid, cseq, cverb, verdict, payload, msg);
+            EmitExecutedTerminal(cid, cseq, cverb, verdict, payload, msg, dequeueHead: true);
         }
 
         private void ClearTwoPhase()
@@ -728,24 +747,23 @@ namespace Parsek.TestCommands
             Application.Quit();
         }
 
-        // A terminal outcome with NO side effect (REJECTED / TIMEOUT): journal
-        // CLAIMED+EXECUTED+DONE around the response so a restart replay skips the id.
+        // A terminal outcome with NO side effect (REJECTED / TIMEOUT): journal CLAIMED, then
+        // route through EmitExecutedTerminal (EXECUTED + response + DONE) so the ack survives an
+        // append failure via the headPendingResponse retry (F6) and DONE lands only after the
+        // response does. dequeueHead=true: the id owns the FIFO head.
         private void WriteTerminalNoSideEffect(ParsedCommand head, string verdict, string msg)
         {
             string id = head.Id;
             string verb = head.Verb ?? string.Empty;
             long seq = NextSeq();
             WriteJournal(TestCommandJournal.FormatClaimed(id, seq, verb, SessionId(), WallClockSeconds()), id, "CLAIMED");
-            WriteJournal(TestCommandJournal.FormatExecuted(id, seq, WallClockSeconds(), verdict, null, msg), id, "EXECUTED");
-            string line = TestCommandResponse.FormatResponseLine(id, verb, verdict, seq, CurrentUt(), null, msg);
-            AppendResponse(line, id);
-            WriteJournal(TestCommandJournal.FormatDone(id, seq, verdict, WallClockSeconds()), id, "DONE");
-            MarkProcessed(id);
+            EmitExecutedTerminal(id, seq, verb, verdict, null, msg, dequeueHead: true);
         }
 
-        // Crash-recovery INTERRUPTED at the live head (journal CLAIMED for this id). Mostly
-        // defensive: such ids are usually seeded into the processed set at startup and
-        // filtered before reaching dispatch.
+        // Crash-recovery INTERRUPTED at the live head (journal already CLAIMED for this id, so
+        // no EXECUTED is written). Routes the ack through FinishTerminalResponse so an append
+        // failure is retried and DONE lands only after the response (F6). Mostly defensive:
+        // such ids are usually seeded into the processed set at startup and filtered first.
         private void InterruptHead(ParsedCommand head)
         {
             string id = head.Id;
@@ -753,16 +771,15 @@ namespace Parsek.TestCommands
             long seq = NextSeq();
             string line = TestCommandResponse.FormatResponseLine(
                 id, head.Verb ?? string.Empty, "INTERRUPTED", seq, CurrentUt(), null, "interrupted-claimed");
-            AppendResponse(line, id);
-            WriteJournal(TestCommandJournal.FormatDone(id, seq, "INTERRUPTED", WallClockSeconds()), id, "DONE");
-            MarkProcessed(id);
+            FinishTerminalResponse(id, seq, "INTERRUPTED", line, dequeueHead: true);
         }
 
-        // Startup crash-recovery terminal (from ReplayAndReconcile). No pending head to
-        // dequeue; just re-ack + DONE + processed-set seed happens in the caller. For the
-        // RewriteResponse (EXECUTED) case the ORIGINAL verdict/payload/msg are supplied so the
-        // rewritten line is byte-equivalent to the pre-crash response; the CLAIMED case keeps
-        // the synthetic interrupted-claimed ack.
+        // Startup crash-recovery terminal (from ReplayAndReconcile). The id was never queued so
+        // dequeueHead=false, but the ack still routes through FinishTerminalResponse so an append
+        // failure is retried on the first Pump and DONE lands only after the response (F6). For
+        // the RewriteResponse (EXECUTED) case the ORIGINAL verdict/payload/msg are supplied so the
+        // rewritten line is byte-equivalent to the pre-crash response; the CLAIMED case keeps the
+        // synthetic interrupted-claimed ack.
         private void WriteRecoveryTerminal(
             string id, string verb, string verdict,
             List<KeyValuePair<string, string>> payload, string msg)
@@ -770,8 +787,7 @@ namespace Parsek.TestCommands
             long seq = NextSeq();
             string line = TestCommandResponse.FormatResponseLine(
                 id, verb ?? string.Empty, verdict, seq, CurrentUt(), payload, msg);
-            AppendResponse(line, id);
-            WriteJournal(TestCommandJournal.FormatDone(id, seq, verdict, WallClockSeconds()), id, "DONE");
+            FinishTerminalResponse(id, seq, verdict, line, dequeueHead: false);
         }
 
         // Head deferral + per-command TIMEOUT conversion. The head tracks when it first
@@ -797,8 +813,9 @@ namespace Parsek.TestCommands
             if (DeferralBudget.ShouldTimeout(deferStartedAtSeconds, now, budget))
             {
                 TestCommandDiagnostics.Timeout(head.Id, head.Verb, now - deferStartedAtSeconds, lastDeferReason);
+                // Dequeue is owned by the terminal completion (immediate or via the
+                // headPendingResponse retry), so the TIMEOUT ack survives an append failure.
                 WriteTerminalNoSideEffect(head, "TIMEOUT", lastDeferReason);
-                pending.Dequeue();
                 ResetDeferTracking();
             }
         }
@@ -827,7 +844,16 @@ namespace Parsek.TestCommands
             };
         }
 
-        private bool IsBatchRunning() => ownedRunner != null && ownedRunner.IsRunning;
+        // A command must never execute while ANY in-game test batch runs: the addon's own
+        // RunTests runner OR the interactive Ctrl+Shift+T shortcut runner (F5). The two runners
+        // share the campaign-isolation baseline machinery, so overlapping a command with either
+        // batch could corrupt the save under test.
+        private bool IsBatchRunning()
+        {
+            if (ownedRunner != null && ownedRunner.IsRunning) return true;
+            InGameTestRunner shortcutRunner = TestRunnerShortcut.ActiveRunnerForGating;
+            return shortcutRunner != null && shortcutRunner.IsRunning;
+        }
 
         private static TestCommandScene MapScene(GameScenes scene)
         {

--- a/Source/Parsek/TestCommands/ParsekTestCommandAddon.cs
+++ b/Source/Parsek/TestCommands/ParsekTestCommandAddon.cs
@@ -140,6 +140,12 @@ namespace Parsek.TestCommands
         internal int SettleCounterForTesting => settleCounter;
         internal bool DisabledForTesting => disabled;
 
+        /// <summary>True once the first armed frame resolved channel paths + touched the
+        /// lock/journal files. Stays false forever when unarmed (TryStartup is the only
+        /// file-touching startup and runs only behind the armed gate), so it is the
+        /// in-game inert-when-unarmed proof: no file access ever happened.</summary>
+        internal bool StartupDoneForTesting => startupDone;
+
         /// <summary>
         /// Pure fail-closed env-gate predicate: ONLY the literal <c>"1"</c> arms the
         /// addon. <c>null</c> (unset), <c>"0"</c>, <c>"true"</c>, and <c>""</c> all stay

--- a/Source/Parsek/TestCommands/SettingWhitelist.cs
+++ b/Source/Parsek/TestCommands/SettingWhitelist.cs
@@ -1,0 +1,177 @@
+using System.Collections.Generic;
+using System.Globalization;
+
+namespace Parsek.TestCommands
+{
+    /// <summary>
+    /// Where a whitelisted setting is authoritatively persisted. 8 of the 16 are
+    /// NOT authoritative through <c>GameParameters.CustomParameterNode</c>: for
+    /// those the <c>ParsekSettingsPersistence</c> sidecar
+    /// (<c>GameData/Parsek/PluginData/settings.cfg</c>) is authoritative and
+    /// <c>ParsekScenario.OnLoad</c> OVERWRITES the GameParameters value on every
+    /// save load. A dispatcher that only mutated the live field would see its
+    /// change silently reverted at the next save load, so those route through the
+    /// matching <c>ParsekSettingsPersistence.Record*</c> path too.
+    /// </summary>
+    internal enum PersistenceRoute
+    {
+        /// <summary>Persisted via GameParameters only (round-trips on the next game save).</summary>
+        GameParameters,
+
+        /// <summary>Persisted via GameParameters AND the ParsekSettingsPersistence sidecar.</summary>
+        GameParametersPlusSidecar,
+    }
+
+    internal enum SettingValueType
+    {
+        Bool,
+        Int,
+        Float,
+    }
+
+    /// <summary>
+    /// Pure decision result of <see cref="SettingWhitelist.TryApply"/>. Carries the
+    /// typed value, the persistence route, and the exact
+    /// <c>ParsekSettingsPersistence.Record*</c> selector (a method-name string, not
+    /// reflection over user input) so the thin Unity applier can dispatch without
+    /// interpreting arbitrary field names. Commands are data, never code.
+    /// </summary>
+    internal struct SettingApplyResult
+    {
+        public bool Accepted;
+
+        /// <summary>Reject reason when <see cref="Accepted"/> is false
+        /// (<c>setting-not-whitelisted</c> / <c>setting-value-invalid</c>).</summary>
+        public string RejectReason;
+
+        public string Name;
+        public SettingValueType Type;
+        public PersistenceRoute Route;
+
+        /// <summary>The exact <c>ParsekSettingsPersistence.Record*</c> method name for a
+        /// sidecar-tracked setting; null for a GameParameters-only setting.</summary>
+        public string RecordMethod;
+
+        public bool BoolValue;
+        public int IntValue;
+        public float FloatValue;
+    }
+
+    /// <summary>
+    /// Explicit allowlist of settings <c>SetSetting</c> may mutate, each mapped to a
+    /// typed parse-and-range check and a persistence route. There is NO reflective
+    /// "set any field": the whitelist switches on the exact name and returns a pure
+    /// decision (typed value + route + Record* selector) for the applier to act on.
+    /// This is the security boundary that keeps commands data, not code.
+    /// </summary>
+    internal static class SettingWhitelist
+    {
+        private struct Entry
+        {
+            public SettingValueType Type;
+            public double Min;
+            public double Max;
+            public PersistenceRoute Route;
+            public string RecordMethod; // null for GameParameters-only
+        }
+
+        // The 16 whitelisted settings. Fields and Record* method names verified
+        // against ParsekSettings.cs and ParsekSettingsPersistence.cs. Note the name
+        // asymmetry: setting `writeReadableSidecarMirrors` -> method
+        // `RecordReadableSidecarMirrors` (the method drops the "write" prefix).
+        private static readonly Dictionary<string, Entry> Table = new Dictionary<string, Entry>
+        {
+            // --- GameParameters-only (8) ---
+            ["autoRecordOnLaunch"] = Bool(PersistenceRoute.GameParameters, null),
+            ["autoRecordOnEva"] = Bool(PersistenceRoute.GameParameters, null),
+            ["autoRecordOnFirstModificationAfterSwitch"] = Bool(PersistenceRoute.GameParameters, null),
+            ["autoMerge"] = Bool(PersistenceRoute.GameParameters, null),
+            ["verboseLogging"] = Bool(PersistenceRoute.GameParameters, null),
+            ["samplingDensity"] = Int(0, 2, PersistenceRoute.GameParameters, null),
+            ["ghostAudioVolume"] = Float(0.0, 1.0, PersistenceRoute.GameParameters, null),
+            ["transitedBodyRotationModeIndex"] = Int(0, 2, PersistenceRoute.GameParameters, null),
+
+            // --- GameParameters + ParsekSettingsPersistence sidecar (8 tracked) ---
+            ["ghostRenderTracing"] = Bool(PersistenceRoute.GameParametersPlusSidecar, "RecordGhostRenderTracing"),
+            ["mapRenderTracing"] = Bool(PersistenceRoute.GameParametersPlusSidecar, "RecordMapRenderTracing"),
+            ["ledgerTracing"] = Bool(PersistenceRoute.GameParametersPlusSidecar, "RecordLedgerTracing"),
+            ["writeReadableSidecarMirrors"] = Bool(PersistenceRoute.GameParametersPlusSidecar, "RecordReadableSidecarMirrors"),
+            ["autoBackupExistingSaves"] = Bool(PersistenceRoute.GameParametersPlusSidecar, "RecordAutoBackupExistingSaves"),
+            ["showCommittedFutureOverlays"] = Bool(PersistenceRoute.GameParametersPlusSidecar, "RecordShowCommittedFutureOverlays"),
+            ["blockCommittedActions"] = Bool(PersistenceRoute.GameParametersPlusSidecar, "RecordBlockCommittedActions"),
+            ["showRouteLines"] = Bool(PersistenceRoute.GameParametersPlusSidecar, "RecordShowRouteLines"),
+        };
+
+        /// <summary>
+        /// Pure whitelist decision. An unknown name -> reject
+        /// <c>setting-not-whitelisted</c>; a value that fails the typed parse or
+        /// range -> reject <c>setting-value-invalid</c>. On accept, returns the
+        /// typed value plus the persistence route and Record* selector. The field is
+        /// never touched here (that is the applier's job).
+        /// </summary>
+        internal static SettingApplyResult TryApply(string name, string rawValue)
+        {
+            var result = new SettingApplyResult { Name = name, Accepted = false };
+
+            if (name == null || !Table.TryGetValue(name, out Entry entry))
+            {
+                result.RejectReason = "setting-not-whitelisted";
+                return result;
+            }
+
+            result.Type = entry.Type;
+            result.Route = entry.Route;
+            result.RecordMethod = entry.RecordMethod;
+
+            switch (entry.Type)
+            {
+                case SettingValueType.Bool:
+                    if (!bool.TryParse(rawValue, out bool bv))
+                    {
+                        result.RejectReason = "setting-value-invalid";
+                        return result;
+                    }
+                    result.BoolValue = bv;
+                    break;
+
+                case SettingValueType.Int:
+                    if (!int.TryParse(rawValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out int iv)
+                        || iv < entry.Min || iv > entry.Max)
+                    {
+                        result.RejectReason = "setting-value-invalid";
+                        return result;
+                    }
+                    result.IntValue = iv;
+                    break;
+
+                case SettingValueType.Float:
+                    if (!float.TryParse(rawValue, NumberStyles.Float, CultureInfo.InvariantCulture, out float fv)
+                        || fv < entry.Min || fv > entry.Max)
+                    {
+                        result.RejectReason = "setting-value-invalid";
+                        return result;
+                    }
+                    result.FloatValue = fv;
+                    break;
+            }
+
+            result.Accepted = true;
+            return result;
+        }
+
+        /// <summary>Whether <paramref name="name"/> is a whitelisted setting.</summary>
+        internal static bool IsWhitelisted(string name) => name != null && Table.ContainsKey(name);
+
+        /// <summary>Read-only view of the whitelisted names (for coverage tests).</summary>
+        internal static IReadOnlyCollection<string> WhitelistedNames => Table.Keys;
+
+        private static Entry Bool(PersistenceRoute route, string recordMethod)
+            => new Entry { Type = SettingValueType.Bool, Route = route, RecordMethod = recordMethod };
+
+        private static Entry Int(int min, int max, PersistenceRoute route, string recordMethod)
+            => new Entry { Type = SettingValueType.Int, Min = min, Max = max, Route = route, RecordMethod = recordMethod };
+
+        private static Entry Float(double min, double max, PersistenceRoute route, string recordMethod)
+            => new Entry { Type = SettingValueType.Float, Min = min, Max = max, Route = route, RecordMethod = recordMethod };
+    }
+}

--- a/Source/Parsek/TestCommands/TestCommandChannelIo.cs
+++ b/Source/Parsek/TestCommands/TestCommandChannelIo.cs
@@ -1,0 +1,75 @@
+using System;
+
+namespace Parsek.TestCommands
+{
+    /// <summary>
+    /// Pure channel-I/O decisions and constants for the ParsekTestCommands seam (M-A2):
+    /// the four fixed KSP-root file names, the persistent-byte-offset advance rule, and
+    /// the bounded append-retry / backoff policy. No UnityEngine / KSP / System.IO usage
+    /// - the raw <c>FileStream</c> work lives in <see cref="ParsekTestCommandAddon"/>,
+    /// and these decisions are the parts of it exercised by xUnit without Unity.
+    /// </summary>
+    internal static class TestCommandChannelIo
+    {
+        // ----- Fixed channel file names (KSP root; see the design's file-location table) -----
+
+        internal const string CommandFileName = "parsek-test-commands.txt";
+        internal const string ResponseFileName = "parsek-test-responses.txt";
+        internal const string JournalFileName = "parsek-test-commands.journal";
+        internal const string LockFileName = "parsek-test-commands.lock";
+
+        // ----- Append retry policy -----
+
+        /// <summary>Bounded append attempts. On exhaustion the addon leaves the id at
+        /// EXECUTED (the response is (re)written next frame / next restart WITHOUT
+        /// re-executing), so an ack is never silently dropped.</summary>
+        internal const int MaxAppendAttempts = 5;
+
+        /// <summary>Base backoff step (ms); the delay scales linearly with the attempt so
+        /// a transient reader lock clears without an unbounded spin.</summary>
+        internal const int BaseBackoffMillis = 20;
+
+        // ----- Offset advance -----
+
+        /// <summary>
+        /// The number of leading bytes in <paramref name="buffer"/><c>[0..count)</c> that
+        /// form COMPLETE, newline-terminated content: one past the last <c>\n</c>, or 0 if
+        /// there is no <c>\n</c>. A torn trailing fragment (bytes after the last <c>\n</c>)
+        /// is NOT consumed, so the persistent byte offset advances only over whole lines
+        /// and the fragment is re-read intact on the next poll.
+        /// </summary>
+        internal static int WholeLineByteCount(byte[] buffer, int count)
+        {
+            if (buffer == null || count <= 0) return 0;
+            int limit = Math.Min(count, buffer.Length);
+            for (int i = limit - 1; i >= 0; i--)
+            {
+                if (buffer[i] == (byte)'\n')
+                    return i + 1;
+            }
+            return 0;
+        }
+
+        // ----- Retry decision -----
+
+        /// <summary>
+        /// True while an append that has just failed its <paramref name="attempt"/>-th try
+        /// (1-based) may retry: attempts <c>1..maxAttempts-1</c> retry; the
+        /// <paramref name="maxAttempts"/>-th failure gives up this frame.
+        /// </summary>
+        internal static bool ShouldRetryAppend(int attempt, int maxAttempts)
+        {
+            return attempt < maxAttempts;
+        }
+
+        /// <summary>
+        /// Bounded backoff (ms) before append retry <paramref name="attempt"/> (1-based):
+        /// linear <see cref="BaseBackoffMillis"/> * attempt.
+        /// </summary>
+        internal static int BackoffMillis(int attempt)
+        {
+            if (attempt < 1) attempt = 1;
+            return BaseBackoffMillis * attempt;
+        }
+    }
+}

--- a/Source/Parsek/TestCommands/TestCommandDiagnostics.cs
+++ b/Source/Parsek/TestCommands/TestCommandDiagnostics.cs
@@ -1,0 +1,68 @@
+using System.Globalization;
+
+namespace Parsek.TestCommands
+{
+    /// <summary>
+    /// Pure diagnostic emitters for the per-command lifecycle of the ParsekTestCommands
+    /// seam (P6.1). Every dispatch / execution branch routes its log line through here so
+    /// none is silent and the grep-able shapes (<c>recv</c>, <c>dispatch -&gt; ...</c>,
+    /// <c>reject</c>, <c>exec ... verdict=</c>, <c>timeout</c>, <c>duplicate</c>) are pinned
+    /// by log-assertion tests via <c>ParsekLog.TestSinkForTesting</c> without a live Unity
+    /// runtime (the addon that calls these is a MonoBehaviour and cannot be exercised
+    /// headless). Goal: a KSP.log reader can reconstruct, for every command id, that it was
+    /// received, which branch it took and why, whether it executed, and the terminal verdict.
+    /// </summary>
+    internal static class TestCommandDiagnostics
+    {
+        internal const string Tag = "TestCommands";
+
+        /// <summary>Command received (one per parsed, non-duplicate command line).</summary>
+        internal static void Receipt(string id, string verb, int argCount)
+            => ParsekLog.Info(Tag, $"recv id={id} cmd={verb ?? "?"} args={argCount.ToString(CultureInfo.InvariantCulture)}");
+
+        /// <summary>Head dispatched to Execute.</summary>
+        internal static void DispatchExecute(string id)
+            => ParsekLog.Info(Tag, $"dispatch id={id} -> EXECUTE");
+
+        /// <summary>Head deferred (first time at the head).</summary>
+        internal static void DispatchDefer(string id, string reason)
+            => ParsekLog.Info(Tag, $"dispatch id={id} -> DEFER reason={reason}");
+
+        /// <summary>Head still deferring (rate-limited per id while it keeps deferring).</summary>
+        internal static void DispatchDeferRepeat(string id, string reason)
+            => ParsekLog.VerboseRateLimited(Tag, "defer-" + id, $"dispatch id={id} -> DEFER reason={reason}", 5.0);
+
+        /// <summary>Terminal REJECTED (malformed / unknown / reserved / whitelist / LoadGame guard).</summary>
+        internal static void DispatchReject(string id, string verb, string reason)
+            => ParsekLog.Warn(Tag, $"reject id={id} cmd={verb ?? "?"} reason={reason}");
+
+        /// <summary>Crash-recovery INTERRUPTED at the live head (journal at CLAIMED).</summary>
+        internal static void DispatchInterrupted(string id, JournalPhase phase)
+            => ParsekLog.Info(Tag, $"dispatch id={id} -> INTERRUPTED (journal={phase})");
+
+        /// <summary>Execution about to start.</summary>
+        internal static void ExecStart(string id, string verb)
+            => ParsekLog.Info(Tag, $"exec id={id} cmd={verb} start");
+
+        /// <summary>Execution produced a terminal verdict.</summary>
+        internal static void ExecVerdict(string id, string verdict)
+            => ParsekLog.Info(Tag, $"exec id={id} verdict={verdict}");
+
+        /// <summary>Two-phase side effect initiated; terminal deferred to completion.</summary>
+        internal static void ExecPending(string id)
+            => ParsekLog.Info(Tag, $"exec id={id} verdict=PENDING (two-phase awaiting completion)");
+
+        /// <summary>Response line landed (Verbose; the IO-failure path logs its own Warn/Error).</summary>
+        internal static void ResponseAppended(string id, string verdict)
+            => ParsekLog.Verbose(Tag, $"response appended id={id} verdict={verdict}");
+
+        /// <summary>Head exceeded its deferral budget and converted to TIMEOUT.</summary>
+        internal static void Timeout(string id, string verb, double deferredSeconds, string reason)
+            => ParsekLog.Warn(Tag,
+                $"timeout id={id} cmd={verb} deferred={deferredSeconds.ToString("F1", CultureInfo.InvariantCulture)}s reason={reason}");
+
+        /// <summary>A command id already terminal / in-flight: skipped, no second response.</summary>
+        internal static void Duplicate(string id)
+            => ParsekLog.Warn(Tag, $"duplicate id={id} ignored");
+    }
+}

--- a/Source/Parsek/TestCommands/TestCommandDispatcher.cs
+++ b/Source/Parsek/TestCommands/TestCommandDispatcher.cs
@@ -137,6 +137,61 @@ namespace Parsek.TestCommands
                 ["FlushAndQuit"] = VerbSceneRequirement.AnyScene,
             };
 
+        /// <summary>
+        /// Pure per-frame dispatch decision for the head command. Evaluation order
+        /// (per the design's dispatch matrix): (1) journal-phase crash recovery for
+        /// this id, (2) parse / verb-class rejects (no side effect), (3) the
+        /// scene/state gate (safe point, batch running, per-verb scene precondition),
+        /// (4) the LoadGame recording-active / load-in-flight guards. The pump only
+        /// ever calls this on the strict-FIFO head command.
+        /// </summary>
+        internal static DispatchResult DecideDispatch(ParsedCommand parsed, DispatchState state)
+        {
+            // 1. Journal-phase crash recovery for this id. A leftover CLAIMED means we
+            // claimed it then crashed mid-execution: do NOT re-execute. (EXECUTED /
+            // DONE ids are filtered by the processed-set upstream and never reach live
+            // dispatch; a fresh None id proceeds.)
+            if (state.JournalPhase == JournalPhase.Claimed)
+                return DispatchResult.Interrupted();
+
+            // 2. Parse / verb-class rejects (terminal REJECTED, no side effect).
+            if (!parsed.ParseOk)
+                return DispatchResult.Reject(parsed.ParseError); // malformed / missing-id / missing-cmd
+
+            TestCommandVerbClass verbClass = TestCommandVerbs.Classify(parsed.Verb);
+            if (verbClass == TestCommandVerbClass.Reserved)
+                return DispatchResult.Reject("not-implemented-v1");
+            if (verbClass == TestCommandVerbClass.Unknown)
+                return DispatchResult.Reject("unknown-command");
+
+            // 3. Scene / state gate.
+            // Safe point: never dispatch during LOADING, a scene transition, or the settle window.
+            if (state.Scene == TestCommandScene.Loading || state.Transitioning || state.SettleCounter > 0)
+                return DispatchResult.Defer("not-safe-point");
+            // No command executes while an in-game test batch runs.
+            if (state.BatchRunning)
+                return DispatchResult.Defer("batch-running");
+
+            VerbSceneRequirement req = RequirementFor(parsed.Verb);
+            if (req == VerbSceneRequirement.RequiresFlight && state.Scene != TestCommandScene.Flight)
+                return DispatchResult.Defer("not-in-flight");
+            if (req == VerbSceneRequirement.RequiresGameLoaded && !state.SettingsPresent)
+                return DispatchResult.Defer("game-not-loaded");
+
+            // 4. LoadGame guards: never silently discard an in-flight recording, and
+            // never overlap two loads.
+            if (parsed.Verb == "LoadGame")
+            {
+                if (state.Recording)
+                    return DispatchResult.Reject("recording-active");
+                if (state.LoadInFlight)
+                    return DispatchResult.Reject("load-in-flight");
+            }
+
+            // 5. Ready to execute.
+            return DispatchResult.Execute();
+        }
+
         /// <summary>The scene/state requirement for an implemented verb.</summary>
         internal static VerbSceneRequirement RequirementFor(string verb)
         {

--- a/Source/Parsek/TestCommands/TestCommandDispatcher.cs
+++ b/Source/Parsek/TestCommands/TestCommandDispatcher.cs
@@ -203,4 +203,62 @@ namespace Parsek.TestCommands
         /// <summary>Read-only view of the precondition table (for coverage tests).</summary>
         internal static IReadOnlyDictionary<string, VerbSceneRequirement> PreconditionTable => Preconditions;
     }
+
+    /// <summary>
+    /// Pure per-command deferral-budget model. A command that sits at the head of the
+    /// queue in Defer longer than its budget is converted to a TIMEOUT terminal (with
+    /// the last defer reason as msg) and the pump advances, so a never-satisfiable
+    /// command never wedges the run. Budgets are wall-clock seconds measured from when
+    /// the command first reached the head and began deferring.
+    /// </summary>
+    internal static class DeferralBudget
+    {
+        /// <summary>Ordinary scene-settle / game-loaded waits.</summary>
+        internal const double DefaultSeconds = 60.0;
+
+        /// <summary>A cold LoadGame + scene settle can take minutes on a large save.</summary>
+        internal const double LoadGameSeconds = 300.0;
+
+        /// <summary>StartRecording may wait for FLIGHT with an unpacked active vessel;
+        /// sized to the scene-arrival wait rather than the fixed default. Chosen value
+        /// (the design specifies "scene-wait budget" without a number); revisit when the
+        /// scenario spec pins it.</summary>
+        internal const double StartRecordingSceneWaitSeconds = 180.0;
+
+        /// <summary>Fallback RunTests budget when the scenario spec supplies none. A full
+        /// in-game batch can run minutes; chosen value pending the scenario's declared
+        /// runtime budget (the authoritative source when provided).</summary>
+        internal const double RunTestsFallbackSeconds = 600.0;
+
+        /// <summary>
+        /// The deferral budget (seconds) for <paramref name="verb"/>. For RunTests the
+        /// scenario's declared runtime budget is authoritative when supplied via
+        /// <paramref name="scenarioBudgetSeconds"/>; otherwise the fallback applies.
+        /// </summary>
+        internal static double BudgetSeconds(string verb, double? scenarioBudgetSeconds = null)
+        {
+            switch (verb)
+            {
+                case "LoadGame":
+                    return LoadGameSeconds;
+                case "StartRecording":
+                    return StartRecordingSceneWaitSeconds;
+                case "RunTests":
+                    return scenarioBudgetSeconds ?? RunTestsFallbackSeconds;
+                default:
+                    return DefaultSeconds;
+            }
+        }
+
+        /// <summary>
+        /// True when a command that first began deferring at
+        /// <paramref name="firstDeferredAtSeconds"/> has, by
+        /// <paramref name="nowSeconds"/>, exceeded <paramref name="budgetSeconds"/> and
+        /// must be converted to a TIMEOUT terminal.
+        /// </summary>
+        internal static bool ShouldTimeout(double firstDeferredAtSeconds, double nowSeconds, double budgetSeconds)
+        {
+            return (nowSeconds - firstDeferredAtSeconds) >= budgetSeconds;
+        }
+    }
 }

--- a/Source/Parsek/TestCommands/TestCommandDispatcher.cs
+++ b/Source/Parsek/TestCommands/TestCommandDispatcher.cs
@@ -1,0 +1,151 @@
+using System.Collections.Generic;
+
+namespace Parsek.TestCommands
+{
+    /// <summary>
+    /// Pure mirror of the KSP <c>GameScenes</c> the dispatcher cares about. The
+    /// future addon maps <c>HighLogic.LoadedScene</c> to this so the dispatch core
+    /// stays Unity-free (no Assembly-CSharp coupling). Only the scenes the
+    /// precondition table distinguishes are enumerated; everything else is
+    /// <see cref="Other"/>.
+    /// </summary>
+    internal enum TestCommandScene
+    {
+        Loading,
+        MainMenu,
+        SpaceCenter,
+        Editor,
+        Flight,
+        TrackingStation,
+        Other,
+    }
+
+    /// <summary>The pump's dispatch outcome for the head command.</summary>
+    internal enum DispatchDecision
+    {
+        /// <summary>Run the verb handler now.</summary>
+        Execute,
+
+        /// <summary>Not ready: leave at head and retry next frame (until its budget expires).</summary>
+        Defer,
+
+        /// <summary>Terminal REJECTED (no side effect): write the verdict and advance.</summary>
+        Reject,
+
+        /// <summary>Crash recovery: journal at CLAIMED for this id; write INTERRUPTED and advance.</summary>
+        Interrupted,
+    }
+
+    /// <summary>Pure result of <see cref="TestCommandDispatcher.DecideDispatch"/>.</summary>
+    internal struct DispatchResult
+    {
+        public DispatchDecision Decision;
+
+        /// <summary>Defer or reject reason (null for Execute / Interrupted).</summary>
+        public string Reason;
+
+        internal static DispatchResult Execute() =>
+            new DispatchResult { Decision = DispatchDecision.Execute };
+
+        internal static DispatchResult Defer(string reason) =>
+            new DispatchResult { Decision = DispatchDecision.Defer, Reason = reason };
+
+        internal static DispatchResult Reject(string reason) =>
+            new DispatchResult { Decision = DispatchDecision.Reject, Reason = reason };
+
+        internal static DispatchResult Interrupted() =>
+            new DispatchResult { Decision = DispatchDecision.Interrupted };
+    }
+
+    /// <summary>
+    /// Immutable snapshot of the Unity/KSP state the dispatcher reads, sampled once
+    /// per poll by the addon and passed to the pure
+    /// <see cref="TestCommandDispatcher.DecideDispatch"/>. Populating this is the
+    /// addon's job (P4.4); the struct itself carries no Unity types.
+    /// </summary>
+    internal struct DispatchState
+    {
+        public TestCommandScene Scene;
+        public bool GameLoaded;
+        public bool SettingsPresent;
+        public bool Recording;
+        public bool HasTree;
+        public bool Transitioning;
+        public int SettleCounter;
+        public bool BatchRunning;
+        public bool LoadInFlight;
+
+        /// <summary>The replayed journal phase for THIS command id (None if fresh).</summary>
+        public JournalPhase JournalPhase;
+    }
+
+    /// <summary>
+    /// The Unity-side contract the pump invokes when a verb is dispatched to Execute.
+    /// One method per v1 verb. Implemented by the addon (P4.4+); a fake stands in for
+    /// pure tests. The dispatcher itself never calls this - it only decides.
+    /// </summary>
+    internal interface ITestCommandExecutor
+    {
+        void SetSetting(ParsedCommand cmd);
+        void StartRecording(ParsedCommand cmd);
+        void StopRecording(ParsedCommand cmd);
+        void CommitTree(ParsedCommand cmd);
+        void DiscardTree(ParsedCommand cmd);
+        void RecordingState(ParsedCommand cmd);
+        void RunTests(ParsedCommand cmd);
+        void LoadGame(ParsedCommand cmd);
+        void MissionMark(ParsedCommand cmd);
+        void FlushAndQuit(ParsedCommand cmd);
+    }
+
+    /// <summary>The scene/state a verb requires before it may execute.</summary>
+    internal enum VerbSceneRequirement
+    {
+        /// <summary>Executable in any settled, non-LOADING scene (read-only or menu-safe verbs).</summary>
+        AnyScene,
+
+        /// <summary>Requires FLIGHT (recorder/tree verbs); else Defer(not-in-flight).</summary>
+        RequiresFlight,
+
+        /// <summary>Requires a loaded game (ParsekSettings.Current != null); else Defer(game-not-loaded).</summary>
+        RequiresGameLoaded,
+    }
+
+    /// <summary>
+    /// Pure per-frame dispatch decision for the ParsekTestCommands seam (M-A2). Owns
+    /// the per-verb precondition table and <c>DecideDispatch</c>; the pump (addon)
+    /// samples <see cref="DispatchState"/> from Unity and acts on the returned
+    /// <see cref="DispatchResult"/>.
+    /// </summary>
+    internal static class TestCommandDispatcher
+    {
+        // Per-verb scene/state precondition. LoadGame's recording-active /
+        // load-in-flight guards and the global batch-running / safe-point gates are
+        // applied in DecideDispatch on top of this table.
+        private static readonly Dictionary<string, VerbSceneRequirement> Preconditions =
+            new Dictionary<string, VerbSceneRequirement>
+            {
+                ["SetSetting"] = VerbSceneRequirement.RequiresGameLoaded,
+                ["StartRecording"] = VerbSceneRequirement.RequiresFlight,
+                ["StopRecording"] = VerbSceneRequirement.RequiresFlight,
+                ["CommitTree"] = VerbSceneRequirement.RequiresFlight,
+                ["DiscardTree"] = VerbSceneRequirement.RequiresFlight,
+                ["RecordingState"] = VerbSceneRequirement.AnyScene,
+                ["RunTests"] = VerbSceneRequirement.AnyScene,
+                ["LoadGame"] = VerbSceneRequirement.AnyScene,
+                ["MissionMark"] = VerbSceneRequirement.AnyScene,
+                ["FlushAndQuit"] = VerbSceneRequirement.AnyScene,
+            };
+
+        /// <summary>The scene/state requirement for an implemented verb.</summary>
+        internal static VerbSceneRequirement RequirementFor(string verb)
+        {
+            return Preconditions.TryGetValue(verb, out VerbSceneRequirement req)
+                ? req
+                : VerbSceneRequirement.AnyScene;
+        }
+
+        /// <summary>Read-only view of the precondition table (for coverage tests).</summary>
+        internal static IReadOnlyDictionary<string, VerbSceneRequirement> PreconditionTable => Preconditions;
+    }
+}

--- a/Source/Parsek/TestCommands/TestCommandExecution.cs
+++ b/Source/Parsek/TestCommands/TestCommandExecution.cs
@@ -1,0 +1,35 @@
+namespace Parsek.TestCommands
+{
+    /// <summary>
+    /// Pure execution-outcome decisions for the ParsekTestCommands pump (M-A2). The addon
+    /// side (a MonoBehaviour) invokes a verb handler and then acts on these decisions; kept
+    /// <c>internal static</c> so the exception-containment and queue-advance rules are
+    /// xUnit-covered without a live Unity runtime.
+    /// </summary>
+    internal static class TestCommandExecution
+    {
+        /// <summary>The two-phase sentinel verdict: the side effect was INITIATED and the
+        /// terminal response is deferred until the operation settles. It is the ONLY verdict
+        /// that holds the FIFO head instead of advancing it.</summary>
+        internal const string PendingVerdict = "__PENDING__";
+
+        /// <summary>
+        /// Maps a caught executor exception to the terminal response it becomes so the id
+        /// completes and the pump advances rather than the whole pump wedging on an unhandled
+        /// throw. The verdict is always <c>ERROR</c>; <paramref name="msg"/> carries the
+        /// exception type name (the response formatter percent-encodes it on the wire).
+        /// </summary>
+        internal static void ExceptionTerminal(string exceptionTypeName, out string verdict, out string msg)
+        {
+            verdict = "ERROR";
+            msg = "exception=" + (string.IsNullOrEmpty(exceptionTypeName) ? "Exception" : exceptionTypeName);
+        }
+
+        /// <summary>
+        /// True when a produced verdict is terminal and therefore advances the strict-FIFO
+        /// head. Only the two-phase <see cref="PendingVerdict"/> sentinel holds the head; every
+        /// real verdict (OK / ERROR / REJECTED / TIMEOUT / INTERRUPTED) advances.
+        /// </summary>
+        internal static bool AdvancesQueue(string verdict) => verdict != PendingVerdict;
+    }
+}

--- a/Source/Parsek/TestCommands/TestCommandFlushAndQuit.cs
+++ b/Source/Parsek/TestCommands/TestCommandFlushAndQuit.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+
+namespace Parsek.TestCommands
+{
+    /// <summary>
+    /// Pure decision + payload for the <c>FlushAndQuit</c> verb (P5.8). If a game is
+    /// loaded the addon forces a "persistent"-slot save so committed data is durable,
+    /// THEN quits deferred one frame (the quit is scheduled only after the response +
+    /// journal DONE are flushed). It deliberately does NOT auto-commit an in-flight
+    /// uncommitted recorder (a bare quit from flight never persisted one); the
+    /// orchestrator sends <c>CommitTree</c> first to keep it. Kept pure so the
+    /// should-save gate + payload shape are xUnit-covered without Unity.
+    /// </summary>
+    internal static class TestCommandFlushAndQuit
+    {
+        /// <summary>
+        /// True when a game save should be forced: a game is loaded AND a save folder is
+        /// resolved. With no game loaded (menu quit) there is nothing to save.
+        /// </summary>
+        internal static bool ShouldSave(bool gameLoaded, bool saveFolderPresent)
+            => gameLoaded && saveFolderPresent;
+
+        internal static List<KeyValuePair<string, string>> BuildPayload(bool saved)
+            => new List<KeyValuePair<string, string>>
+            {
+                new KeyValuePair<string, string>("saved", saved ? "true" : "false"),
+            };
+    }
+}

--- a/Source/Parsek/TestCommands/TestCommandJournal.cs
+++ b/Source/Parsek/TestCommands/TestCommandJournal.cs
@@ -1,0 +1,253 @@
+using System.Collections.Generic;
+using System.Globalization;
+
+namespace Parsek.TestCommands
+{
+    /// <summary>
+    /// The lifecycle phase recorded for a command id in the write-ahead journal.
+    /// Ordered so <see cref="TestCommandJournal.ReplayIntoPhaseMap"/> can keep the
+    /// highest phase seen per id: None &lt; Claimed &lt; Executed &lt; Done.
+    /// </summary>
+    internal enum JournalPhase
+    {
+        None = 0,
+        Claimed = 1,
+        Executed = 2,
+        Done = 3,
+    }
+
+    /// <summary>The recovery action for a command id given its replayed phase.</summary>
+    internal enum RecoveryAction
+    {
+        /// <summary>No journal entry: run the side effect normally.</summary>
+        Execute,
+
+        /// <summary>At CLAIMED (crashed mid-execution): do NOT re-execute; write an
+        /// INTERRUPTED terminal response and mark DONE.</summary>
+        Interrupted,
+
+        /// <summary>At EXECUTED (side effect ran, response maybe not written): skip
+        /// execution, (re)write the response, mark DONE.</summary>
+        RewriteResponse,
+
+        /// <summary>At DONE: fully handled; skip entirely.</summary>
+        Skip,
+    }
+
+    /// <summary>Pure result of parsing one journal line.</summary>
+    internal struct JournalLine
+    {
+        public bool Ok;
+        public string Id;
+        public JournalPhase Phase;
+        public long Seq;
+        public string Verb;
+        public string Session;
+        public string Verdict;
+        public double T;
+    }
+
+    /// <summary>
+    /// Pure write-ahead-log (WAL) grammar and replay for the ParsekTestCommands
+    /// seam (M-A2). The journal is the durable at-most-once mechanism: execution
+    /// happens ONLY on the transition from "no entry" to CLAIMED -> EXECUTED. Replay
+    /// folds the append-only journal into a per-id highest-phase map, tolerating a
+    /// torn (non-newline-terminated) trailing line, and <see cref="DecideRecovery"/>
+    /// maps a phase to the crash-recovery action.
+    /// </summary>
+    internal static class TestCommandJournal
+    {
+        // ----- Formatters (bare lines; the append path adds the newline) -----
+
+        internal static string FormatClaimed(string id, long seq, string verb, string session, double t)
+        {
+            return "id=" + id
+                + " phase=CLAIMED"
+                + " seq=" + seq.ToString(CultureInfo.InvariantCulture)
+                + " verb=" + verb
+                + " session=" + session
+                + " t=" + t.ToString("R", CultureInfo.InvariantCulture);
+        }
+
+        internal static string FormatExecuted(string id, long seq, double t)
+        {
+            return "id=" + id
+                + " phase=EXECUTED"
+                + " seq=" + seq.ToString(CultureInfo.InvariantCulture)
+                + " t=" + t.ToString("R", CultureInfo.InvariantCulture);
+        }
+
+        internal static string FormatDone(string id, long seq, string verdict, double t)
+        {
+            return "id=" + id
+                + " phase=DONE"
+                + " seq=" + seq.ToString(CultureInfo.InvariantCulture)
+                + " verdict=" + verdict
+                + " t=" + t.ToString("R", CultureInfo.InvariantCulture);
+        }
+
+        // ----- Parse -----
+
+        /// <summary>
+        /// Parses one whole journal line into a <see cref="JournalLine"/>. Requires a
+        /// parseable <c>id</c> and a known <c>phase</c>; other fields are optional.
+        /// Returns false (Ok=false) for a line missing id/phase or with an unknown
+        /// phase token.
+        /// </summary>
+        internal static bool TryParseLine(string line, out JournalLine parsed)
+        {
+            parsed = new JournalLine { Phase = JournalPhase.None };
+            if (string.IsNullOrEmpty(line)) return false;
+
+            string[] tokens = line.Split(new[] { ' ', '\t' }, System.StringSplitOptions.RemoveEmptyEntries);
+            bool sawId = false;
+            bool sawPhase = false;
+
+            foreach (string token in tokens)
+            {
+                if (!TestCommandProtocol.TrySplitToken(token, out string key, out string value))
+                    continue; // tolerate stray tokens
+
+                switch (key)
+                {
+                    case "id":
+                        parsed.Id = value;
+                        sawId = true;
+                        break;
+                    case "phase":
+                        if (!TryParsePhase(value, out JournalPhase phase))
+                            return false;
+                        parsed.Phase = phase;
+                        sawPhase = true;
+                        break;
+                    case "seq":
+                        if (long.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out long seq))
+                            parsed.Seq = seq;
+                        break;
+                    case "verb":
+                        parsed.Verb = value;
+                        break;
+                    case "session":
+                        parsed.Session = value;
+                        break;
+                    case "verdict":
+                        parsed.Verdict = value;
+                        break;
+                    case "t":
+                        if (double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out double t))
+                            parsed.T = t;
+                        break;
+                }
+            }
+
+            if (!sawId || !sawPhase) return false;
+            parsed.Ok = true;
+            return true;
+        }
+
+        // ----- Replay -----
+
+        /// <summary>
+        /// Replays a whole journal file's contents into a per-id highest-phase map. A
+        /// torn trailing line (the file does not end in <c>\n</c>) is ignored: it was
+        /// never durably committed. Only whole, newline-terminated lines drive the map.
+        /// </summary>
+        internal static Dictionary<string, JournalPhase> ReplayIntoPhaseMap(string fileContent)
+        {
+            return ReplayIntoPhaseMap(SplitCompleteLines(fileContent));
+        }
+
+        /// <summary>
+        /// Replays already-extracted whole journal lines into a per-id highest-phase
+        /// map (max phase per id; duplicate lines from crash-recovery rewrites keep
+        /// the highest).
+        /// </summary>
+        internal static Dictionary<string, JournalPhase> ReplayIntoPhaseMap(IEnumerable<string> lines)
+        {
+            var map = new Dictionary<string, JournalPhase>();
+            if (lines == null) return map;
+
+            foreach (string line in lines)
+            {
+                if (!TryParseLine(line, out JournalLine jl)) continue;
+                if (map.TryGetValue(jl.Id, out JournalPhase existing))
+                {
+                    if (jl.Phase > existing)
+                        map[jl.Id] = jl.Phase;
+                }
+                else
+                {
+                    map[jl.Id] = jl.Phase;
+                }
+            }
+            return map;
+        }
+
+        /// <summary>
+        /// Extracts whole, newline-terminated lines from raw file content. A final
+        /// segment without a trailing <c>\n</c> is a torn line and is dropped. <c>\r</c>
+        /// before a <c>\n</c> is stripped so CRLF content parses the same as LF.
+        /// </summary>
+        internal static List<string> SplitCompleteLines(string content)
+        {
+            var lines = new List<string>();
+            if (string.IsNullOrEmpty(content)) return lines;
+
+            int start = 0;
+            for (int i = 0; i < content.Length; i++)
+            {
+                if (content[i] == '\n')
+                {
+                    int end = i;
+                    if (end > start && content[end - 1] == '\r')
+                        end--;
+                    lines.Add(content.Substring(start, end - start));
+                    start = i + 1;
+                }
+            }
+            // Any content after the last '\n' is a torn trailing line: ignore it.
+            return lines;
+        }
+
+        // ----- Recovery decision -----
+
+        /// <summary>
+        /// Maps a replayed phase to the crash-recovery action. The <paramref name="id"/>
+        /// is carried for logging/correlation only; the decision is phase-driven.
+        /// </summary>
+        internal static RecoveryAction DecideRecovery(string id, JournalPhase phase)
+        {
+            switch (phase)
+            {
+                case JournalPhase.Claimed:
+                    return RecoveryAction.Interrupted;
+                case JournalPhase.Executed:
+                    return RecoveryAction.RewriteResponse;
+                case JournalPhase.Done:
+                    return RecoveryAction.Skip;
+                default:
+                    return RecoveryAction.Execute;
+            }
+        }
+
+        /// <summary>Convenience: recovery action for an id looked up in a replayed map.</summary>
+        internal static RecoveryAction DecideRecovery(Dictionary<string, JournalPhase> phaseMap, string id)
+        {
+            JournalPhase phase = JournalPhase.None;
+            if (phaseMap != null && id != null)
+                phaseMap.TryGetValue(id, out phase);
+            return DecideRecovery(id, phase);
+        }
+
+        private static bool TryParsePhase(string value, out JournalPhase phase)
+        {
+            switch (value)
+            {
+                case "CLAIMED": phase = JournalPhase.Claimed; return true;
+                case "EXECUTED": phase = JournalPhase.Executed; return true;
+                case "DONE": phase = JournalPhase.Done; return true;
+                default: phase = JournalPhase.None; return false;
+            }
+        }
+    }
+}

--- a/Source/Parsek/TestCommands/TestCommandJournal.cs
+++ b/Source/Parsek/TestCommands/TestCommandJournal.cs
@@ -45,6 +45,14 @@ namespace Parsek.TestCommands
         public string Session;
         public string Verdict;
         public double T;
+
+        /// <summary>Decoded free-text message (EXECUTED lines, for true response rewrite);
+        /// null when the line carried no <c>msg=</c> token or it was empty.</summary>
+        public string Msg;
+
+        /// <summary>Decoded verb-specific payload pairs (EXECUTED lines, for true response
+        /// rewrite); null when the line carried no <c>payload=</c> token.</summary>
+        public List<KeyValuePair<string, string>> Payload;
     }
 
     /// <summary>
@@ -69,12 +77,57 @@ namespace Parsek.TestCommands
                 + " t=" + t.ToString("R", CultureInfo.InvariantCulture);
         }
 
-        internal static string FormatExecuted(string id, long seq, double t)
+        /// <summary>
+        /// The EXECUTED write-ahead line. It now carries the terminal
+        /// <paramref name="verdict"/> plus the percent-encoded <paramref name="payload"/> and
+        /// <paramref name="msg"/> so a crash-recovery replay at EXECUTED can re-emit the
+        /// ORIGINAL response line (true RewriteResponse) instead of a synthetic INTERRUPTED
+        /// ack. The <c>payload</c> token is the whole space-joined <c>key=encodedValue</c>
+        /// list percent-encoded once more so it survives as a single wire token.
+        /// </summary>
+        internal static string FormatExecuted(
+            string id, long seq, double t, string verdict,
+            List<KeyValuePair<string, string>> payload, string msg)
         {
             return "id=" + id
                 + " phase=EXECUTED"
                 + " seq=" + seq.ToString(CultureInfo.InvariantCulture)
-                + " t=" + t.ToString("R", CultureInfo.InvariantCulture);
+                + " t=" + t.ToString("R", CultureInfo.InvariantCulture)
+                + " verdict=" + TestCommandProtocol.Encode(verdict ?? string.Empty)
+                + " payload=" + TestCommandProtocol.Encode(SerializePayload(payload))
+                + " msg=" + TestCommandProtocol.Encode(msg ?? string.Empty);
+        }
+
+        // Serializes a payload list into one string of space-joined key=encodedValue pairs.
+        // Keys are literal identifiers (safe); values are percent-encoded. The whole result
+        // is percent-encoded again by the caller so it rides as a single journal token.
+        private static string SerializePayload(List<KeyValuePair<string, string>> payload)
+        {
+            if (payload == null || payload.Count == 0) return string.Empty;
+            var sb = new System.Text.StringBuilder();
+            for (int i = 0; i < payload.Count; i++)
+            {
+                if (i > 0) sb.Append(' ');
+                sb.Append(payload[i].Key).Append('=')
+                    .Append(TestCommandProtocol.Encode(payload[i].Value ?? string.Empty));
+            }
+            return sb.ToString();
+        }
+
+        // Inverse of SerializePayload: splits the (already once-decoded) payload string into
+        // key=value pairs, decoding each value. A malformed pair is skipped defensively.
+        private static List<KeyValuePair<string, string>> DeserializePayload(string s)
+        {
+            var list = new List<KeyValuePair<string, string>>();
+            if (string.IsNullOrEmpty(s)) return list;
+            string[] tokens = s.Split(new[] { ' ' }, System.StringSplitOptions.RemoveEmptyEntries);
+            foreach (string tok in tokens)
+            {
+                if (TestCommandProtocol.TrySplitToken(tok, out string key, out string rawVal)
+                    && TestCommandProtocol.TryDecode(rawVal, out string val))
+                    list.Add(new KeyValuePair<string, string>(key, val));
+            }
+            return list;
         }
 
         internal static string FormatDone(string id, long seq, string verdict, double t)
@@ -131,7 +184,18 @@ namespace Parsek.TestCommands
                         parsed.Session = value;
                         break;
                     case "verdict":
-                        parsed.Verdict = value;
+                        // Encoded on EXECUTED lines, raw on DONE lines; decode is identity for
+                        // the raw (encoding-safe verdict) case.
+                        if (TestCommandProtocol.TryDecode(value, out string verdictDec))
+                            parsed.Verdict = verdictDec;
+                        break;
+                    case "payload":
+                        if (TestCommandProtocol.TryDecode(value, out string payloadDec))
+                            parsed.Payload = DeserializePayload(payloadDec);
+                        break;
+                    case "msg":
+                        if (TestCommandProtocol.TryDecode(value, out string msgDec))
+                            parsed.Msg = msgDec;
                         break;
                     case "t":
                         if (double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out double t))
@@ -253,6 +317,38 @@ namespace Parsek.TestCommands
             if (!TryParsePhase(phaseToken, out JournalPhase phase)) return;
             if (!map.TryGetValue(id, out JournalPhase existing) || phase > existing)
                 map[id] = phase;
+        }
+
+        /// <summary>
+        /// Recovers the ORIGINAL terminal response fields (verdict / payload / msg) stored on
+        /// the last whole EXECUTED line for <paramref name="id"/>, so a RewriteResponse
+        /// recovery re-emits the same response the pre-crash run would have (byte-equivalent in
+        /// verdict / payload / msg; only <c>seq</c> and <c>ut</c> legitimately differ). Returns
+        /// false when no EXECUTED line carries the enriched fields (a torn / pre-enrichment
+        /// line), so the caller can fall back. <paramref name="msg"/> is normalized empty -&gt;
+        /// null to match a null-msg original response exactly.
+        /// </summary>
+        internal static bool TryGetExecutedResponse(
+            IEnumerable<string> lines, string id,
+            out string verdict, out List<KeyValuePair<string, string>> payload, out string msg)
+        {
+            verdict = null;
+            payload = null;
+            msg = null;
+            if (lines == null || id == null) return false;
+
+            bool found = false;
+            foreach (string line in lines)
+            {
+                if (!TryParseLine(line, out JournalLine jl)) continue;
+                if (jl.Phase != JournalPhase.Executed || jl.Id != id) continue;
+                if (jl.Verdict == null) continue; // pre-enrichment EXECUTED line: no stored verdict
+                verdict = jl.Verdict;
+                payload = jl.Payload;
+                msg = string.IsNullOrEmpty(jl.Msg) ? null : jl.Msg;
+                found = true; // last EXECUTED line for the id wins
+            }
+            return found;
         }
 
         private static bool TryParsePhase(string value, out JournalPhase phase)

--- a/Source/Parsek/TestCommands/TestCommandJournal.cs
+++ b/Source/Parsek/TestCommands/TestCommandJournal.cs
@@ -239,6 +239,22 @@ namespace Parsek.TestCommands
             return DecideRecovery(id, phase);
         }
 
+        /// <summary>
+        /// Raises the replayed phase for <paramref name="id"/> in <paramref name="map"/> to the
+        /// phase named by <paramref name="phaseToken"/> (<c>CLAIMED</c> / <c>EXECUTED</c> /
+        /// <c>DONE</c>), keeping the highest phase seen. The addon mirrors every durable journal
+        /// write here so a same-process re-dispatch of an already-claimed id can never read
+        /// <see cref="JournalPhase.None"/> from the map (defense-in-depth at-most-once): an
+        /// unknown token or a lower phase is a no-op.
+        /// </summary>
+        internal static void MirrorPhaseIntoMap(Dictionary<string, JournalPhase> map, string id, string phaseToken)
+        {
+            if (map == null || string.IsNullOrEmpty(id)) return;
+            if (!TryParsePhase(phaseToken, out JournalPhase phase)) return;
+            if (!map.TryGetValue(id, out JournalPhase existing) || phase > existing)
+                map[id] = phase;
+        }
+
         private static bool TryParsePhase(string value, out JournalPhase phase)
         {
             switch (value)

--- a/Source/Parsek/TestCommands/TestCommandLoadGame.cs
+++ b/Source/Parsek/TestCommands/TestCommandLoadGame.cs
@@ -1,0 +1,38 @@
+using System.Collections.Generic;
+
+namespace Parsek.TestCommands
+{
+    /// <summary>
+    /// Pure decision + payload helpers for the two-phase <c>LoadGame</c> boot verb
+    /// (P5.7). The Unity side realises the <c>.sfs</c> into a KSP <c>Game</c> via
+    /// <c>GamePersistence.LoadGame</c> and hands the primitive shape of that result here:
+    /// a null / incompatible game or an out-of-range active-vessel index cannot be
+    /// focused, so the verb fails with <c>load-failed</c> rather than sending
+    /// <c>FlightDriver.StartAndFocusVessel</c> a bad index (design edge case 27). Kept
+    /// pure so the focusability decision + completion payload are xUnit-covered without
+    /// a live KSP <c>Game</c>.
+    /// </summary>
+    internal static class TestCommandLoadGame
+    {
+        /// <summary>
+        /// True when the loaded game can be focused: it exists, has a flight state with
+        /// a proto-vessel list, and its active-vessel index is in range.
+        /// </summary>
+        internal static bool IsLoadedGameFocusable(
+            bool gamePresent, bool flightStatePresent, bool protoVesselsPresent,
+            int activeVesselIdx, int protoVesselCount)
+        {
+            if (!gamePresent || !flightStatePresent || !protoVesselsPresent)
+                return false;
+            return activeVesselIdx >= 0 && activeVesselIdx < protoVesselCount;
+        }
+
+        /// <summary>Terminal completion payload once the new scene settles with a game loaded.</summary>
+        internal static List<KeyValuePair<string, string>> BuildCompletePayload(string sceneName, string save)
+            => new List<KeyValuePair<string, string>>
+            {
+                new KeyValuePair<string, string>("scene", sceneName ?? string.Empty),
+                new KeyValuePair<string, string>("save", save ?? string.Empty),
+            };
+    }
+}

--- a/Source/Parsek/TestCommands/TestCommandLoadGame.cs
+++ b/Source/Parsek/TestCommands/TestCommandLoadGame.cs
@@ -15,14 +15,17 @@ namespace Parsek.TestCommands
     internal static class TestCommandLoadGame
     {
         /// <summary>
-        /// True when the loaded game can be focused: it exists, has a flight state with
-        /// a proto-vessel list, and its active-vessel index is in range.
+        /// True when the loaded game can be focused: it exists, is version-COMPATIBLE
+        /// (<c>Game.compatible</c>, the gate v0.5.4 <c>TestingTools.LoadSave</c> applied), has
+        /// a flight state with a proto-vessel list, and its active-vessel index is in range.
+        /// An incompatible game (a save from a mismatched KSP / mod version) must fail with
+        /// <c>load-failed</c> rather than being flown into a broken scene.
         /// </summary>
         internal static bool IsLoadedGameFocusable(
-            bool gamePresent, bool flightStatePresent, bool protoVesselsPresent,
+            bool gamePresent, bool compatible, bool flightStatePresent, bool protoVesselsPresent,
             int activeVesselIdx, int protoVesselCount)
         {
-            if (!gamePresent || !flightStatePresent || !protoVesselsPresent)
+            if (!gamePresent || !compatible || !flightStatePresent || !protoVesselsPresent)
                 return false;
             return activeVesselIdx >= 0 && activeVesselIdx < protoVesselCount;
         }

--- a/Source/Parsek/TestCommands/TestCommandMissionMark.cs
+++ b/Source/Parsek/TestCommands/TestCommandMissionMark.cs
@@ -1,0 +1,29 @@
+using System.Globalization;
+
+namespace Parsek.TestCommands
+{
+    /// <summary>
+    /// Pure formatter + emit for the <c>MissionMark</c> verb (P5.3). Emits a stable,
+    /// grep-able <c>[Parsek][INFO][TestCommands] MISSIONMARK label=&lt;label&gt;
+    /// ut=&lt;ut&gt;</c> log line that the external orchestrator correlates against its
+    /// own timeline (an H3-style checkpoint marker). The message shape is a load-bearing
+    /// contract: if it drifts, the orchestration correlation breaks, so the format is
+    /// pinned by a log-assertion test. <c>ut</c> renders <c>none</c> when no game is
+    /// loaded (MissionMark is valid in any scene, including the menus).
+    /// </summary>
+    internal static class TestCommandMissionMark
+    {
+        internal const string Tag = "TestCommands";
+
+        /// <summary>The stable message body (without the <c>[Parsek][LEVEL][Sub]</c> prefix).</summary>
+        internal static string FormatMarkMessage(string label, double? ut)
+        {
+            string utText = ut.HasValue ? ut.Value.ToString("R", CultureInfo.InvariantCulture) : "none";
+            return "MISSIONMARK label=" + (label ?? string.Empty) + " ut=" + utText;
+        }
+
+        /// <summary>Emits the stable MISSIONMARK line at Info level.</summary>
+        internal static void EmitMark(string label, double? ut)
+            => ParsekLog.Info(Tag, FormatMarkMessage(label, ut));
+    }
+}

--- a/Source/Parsek/TestCommands/TestCommandProtocol.cs
+++ b/Source/Parsek/TestCommands/TestCommandProtocol.cs
@@ -12,19 +12,21 @@ namespace Parsek.TestCommands
     /// type is exercised entirely by xUnit without a live Unity runtime.
     ///
     /// <para>Value encoding: a value that contains whitespace, <c>=</c>, <c>%</c>,
-    /// or a control character is percent-encoded (<c>%20</c> for space, <c>%25</c>
-    /// for <c>%</c>, <c>%3D</c> for <c>=</c>). Encoding is byte-oriented over the
-    /// UTF-8 form of the string, so a multibyte character that needs escaping
-    /// round-trips exactly. Numeric values use <see cref="CultureInfo.InvariantCulture"/>.</para>
+    /// a control character, or ANY non-ASCII byte (&gt;= 0x7F) is percent-encoded
+    /// (<c>%20</c> for space, <c>%25</c> for <c>%</c>, <c>%3D</c> for <c>=</c>).
+    /// Encoding is byte-oriented over the UTF-8 form of the string, so every non-ASCII
+    /// character is escaped and the encoded token is pure ASCII that round-trips
+    /// exactly. Numeric values use <see cref="CultureInfo.InvariantCulture"/>.</para>
     /// </summary>
     internal static class TestCommandProtocol
     {
         /// <summary>
         /// Percent-encodes <paramref name="value"/> for a single wire token.
-        /// Encodes <c>%</c>, <c>=</c>, ASCII space, control chars (&lt;= 0x20 and
-        /// 0x7F), and any other non-printable byte; all other bytes pass through
-        /// literally. Byte-oriented over the UTF-8 form so it round-trips with
-        /// <see cref="TryDecode"/>.
+        /// Encodes <c>%</c>, <c>=</c>, ASCII space and control chars (&lt;= 0x20),
+        /// and every byte &gt;= 0x7F (DEL plus all UTF-8 multibyte lead/continuation
+        /// bytes); only printable ASCII (0x21..0x7E, minus <c>%</c>/<c>=</c>) passes
+        /// through literally. Byte-oriented over the UTF-8 form so the encoded token is
+        /// pure ASCII and round-trips with <see cref="TryDecode"/>.
         /// </summary>
         internal static string Encode(string value)
         {
@@ -114,9 +116,12 @@ namespace Parsek.TestCommands
         private static bool NeedsEncoding(byte b)
         {
             // '%' (0x25) and '=' (0x3D) are the reserved delimiters; anything
-            // <= space (0x20, includes tab/newline/CR) or DEL (0x7F) is a control
-            // or whitespace byte that must not appear raw in a token.
-            return b == (byte)'%' || b == (byte)'=' || b <= 0x20 || b == 0x7F;
+            // <= space (0x20, includes tab/newline/CR) is a control or whitespace
+            // byte; and every byte >= DEL (0x7F) is either DEL or a UTF-8 multibyte
+            // lead/continuation byte. Encoding ALL of the latter keeps every wire
+            // token pure ASCII, so a non-ASCII value (a body name like "Mun" with a
+            // u-umlaut, CJK text) never rides raw and round-trips byte-for-byte.
+            return b == (byte)'%' || b == (byte)'=' || b <= 0x20 || b >= 0x7F;
         }
     }
 

--- a/Source/Parsek/TestCommands/TestCommandProtocol.cs
+++ b/Source/Parsek/TestCommands/TestCommandProtocol.cs
@@ -1,0 +1,154 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+
+namespace Parsek.TestCommands
+{
+    /// <summary>
+    /// Pure wire-protocol primitives for the ParsekTestCommands seam (M-A2):
+    /// the percent codec, the <see cref="ParsedCommand"/> result struct, and the
+    /// <c>key=value</c> token splitter. No UnityEngine / KSP API usage — this
+    /// type is exercised entirely by xUnit without a live Unity runtime.
+    ///
+    /// <para>Value encoding: a value that contains whitespace, <c>=</c>, <c>%</c>,
+    /// or a control character is percent-encoded (<c>%20</c> for space, <c>%25</c>
+    /// for <c>%</c>, <c>%3D</c> for <c>=</c>). Encoding is byte-oriented over the
+    /// UTF-8 form of the string, so a multibyte character that needs escaping
+    /// round-trips exactly. Numeric values use <see cref="CultureInfo.InvariantCulture"/>.</para>
+    /// </summary>
+    internal static class TestCommandProtocol
+    {
+        /// <summary>
+        /// Percent-encodes <paramref name="value"/> for a single wire token.
+        /// Encodes <c>%</c>, <c>=</c>, ASCII space, control chars (&lt;= 0x20 and
+        /// 0x7F), and any other non-printable byte; all other bytes pass through
+        /// literally. Byte-oriented over the UTF-8 form so it round-trips with
+        /// <see cref="TryDecode"/>.
+        /// </summary>
+        internal static string Encode(string value)
+        {
+            if (value == null) return string.Empty;
+            byte[] bytes = Encoding.UTF8.GetBytes(value);
+            var sb = new StringBuilder(bytes.Length);
+            foreach (byte b in bytes)
+            {
+                if (NeedsEncoding(b))
+                {
+                    sb.Append('%');
+                    sb.Append(b.ToString("X2", CultureInfo.InvariantCulture));
+                }
+                else
+                {
+                    sb.Append((char)b);
+                }
+            }
+            return sb.ToString();
+        }
+
+        /// <summary>
+        /// Percent-decodes <paramref name="encoded"/>. Returns false on a malformed
+        /// escape (a <c>%</c> not followed by exactly two hex digits). On success
+        /// <paramref name="decoded"/> is the literal value.
+        /// </summary>
+        internal static bool TryDecode(string encoded, out string decoded)
+        {
+            decoded = null;
+            if (encoded == null)
+            {
+                decoded = string.Empty;
+                return true;
+            }
+
+            var bytes = new List<byte>(encoded.Length);
+            int i = 0;
+            while (i < encoded.Length)
+            {
+                char c = encoded[i];
+                if (c == '%')
+                {
+                    if (i + 2 >= encoded.Length)
+                        return false;
+                    string hex = encoded.Substring(i + 1, 2);
+                    if (!byte.TryParse(hex, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out byte b))
+                        return false;
+                    bytes.Add(b);
+                    i += 3;
+                }
+                else if (c < 128)
+                {
+                    bytes.Add((byte)c);
+                    i++;
+                }
+                else
+                {
+                    // A raw multibyte char (should not appear in well-formed encoded
+                    // input, but decode defensively rather than corrupting it).
+                    byte[] enc = Encoding.UTF8.GetBytes(c.ToString());
+                    bytes.AddRange(enc);
+                    i++;
+                }
+            }
+
+            decoded = Encoding.UTF8.GetString(bytes.ToArray());
+            return true;
+        }
+
+        /// <summary>
+        /// Splits a single <c>key=value</c> token at the FIRST <c>=</c>. The value
+        /// portion is returned still percent-encoded (the caller decodes it).
+        /// Returns false for a bare token with no <c>=</c> or an empty key.
+        /// </summary>
+        internal static bool TrySplitToken(string token, out string key, out string rawValue)
+        {
+            key = null;
+            rawValue = null;
+            if (string.IsNullOrEmpty(token)) return false;
+            int idx = token.IndexOf('=');
+            if (idx <= 0) return false; // no '=' or empty key
+            key = token.Substring(0, idx);
+            rawValue = token.Substring(idx + 1);
+            return true;
+        }
+
+        private static bool NeedsEncoding(byte b)
+        {
+            // '%' (0x25) and '=' (0x3D) are the reserved delimiters; anything
+            // <= space (0x20, includes tab/newline/CR) or DEL (0x7F) is a control
+            // or whitespace byte that must not appear raw in a token.
+            return b == (byte)'%' || b == (byte)'=' || b <= 0x20 || b == 0x7F;
+        }
+    }
+
+    /// <summary>
+    /// Pure result of parsing one command line (<see cref="TestCommandParser.ParseLine"/>).
+    /// </summary>
+    internal struct ParsedCommand
+    {
+        /// <summary>The raw line content (newline stripped).</summary>
+        public string RawLine;
+
+        /// <summary>1-based position of the line in the command file.</summary>
+        public int LineNumber;
+
+        /// <summary>Decoded <c>id</c> token value; null if the id token was absent.</summary>
+        public string Id;
+
+        /// <summary>Decoded <c>cmd</c> token value; null if the cmd token was absent.</summary>
+        public string Verb;
+
+        /// <summary>Decoded verb-specific args (excludes id/cmd).</summary>
+        public Dictionary<string, string> Args;
+
+        /// <summary>True when the line parsed into a well-formed command envelope.</summary>
+        public bool ParseOk;
+
+        /// <summary>Reason string when <see cref="ParseOk"/> is false
+        /// (<c>malformed</c> / <c>missing-id</c> / <c>missing-cmd</c>).</summary>
+        public string ParseError;
+
+        /// <summary>True for a blank line or a <c>#</c> comment: skip silently, no
+        /// response is written. Distinct from a malformed line, which is REJECTED.</summary>
+        public bool Ignored;
+    }
+}

--- a/Source/Parsek/TestCommands/TestCommandProtocol.cs
+++ b/Source/Parsek/TestCommands/TestCommandProtocol.cs
@@ -223,6 +223,55 @@ namespace Parsek.TestCommands
     }
 
     /// <summary>
+    /// Pure formatter for a terminal response line appended by the addon. Field
+    /// order is fixed and grep-stable: <c>id cmd verdict seq</c>, then <c>ut</c>
+    /// (only when a game is loaded), then verb-specific payload keys, then an
+    /// optional <c>msg</c>. Values are percent-encoded and numbers use
+    /// <see cref="CultureInfo.InvariantCulture"/>, matching the command grammar so
+    /// one reader handles both. The returned line carries NO trailing newline;
+    /// the append path adds it.
+    /// </summary>
+    internal static class TestCommandResponse
+    {
+        internal static string FormatResponseLine(
+            string id,
+            string cmd,
+            string verdict,
+            long seq,
+            double? ut,
+            IEnumerable<KeyValuePair<string, string>> payload,
+            string msg)
+        {
+            var sb = new StringBuilder();
+            sb.Append("id=").Append(TestCommandProtocol.Encode(id));
+            sb.Append(" cmd=").Append(TestCommandProtocol.Encode(cmd));
+            sb.Append(" verdict=").Append(TestCommandProtocol.Encode(verdict));
+            sb.Append(" seq=").Append(seq.ToString(CultureInfo.InvariantCulture));
+
+            if (ut.HasValue)
+            {
+                sb.Append(" ut=").Append(ut.Value.ToString("R", CultureInfo.InvariantCulture));
+            }
+
+            if (payload != null)
+            {
+                foreach (KeyValuePair<string, string> kv in payload)
+                {
+                    // Keys are literal identifiers; values are percent-encoded.
+                    sb.Append(' ').Append(kv.Key).Append('=').Append(TestCommandProtocol.Encode(kv.Value));
+                }
+            }
+
+            if (msg != null)
+            {
+                sb.Append(" msg=").Append(TestCommandProtocol.Encode(msg));
+            }
+
+            return sb.ToString();
+        }
+    }
+
+    /// <summary>
     /// Pure result of parsing one command line (<see cref="TestCommandParser.ParseLine"/>).
     /// </summary>
     internal struct ParsedCommand

--- a/Source/Parsek/TestCommands/TestCommandProtocol.cs
+++ b/Source/Parsek/TestCommands/TestCommandProtocol.cs
@@ -144,6 +144,11 @@ namespace Parsek.TestCommands
         internal static ParsedCommand ParseLine(string rawLine, int lineNumber)
         {
             string content = StripTrailingNewline(rawLine ?? string.Empty);
+            // N3: a UTF-8 BOM (U+FEFF) can lead the first line of a command file written by an
+            // editor / some tooling; strip it before tokenizing so the first command's id
+            // token is not prefixed with the BOM (which would otherwise fail the id check).
+            if (content.Length > 0 && content[0] == '\uFEFF')
+                content = content.Substring(1);
             var result = new ParsedCommand
             {
                 RawLine = content,

--- a/Source/Parsek/TestCommands/TestCommandProtocol.cs
+++ b/Source/Parsek/TestCommands/TestCommandProtocol.cs
@@ -121,6 +121,108 @@ namespace Parsek.TestCommands
     }
 
     /// <summary>
+    /// Pure command-line envelope parser. Splits one command line into an
+    /// <see cref="ParsedCommand"/>: <c>id</c> must be the first token and
+    /// <c>cmd</c> the second; remaining <c>key=value</c> args come in any order.
+    /// Blank lines and <c>#</c> comments are flagged <see cref="ParsedCommand.Ignored"/>
+    /// (skipped, no response); everything else that fails the envelope is a
+    /// malformed / missing-id / missing-cmd reject.
+    /// </summary>
+    internal static class TestCommandParser
+    {
+        /// <summary>
+        /// Parses one command line. <paramref name="rawLine"/> may include a
+        /// trailing newline (stripped here); <paramref name="lineNumber"/> is the
+        /// 1-based file position, used for the <c>line#&lt;n&gt;</c> fallback id
+        /// when a malformed line has no usable <c>id</c> token.
+        /// </summary>
+        internal static ParsedCommand ParseLine(string rawLine, int lineNumber)
+        {
+            string content = StripTrailingNewline(rawLine ?? string.Empty);
+            var result = new ParsedCommand
+            {
+                RawLine = content,
+                LineNumber = lineNumber,
+                Args = new Dictionary<string, string>(),
+                ParseOk = false,
+            };
+
+            string trimmed = content.Trim();
+            if (trimmed.Length == 0)
+            {
+                result.Ignored = true;
+                return result;
+            }
+            if (trimmed[0] == '#')
+            {
+                result.Ignored = true;
+                return result;
+            }
+
+            string[] tokens = content.Split(new[] { ' ', '\t' }, StringSplitOptions.RemoveEmptyEntries);
+
+            var pairs = new List<KeyValuePair<string, string>>(tokens.Length);
+            bool malformed = false;
+            foreach (string token in tokens)
+            {
+                if (!TestCommandProtocol.TrySplitToken(token, out string key, out string rawValue)
+                    || !TestCommandProtocol.TryDecode(rawValue, out string value))
+                {
+                    malformed = true;
+                    break;
+                }
+                pairs.Add(new KeyValuePair<string, string>(key, value));
+                // Salvage the id early so a malformed line still correlates by its
+                // real id when the first token was a valid id=... token.
+                if (pairs.Count == 1 && key == "id")
+                    result.Id = value;
+            }
+
+            if (malformed)
+            {
+                result.ParseError = "malformed";
+                return result;
+            }
+
+            if (pairs.Count == 0 || pairs[0].Key != "id")
+            {
+                result.ParseError = "missing-id";
+                return result;
+            }
+            result.Id = pairs[0].Value;
+
+            if (pairs.Count < 2 || pairs[1].Key != "cmd")
+            {
+                result.ParseError = "missing-cmd";
+                return result;
+            }
+            result.Verb = pairs[1].Value;
+
+            for (int i = 2; i < pairs.Count; i++)
+                result.Args[pairs[i].Key] = pairs[i].Value; // unknown keys kept; last wins
+
+            result.ParseOk = true;
+            return result;
+        }
+
+        /// <summary>
+        /// The correlation id used in a response when a malformed line carries no
+        /// usable <c>id</c> token: <c>line#&lt;n&gt;</c> for the 1-based line number.
+        /// </summary>
+        internal static string FallbackId(int lineNumber)
+            => "line#" + lineNumber.ToString(CultureInfo.InvariantCulture);
+
+        private static string StripTrailingNewline(string s)
+        {
+            if (s.EndsWith("\r\n", StringComparison.Ordinal))
+                return s.Substring(0, s.Length - 2);
+            if (s.EndsWith("\n", StringComparison.Ordinal) || s.EndsWith("\r", StringComparison.Ordinal))
+                return s.Substring(0, s.Length - 1);
+            return s;
+        }
+    }
+
+    /// <summary>
     /// Pure result of parsing one command line (<see cref="TestCommandParser.ParseLine"/>).
     /// </summary>
     internal struct ParsedCommand

--- a/Source/Parsek/TestCommands/TestCommandProtocol.cs
+++ b/Source/Parsek/TestCommands/TestCommandProtocol.cs
@@ -191,12 +191,32 @@ namespace Parsek.TestCommands
             }
             result.Id = pairs[0].Value;
 
+            // The id is the journal dedup key AND is written raw into journal/response
+            // lines. Reject any id that is not encoding-stable (decodes to a value that
+            // would itself need percent-encoding): a decoded space would journal-tokenize
+            // to a shorter id (a re-execution-after-restart hole where "a b" != "a"), and a
+            // decoded newline (id=a%0Ab) would forge a journal line. Encode(id) == id iff
+            // the id is safe to embed verbatim.
+            if (TestCommandProtocol.Encode(result.Id) != result.Id)
+            {
+                result.ParseError = "malformed-id";
+                return result;
+            }
+
             if (pairs.Count < 2 || pairs[1].Key != "cmd")
             {
                 result.ParseError = "missing-cmd";
                 return result;
             }
             result.Verb = pairs[1].Value;
+
+            // The verb is written raw into the CLAIMED journal line; reject a
+            // non-encoding-stable verb for the same journal-forgery / tokenization reason.
+            if (TestCommandProtocol.Encode(result.Verb) != result.Verb)
+            {
+                result.ParseError = "malformed-verb";
+                return result;
+            }
 
             for (int i = 2; i < pairs.Count; i++)
                 result.Args[pairs[i].Key] = pairs[i].Value; // unknown keys kept; last wins

--- a/Source/Parsek/TestCommands/TestCommandRecordingState.cs
+++ b/Source/Parsek/TestCommands/TestCommandRecordingState.cs
@@ -1,0 +1,36 @@
+using System.Collections.Generic;
+using System.Globalization;
+
+namespace Parsek.TestCommands
+{
+    /// <summary>
+    /// Pure payload builder for the <c>RecordingState</c> verb (P5.2). The Unity side
+    /// samples <c>ParsekFlight.Instance?.CaptureRecorderState()</c> and feeds the
+    /// primitive fields here; with no live flight instance (any non-flight scene, or
+    /// flight not yet ready) the recorder is definitionally not recording, so the
+    /// snapshot collapses to <c>recording=false</c> with an empty tree and zero points.
+    /// Kept pure so the field names / null handling are xUnit-covered without Unity.
+    /// </summary>
+    internal static class TestCommandRecordingState
+    {
+        /// <summary>
+        /// Builds the <c>recording / tree / points / scene</c> payload. When
+        /// <paramref name="hasFlight"/> is false the recorder fields are forced to the
+        /// not-recording snapshot regardless of the other inputs.
+        /// </summary>
+        internal static List<KeyValuePair<string, string>> BuildPayload(
+            bool hasFlight, bool isRecording, string treeId, int points, string sceneName)
+        {
+            bool recording = hasFlight && isRecording;
+            string tree = hasFlight ? (treeId ?? string.Empty) : string.Empty;
+            int pointCount = hasFlight ? points : 0;
+            return new List<KeyValuePair<string, string>>
+            {
+                new KeyValuePair<string, string>("recording", recording ? "true" : "false"),
+                new KeyValuePair<string, string>("tree", tree),
+                new KeyValuePair<string, string>("points", pointCount.ToString(CultureInfo.InvariantCulture)),
+                new KeyValuePair<string, string>("scene", sceneName ?? string.Empty),
+            };
+        }
+    }
+}

--- a/Source/Parsek/TestCommands/TestCommandRecordingVerbs.cs
+++ b/Source/Parsek/TestCommands/TestCommandRecordingVerbs.cs
@@ -43,5 +43,24 @@ namespace Parsek.TestCommands
                 p.Add(new KeyValuePair<string, string>("idle", "true"));
             return p;
         }
+
+        /// <summary>CommitTree success payload (only reached with an active tree).</summary>
+        internal static List<KeyValuePair<string, string>> BuildCommitPayload()
+            => new List<KeyValuePair<string, string>>
+            {
+                new KeyValuePair<string, string>("committed", "true"),
+            };
+
+        /// <summary>
+        /// DiscardTree payload: <c>discarded=true</c> when an active tree was torn down;
+        /// <c>nothing=true</c> when there was no active tree (idempotent no-op).
+        /// </summary>
+        internal static List<KeyValuePair<string, string>> BuildDiscardPayload(bool hadTree)
+            => new List<KeyValuePair<string, string>>
+            {
+                hadTree
+                    ? new KeyValuePair<string, string>("discarded", "true")
+                    : new KeyValuePair<string, string>("nothing", "true"),
+            };
     }
 }

--- a/Source/Parsek/TestCommands/TestCommandRecordingVerbs.cs
+++ b/Source/Parsek/TestCommands/TestCommandRecordingVerbs.cs
@@ -1,0 +1,47 @@
+using System.Collections.Generic;
+
+namespace Parsek.TestCommands
+{
+    /// <summary>
+    /// Pure success-payload builders for the four recorder/tree verbs (P5.4 / P5.5).
+    /// The Unity side samples ParsekFlight state around the actual
+    /// <c>StartRecording</c> / <c>StopRecording</c> / <c>CommitTreeFlight</c> /
+    /// <c>AutoDiscardActiveTreeWithMessage</c> calls (which all return void) and feeds
+    /// the sampled booleans here. The no-op flags (<c>already</c> / <c>idle</c> /
+    /// <c>nothing</c>) are the idempotency signals the orchestrator reads, so their
+    /// presence rules are pinned by xUnit without Unity.
+    /// </summary>
+    internal static class TestCommandRecordingVerbs
+    {
+        /// <summary>
+        /// StartRecording payload: always <c>recordingId</c> (sampled after the call);
+        /// <c>already=true</c> only when a recorder was already live (no second recorder
+        /// was forced).
+        /// </summary>
+        internal static List<KeyValuePair<string, string>> BuildStartPayload(bool alreadyLive, string recordingId)
+        {
+            var p = new List<KeyValuePair<string, string>>
+            {
+                new KeyValuePair<string, string>("recordingId", recordingId ?? string.Empty),
+            };
+            if (alreadyLive)
+                p.Add(new KeyValuePair<string, string>("already", "true"));
+            return p;
+        }
+
+        /// <summary>
+        /// StopRecording payload: <c>stopped</c> reflects whether a live recorder was
+        /// stopped; <c>idle=true</c> only when there was no recorder (idempotent no-op).
+        /// </summary>
+        internal static List<KeyValuePair<string, string>> BuildStopPayload(bool wasLive)
+        {
+            var p = new List<KeyValuePair<string, string>>
+            {
+                new KeyValuePair<string, string>("stopped", wasLive ? "true" : "false"),
+            };
+            if (!wasLive)
+                p.Add(new KeyValuePair<string, string>("idle", "true"));
+            return p;
+        }
+    }
+}

--- a/Source/Parsek/TestCommands/TestCommandRunTests.cs
+++ b/Source/Parsek/TestCommands/TestCommandRunTests.cs
@@ -1,0 +1,27 @@
+using System.Collections.Generic;
+using System.Globalization;
+
+namespace Parsek.TestCommands
+{
+    /// <summary>
+    /// Pure result-payload builder for the two-phase <c>RunTests</c> verb (P5.6). When
+    /// the owned <c>InGameTestRunner</c> batch stops running, the addon reads its
+    /// Passed / Failed / Skipped counts and feeds them here; the exported results file
+    /// name is a fixed contract the orchestrator tails. Kept pure so the payload shape
+    /// is xUnit-covered without Unity.
+    /// </summary>
+    internal static class TestCommandRunTests
+    {
+        /// <summary>The fixed results file name (in the KSP root) the runner exports to.</summary>
+        internal const string ResultsFileName = "parsek-test-results.txt";
+
+        internal static List<KeyValuePair<string, string>> BuildResultPayload(int passed, int failed, int skipped)
+            => new List<KeyValuePair<string, string>>
+            {
+                new KeyValuePair<string, string>("passed", passed.ToString(CultureInfo.InvariantCulture)),
+                new KeyValuePair<string, string>("failed", failed.ToString(CultureInfo.InvariantCulture)),
+                new KeyValuePair<string, string>("skipped", skipped.ToString(CultureInfo.InvariantCulture)),
+                new KeyValuePair<string, string>("results", ResultsFileName),
+            };
+    }
+}

--- a/Source/Parsek/TestCommands/TestCommandSettingApplier.cs
+++ b/Source/Parsek/TestCommands/TestCommandSettingApplier.cs
@@ -1,0 +1,44 @@
+using System;
+
+namespace Parsek.TestCommands
+{
+    /// <summary>
+    /// Pure route dispatch for an accepted <c>SetSetting</c> (P5.1 / C3). The
+    /// <see cref="SettingWhitelist"/> already produced the typed value and the
+    /// <see cref="PersistenceRoute"/>; this applier decides which side effects the
+    /// thin Unity applier must run:
+    /// <list type="bullet">
+    /// <item><description>ALWAYS set the live <c>ParsekSettings.Current</c> field
+    /// (<paramref name="setLiveField"/>).</description></item>
+    /// <item><description>For a <see cref="PersistenceRoute.GameParametersPlusSidecar"/>
+    /// setting ALSO invoke the exact <c>ParsekSettingsPersistence.Record*</c> member
+    /// (<paramref name="invokeRecordMethod"/>), so the value survives the next
+    /// <c>ParsekScenario.OnLoad</c> <c>ApplyTo</c> (which OVERWRITES the GameParameters
+    /// value at every save load, including a <c>LoadGame</c>-driven load).</description></item>
+    /// </list>
+    /// The two side effects are passed as delegates so the routing decision is
+    /// exercised by xUnit with spies (asserting the route enum + that the Record*
+    /// path fires for the 8 tracked names and NOT for the 8 GameParameters-only
+    /// names) without a live Unity <c>ParsekSettings</c> (which derives from the
+    /// Assembly-CSharp <c>GameParameters.CustomParameterNode</c> and cannot be
+    /// constructed headless).
+    /// </summary>
+    internal static class TestCommandSettingApplier
+    {
+        /// <summary>
+        /// Applies an accepted whitelist decision. Precondition:
+        /// <c>result.Accepted == true</c> (the caller rejects before calling this).
+        /// Sets the live field unconditionally; invokes the Record* selector only for
+        /// a sidecar-tracked setting.
+        /// </summary>
+        internal static void ApplySetting(
+            SettingApplyResult result,
+            Action<SettingApplyResult> setLiveField,
+            Action<SettingApplyResult> invokeRecordMethod)
+        {
+            setLiveField(result);
+            if (result.Route == PersistenceRoute.GameParametersPlusSidecar)
+                invokeRecordMethod(result);
+        }
+    }
+}

--- a/Source/Parsek/TestCommands/TestCommandVerbs.cs
+++ b/Source/Parsek/TestCommands/TestCommandVerbs.cs
@@ -1,0 +1,80 @@
+using System.Collections.Generic;
+
+namespace Parsek.TestCommands
+{
+    /// <summary>
+    /// Classification of a command verb against the known-verb table.
+    /// </summary>
+    internal enum TestCommandVerbClass
+    {
+        /// <summary>A v1 verb this addon implements.</summary>
+        Implemented,
+
+        /// <summary>A recognized phase-3+ verb, not implemented in v1
+        /// (REJECTED with <c>not-implemented-v1</c> so the orchestrator can probe
+        /// capability rather than confuse it with a typo).</summary>
+        Reserved,
+
+        /// <summary>Not a known verb (REJECTED with <c>unknown-command</c>).</summary>
+        Unknown,
+    }
+
+    /// <summary>
+    /// Pure known-verb table for the ParsekTestCommands seam (M-A2). Verb match is
+    /// case-sensitive and exact. Reserving the phase-3 names now keeps the wire
+    /// envelope (id/cmd/args, percent-encoding, journal, verdicts) designed once so
+    /// later commands slot in without a format break.
+    /// </summary>
+    internal static class TestCommandVerbs
+    {
+        // Implemented (v1): 10 verbs.
+        private static readonly HashSet<string> ImplementedVerbs = new HashSet<string>
+        {
+            "SetSetting",
+            "StartRecording",
+            "StopRecording",
+            "CommitTree",
+            "DiscardTree",
+            "RecordingState",
+            "RunTests",
+            "LoadGame",
+            "MissionMark",
+            "FlushAndQuit",
+        };
+
+        // Reserved (recognized, not implemented in v1): 15 verbs.
+        private static readonly HashSet<string> ReservedVerbs = new HashSet<string>
+        {
+            "StartLoopPlayback",
+            "StopPlayback",
+            "EnterWatchMode",
+            "InvokeRewind",
+            "AnswerMergeDialog",
+            "KscAction",
+            "SealSlot",
+            "StashSlot",
+            "FlySlot",
+            "RouteCommand",
+            "MissionConfig",
+            "TimeJump",
+            "SimulateStockSwitchClick",
+            "CrashAfterJournalPhase",
+            "RunInvariantReport",
+        };
+
+        internal static TestCommandVerbClass Classify(string verb)
+        {
+            if (verb != null && ImplementedVerbs.Contains(verb))
+                return TestCommandVerbClass.Implemented;
+            if (verb != null && ReservedVerbs.Contains(verb))
+                return TestCommandVerbClass.Reserved;
+            return TestCommandVerbClass.Unknown;
+        }
+
+        /// <summary>Read-only view of the implemented v1 verbs (for coverage tests).</summary>
+        internal static IReadOnlyCollection<string> ImplementedVerbNames => ImplementedVerbs;
+
+        /// <summary>Read-only view of the reserved phase-3 verbs (for coverage tests).</summary>
+        internal static IReadOnlyCollection<string> ReservedVerbNames => ReservedVerbs;
+    }
+}

--- a/docs/dev/design-autotest-command-seam.md
+++ b/docs/dev/design-autotest-command-seam.md
@@ -144,8 +144,15 @@ Grammar rules:
   GUID). It is the ack correlation key and the journal dedup key. Ids must be unique
   across process restarts within one logical run; the orchestrator either uses
   monotonic-across-run ids or truncates the three channel files between runs (see
-  Backward Compatibility).
-- `cmd`: the verb. Case-sensitive, exact match against the known-verb table.
+  Backward Compatibility). The id MUST be encoding-stable: because it is embedded VERBATIM
+  (not re-encoded) into journal and response lines, a decoded id that would itself need
+  percent-encoding is rejected at parse time (`REJECTED msg=malformed-id`). This closes two
+  holes: a decoded space (`id=a%20b` -> "a b") would journal-tokenize to a shorter id "a" (a
+  re-execution-after-restart mismatch), and a decoded newline (`id=a%0Ab`) would forge a
+  journal line. In practice monotonic integers and GUIDs are always encoding-stable.
+- `cmd`: the verb. Case-sensitive, exact match against the known-verb table. Like the id it
+  must be encoding-stable (it is written raw into the `CLAIMED` journal line); an
+  encoding-unsafe verb is `REJECTED msg=malformed-verb`.
 - Optional `v=<n>`: protocol version, default `1`. Unknown keys are ignored (forward
   compatibility), so phase-3 verbs may add new keys freely.
 - **Value encoding**: a value that contains whitespace, `=`, `%`, or a control character
@@ -202,8 +209,10 @@ and BEFORE the journal `DONE` leaves the id at `EXECUTED`; on restart the addon 
 the response line from `EXECUTED` (it cannot know the first append survived). The
 orchestrator therefore treats the FIRST terminal response line for a given id as
 authoritative and IGNORES any later duplicate line for that same id -- later duplicates are
-crash-recovery rewrites, not new outcomes. (A rewritten line is byte-equivalent in verdict;
-only `seq` differs, since it is a fresh per-process counter.)
+crash-recovery rewrites, not new outcomes. (A rewritten line is byte-equivalent in verdict,
+payload, AND msg -- the recovery re-emits the ORIGINAL terminal outcome stored on the
+enriched `EXECUTED` journal line, see the Journal grammar -- only `seq` and `ut` differ, since
+`seq` is a fresh per-process counter and `ut` is re-sampled at recovery time.)
 
 ### Journal line grammar (WAL)
 
@@ -211,20 +220,31 @@ Append-only, newline terminated. One line per phase transition:
 
 ```
 id=0002 phase=CLAIMED seq=2 verb=StartRecording session=7f3a... t=17390512.884
-id=0002 phase=EXECUTED seq=2 t=17390512.951
+id=0002 phase=EXECUTED seq=2 t=17390512.951 verdict=OK payload=recordingId%3Dabc123 msg=
 id=0002 phase=DONE seq=2 verdict=OK t=17390512.960
 ```
 
 `session` is `ParsekProcess.ProcessSessionId` (the AppDomain-lifetime GUID) so a journal
 can be attributed to a specific process run. `t` is wall-clock seconds (InvariantCulture).
-On addon startup the journal is replayed into an in-memory map `id -> highest phase seen`:
+
+The `EXECUTED` line is ENRICHED: it stores the terminal `verdict`, the whole verb-specific
+`payload`, and any `msg` so a crash-recovery replay at `EXECUTED` can re-emit the ORIGINAL
+response line (true RewriteResponse), not a synthetic ack. The `payload` value is the
+space-joined `key=encodedValue` list percent-encoded ONCE MORE so the whole list rides as a
+single wire token (`payload=recordingId%3Dabc123`); an empty payload / msg is written as an
+empty token (`payload=` / `msg=`). Because ids and verbs are encoding-stable (rejected at
+parse time otherwise, see the command grammar), the id/verb embed verbatim and only the
+payload/msg/verdict fields are encoded. On addon startup the journal is replayed into an
+in-memory map `id -> highest phase seen`:
 
 - id at `DONE`  -> already fully handled; skip (no re-execute, no re-respond).
-- id at `EXECUTED` (no `DONE`) -> side effect ran; skip execution, (re)write the response
-  line, append `DONE`. This recovers a crash or an IO failure between side effect and
-  response.
+- id at `EXECUTED` (no `DONE`) -> side effect ran; skip execution, re-emit the ORIGINAL
+  terminal response from the stored `verdict`/`payload`/`msg` (byte-equivalent to the
+  pre-crash response modulo `seq`/`ut`), append `DONE`. This recovers a crash or an IO
+  failure between side effect and response. A pre-enrichment / torn `EXECUTED` line with no
+  stored verdict falls back to an `INTERRUPTED msg=recovered-executed` ack.
 - id at `CLAIMED` (no `EXECUTED`) -> crashed mid-execution; do NOT re-execute; write an
-  `INTERRUPTED` terminal response and append `DONE`.
+  `INTERRUPTED msg=interrupted-claimed` terminal response and append `DONE`.
 
 Journal replay tolerates a TORN TRAILING LINE: a crash mid-append can leave a final journal
 line without a terminating `\n`; replay ignores any trailing line that is not

--- a/docs/dev/design-autotest-command-seam.md
+++ b/docs/dev/design-autotest-command-seam.md
@@ -366,8 +366,12 @@ recovery, above), and seed the in-memory processed-id set + command-file byte of
 
 1. If not armed, return. If `HighLogic.LoadedScene == LOADING`, `sceneTransitioning`, or
    the settle counter > 0, return (no safe point).
-2. If an in-game test batch is running (`InGameTestRunner.IsRunning` on the runner the
-   addon owns for `RunTests`), return - do not execute other commands mid-batch.
+2. If an in-game test batch is running, return - do not execute other commands mid-batch.
+   The gate is an OR of BOTH runners that can own a batch: the runner the addon owns for
+   `RunTests`, AND the interactive Ctrl+Shift+T runner (via
+   `TestRunnerShortcut.ActiveRunnerForGating`). Both share the campaign-isolation baseline
+   machinery, so a command overlapping either batch could corrupt the save under test; the
+   pure `DecideDispatch` re-checks this via `DispatchState.BatchRunning`.
 3. Read any whole new lines appended since the last byte offset. Parse each into the
    pending FIFO queue (skipping ids already terminal per the journal / processed set). The
    addon opens the command file for reading with `FileShare.ReadWrite` so the external
@@ -394,11 +398,11 @@ parsed, N deferred), with bounded per-command Info lines (command counts are sma
 | Verb | Scene/state precondition | Action | Success payload |
 |---|---|---|---|
 | `SetSetting` | game loaded (`ParsekSettings.Current != null`), any scene; else Defer | typed whitelist setter mutates `ParsekSettings.Current` | `name`, `value` echoed |
-| `StartRecording` | FLIGHT with a loaded, unpacked active vessel, not restoring/re-fly/merge-journal; else Defer | `ParsekFlight.StartRecording(...)` | `recordingId`, `already=true` if a recorder was live |
+| `StartRecording` | FLIGHT with a loaded, unpacked active vessel, not restoring/re-fly/merge-journal; else Defer | `ParsekFlight.StartRecording(...)`, then RE-SAMPLE `HasLiveRecorderForTagging()`; a refusal (vessel not ready / packed / guard blocked) is `ERROR msg=start-refused`, never a false OK (F4) | `recordingId`, `already=true` if a recorder was live |
 | `StopRecording` | FLIGHT; else Defer | `ParsekFlight.StopRecording()` (idempotent: OK with `idle=true` if no recorder) | `stopped` bool |
 | `CommitTree` | FLIGHT with `activeTree != null`; if no tree -> `ERROR msg=no-active-tree` (mirrors `CommitTreeFlight`'s guard) | `ParsekFlight.CommitTreeFlight()` | `committed=true` |
 | `DiscardTree` | FLIGHT; if no active tree -> OK `nothing=true` | stop recorder if live, then `ParsekFlight.AutoDiscardActiveTreeWithMessage(reason, screenMessage, ledgerRecalcReason)` (the wrong-context-caller entry point) with test-command-specific strings | `discarded` bool |
-| `RecordingState` | any scene (read-only) | snapshot recorder/tree state (reuses `ParsekLog.FormatRecState` inputs) | `recording`, `tree`, `points`, `scene` |
+| `RecordingState` | any scene (read-only) | snapshot recorder/tree state (reuses `ParsekLog.FormatRecState` inputs) | `recording`, `tree` (the `RecordingTree.Id` of the active tree, empty when none - adjudication B), `points`, `scene` |
 | `RunTests` | any scene the runner supports; else Defer | `InGameTestRunner.RunAll()` (no `category`) or `RunCategory(category)`; response deferred until `IsRunning` goes true->false and `ExportResultsFile` ran | `passed`, `failed`, `skipped`, `results=parsek-test-results.txt` |
 | `LoadGame` | any scene incl. MAINMENU (the BOOT CHANNEL); Reject if a recorder is live (`msg=recording-active`) or a load is already in flight (`msg=load-in-flight`) | long-running two-phase (like `RunTests`): journal `CLAIMED` -> initiate load (`HighLogic.SaveFolder = dir`; `GamePersistence.LoadGame(...)`; `FlightDriver.StartAndFocusVessel(...)` - the same Assembly-CSharp-only sequence as v0.5.4 `TestingTools.LoadSave`, no kRPC types); response deferred until the new scene settles with `HighLogic.CurrentGame != null`, then journal `EXECUTED` + terminal response; a null / incompatible game -> `ERROR msg=load-failed` | `scene`, `save` |
 | `MissionMark` | any scene | emit a stable `[Parsek][Info][TestCommands] MISSIONMARK label=<label> ut=<ut>` log line (H3-style correlation) | `label` echoed |
@@ -571,6 +575,37 @@ Exhaustive. Each: scenario -> expected behavior -> v1 or deferred.
     in-flight recording; the orchestrator must send `CommitTree` or `DiscardTree` first.
     A second `LoadGame` while one is already in flight is Rejected `msg=load-in-flight`.
     v1 (behavior documented, not a bug).
+
+## Deferred Items and Open Questions
+
+Tracked follow-ups deliberately NOT implemented in the M-A2 fix round (reviewer nits + a
+design deferral). None blocks the seam; each is recorded so it is not lost.
+
+- **Vessel-ready Defer for `StartRecording` (F4 follow-up).** The v1 handler contains a
+  refusal by RE-SAMPLING the recorder after `ParsekFlight.StartRecording` and returning
+  `ERROR msg=start-refused` (better than a false OK). The cleaner long-term fix is a new
+  `DispatchState` readiness bit (active vessel loaded + unpacked + not restoring/re-fly/
+  merge-journal) so the command DEFERS until FLIGHT is genuinely ready and only executes
+  when `StartRecording` will succeed, converting a transient refusal into a normal wait
+  rather than a terminal error. Deferred because it widens the dispatch state and wants its
+  own decision-matrix coverage; not done in this pass.
+- **N1: deferral-budget timing uses wall-clock.** `WallClockSeconds()` is
+  `DateTime.UtcNow`-based; an NTP / clock adjustment mid-run could distort a per-command
+  deferral budget. A monotonic source (`Stopwatch` / `Time.realtimeSinceStartup`) would be
+  more robust. Low impact on a dev PC; tracked.
+- **N2: `line#<n>` fallback id is per-process.** The `FallbackId(lineNumber)` correlation id
+  for an id-less malformed line resets its line counter each process, so the same
+  `line#<n>` can denote a different line across a restart. Only affects malformed, id-less
+  lines (which are REJECTED); tracked.
+- **N4: command-file byte offset is not persisted.** `commandByteOffset` is in-memory and
+  resets to 0 on restart, forcing one full command-file rescan on the first post-restart
+  poll (deduped by the processed-set, so correct, but O(file)). A persisted offset would
+  avoid the rescan on very long runs. Tracked.
+- **N5: startup multi-id recovery shares one retry slot.** The `headPendingResponse` slot
+  holds a single deferred ack; if several startup recovery acks fail their append in the
+  same session, only the last retries within that session (the rest are backstopped by
+  cross-restart re-recovery, since no `DONE` is written until the append lands). Acceptable
+  given the restart durability, but tracked.
 
 ## What Doesn't Change
 

--- a/docs/dev/design-autotest-command-seam.md
+++ b/docs/dev/design-autotest-command-seam.md
@@ -606,6 +606,23 @@ design deferral). None blocks the seam; each is recorded so it is not lost.
   same session, only the last retries within that session (the rest are backstopped by
   cross-restart re-recovery, since no `DONE` is written until the append lands). Acceptable
   given the restart durability, but tracked.
+- **R1: LoadGame completion predicate is minimal.** Completion checks only
+  `HighLogic.CurrentGame != null` after the transition drains; safe today because
+  `HighLogic.LoadScene` raises the transition flag synchronously inside
+  `StartAndFocusVessel`. Requiring scene == FLIGHT or a seen-transition-since-initiation
+  bit would remove the brittleness. A post-initiation failure that dumps back to the menu
+  currently surfaces as TIMEOUT rather than load-failed.
+- **R2: lock Unknown-liveness tie-break effectively always reclaims.** When the pid probe
+  returns Unknown (e.g. access denied on a live foreign process), `DecideLockOwnership`
+  compares the existing lock's t against now, which an existing lock always loses, so the
+  channel can be stolen from a live-but-unprobeable instance. Acceptable on a single-user
+  dev box; an age threshold would harden it.
+- **R3: scenarioBudgetSeconds is never wired.** `DeferralBudget.BudgetSeconds` accepts a
+  scenario-spec budget parameter that no caller supplies yet; the design's
+  "budget from the scenario spec" is deferred to the M-A5 harness integration.
+- **R4: no strict-FIFO unit test.** The queue/timeout mechanics live in the MonoBehaviour;
+  the dispatch-decision half is pure-tested but head-only ordering itself is not. A future
+  pure pump-step extraction would make it unit-testable.
 
 ## What Doesn't Change
 


### PR DESCRIPTION
## Summary

Second implementation module of the automated-testing initiative (design doc: docs/dev/design-autotest-command-seam.md, updated in this PR to match HEAD).

A file-drop command channel for external test orchestration, env-gated (PARSEK_TEST_COMMANDS=1), provably inert in normal play:

- **Pure core** (zero Unity/KSP in the decision surface): wire protocol with percent-encoding and forward-reserved phase-3 verbs, three-phase write-ahead journal (CLAIMED/EXECUTED/DONE) delivering at-most-once execution across the full crash matrix, dispatch decisions with per-verb scene/state preconditions and deferral budgets with TIMEOUT conversion, pid-liveness lock for dual-instance safety, settings whitelist with per-setting persistence routes.
- **Thin DDOL addon**: safe-point-gated pump, share-tolerant channel I/O with bounded retry, journal replay + recovery at startup, exception containment (a throwing verb converts to a terminal ERROR - can never re-execute a side effect).
- **Ten v1 verbs**: SetSetting (routes the 8 sidecar-authoritative settings through ParsekSettingsPersistence.Record* so they survive save loads), StartRecording/StopRecording (state sampled around the void production calls; refusals surface as start-refused), CommitTree/DiscardTree, RecordingState, MissionMark (log-contract-pinned MSN-001), RunTests (two-phase over the existing InGameTestRunner), LoadGame (the boot channel - executes at MAINMENU, replacing the kRPC-master-only auto-load flags absent at the v0.5.4 pin), FlushAndQuit (commit-safe quit with durable ack before Application.Quit).

## Review

Passed a clean-context adversarial review; all blockers and should-fixes applied, including true RewriteResponse crash recovery (EXECUTED journal lines now carry the original verdict/payload), journal id-encoding hardening against WAL forgery, non-ASCII codec correctness, and batch-gate coverage of shortcut-driven runners. Reviewer + fix-round deferred items are tracked in the design doc.

## Test plan

236 seam tests (crash matrix, dispatch matrix, whitelist routing, codec, lock, budgets, log contracts); full suite 17887 passed / 0 failed. In-game: TC-A (inert-when-unarmed) automated; TC-B/TC-C sequence tests are PENDING-OPERATOR with a runbook (the env gate is process-start-only by security design). Production surface: Source/Parsek/TestCommands/ only; no recording/schema/save-format changes.