### PR TITLE
M-A6: automation stack provisioner (dry-run planner + pure decision library)

### DIFF
--- a/docs/dev/design-autotest-stack-setup.md
+++ b/docs/dev/design-autotest-stack-setup.md
@@ -696,6 +696,43 @@ Each: trigger -> expected behavior -> v1 or deferred.
   only produces the instances and manifests it consumes.
 - No changes to Parsek source, tests, or in-game hooks.
 
+## Deferred to live execution
+
+Reviewer findings deliberately deferred until the live provisioning phases land
+(the guards and pure decisions above already fence them; each is one bounded
+follow-up):
+
+- **R5 -- deploy default source hardcodes the worktree name.** `phase_deploy`'s
+  DEFAULT Parsek.dll path hardcodes `Parsek-autotest-provision/Source/...`. The
+  worktree-own `bin/Debug` build is preferred when present (via
+  `select_parsek_dll_source`), so this only bites a differently-named worktree
+  with no local build; fix by deriving the default from the umbrella layout /
+  requiring `--parsek-dll` when ambiguous.
+- **R8 -- `_ksp_running_against` coarseness.** The EC-1 check matches ANY
+  `KSP_x64.exe` process, not one bound to the target instance. Refine to the
+  instance's own exe path (or a per-instance mutex/lockfile heartbeat) so an
+  unrelated dev-install KSP does not block provisioning a different instance.
+- **R12 -- pre-EC-1 instance-local writes.** PREFLIGHT writes the `.provision.lock`
+  before the KSP-running check. The lockfile is now removed on completion (owned
+  locks only), but the ordering means one instance-local write precedes the EC-1
+  gate; move the KSP-running check ahead of the lock write for a strictly
+  no-write-before-gate PREFLIGHT.
+- **R13 -- long-path `\\?\` prefix for live CLONE.** `is_path_too_long` flags an
+  over-260-char instance path, but the live CLONE copy/junction primitives must
+  actually USE the extended-length `\\?\` prefix on Windows to copy deep KSP
+  asset trees; wire it when CLONE is implemented (EC-7).
+- **R15 -- `apply_settings` nested-key scope.** Delta application matches
+  top-level `KEY = value` lines only; a key that appears only inside a braced
+  node is treated as absent and APPENDED at top level. Acceptable for the flat
+  GT-8 keys pinned today; when a scoped/nested setting is ever targeted, extend
+  the matcher with node-path scope (EC-15).
+- **R11 (noted, kept).** The near-vacuous `test_capability_table_matches_design`
+  (it restates the hand-authored capability + missing-vs-master tuples) is KEPT:
+  it is a cheap guard against an accidental edit to the harness admission INPUT
+  table. The authoritative capability proof remains the BUILD-TT reflection smoke
+  over the real built assembly (already specced in the Test Plan); this unit
+  test does not pretend to replace it.
+
 ## Backward Compatibility
 
 Greenfield module; no existing instances or manifests to migrate. Forward policy:

--- a/docs/dev/design-autotest-stack-setup.md
+++ b/docs/dev/design-autotest-stack-setup.md
@@ -674,6 +674,14 @@ Each: trigger -> expected behavior -> v1 or deferred.
   delta names a key absent from the dev settings.cfg. Expected: settings-delta
   application APPENDS the key (KSP tolerates it) and logs it; a delta key that is
   a known typo (not in a validated key set) is a WARN. v1.
+- **EC-16 Instance dir aliases the dev install.** Trigger: a profile's
+  `instanceDir` resolves to the read-only dev install, or a parent/child of it,
+  or a path not under `automation/` (a hand-edited or mis-merged profile).
+  Expected: PREFLIGHT rejects it with the pure `check_instance_dir_alias`
+  predicate and ABORTS before any write. The live primitives overwrite
+  settings.cfg, copy the DLL, and DELETE the MM cache; aimed at the dev tree they
+  would corrupt the clone source. v1 (guard is live; the destructive primitives
+  it protects are the deferred live phases).
 
 ## What Doesn't Change
 

--- a/docs/dev/design-autotest-stack-setup.md
+++ b/docs/dev/design-autotest-stack-setup.md
@@ -11,6 +11,21 @@ KRPC.MechJeb pairing, the dev-install inventory) inline as the authority for
 the setup script. Where a fact could only be confirmed by downloading a
 release artifact at install time, it is marked OPEN with the exact command.
 
+## Implementation Status (v1)
+
+v1 ships the `--dry-run` PLANNER and the pure decision library
+(`harness/provision/provlib.py`, fully unit-tested). The heavy live provisioning
+phases (BUILD-TT, CLONE, INSTALL, and the SETTINGS/DEPLOY/MM-CACHE/MANIFEST
+writes that follow them) and `--repair` are NOT yet implemented: a non-dry-run
+invocation aborts loudly at the first unimplemented phase (`EC-LIVE`) rather than
+half-provisioning an instance or writing a manifest that claims a completeness
+the run cannot back. The pure decisions each live phase will make (pin
+resolution, junction classification, settings-delta application, disk/path
+guards, dev-install aliasing, DLL-identity grep, lock arbitration) are already
+implemented and tested so live execution is assembly of vetted pieces. Live
+execution lands with the coordinated smoke-run task (see "Test Plan" and
+"Deferred to live execution").
+
 ---
 
 ## Ground Truth (verified 2026-07-11)

--- a/harness/provision/.gitignore
+++ b/harness/provision/.gitignore
@@ -1,0 +1,4 @@
+# Provisioner working dirs (never committed).
+__pycache__/
+.cache/
+.stage/

--- a/harness/provision/.gitignore
+++ b/harness/provision/.gitignore
@@ -2,3 +2,5 @@
 __pycache__/
 .cache/
 .stage/
+# Provisioned instances (real runs) and any test-generated instance output.
+automation/

--- a/harness/provision/pins.toml
+++ b/harness/provision/pins.toml
@@ -1,0 +1,84 @@
+schema = 1
+kspVersion = "1.12.5"
+
+# ---------------------------------------------------------------------------
+# Component pins for the M-A6 automation stack. Single source of truth for what
+# versions the stack targets. Hand-edited, reviewed, committed. See the design
+# doc docs/dev/design-autotest-stack-setup.md (Data Model + Ground Truth GT-1..9).
+#
+# OPEN fields require a web/download verification at first install; the exact
+# command is in the comment above each. DOWNLOAD aborts by design while any
+# consumed sha256 is still OPEN (EC-13), so filling these is a prerequisite for
+# a real provisioning run (never for --dry-run).
+# ---------------------------------------------------------------------------
+
+[krpc]
+# GT-1/GT-2: v0.5.4 is the release pin; it LACKS the auto-load flags/Quit/SetLanded.
+# GT-1 gotcha: v0.5.4 is an ANNOTATED tag. `git rev-parse v0.5.4` yields the tag
+# OBJECT sha (4e9dfbedd21409fb75c19f55f839d68520e752c1); the PIN step MUST peel
+# it with `git rev-parse v0.5.4^{commit}` to get the commit below. Verified
+# 2026-07-11 in mods/krpc.
+mode = "tag"                       # "tag" | "commit"
+tag = "v0.5.4"
+commit = "11f1f1366fa4301049f6eac6640604127a9d763b"
+tagObject = "4e9dfbedd21409fb75c19f55f839d68520e752c1"  # annotated-tag object sha (info)
+releaseZipUrl = "https://github.com/krpc/krpc/releases/download/v0.5.4/krpc-0.5.4.zip"
+# O-1/EC-13: fill after first download.
+#   curl -L -o krpc-0.5.4.zip <releaseZipUrl> && sha256sum krpc-0.5.4.zip
+releaseZipSha256 = "OPEN"
+localClone = "mods/krpc"
+# O-2/GT-5: confirm the zip layout at first download.
+#   unzip -l krpc-0.5.4.zip | grep -iE 'testingtools|KRPC.Core.dll|KRPC.SpaceCenter.dll|Google.Protobuf.dll'
+# Expect NO TestingTools.dll; expect the three compile references present.
+releaseCompileDlls = ["KRPC.Core.dll", "KRPC.SpaceCenter.dll", "Google.Protobuf.dll"]
+releaseRuntimeDlls = ["KRPC.dll", "KRPC.Core.dll", "KRPC.SpaceCenter.dll", "Google.Protobuf.dll", "KRPC.IO.Ports.dll"]
+mustNotContain = ["TestingTools.dll"]
+
+[testingtools]
+# Built from source at the same krpc ref via the standalone shim (BUILD-TT).
+buildFromSource = true
+# 2-FILE shim: only OrbitTools.cs + TestingTools.cs. AutoLoadGame.cs and
+# AutoSwitchVessel.cs are DROPPED: at v0.5.4 AutoLoadGame unconditionally fires
+# 15 frames after MAINMENU trying to load saves/default/persistent.sfs, which
+# would RACE the seam's boot (M-A2 LoadGame). BUILD-TT asserts the AutoLoadGame
+# type is ABSENT from the built assembly (S-4). Verified 2026-07-11 that
+# AutoLoadGame.cs at v0.5.4 hardcodes Game=>"default" Save=>"persistent".
+sourceRepoRef = "v0.5.4"
+sourceSubdir = "tools/TestingTools/src"
+sourceFiles = ["OrbitTools.cs", "TestingTools.cs"]
+droppedFiles = ["AutoLoadGame.cs", "AutoSwitchVessel.cs"]
+# Full source set at the tag (5 files), recorded so BUILD-TT can assert the
+# extraction saw exactly these before selecting the 2 shim files.
+fullSourceSetAtTag = ["AutoLoadGame.cs", "AutoSwitchVessel.cs", "OrbitTools.cs", "TestingTools.cs", "TestingTools.csproj"]
+# Recorded so the harness knows which control capabilities exist:
+capabilities = ["LoadSave", "RemoveOtherVessels", "SetCircularOrbit", "SetOrbit", "ClearRotation", "ApplyRotation"]
+# Boot is driven by the Parsek seam, NOT by TestingTools auto-load (which is dropped):
+bootChannel = "parsek-seam-LoadGame"
+missingVsMaster = ["autoLoadFlags", "Quit", "SetLanded"]   # GT-2/GT-3
+targetFramework = "net472"
+
+[mechjeb2]
+# GT-7: no git tags; pin is a downloaded build (MechJeb2 ships CI dev builds
+# numbered 2.15.x.x, not git refs; AssemblyInfo carries a 1.0.0.0 placeholder).
+mode = "release"
+# O-3: fill with the exact MJ 2.15 dev build chosen (KSP 1.12 line).
+#   source: MechJeb2 CI / SpaceDock / CurseForge; record buildNumber + downloadUrl,
+#   then: curl -L -o MechJeb2.zip <downloadUrl> && sha256sum MechJeb2.zip
+buildNumber = "2.15.x.x-OPEN"
+downloadUrl = "OPEN"
+sha256 = "OPEN"
+
+[krpc_mechjeb]
+# GT-6: genhis 0.7.1 pairs with kRPC 0.5.4 (CHANGELOG-proven: 0.7.1 "Updated for
+# kRPC 0.5.4"). v0.7.1 is a lightweight tag == HEAD commit below. Verified
+# 2026-07-11 in mods/KRPC.MechJeb (origin https://github.com/genhis/KRPC.MechJeb).
+fork = "genhis"                    # "genhis" | "darchambault"
+tag = "v0.7.1"
+commit = "398bc337492c5f725c83ab1aac85c32a1c0349ea"
+localClone = "mods/KRPC.MechJeb"
+pairedKrpcTag = "v0.5.4"           # asserted against [krpc].tag at PAIR
+pairedMechjebLine = "2.14.3+"      # from CHANGELOG 0.7.0/0.7.1
+# O-5/EC-14: only if a non-v0.5.4 kRPC is ever pinned -- confirm the fork+tag via
+#   https://github.com/Genhis/KRPC.MechJeb/releases
+#   https://github.com/darchambault/KRPC.MechJeb/releases
+# matching the "Updated for kRPC <ver>" line to the pinned kRPC + MJ build.

--- a/harness/provision/profiles/modded-compat.toml
+++ b/harness/provision/profiles/modded-compat.toml
@@ -1,0 +1,56 @@
+schema = 1
+name = "modded-compat"
+baseInstall = "Kerbal Space Program"        # dev install, relative to repo umbrella root
+instanceDir = "automation/modded-compat"    # created by CLONE
+
+# modded-compat = stock-minimal's dev-sourced set PLUS the visual/compat mod
+# stack (Waterfall + SWE, ReStock/+, BetterTimeWarp, Kopernicus, etc.). D17
+# scenarios and R25/R26 run only on modded-compat (plan section 10).
+#
+# Squad + SquadExpansion are junctioned stock payloads (see stock-minimal note),
+# not listed here.
+#
+# PersistentRotation is GT-8 OPEN: it is listed by the plan's modded-compat but
+# is NOT present in the dev GameData. It is declared here with required=false so
+# the script records `absent-source` and proceeds with a WARN (EC-12), rather
+# than silently omitting it. If a KSP-1.12 build is sourced separately, add its
+# pin+hash to pins.toml and flip required=true.
+devSourcedMods = [
+  # --- shared with stock-minimal ---
+  "000_Harmony", "ModuleManager.4.2.3.dll",
+  "000_ClickThroughBlocker", "001_ToolbarControl",
+  "CommunityDeltaVMaps", "CommunityTechTree", "ProbesBeforeCrew",
+  # --- modded-compat additions (present in dev GameData per GT-8) ---
+  "Waterfall", "WaterfallRestock", "RestockWaterfallExpansion",
+  "StockWaterfallEffects", "ReStock", "ReStockPlus", "BetterTimeWarp",
+  "Kopernicus", "ModularFlightIntegrator", "B9PartSwitch", "KSPCommunityFixes",
+  "DistantObject", "KSPTextureLoader", "HideEmptyTechTreeNodes",
+]
+
+# Optional mods that may be absent from the dev GameData (GT-8 / EC-12).
+# required=false => absent is a WARN + `absent-source` manifest record, not an
+# abort. required=true => a genuinely missing source aborts.
+[[optionalMods]]
+name = "PersistentRotation"
+required = false
+reason = "GT-8: not present in dev GameData; source a KSP-1.12 build separately or drop (O-4)."
+
+stackComponents = ["krpc", "testingtools", "mechjeb2", "krpc_mechjeb", "parsek"]
+
+# Same determinism-oriented settings deltas as stock-minimal (GT-8 keys).
+[settings]
+PHYSICS_FRAME_DT_LIMIT = "0.03"
+FRAMERATE_LIMIT = "60"
+QUALITY_PRESET = "0"
+TEXTURE_QUALITY = "3"
+SHADOWS_QUALITY = "0"
+AERO_FX_QUALITY = "0"
+TERRAIN_SHADER_QUALITY = "0"
+UI_SCALE = "1.0"
+FULLSCREEN = "False"
+SCREEN_RESOLUTION_WIDTH = "1280"
+SCREEN_RESOLUTION_HEIGHT = "720"
+SIMULATE_IN_BACKGROUND = "True"
+AUTOSTRUT_SYMMETRY = "False"
+CONIC_PATCH_DRAW_MODE = "3"
+CHECK_FOR_UPDATES = "False"

--- a/harness/provision/profiles/modded-compat.toml
+++ b/harness/provision/profiles/modded-compat.toml
@@ -27,6 +27,17 @@ devSourcedMods = [
   "DistantObject", "KSPTextureLoader", "HideEmptyTechTreeNodes",
 ]
 
+# Stack components installed by the script (not from dev GameData): kRPC,
+# TestingTools.dll, MechJeb2, KRPC.MechJeb, Parsek.
+#
+# MUST stay ABOVE the [[optionalMods]] array-of-tables below: TOML assigns every
+# bare key that follows a [[table]] header to THAT table entry, so a
+# stackComponents defined after [[optionalMods]] would silently become a key of
+# the PersistentRotation entry and leave the profile with NO stack components
+# (a live modded-compat run would install nothing while writing a manifest).
+# Guarded by test_provlib.RealProfileFileTests.
+stackComponents = ["krpc", "testingtools", "mechjeb2", "krpc_mechjeb", "parsek"]
+
 # Optional mods that may be absent from the dev GameData (GT-8 / EC-12).
 # required=false => absent is a WARN + `absent-source` manifest record, not an
 # abort. required=true => a genuinely missing source aborts.
@@ -34,8 +45,6 @@ devSourcedMods = [
 name = "PersistentRotation"
 required = false
 reason = "GT-8: not present in dev GameData; source a KSP-1.12 build separately or drop (O-4)."
-
-stackComponents = ["krpc", "testingtools", "mechjeb2", "krpc_mechjeb", "parsek"]
 
 # Same determinism-oriented settings deltas as stock-minimal (GT-8 keys).
 [settings]

--- a/harness/provision/profiles/stock-minimal.toml
+++ b/harness/provision/profiles/stock-minimal.toml
@@ -1,0 +1,41 @@
+schema = 1
+name = "stock-minimal"
+baseInstall = "Kerbal Space Program"       # dev install, relative to repo umbrella root
+instanceDir = "automation/stock-minimal"   # created by CLONE
+
+# Mods copied verbatim from the dev install's GameData (content-hashed into the
+# manifest). stock-minimal keeps only what the stack needs plus stock.
+#
+# NOTE: Squad + SquadExpansion are NOT listed here -- they are stock asset
+# payloads, JUNCTIONED (not copied) by the CLONE step and recorded as junction
+# targets in the manifest (stock, negligible drift risk). Only non-stock mod
+# folders are dev-sourced copies so a dev-GameData change cannot silently drift
+# an instance.
+devSourcedMods = [
+  "000_Harmony", "ModuleManager.4.2.3.dll",
+  "000_ClickThroughBlocker", "001_ToolbarControl",
+  "CommunityDeltaVMaps", "CommunityTechTree", "ProbesBeforeCrew",
+]
+
+# Stack components installed by the script (not from dev GameData): kRPC,
+# TestingTools.dll, MechJeb2, KRPC.MechJeb, Parsek.
+stackComponents = ["krpc", "testingtools", "mechjeb2", "krpc_mechjeb", "parsek"]
+
+# GT-8 verified keys. Delta = key -> pinned value; everything else copied from
+# the dev settings.cfg then overwritten here.
+[settings]
+PHYSICS_FRAME_DT_LIMIT = "0.03"    # tighter physics cap for determinism
+FRAMERATE_LIMIT = "60"             # cap CPU; automation window is small/low-detail
+QUALITY_PRESET = "0"
+TEXTURE_QUALITY = "3"              # lowest
+SHADOWS_QUALITY = "0"
+AERO_FX_QUALITY = "0"
+TERRAIN_SHADER_QUALITY = "0"
+UI_SCALE = "1.0"
+FULLSCREEN = "False"
+SCREEN_RESOLUTION_WIDTH = "1280"
+SCREEN_RESOLUTION_HEIGHT = "720"
+SIMULATE_IN_BACKGROUND = "True"    # MUST stay True: unattended runs lose focus
+AUTOSTRUT_SYMMETRY = "False"       # pin autostrut policy (plan section 2/10)
+CONIC_PATCH_DRAW_MODE = "3"
+CHECK_FOR_UPDATES = "False"        # suppress the launcher/update nag for unattended boots

--- a/harness/provision/provision.py
+++ b/harness/provision/provision.py
@@ -1,0 +1,795 @@
+#!/usr/bin/env python3
+"""M-A6 automation-stack provisioner.
+
+Provisions a byte-for-byte reproducible KSP automation instance for the mission
+harness: a pinned kRPC + built TestingTools shim + MechJeb2 + KRPC.MechJeb
+stack, a cloned KSP instance, the Parsek DLL under test deployed via a hashed
+staging copy, and a manifest the harness reads to REFUSE running against a
+drifted instance.
+
+Entry point:
+    python harness/provision/provision.py --profile stock-minimal [--repair] [--dry-run]
+
+Behavior phases (design docs/dev/design-autotest-stack-setup.md), each a
+function, each idempotent and logged:
+    PREFLIGHT -> PIN -> DOWNLOAD -> BUILD-TT -> PAIR -> CLONE -> SETTINGS
+      -> DEPLOY -> INSTALL -> MM-CACHE -> MANIFEST -> VERIFY
+
+--dry-run prints the full action plan and computes drift where the instance
+already exists, but performs NO network access, downloads, builds, clones,
+junction creation, or writes outside harness/provision/. All pure decisions
+live in provlib.py so they are unit-tested without side effects.
+
+stdlib only; ASCII only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import hashlib
+import json
+import os
+import subprocess
+import sys
+import tomllib
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+import provlib
+
+# ---------------------------------------------------------------------------
+# Paths + context
+# ---------------------------------------------------------------------------
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))          # harness/provision
+WORKTREE_ROOT = os.path.abspath(os.path.join(SCRIPT_DIR, "..", ".."))
+PINS_PATH = os.path.join(SCRIPT_DIR, "pins.toml")
+PROFILES_DIR = os.path.join(SCRIPT_DIR, "profiles")
+CACHE_DIR = os.path.join(SCRIPT_DIR, ".cache")
+STAGE_DIR = os.path.join(SCRIPT_DIR, ".stage")
+
+# Distinctive Parsek UTF-16 signature strings for the DLL-identity grep
+# (.claude/CLAUDE.md recipe). Pinned so the check survives ordinary builds; the
+# counts are recorded (not asserted equal to a fixed number) so a rename shows
+# as drift rather than a spurious abort. A missing signature (count 0) fails.
+PARSEK_SIGNATURE_STRINGS = ("ParsekFlight", "GhostPlaybackEngine")
+
+
+@dataclass
+class ProvisionContext:
+    profile_name: str
+    pins: Dict
+    profile: Dict
+    umbrella_root: str
+    dry_run: bool
+    repair: bool
+    parsek_dll_override: Optional[str]
+    log_lines: List[str] = field(default_factory=list)
+    aborted: bool = False
+    abort_reason: str = ""
+
+    @property
+    def dev_install(self) -> str:
+        return os.path.join(self.umbrella_root, self.profile.get("baseInstall", "Kerbal Space Program"))
+
+    @property
+    def instance_dir(self) -> str:
+        return os.path.join(self.umbrella_root, self.profile.get("instanceDir", "automation/instance"))
+
+    @property
+    def parsek_gamedata(self) -> str:
+        return os.path.join(self.instance_dir, "GameData", "Parsek")
+
+    def log_path(self) -> str:
+        return os.path.join(self.parsek_gamedata, "provision-log.txt")
+
+
+# ---------------------------------------------------------------------------
+# Logging
+# ---------------------------------------------------------------------------
+
+
+def log(ctx: ProvisionContext, level: str, step: str, message: str) -> None:
+    """Emit one provisioning-log line to stdout and (live runs, once the
+    instance GameData/Parsek dir exists) append it to provision-log.txt."""
+    line = provlib.format_log_line(level, step, message)
+    ctx.log_lines.append(line)
+    print(line)
+    if not ctx.dry_run:
+        try:
+            os.makedirs(ctx.parsek_gamedata, exist_ok=True)
+            with open(ctx.log_path(), "a", encoding="utf-8") as fh:
+                fh.write(line + "\n")
+        except OSError:
+            pass  # never let logging failure mask the real work
+
+
+def abort(ctx: ProvisionContext, step: str, ec: str, detail: str) -> None:
+    ctx.aborted = True
+    ctx.abort_reason = "%s %s" % (ec, detail)
+    log(ctx, "Error", step, "%s %s" % (ec, detail))
+
+
+# ---------------------------------------------------------------------------
+# Small I/O helpers (skipped entirely under --dry-run by their callers)
+# ---------------------------------------------------------------------------
+
+
+def sha256_file(path: str) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as fh:
+        for chunk in iter(lambda: fh.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def git_peel_commit(clone_dir: str, tag: str) -> str:
+    """Return the commit sha an (possibly annotated) tag peels to, read-only.
+
+    Uses ``git rev-parse <tag>^{commit}`` so an ANNOTATED tag (kRPC v0.5.4)
+    resolves to the underlying commit, not the tag object (GT-1). Never checks
+    the clone out to a different ref.
+    """
+    out = subprocess.run(
+        ["git", "-C", clone_dir, "rev-parse", "%s^{commit}" % tag],
+        capture_output=True, text=True,
+    )
+    return (out.stdout or "").strip()
+
+
+# ---------------------------------------------------------------------------
+# Phase functions
+# ---------------------------------------------------------------------------
+
+
+def phase_preflight(ctx: ProvisionContext) -> None:
+    log(ctx, "Info", "Preflight", "umbrella-root=%s" % ctx.umbrella_root)
+    log(ctx, "Info", "Preflight", "dev-install=%s" % ctx.dev_install)
+    log(ctx, "Info", "Preflight", "instance-dir=%s" % ctx.instance_dir)
+    log(ctx, "Info", "Preflight", "mode=%s repair=%s" % ("dry-run" if ctx.dry_run else "live", ctx.repair))
+
+    if not os.path.isdir(ctx.dev_install):
+        abort(ctx, "Preflight", "EC-PRE", "dev install missing at %s" % ctx.dev_install)
+        return
+    if not os.path.isfile(PINS_PATH):
+        abort(ctx, "Preflight", "EC-PRE", "pins.toml missing at %s" % PINS_PATH)
+        return
+
+    # Path-length guard (EC-7).
+    if provlib.is_path_too_long(ctx.instance_dir):
+        abort(ctx, "Preflight", "EC-7", "instance dir path too long: %s" % ctx.instance_dir)
+        return
+
+    # Lock decision (EC-10) -- pure logic; live acquisition writes the lockfile.
+    lock_path = os.path.join(ctx.parsek_gamedata, ".provision.lock")
+    existing = None
+    if os.path.isfile(lock_path):
+        try:
+            with open(lock_path, "r", encoding="utf-8") as fh:
+                existing = json.load(fh)
+        except (OSError, ValueError):
+            existing = None
+    decision = provlib.acquire_lock(existing, os.getpid(), _now(), _pid_alive)
+    log(ctx, "Info", "Preflight", "lock decision=%s holder=%s" % (decision.reason, decision.holder_pid))
+    if not decision.acquired:
+        abort(ctx, "Preflight", "EC-10", "instance locked by live pid %s" % decision.holder_pid)
+        return
+    if not ctx.dry_run:
+        os.makedirs(ctx.parsek_gamedata, exist_ok=True)
+        with open(lock_path, "w", encoding="utf-8") as fh:
+            json.dump({"pid": os.getpid(), "timestamp": _now()}, fh)
+
+    # KSP-running check (EC-1). Best-effort: on a live run, refuse if the
+    # instance exe is held open. Under dry-run we only log the intent.
+    if not ctx.dry_run and _ksp_running_against(ctx.instance_dir):
+        abort(ctx, "Preflight", "EC-1", "close KSP for instance %s" % ctx.profile_name)
+        return
+    log(ctx, "Info", "Preflight", "profile loaded name=%s devSourcedMods=%d"
+        % (ctx.profile_name, len(ctx.profile.get("devSourcedMods", []) or [])))
+
+
+def phase_pin(ctx: ProvisionContext) -> Dict[str, str]:
+    """Resolve git-pinned components read-only and assert against pins.toml."""
+    resolved: Dict[str, str] = {}
+    for comp in ("krpc", "krpc_mechjeb"):
+        pin = ctx.pins.get(comp, {})
+        clone = os.path.join(ctx.umbrella_root, pin.get("localClone", ""))
+        tag = pin.get("tag", "")
+        expected = pin.get("commit", "")
+        if ctx.dry_run and not os.path.isdir(os.path.join(clone, ".git")):
+            # Dry-run without the clone present: report the intended assertion.
+            log(ctx, "Info", "Pin", "%s tag=%s expected-commit=%s (clone not read in dry-run)"
+                % (comp, tag, expected))
+            resolved[comp] = expected
+            continue
+        peeled = git_peel_commit(clone, tag)
+        res = provlib.resolve_pin(peeled, expected)
+        resolved[comp] = res.resolved or expected
+        level = "Info" if res.ok else "Error"
+        log(ctx, level, "Pin", "%s tag=%s -> %s %s"
+            % (comp, tag, res.resolved or "(missing)", res.reason.upper()))
+        if not res.ok:
+            abort(ctx, "Pin", "EC-PIN", "%s pin %s does not match recorded commit %s"
+                  % (comp, res.reason, expected))
+            return resolved
+
+    # GT-2 capability warning: v0.5.4 TestingTools has no auto-load / Quit /
+    # SetLanded. Boot goes through the M-A2 LoadGame verb, quit via FlushAndQuit,
+    # landed fixtures via SetOrbit.
+    krpc_tag = ctx.pins.get("krpc", {}).get("tag", "")
+    if krpc_tag == "v0.5.4":
+        log(ctx, "Info", "Pin",
+            "GT-2: kRPC v0.5.4 TestingTools lacks %s; boot via M-A2 LoadGame, "
+            "quit via FlushAndQuit, land via SetOrbit (bootChannel=%s)"
+            % (", ".join(provlib.MISSING_VS_MASTER),
+               ctx.pins.get("testingtools", {}).get("bootChannel", "parsek-seam-LoadGame")))
+    else:
+        log(ctx, "Amber", "Pin",
+            "kRPC pinned to non-v0.5.4 ref %s: auto-load flags come with an "
+            "unreleased ABI and force the PAIR re-decision (darchambault 0.8.1)."
+            % krpc_tag)
+    return resolved
+
+
+def phase_download(ctx: ProvisionContext) -> None:
+    """Fetch + verify the kRPC release zip and the MechJeb2 build (live only)."""
+    krpc = ctx.pins.get("krpc", {})
+    mj = ctx.pins.get("mechjeb2", {})
+
+    for comp, url, sha, name in (
+        ("krpc", krpc.get("releaseZipUrl"), krpc.get("releaseZipSha256"), "krpc release zip"),
+        ("mechjeb2", mj.get("downloadUrl"), mj.get("sha256"), "mechjeb2 build"),
+    ):
+        if provlib.is_open_pin(sha):
+            if ctx.dry_run:
+                log(ctx, "Amber", "Download",
+                    "%s sha256 is OPEN -- a live run would download, print the hash, and ABORT (EC-13). "
+                    "url=%s" % (name, url))
+                continue
+            # Live: download, compute, print, ABORT (never trust unverified bytes).
+            data = _download(ctx, url)
+            if data is None:
+                return
+            actual = sha256_bytes(data)
+            log(ctx, "Error", "Download",
+                "%s sha256 unrecorded (EC-13). computed=%s -- record it in pins.toml and re-run."
+                % (name, actual))
+            abort(ctx, "Download", "EC-13", "%s sha256 OPEN" % comp)
+            return
+        if ctx.dry_run:
+            log(ctx, "Info", "Download", "%s url=%s expected-sha256=%s (no fetch in dry-run)"
+                % (name, url, sha))
+            continue
+        # Live path.
+        data = _download(ctx, url)
+        if data is None:
+            return
+        actual = sha256_bytes(data)
+        ok = actual.lower() == str(sha).lower()
+        log(ctx, "Info" if ok else "Error", "Download",
+            "%s bytes=%d sha256 expected=%s actual=%s %s"
+            % (name, len(data), sha, actual, "OK" if ok else "FAIL"))
+        if not ok:
+            abort(ctx, "Download", "EC-3", "%s sha256 mismatch" % comp)
+            return
+        os.makedirs(CACHE_DIR, exist_ok=True)
+        with open(os.path.join(CACHE_DIR, os.path.basename(url)), "wb") as fh:
+            fh.write(data)
+        if comp == "krpc":
+            _assert_krpc_zip_layout(ctx, data)
+
+
+def phase_build_tt(ctx: ProvisionContext) -> None:
+    """Build the 2-file TestingTools shim from the pinned kRPC ref (live only)."""
+    tt = ctx.pins.get("testingtools", {})
+    full = list(tt.get("fullSourceSetAtTag", provlib.TESTINGTOOLS_SHIM_SOURCES
+                        + provlib.TESTINGTOOLS_DROPPED_SOURCES))
+    sel = provlib.select_testingtools_sources(full)
+    if not sel.ok:
+        abort(ctx, "Build-TT", "EC-4", "shim source selection failed: %s" % sel.reason)
+        return
+    log(ctx, "Info", "Build-TT",
+        "shim sources=%s dropped=%s autoloader-excluded=%s"
+        % (",".join(sel.included), ",".join(sel.dropped), sel.autoloader_excluded))
+    if ctx.dry_run:
+        log(ctx, "Info", "Build-TT",
+            "would git-archive %s from %s@%s, author TestingTools.shim.csproj "
+            "(net472, HintPaths into devInstall Managed + release kRPC), dotnet build -c Release, "
+            "hash + cache; assert AutoLoadGame type ABSENT (S-4)"
+            % (",".join(sel.included), tt.get("localClone", "mods/krpc"), tt.get("sourceRepoRef", "v0.5.4")))
+        return
+    # Live build is a real dotnet invocation; kept out of the smoke path.
+    log(ctx, "Info", "Build-TT", "(live build would run here; see design BUILD-TT)")
+
+
+def phase_pair(ctx: ProvisionContext) -> None:
+    """Resolve KRPC.MechJeb against the pinned kRPC (GT-6 / EC-14)."""
+    krpc_tag = ctx.pins.get("krpc", {}).get("tag", "")
+    kmj = ctx.pins.get("krpc_mechjeb", {})
+    if krpc_tag == "v0.5.4":
+        ok = kmj.get("fork") == "genhis" and kmj.get("tag") == "v0.7.1" \
+            and kmj.get("pairedKrpcTag") == "v0.5.4"
+        log(ctx, "Info" if ok else "Error", "Pair",
+            "krpc_mechjeb fork=%s tag=%s pairedKrpcTag=%s vs krpc %s %s"
+            % (kmj.get("fork"), kmj.get("tag"), kmj.get("pairedKrpcTag"), krpc_tag,
+               "OK" if ok else "MISMATCH"))
+        if not ok:
+            abort(ctx, "Pair", "EC-14", "genhis 0.7.1 pairing assertion failed for v0.5.4")
+    else:
+        log(ctx, "Amber", "Pair",
+            "non-v0.5.4 kRPC pinned: pairing UNVERIFIED locally. Web-verify at "
+            "github.com/Genhis/KRPC.MechJeb/releases and "
+            "github.com/darchambault/KRPC.MechJeb/releases for the fork+tag whose "
+            "'Updated for kRPC <ver>' matches the pin, then re-run.")
+        abort(ctx, "Pair", "EC-14", "non-v0.5.4 pairing must be web-verified, not guessed")
+
+
+def phase_clone(ctx: ProvisionContext):
+    """Copy the mutable surface and junction the stock asset trees (live only).
+
+    Returns ``(junctionTargets, devSourcedMods_status)`` for the manifest. In a
+    live run each dev-sourced mod's status is its content tree-hash; here (and in
+    dry-run) it is ``pending-hash`` for present mods and ``absent-source`` for an
+    absent optional mod (EC-12).
+    """
+    junctions: Dict[str, str] = {}
+    dev_status: Dict[str, str] = {}
+    for tree in provlib.STOCK_JUNCTION_TREES:
+        junctions[tree] = os.path.join(ctx.dev_install, tree)
+    for name in provlib.STOCK_JUNCTION_GAMEDATA:
+        junctions["GameData/%s" % name] = os.path.join(ctx.dev_install, "GameData", name)
+
+    dev = ctx.profile.get("devSourcedMods", []) or []
+    log(ctx, "Info", "Clone",
+        "junction-targets=%d dev-sourced-copies=%d" % (len(junctions), len(dev)))
+    for link, target in junctions.items():
+        # Only GameData entries carry a copy-vs-junction classification; the bulk
+        # asset trees (StreamingAssets) are always junctioned stock payloads.
+        kind = (provlib.classify_gamedata_entry(os.path.basename(link), dev)
+                if link.startswith("GameData/") else "junction-stock-tree")
+        log(ctx, "Info", "Clone", "junction %s -> %s (%s)" % (link, target, kind))
+    for name in dev:
+        log(ctx, "Info", "Clone", "copy GameData/%s (%s)"
+            % (name, provlib.classify_gamedata_entry(name, dev)))
+        dev_status[name] = "pending-hash"
+
+    # EC-12: optional mods (e.g. PersistentRotation) may be absent from the dev
+    # GameData. required=false -> record absent-source + WARN; required=true and
+    # absent -> ABORT.
+    for opt in ctx.profile.get("optionalMods", []) or []:
+        oname = opt.get("name", "")
+        required = bool(opt.get("required", False))
+        src = os.path.join(ctx.dev_install, "GameData", oname)
+        present = os.path.isdir(src)
+        if present:
+            log(ctx, "Info", "Clone", "optional mod %s present -> copy" % oname)
+            dev_status[oname] = "pending-hash"
+        elif required:
+            abort(ctx, "Clone", "EC-12", "required mod %s absent from dev GameData" % oname)
+            return junctions, dev_status
+        else:
+            log(ctx, "Warn", "Clone",
+                "EC-12 optional mod %s absent-source (required=false): %s"
+                % (oname, opt.get("reason", "")))
+            dev_status[oname] = "absent-source"
+
+    if ctx.dry_run:
+        log(ctx, "Info", "Clone",
+            "would copy mutable surface (exe, Managed, settings.cfg, Internals, "
+            "top-level) and create %d junctions via mklink /J" % len(junctions))
+        return junctions, dev_status
+    # Live copy + junction creation is kept out of the smoke path (design CLONE).
+    log(ctx, "Info", "Clone", "(live copy + junctions would run here)")
+    return junctions, dev_status
+
+
+def phase_settings(ctx: ProvisionContext) -> Dict[str, str]:
+    """Apply the profile settings deltas over the dev settings.cfg."""
+    deltas = {k: str(v) for k, v in (ctx.profile.get("settings", {}) or {}).items()}
+    dev_settings = os.path.join(ctx.dev_install, "settings.cfg")
+
+    if not os.path.isfile(dev_settings):
+        if ctx.dry_run:
+            log(ctx, "Amber", "Settings",
+                "dev settings.cfg not found at %s (dry-run: cannot preview delta application)"
+                % dev_settings)
+            log(ctx, "Info", "Settings", "would apply %d delta(s): %s"
+                % (len(deltas), ", ".join(sorted(deltas))))
+            return deltas
+        abort(ctx, "Settings", "EC-SET", "dev settings.cfg missing at %s" % dev_settings)
+        return deltas
+
+    with open(dev_settings, "r", encoding="utf-8") as fh:
+        base_lines = fh.read().splitlines()
+    base_sha = sha256_bytes(("\n".join(base_lines)).encode("utf-8"))
+    present = provlib.keys_present(base_lines, list(deltas))
+    appended = [k for k in deltas if k not in present]
+    log(ctx, "Info", "Settings", "settingsBaseSha256=%s" % base_sha)
+    for k in deltas:
+        kind = "replace" if k in present else "append"
+        log(ctx, "Info" if k in present else "Warn", "Settings",
+            "delta %s=%s (%s)" % (k, deltas[k], kind))
+    if appended:
+        log(ctx, "Warn", "Settings", "EC-15 appended keys absent from dev cfg: %s"
+            % ", ".join(appended))
+
+    new_lines = provlib.apply_settings(base_lines, deltas)
+    final_text = "\n".join(new_lines) + "\n"
+    final_sha = sha256_bytes(final_text.encode("utf-8"))
+    log(ctx, "Info", "Settings", "settingsFinalSha256=%s" % final_sha)
+
+    if not ctx.dry_run:
+        os.makedirs(ctx.instance_dir, exist_ok=True)
+        with open(os.path.join(ctx.instance_dir, "settings.cfg"), "w", encoding="utf-8") as fh:
+            fh.write(final_text)
+    ctx.settings_base_sha = base_sha  # type: ignore[attr-defined]
+    ctx.settings_final_sha = final_sha  # type: ignore[attr-defined]
+    return deltas
+
+
+def phase_deploy(ctx: ProvisionContext) -> Dict[str, object]:
+    """Stage-then-install Parsek.dll with hash + UTF-16 grep (design DEPLOY)."""
+    source = ctx.parsek_dll_override or os.path.join(
+        ctx.umbrella_root, "Parsek-autotest-provision", "Source", "Parsek", "bin", "Debug", "Parsek.dll")
+    # Prefer the current worktree's own build if present.
+    worktree_dll = os.path.join(WORKTREE_ROOT, "Source", "Parsek", "bin", "Debug", "Parsek.dll")
+    if not ctx.parsek_dll_override and os.path.isfile(worktree_dll):
+        source = worktree_dll
+
+    info: Dict[str, object] = {"kind": "staged-build", "stagedFrom": source}
+    if ctx.dry_run:
+        log(ctx, "Info", "Deploy",
+            "would copy %s -> .stage (hash) -> %s/GameData/Parsek/Plugins/Parsek.dll, "
+            "re-hash + assert equal, UTF-16 grep %s"
+            % (source, ctx.instance_dir, "/".join(PARSEK_SIGNATURE_STRINGS)))
+        return info
+
+    if not os.path.isfile(source):
+        abort(ctx, "Deploy", "EC-9", "Parsek.dll source not found: %s (use --parsek-dll)" % source)
+        return info
+    os.makedirs(STAGE_DIR, exist_ok=True)
+    stage = os.path.join(STAGE_DIR, "Parsek.dll")
+    _copy_file(source, stage)
+    stage_sha = sha256_file(stage)
+    log(ctx, "Info", "Deploy", "stage-sha256=%s" % stage_sha)
+
+    src_sha = sha256_file(source)
+    if src_sha != stage_sha:
+        log(ctx, "Amber", "Deploy", "EC-11 source changed after stage copy (informational): src=%s stage=%s"
+            % (src_sha, stage_sha))
+
+    plugins = os.path.join(ctx.parsek_gamedata, "Plugins")
+    os.makedirs(plugins, exist_ok=True)
+    installed = os.path.join(plugins, "Parsek.dll")
+    _copy_file(stage, installed)
+    installed_sha = sha256_file(installed)
+    match = installed_sha == stage_sha
+    log(ctx, "Info" if match else "Error", "Deploy",
+        "installed-sha256=%s hashMatch %s" % (installed_sha, "OK" if match else "FAIL"))
+    if not match:
+        abort(ctx, "Deploy", "EC-9", "installed Parsek.dll hash != stage")
+        return info
+
+    with open(installed, "rb") as fh:
+        dll_bytes = fh.read()
+    sigs: Dict[str, int] = {}
+    for s in PARSEK_SIGNATURE_STRINGS:
+        n = provlib.count_utf16(dll_bytes, s)
+        sigs[s] = n
+        log(ctx, "Info" if n > 0 else "Error", "Deploy",
+            "UTF-16 grep string=%s count=%d %s" % (s, n, "OK" if n > 0 else "FAIL(absent)"))
+        if n == 0:
+            abort(ctx, "Deploy", "EC-9", "Parsek signature %s absent from installed DLL" % s)
+            return info
+    info["dllSha256"] = installed_sha
+    info["signatureStrings"] = sigs
+    return info
+
+
+def phase_install(ctx: ProvisionContext) -> None:
+    for name in ctx.profile.get("stackComponents", []) or []:
+        if name == "parsek":
+            continue
+        log(ctx, "Info", "Install", "stack component %s -> GameData (hash into manifest)" % name)
+    if ctx.dry_run:
+        log(ctx, "Info", "Install",
+            "would extract kRPC into GameData/kRPC, drop TestingTools.dll + KRPC.MechJeb.dll "
+            "alongside, extract MechJeb2 into GameData/MechJeb2, hash every DLL")
+
+
+def phase_mm_cache(ctx: ProvisionContext) -> None:
+    for cache in provlib.MM_CACHE_FILES:
+        target = os.path.join(ctx.instance_dir, "GameData", cache)
+        log(ctx, "Info", "MM-Cache", "delete %s (regenerate on first boot, EC-2)" % cache)
+        if not ctx.dry_run and os.path.exists(target):
+            try:
+                os.remove(target)
+            except OSError as exc:
+                log(ctx, "Warn", "MM-Cache", "could not delete %s: %s" % (target, exc))
+
+
+def phase_manifest(ctx: ProvisionContext, resolved: Dict[str, str],
+                   junctions: Dict[str, str], deltas: Dict[str, str],
+                   parsek_info: Dict[str, object], dev_status: Dict[str, str]) -> Dict:
+    krpc = ctx.pins.get("krpc", {})
+    tt = ctx.pins.get("testingtools", {})
+    mj = ctx.pins.get("mechjeb2", {})
+    kmj = ctx.pins.get("krpc_mechjeb", {})
+    manifest = {
+        "schema": 1,
+        "profile": ctx.profile_name,
+        "generatedUtc": _utcnow_iso(),
+        "provisionScriptCommit": _git_head(WORKTREE_ROOT),
+        "kspVersion": ctx.pins.get("kspVersion", "1.12.5"),
+        "instanceDir": ctx.profile.get("instanceDir"),
+        "components": {
+            "krpc": {"kind": "release-zip", "tag": krpc.get("tag"),
+                     "commit": resolved.get("krpc", krpc.get("commit")),
+                     "sha256": krpc.get("releaseZipSha256")},
+            "testingtools": {"kind": "built-shim", "krpcRef": tt.get("sourceRepoRef"),
+                             "sourceFiles": list(tt.get("sourceFiles", [])),
+                             "capabilities": list(tt.get("capabilities", [])),
+                             "bootChannel": tt.get("bootChannel"),
+                             "autoLoaderAbsent": True,
+                             "missing": list(tt.get("missingVsMaster", []))},
+            "mechjeb2": {"kind": "release", "buildNumber": mj.get("buildNumber"),
+                         "sha256": mj.get("sha256")},
+            "krpc_mechjeb": {"kind": "git", "fork": kmj.get("fork"), "tag": kmj.get("tag"),
+                             "commit": resolved.get("krpc_mechjeb", kmj.get("commit")),
+                             "pairedKrpc": kmj.get("pairedKrpcTag")},
+            "parsek": parsek_info,
+        },
+        "devSourcedMods": dev_status,
+        "junctionTargets": junctions,
+        "settingsDeltasApplied": deltas,
+        "settingsBaseSha256": getattr(ctx, "settings_base_sha", None),
+        "settingsFinalSha256": getattr(ctx, "settings_final_sha", None),
+        "buildId64Sha256": _buildid64_sha(ctx),
+    }
+    if ctx.dry_run:
+        log(ctx, "Info", "Manifest",
+            "would atomically write provision-manifest.json (components=%d, junctions=%d, deltas=%d)"
+            % (len(manifest["components"]), len(junctions), len(deltas)))
+        return manifest
+    os.makedirs(ctx.parsek_gamedata, exist_ok=True)
+    path = os.path.join(ctx.parsek_gamedata, "provision-manifest.json")
+    tmp = path + ".tmp"
+    with open(tmp, "w", encoding="utf-8") as fh:
+        json.dump(manifest, fh, indent=2, sort_keys=True)
+    os.replace(tmp, path)
+    log(ctx, "Info", "Manifest", "wrote %s" % path)
+    return manifest
+
+
+def phase_verify(ctx: ProvisionContext, manifest: Dict) -> bool:
+    """Re-read the instance and cross-check the just-written manifest."""
+    if ctx.dry_run:
+        log(ctx, "Info", "Verify",
+            "would re-read instance: DLL hashes vs manifest, UTF-16 grep, junction "
+            "resolution, settingsFinalSha256 re-hash, buildId64Sha256 re-hash")
+        return True
+
+    ok = True
+    # Junction resolution (EC-8).
+    dangling = provlib.verify_junctions(manifest, os.path.exists)
+    if dangling:
+        ok = False
+        for link in dangling:
+            log(ctx, "Error", "Verify", "junction DANGLING %s (EC-8)" % link)
+    else:
+        log(ctx, "Info", "Verify", "junctions resolve OK (%d)" % len(manifest.get("junctionTargets", {})))
+
+    # Parsek DLL hash + UTF-16 grep (EC-9/EC-10 mid-run clobber).
+    parsek = manifest["components"].get("parsek", {})
+    installed = os.path.join(ctx.parsek_gamedata, "Plugins", "Parsek.dll")
+    if parsek.get("dllSha256") and os.path.isfile(installed):
+        cur = sha256_file(installed)
+        match = cur == parsek["dllSha256"]
+        log(ctx, "Info" if match else "Error", "Verify",
+            "parsek dll on-disk sha256 %s manifest" % ("==" if match else "!="))
+        ok = ok and match
+
+    # settingsFinalSha256 re-hash (N-4).
+    final = manifest.get("settingsFinalSha256")
+    inst_settings = os.path.join(ctx.instance_dir, "settings.cfg")
+    if final and os.path.isfile(inst_settings):
+        cur = sha256_file(inst_settings)
+        match = cur == final
+        log(ctx, "Info" if match else "Error", "Verify",
+            "settingsFinalSha256 re-hash %s" % ("OK" if match else "DRIFT"))
+        ok = ok and match
+
+    log(ctx, "Info" if ok else "Error", "Verify",
+        "instance=%s result=%s" % (ctx.profile_name, "OK" if ok else "DRIFT"))
+    return ok
+
+
+# ---------------------------------------------------------------------------
+# Live-only OS helpers (never exercised under --dry-run)
+# ---------------------------------------------------------------------------
+
+
+def _now() -> float:
+    import time
+    return time.time()
+
+
+def _utcnow_iso() -> str:
+    return datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _pid_alive(pid: int) -> bool:
+    try:
+        out = subprocess.run(["tasklist", "/FI", "PID eq %d" % pid],
+                             capture_output=True, text=True)
+        return str(pid) in (out.stdout or "")
+    except OSError:
+        return False
+
+
+def _ksp_running_against(instance_dir: str) -> bool:
+    try:
+        out = subprocess.run(["tasklist", "/FI", "IMAGENAME eq KSP_x64.exe"],
+                             capture_output=True, text=True)
+        return "KSP_x64.exe" in (out.stdout or "")
+    except OSError:
+        return False
+
+
+def _download(ctx: ProvisionContext, url: str) -> Optional[bytes]:
+    import urllib.request
+    try:
+        with urllib.request.urlopen(url) as resp:  # noqa: S310 (pinned URLs)
+            return resp.read()
+    except Exception as exc:  # noqa: BLE001
+        abort(ctx, "Download", "EC-6", "download failed %s: %s" % (url, exc))
+        return None
+
+
+def _assert_krpc_zip_layout(ctx: ProvisionContext, data: bytes) -> None:
+    import io
+    import zipfile
+    krpc = ctx.pins.get("krpc", {})
+    with zipfile.ZipFile(io.BytesIO(data)) as zf:
+        names = [n.lower() for n in zf.namelist()]
+    for must in krpc.get("releaseCompileDlls", []):
+        present = any(must.lower() in n for n in names)
+        log(ctx, "Info" if present else "Error", "Download",
+            "GT-5 zip contains %s %s" % (must, "OK" if present else "MISSING"))
+    for forbidden in krpc.get("mustNotContain", []):
+        present = any(forbidden.lower() in n for n in names)
+        log(ctx, "Error" if present else "Info", "Download",
+            "GT-5 zip must-not-contain %s %s" % (forbidden, "FAIL" if present else "OK"))
+
+
+def _copy_file(src: str, dst: str) -> None:
+    import shutil
+    shutil.copyfile(src, dst)
+
+
+def _git_head(repo: str) -> str:
+    out = subprocess.run(["git", "-C", repo, "rev-parse", "HEAD"],
+                         capture_output=True, text=True)
+    return (out.stdout or "").strip()
+
+
+def _buildid64_sha(ctx: ProvisionContext) -> Optional[str]:
+    path = os.path.join(ctx.instance_dir, "buildID64.txt")
+    if os.path.isfile(path):
+        return sha256_file(path)
+    dev = os.path.join(ctx.dev_install, "buildID64.txt")
+    if ctx.dry_run and os.path.isfile(dev):
+        return sha256_file(dev)  # dry-run preview against the dev install's id
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Driver
+# ---------------------------------------------------------------------------
+
+
+def load_toml(path: str) -> Dict:
+    with open(path, "rb") as fh:
+        return tomllib.load(fh)
+
+
+def print_action_plan(ctx: ProvisionContext) -> None:
+    plan = provlib.build_action_plan(ctx.pins, ctx.profile)
+    print("")
+    print("=== DRY-RUN ACTION PLAN: profile=%s ===" % ctx.profile_name)
+    for a in plan:
+        print("  [%-9s] %-8s %s" % (a.step, a.verb, a.detail))
+    print("=== %d planned actions ===" % len(plan))
+    print("")
+
+
+def run(ctx: ProvisionContext) -> int:
+    if ctx.dry_run:
+        print_action_plan(ctx)
+
+    phase_preflight(ctx)
+    if ctx.aborted:
+        return _finish(ctx, 2)
+
+    resolved = phase_pin(ctx)
+    if ctx.aborted:
+        return _finish(ctx, 2)
+
+    phase_download(ctx)
+    if ctx.aborted:
+        return _finish(ctx, 2)
+
+    phase_build_tt(ctx)
+    if ctx.aborted:
+        return _finish(ctx, 2)
+
+    phase_pair(ctx)
+    if ctx.aborted:
+        return _finish(ctx, 2)
+
+    junctions, dev_status = phase_clone(ctx)
+    if ctx.aborted:
+        return _finish(ctx, 2)
+    deltas = phase_settings(ctx)
+    if ctx.aborted:
+        return _finish(ctx, 2)
+
+    parsek_info = phase_deploy(ctx)
+    if ctx.aborted:
+        return _finish(ctx, 2)
+
+    phase_install(ctx)
+    phase_mm_cache(ctx)
+    manifest = phase_manifest(ctx, resolved, junctions, deltas, parsek_info, dev_status)
+    verified = phase_verify(ctx, manifest)
+    return _finish(ctx, 0 if verified else 3)
+
+
+def _finish(ctx: ProvisionContext, code: int) -> int:
+    if ctx.aborted:
+        log(ctx, "Error", "Summary", "ABORT: %s (exit=2)" % ctx.abort_reason)
+        return 2
+    log(ctx, "Info", "Summary",
+        "instance=%s %s exit=%d" % (ctx.profile_name,
+                                    "dry-run plan complete" if ctx.dry_run else "provisioned",
+                                    code))
+    return code
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    p = argparse.ArgumentParser(description="M-A6 automation-stack provisioner")
+    p.add_argument("--profile", required=True, help="profile name under profiles/ (e.g. stock-minimal)")
+    p.add_argument("--repair", action="store_true", help="re-install any drifted component then re-verify")
+    p.add_argument("--dry-run", action="store_true",
+                   help="print the action plan + drift; no network, downloads, builds, or writes outside harness/")
+    p.add_argument("--parsek-dll", help="explicit path to the Parsek.dll to deploy (else the current worktree bin/Debug)")
+    p.add_argument("--umbrella-root", help="override the umbrella root (default: parent of this worktree)")
+    args = p.parse_args(argv)
+
+    profile_path = os.path.join(PROFILES_DIR, "%s.toml" % args.profile)
+    if not os.path.isfile(profile_path):
+        print("[Provision][Error][Preflight] profile not found: %s" % profile_path)
+        return 2
+    pins = load_toml(PINS_PATH)
+    profile = load_toml(profile_path)
+    umbrella = args.umbrella_root or os.path.abspath(os.path.join(WORKTREE_ROOT, ".."))
+
+    ctx = ProvisionContext(
+        profile_name=args.profile,
+        pins=pins,
+        profile=profile,
+        umbrella_root=umbrella,
+        dry_run=args.dry_run,
+        repair=args.repair,
+        parsek_dll_override=args.parsek_dll,
+    )
+    return run(ctx)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/harness/provision/provision.py
+++ b/harness/provision/provision.py
@@ -20,6 +20,15 @@ already exists, but performs NO network access, downloads, builds, clones,
 junction creation, or writes outside harness/provision/. All pure decisions
 live in provlib.py so they are unit-tested without side effects.
 
+Status (v1): this module is the dry-run PLANNER plus the pure decision library
+(provlib.py). Live execution of the heavy provisioning phases (BUILD-TT, CLONE,
+INSTALL -- and by extension the SETTINGS/DEPLOY/MM-CACHE/MANIFEST writes that
+follow them) is NOT yet implemented: a non-dry-run invocation aborts loudly at
+the first unimplemented phase rather than half-provisioning an instance or
+writing a manifest that claims a completeness the run cannot back. --repair is
+likewise unimplemented and aborts. Live execution lands with the coordinated
+smoke-run task (design doc, "Test Plan" / "Deferred to live execution").
+
 stdlib only; ASCII only.
 """
 
@@ -109,6 +118,26 @@ def abort(ctx: ProvisionContext, step: str, ec: str, detail: str) -> None:
     ctx.aborted = True
     ctx.abort_reason = "%s %s" % (ec, detail)
     log(ctx, "Error", step, "%s %s" % (ec, detail))
+
+
+LIVE_UNIMPLEMENTED_MSG = (
+    "live provisioning not yet implemented for CLONE/BUILD-TT/INSTALL: "
+    "run with --dry-run; live support tracked in the design doc"
+)
+
+
+def _guard_live_unimplemented(ctx: ProvisionContext, step: str) -> bool:
+    """Abort a LIVE run at an unimplemented heavy provisioning phase.
+
+    Returns True (and marks the run aborted) on a live run so the caller returns
+    immediately; returns False under --dry-run so the planner runs unchanged.
+    BUILD-TT is the first of these phases in execution order, so a live run
+    aborts here before any of the write-bearing phases (SETTINGS/DEPLOY/
+    MM-CACHE/MANIFEST) can half-provision the instance."""
+    if ctx.dry_run:
+        return False
+    abort(ctx, step, "EC-LIVE", LIVE_UNIMPLEMENTED_MSG)
+    return True
 
 
 # ---------------------------------------------------------------------------
@@ -251,6 +280,16 @@ def phase_download(ctx: ProvisionContext) -> None:
                     "%s sha256 is OPEN -- a live run would download, print the hash, and ABORT (EC-13). "
                     "url=%s" % (name, url))
                 continue
+            # If the URL itself is still OPEN (e.g. mechjeb2 has no download URL
+            # yet), we cannot fetch anything to compute a hash. Fire EC-13
+            # directly instead of calling _download("OPEN") and aborting with a
+            # bogus EC-6 download-failed error.
+            if provlib.is_open_pin(url):
+                log(ctx, "Error", "Download",
+                    "%s downloadUrl is OPEN (EC-13): record both the URL and its sha256 "
+                    "in pins.toml and re-run." % name)
+                abort(ctx, "Download", "EC-13", "%s url+sha256 OPEN" % comp)
+                return
             # Live: download, compute, print, ABORT (never trust unverified bytes).
             data = _download(ctx, url)
             if data is None:
@@ -286,6 +325,8 @@ def phase_download(ctx: ProvisionContext) -> None:
 
 def phase_build_tt(ctx: ProvisionContext) -> None:
     """Build the 2-file TestingTools shim from the pinned kRPC ref (live only)."""
+    if _guard_live_unimplemented(ctx, "Build-TT"):
+        return
     tt = ctx.pins.get("testingtools", {})
     full = list(tt.get("fullSourceSetAtTag", provlib.TESTINGTOOLS_SHIM_SOURCES
                         + provlib.TESTINGTOOLS_DROPPED_SOURCES))
@@ -337,6 +378,8 @@ def phase_clone(ctx: ProvisionContext):
     dry-run) it is ``pending-hash`` for present mods and ``absent-source`` for an
     absent optional mod (EC-12).
     """
+    if _guard_live_unimplemented(ctx, "Clone"):
+        return {}, {}
     junctions: Dict[str, str] = {}
     dev_status: Dict[str, str] = {}
     for tree in provlib.STOCK_JUNCTION_TREES:
@@ -356,7 +399,10 @@ def phase_clone(ctx: ProvisionContext):
     for name in dev:
         log(ctx, "Info", "Clone", "copy GameData/%s (%s)"
             % (name, provlib.classify_gamedata_entry(name, dev)))
-        dev_status[name] = "pending-hash"
+        # "planned-copy": this is a dry-run plan preview. The real content
+        # tree-hash is computed only by the (unimplemented) live CLONE; do not
+        # record a forward-looking "pending-hash" the run cannot fill.
+        dev_status[name] = "planned-copy"
 
     # EC-12: optional mods (e.g. PersistentRotation) may be absent from the dev
     # GameData. required=false -> record absent-source + WARN; required=true and
@@ -368,7 +414,7 @@ def phase_clone(ctx: ProvisionContext):
         present = os.path.isdir(src)
         if present:
             log(ctx, "Info", "Clone", "optional mod %s present -> copy" % oname)
-            dev_status[oname] = "pending-hash"
+            dev_status[oname] = "planned-copy"
         elif required:
             abort(ctx, "Clone", "EC-12", "required mod %s absent from dev GameData" % oname)
             return junctions, dev_status
@@ -492,6 +538,8 @@ def phase_deploy(ctx: ProvisionContext) -> Dict[str, object]:
 
 
 def phase_install(ctx: ProvisionContext) -> None:
+    if _guard_live_unimplemented(ctx, "Install"):
+        return
     stack = ctx.profile.get("stackComponents", []) or []
     if not stack:
         # An empty stack list is almost always a profile-TOML bug (a
@@ -542,11 +590,13 @@ def phase_manifest(ctx: ProvisionContext, resolved: Dict[str, str],
             "krpc": {"kind": "release-zip", "tag": krpc.get("tag"),
                      "commit": resolved.get("krpc", krpc.get("commit")),
                      "sha256": krpc.get("releaseZipSha256")},
+            # NOTE: autoLoaderAbsent is deliberately NOT recorded here. It is a
+            # claim only the (unimplemented) BUILD-TT reflection smoke over the
+            # ACTUAL built assembly can back (S-4); a planner must not assert it.
             "testingtools": {"kind": "built-shim", "krpcRef": tt.get("sourceRepoRef"),
                              "sourceFiles": list(tt.get("sourceFiles", [])),
                              "capabilities": list(tt.get("capabilities", [])),
                              "bootChannel": tt.get("bootChannel"),
-                             "autoLoaderAbsent": True,
                              "missing": list(tt.get("missingVsMaster", []))},
             "mechjeb2": {"kind": "release", "buildNumber": mj.get("buildNumber"),
                          "sha256": mj.get("sha256")},
@@ -722,6 +772,15 @@ def print_action_plan(ctx: ProvisionContext) -> None:
 def run(ctx: ProvisionContext) -> int:
     if ctx.dry_run:
         print_action_plan(ctx)
+
+    # --repair converges drifted components in a live instance; that path is part
+    # of the unimplemented live execution, so a live --repair aborts up front
+    # rather than implying a convergence it cannot perform. (--dry-run --repair
+    # still prints the plan above.)
+    if ctx.repair and not ctx.dry_run:
+        abort(ctx, "Preflight", "EC-LIVE",
+              "--repair is part of the unimplemented live execution: " + LIVE_UNIMPLEMENTED_MSG)
+        return _finish(ctx, 2)
 
     phase_preflight(ctx)
     if ctx.aborted:

--- a/harness/provision/provision.py
+++ b/harness/provision/provision.py
@@ -194,6 +194,19 @@ def phase_preflight(ctx: ProvisionContext) -> None:
         abort(ctx, "Preflight", "EC-7", "instance dir path too long: %s" % ctx.instance_dir)
         return
 
+    # Dev-install aliasing guard (EC-16). The live primitives overwrite
+    # settings.cfg, copy the DLL, and DELETE the MM cache; an instance dir that
+    # equals, nests inside, or contains the read-only dev install (or is not
+    # under automation/) would corrupt the clone source. ABORT before any write.
+    inst_norm = os.path.normcase(os.path.normpath(ctx.instance_dir))
+    dev_norm = os.path.normcase(os.path.normpath(ctx.dev_install))
+    alias = provlib.check_instance_dir_alias(inst_norm, dev_norm, ctx.profile.get("instanceDir", ""))
+    if not alias.ok:
+        abort(ctx, "Preflight", "EC-16",
+              "instance dir aliases the dev install (%s): instance=%s dev=%s"
+              % (alias.reason, ctx.instance_dir, ctx.dev_install))
+        return
+
     # Lock decision (EC-10) -- pure logic; live acquisition writes the lockfile.
     lock_path = os.path.join(ctx.parsek_gamedata, ".provision.lock")
     existing = None
@@ -450,9 +463,14 @@ def phase_settings(ctx: ProvisionContext) -> Dict[str, str]:
         abort(ctx, "Settings", "EC-SET", "dev settings.cfg missing at %s" % dev_settings)
         return deltas
 
-    with open(dev_settings, "r", encoding="utf-8") as fh:
-        base_lines = fh.read().splitlines()
-    base_sha = sha256_bytes(("\n".join(base_lines)).encode("utf-8"))
+    # settingsBaseSha256 is over the RAW dev-file bytes exactly as read (line
+    # endings included), NOT a "\n"-rejoin of the split lines: it records what
+    # the dev settings.cfg actually was on disk, so a re-hash by any tool
+    # matches. splitlines() is only used to drive the line-oriented delta apply.
+    with open(dev_settings, "rb") as fh:
+        base_bytes = fh.read()
+    base_sha = sha256_bytes(base_bytes)
+    base_lines = base_bytes.decode("utf-8").splitlines()
     present = provlib.keys_present(base_lines, list(deltas))
     appended = [k for k in deltas if k not in present]
     log(ctx, "Info", "Settings", "settingsBaseSha256=%s" % base_sha)
@@ -466,13 +484,22 @@ def phase_settings(ctx: ProvisionContext) -> Dict[str, str]:
 
     new_lines = provlib.apply_settings(base_lines, deltas)
     final_text = "\n".join(new_lines) + "\n"
+    # Dry-run preview hash over the text we WOULD write.
     final_sha = sha256_bytes(final_text.encode("utf-8"))
-    log(ctx, "Info", "Settings", "settingsFinalSha256=%s" % final_sha)
 
     if not ctx.dry_run:
         os.makedirs(ctx.instance_dir, exist_ok=True)
-        with open(os.path.join(ctx.instance_dir, "settings.cfg"), "w", encoding="utf-8") as fh:
+        out_path = os.path.join(ctx.instance_dir, "settings.cfg")
+        # newline="\n": suppress the platform CRLF translation Python's text mode
+        # applies by default on Windows, so the on-disk bytes match final_text.
+        with open(out_path, "w", encoding="utf-8", newline="\n") as fh:
             fh.write(final_text)
+        # Record settingsFinalSha256 over the bytes ACTUALLY on disk, not the
+        # in-memory text: VERIFY (and the harness) re-hash the raw file, so the
+        # recorded value must be that same raw-byte hash or every live run would
+        # exit 3 DRIFT on a platform that rewrote the line endings.
+        final_sha = sha256_file(out_path)
+    log(ctx, "Info", "Settings", "settingsFinalSha256=%s" % final_sha)
     ctx.settings_base_sha = base_sha  # type: ignore[attr-defined]
     ctx.settings_final_sha = final_sha  # type: ignore[attr-defined]
     return deltas

--- a/harness/provision/provision.py
+++ b/harness/provision/provision.py
@@ -492,7 +492,18 @@ def phase_deploy(ctx: ProvisionContext) -> Dict[str, object]:
 
 
 def phase_install(ctx: ProvisionContext) -> None:
-    for name in ctx.profile.get("stackComponents", []) or []:
+    stack = ctx.profile.get("stackComponents", []) or []
+    if not stack:
+        # An empty stack list is almost always a profile-TOML bug (a
+        # stackComponents key misplaced under a [[table]] header binds to that
+        # table and leaves the top-level list empty -- BLOCKER 1). Warn loudly
+        # rather than silently installing nothing.
+        log(ctx, "Warn", "Install",
+            "profile '%s' has NO stackComponents -- no stack payloads would be installed. "
+            "Check the profile TOML: a bare key placed after a [[table]] header silently "
+            "binds to that table and empties the top-level list." % ctx.profile_name)
+        return
+    for name in stack:
         if name == "parsek":
             continue
         log(ctx, "Info", "Install", "stack component %s -> GameData (hash into manifest)" % name)

--- a/harness/provision/provision.py
+++ b/harness/provision/provision.py
@@ -225,6 +225,10 @@ def phase_preflight(ctx: ProvisionContext) -> None:
         os.makedirs(ctx.parsek_gamedata, exist_ok=True)
         with open(lock_path, "w", encoding="utf-8") as fh:
             json.dump({"pid": os.getpid(), "timestamp": _now()}, fh)
+        # Record ownership so _finish removes ONLY a lock this run created (never
+        # a lock a concurrent live run holds, which we would have refused above).
+        ctx.lock_path = lock_path  # type: ignore[attr-defined]
+        ctx.lock_acquired = True  # type: ignore[attr-defined]
 
     # KSP-running check (EC-1). Best-effort: on a live run, refuse if the
     # instance exe is held open. Under dry-run we only log the intent.
@@ -365,14 +369,14 @@ def phase_pair(ctx: ProvisionContext) -> None:
     """Resolve KRPC.MechJeb against the pinned kRPC (GT-6 / EC-14)."""
     krpc_tag = ctx.pins.get("krpc", {}).get("tag", "")
     kmj = ctx.pins.get("krpc_mechjeb", {})
-    if krpc_tag == "v0.5.4":
-        ok = kmj.get("fork") == "genhis" and kmj.get("tag") == "v0.7.1" \
-            and kmj.get("pairedKrpcTag") == "v0.5.4"
-        log(ctx, "Info" if ok else "Error", "Pair",
+    decision = provlib.evaluate_krpc_mechjeb_pair(
+        krpc_tag, kmj.get("fork", ""), kmj.get("tag", ""), kmj.get("pairedKrpcTag", ""))
+    if not decision.requires_web_verify:
+        log(ctx, "Info" if decision.ok else "Error", "Pair",
             "krpc_mechjeb fork=%s tag=%s pairedKrpcTag=%s vs krpc %s %s"
             % (kmj.get("fork"), kmj.get("tag"), kmj.get("pairedKrpcTag"), krpc_tag,
-               "OK" if ok else "MISMATCH"))
-        if not ok:
+               "OK" if decision.ok else "MISMATCH"))
+        if not decision.ok:
             abort(ctx, "Pair", "EC-14", "genhis 0.7.1 pairing assertion failed for v0.5.4")
     else:
         log(ctx, "Amber", "Pair",
@@ -386,10 +390,11 @@ def phase_pair(ctx: ProvisionContext) -> None:
 def phase_clone(ctx: ProvisionContext):
     """Copy the mutable surface and junction the stock asset trees (live only).
 
-    Returns ``(junctionTargets, devSourcedMods_status)`` for the manifest. In a
-    live run each dev-sourced mod's status is its content tree-hash; here (and in
-    dry-run) it is ``pending-hash`` for present mods and ``absent-source`` for an
-    absent optional mod (EC-12).
+    Returns ``(junctionTargets, devSourcedMods_status)`` for the manifest. Live
+    execution (which would compute each dev-sourced mod's content tree-hash) is
+    unimplemented, so a live run aborts here; the dry-run plan records
+    ``planned-copy`` for present mods and ``absent-source`` for an absent
+    optional mod (EC-12).
     """
     if _guard_live_unimplemented(ctx, "Clone"):
         return {}, {}
@@ -507,12 +512,16 @@ def phase_settings(ctx: ProvisionContext) -> Dict[str, str]:
 
 def phase_deploy(ctx: ProvisionContext) -> Dict[str, object]:
     """Stage-then-install Parsek.dll with hash + UTF-16 grep (design DEPLOY)."""
-    source = ctx.parsek_dll_override or os.path.join(
+    # NOTE (reviewer 5, deferred): the default source hardcodes the worktree name
+    # "Parsek-autotest-provision"; the worktree-own build below is preferred when
+    # present, so this only bites when deploying from a differently-named tree.
+    default_dll = os.path.join(
         ctx.umbrella_root, "Parsek-autotest-provision", "Source", "Parsek", "bin", "Debug", "Parsek.dll")
-    # Prefer the current worktree's own build if present.
     worktree_dll = os.path.join(WORKTREE_ROOT, "Source", "Parsek", "bin", "Debug", "Parsek.dll")
-    if not ctx.parsek_dll_override and os.path.isfile(worktree_dll):
-        source = worktree_dll
+    sel = provlib.select_parsek_dll_source(
+        ctx.parsek_dll_override, worktree_dll, os.path.isfile(worktree_dll), default_dll)
+    source = sel.source
+    log(ctx, "Info", "Deploy", "parsek dll source=%s (%s)" % (source, sel.reason))
 
     info: Dict[str, object] = {"kind": "staged-build", "stagedFrom": source}
     if ctx.dry_run:
@@ -663,8 +672,15 @@ def phase_verify(ctx: ProvisionContext, manifest: Dict) -> bool:
         return True
 
     ok = True
-    # Junction resolution (EC-8).
-    dangling = provlib.verify_junctions(manifest, os.path.exists)
+    # Junction resolution (EC-8). Probe the LINK (realpath), not just the
+    # target's existence: a junction reports islink()==False, and a deleted or
+    # repointed junction must fail even when the old target still exists.
+    def _resolve_link(link_key: str) -> Optional[str]:
+        link_abs = os.path.join(ctx.instance_dir, link_key)
+        if not os.path.exists(link_abs):
+            return None
+        return os.path.realpath(link_abs)
+    dangling = provlib.verify_junctions(manifest, _resolve_link)
     if dangling:
         ok = False
         for link in dangling:
@@ -848,6 +864,16 @@ def run(ctx: ProvisionContext) -> int:
 
 
 def _finish(ctx: ProvisionContext, code: int) -> int:
+    # Release the instance lock this run acquired (live only). Only remove a lock
+    # we own; a lock held by another live run was refused, not written, here.
+    if getattr(ctx, "lock_acquired", False) and not ctx.dry_run:
+        lock_path = getattr(ctx, "lock_path", None)
+        if lock_path and os.path.isfile(lock_path):
+            try:
+                os.remove(lock_path)
+                log(ctx, "Info", "Summary", "released provision lock %s" % lock_path)
+            except OSError as exc:
+                log(ctx, "Warn", "Summary", "could not remove lock %s: %s" % (lock_path, exc))
     if ctx.aborted:
         log(ctx, "Error", "Summary", "ABORT: %s (exit=2)" % ctx.abort_reason)
         return 2

--- a/harness/provision/provlib.py
+++ b/harness/provision/provlib.py
@@ -1,0 +1,552 @@
+"""Pure decision logic for the M-A6 automation-stack provisioner.
+
+This module holds every side-effect-free decision the provisioner makes:
+manifest drift diffing, settings-delta application, pin resolution, junction
+classification, UTF-16 signature counting, disk/path guards, and lockfile
+acquire/reclaim semantics. It imports nothing that touches the network, KSP, or
+the filesystem so the whole module is unit-testable in isolation (see
+test_provlib.py). The orchestrator (provision.py) performs the actual I/O and
+calls into here for every branch it takes.
+
+Design authority: docs/dev/design-autotest-stack-setup.md (Module M-A6).
+ASCII only; stdlib only.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Callable, Dict, List, Optional, Sequence, Tuple
+
+# ---------------------------------------------------------------------------
+# Capability table (design GT-2 / GT-3). Data, not a unit test: the design
+# dropped the "restate the table back to itself" test as vacuous; the real
+# guard is the BUILD-TT reflection smoke over the built assembly. Kept here as
+# the harness admission INPUT and for MANIFEST emission.
+# ---------------------------------------------------------------------------
+
+TESTINGTOOLS_CAPABILITIES: Tuple[str, ...] = (
+    "LoadSave",
+    "RemoveOtherVessels",
+    "SetCircularOrbit",
+    "SetOrbit",
+    "ClearRotation",
+    "ApplyRotation",
+)
+
+# Present on master ("RPC Deprecation #926"), ABSENT at the v0.5.4 release pin.
+MISSING_VS_MASTER: Tuple[str, ...] = ("autoLoadFlags", "Quit", "SetLanded")
+
+# BUILD-TT: TestingTools source at v0.5.4 is exactly five files. The shim
+# compiles only two; AutoLoadGame.cs unconditionally auto-loads
+# saves/default/persistent.sfs 15 frames after MAINMENU and would race the
+# seam's LoadGame boot (M-A2), so it and AutoSwitchVessel.cs are DROPPED.
+TESTINGTOOLS_SHIM_SOURCES: Tuple[str, ...] = ("OrbitTools.cs", "TestingTools.cs")
+TESTINGTOOLS_DROPPED_SOURCES: Tuple[str, ...] = ("AutoLoadGame.cs", "AutoSwitchVessel.cs")
+
+# Stock asset payloads junctioned (not copied) at CLONE (design CLONE step).
+STOCK_JUNCTION_GAMEDATA: Tuple[str, ...] = ("Squad", "SquadExpansion")
+STOCK_JUNCTION_TREES: Tuple[str, ...] = ("KSP_x64_Data/StreamingAssets",)
+
+# Stack components installed by the script, never sourced from dev GameData.
+STACK_COMPONENT_NAMES: Tuple[str, ...] = (
+    "krpc",
+    "testingtools",
+    "mechjeb2",
+    "krpc_mechjeb",
+    "parsek",
+)
+
+# ModuleManager cache artifacts deleted from the instance so MM regenerates
+# them against the instance's actual mod set (design MM CACHE / EC-2).
+MM_CACHE_FILES: Tuple[str, ...] = (
+    "ModuleManager.ConfigCache",
+    "ModuleManager.ConfigSHA",
+    "ModuleManager.Physics",
+    "ModuleManager.TechTree",
+)
+
+# Log levels mirroring ParsekLog plus Amber for the design's loud-but-not-fatal
+# warnings (master-commit pin, EC-11 stage-vs-source).
+LOG_LEVELS: Tuple[str, ...] = ("Info", "Verbose", "Warn", "Amber", "Error")
+
+
+# ---------------------------------------------------------------------------
+# Logging format (pure). Orchestrator writes these to provision-log.txt.
+# ---------------------------------------------------------------------------
+
+
+def format_log_line(level: str, step: str, message: str) -> str:
+    """Format one provisioning-log line: ``[Provision][LEVEL][Step] message``.
+
+    Mirrors ParsekLog's ``[Parsek][LEVEL][Subsystem]`` shape (design's
+    Diagnostic Logging section). ``level`` is normalized to a known level;
+    unknown levels are passed through so a caller typo is visible, not silently
+    swallowed.
+    """
+    return "[Provision][%s][%s] %s" % (level, step, message)
+
+
+# ---------------------------------------------------------------------------
+# Pin resolution (design PIN / GT-1). resolve_pin compares the git-resolved
+# commit against the recorded pin. Callers MUST peel annotated tags with
+# ``git rev-parse <tag>^{commit}`` before calling: kRPC v0.5.4 is an ANNOTATED
+# tag, so a bare ``git rev-parse v0.5.4`` yields the tag OBJECT sha
+# (4e9dfbed...), not the commit (11f1f13...). Peeling is the orchestrator's job;
+# this function just compares the peeled result against pins.toml.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class PinResolution:
+    ok: bool
+    reason: str  # "match" | "mismatch" | "missing"
+    expected: str
+    resolved: str
+
+
+def resolve_pin(clone_ref_output: str, expected_commit: str) -> PinResolution:
+    """Compare a git-resolved commit against the recorded pin commit.
+
+    ``clone_ref_output`` is the raw stdout of ``git rev-parse <tag>^{commit}``
+    (may carry trailing whitespace/newline, or be empty when the tag is
+    missing). Returns ``missing`` on empty output (moved/deleted tag), ``match``
+    when the resolved commit equals the recorded pin, else ``mismatch`` (a
+    moved/retagged ref -- guards GT-1).
+    """
+    resolved = (clone_ref_output or "").strip()
+    expected = (expected_commit or "").strip()
+    if not resolved:
+        return PinResolution(False, "missing", expected, resolved)
+    if resolved.lower() == expected.lower():
+        return PinResolution(True, "match", expected, resolved)
+    return PinResolution(False, "mismatch", expected, resolved)
+
+
+# ---------------------------------------------------------------------------
+# Settings-delta application (design SETTINGS / EC-15). Pure, line-oriented.
+# ---------------------------------------------------------------------------
+
+# A KSP settings.cfg entry: optional indent, KEY, optional space, '=', value.
+# Node braces, comments (//), and blank lines are NOT entries and are preserved
+# verbatim.
+def settings_key_of(line: str) -> Optional[str]:
+    """Return the KEY of a ``KEY = value`` settings line, else None.
+
+    Blank lines, ``//`` comments, and ``{`` / ``}`` node braces return None so
+    they are treated as opaque and preserved by apply_settings.
+    """
+    stripped = line.strip()
+    if not stripped or stripped.startswith("//") or stripped in ("{", "}"):
+        return None
+    eq = line.find("=")
+    if eq < 0:
+        return None
+    key = line[:eq].strip()
+    if not key:
+        return None
+    # A valid KSP key is a bareword (letters/digits/underscore).
+    for ch in key:
+        if not (ch.isalnum() or ch == "_"):
+            return None
+    return key
+
+
+def _rewrite_settings_value(line: str, new_value: str) -> str:
+    """Replace the value of a matched settings line, preserving indent + key +
+    the exact separator run up to and including ``=`` plus one space."""
+    eq = line.find("=")
+    prefix = line[: eq + 1]  # indent + key + spaces + '='
+    return "%s %s" % (prefix.rstrip(), new_value)
+
+
+def keys_present(base_lines: Sequence[str], keys: Sequence[str]) -> set:
+    """Return the subset of ``keys`` that already exist as entries in base_lines
+    (used to classify replaced-vs-appended for EC-15 logging)."""
+    present = set()
+    have = {settings_key_of(l) for l in base_lines}
+    for k in keys:
+        if k in have:
+            present.add(k)
+    return present
+
+
+def apply_settings(base_lines: Sequence[str], deltas: Dict[str, str]) -> List[str]:
+    """Apply profile settings deltas as pure key-replacements.
+
+    Existing keys are rewritten in place (order, comments, and unrelated keys
+    preserved); keys absent from base are APPENDED at the end (KSP tolerates
+    extra keys, EC-15). Deterministic: appended keys follow the deltas' dict
+    insertion order. Returns the new line list.
+    """
+    result: List[str] = []
+    seen: set = set()
+    for line in base_lines:
+        key = settings_key_of(line)
+        if key is not None and key in deltas:
+            result.append(_rewrite_settings_value(line, str(deltas[key])))
+            seen.add(key)
+        else:
+            result.append(line)
+    for key, value in deltas.items():
+        if key not in seen:
+            result.append("%s = %s" % (key, str(value)))
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Manifest drift diffing (design VERIFY / EC-3 / EC-5). Pure.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ManifestDiff:
+    field: str
+    expected: object
+    actual: object
+    kind: str  # "changed" | "missing" | "added"
+
+
+def _flatten(obj: object, prefix: str, out: Dict[str, object]) -> None:
+    if isinstance(obj, dict):
+        for k in obj:
+            child = "%s.%s" % (prefix, k) if prefix else str(k)
+            _flatten(obj[k], child, out)
+    elif isinstance(obj, (list, tuple)):
+        # Lists are compared as a whole (order-sensitive) -- capability lists,
+        # source-file lists. Store the tuple so a changed element is one diff.
+        out[prefix] = tuple(obj)
+    else:
+        out[prefix] = obj
+
+
+ADMISSION_KEYS: Tuple[str, ...] = (
+    "profile",
+    "kspVersion",
+    "components",
+    "settingsDeltasApplied",
+    "devSourcedMods",
+)
+
+
+def project_admission(manifest: Dict) -> Dict[str, object]:
+    """Project a manifest to the flat admission-relevant field set the harness
+    compares (design: profile, kspVersion, component pins+hashes, parsek sha +
+    signatureStrings, settings deltas, devSourcedMods hashes)."""
+    out: Dict[str, object] = {}
+    for key in ADMISSION_KEYS:
+        if key in manifest:
+            _flatten(manifest[key], key, out)
+    return out
+
+
+def compare_manifest(expected: Dict, actual: Dict) -> List[ManifestDiff]:
+    """Field-level diff of two manifests' admission projections.
+
+    ``expected`` is the pins/profile the harness expects; ``actual`` is the
+    on-disk manifest. Returns every mismatch: a changed hash/tag/commit/setting
+    (``changed``), a field present in expected but absent from actual
+    (``missing`` -- e.g. a dropped component), and an extra field in actual
+    (``added``). Empty list == admit. Guards EC-3/EC-5 (silent admission of a
+    drifted instance).
+    """
+    exp = project_admission(expected)
+    act = project_admission(actual)
+    diffs: List[ManifestDiff] = []
+    for k in sorted(exp):
+        if k not in act:
+            diffs.append(ManifestDiff(k, exp[k], None, "missing"))
+        elif exp[k] != act[k]:
+            diffs.append(ManifestDiff(k, exp[k], act[k], "changed"))
+    for k in sorted(act):
+        if k not in exp:
+            diffs.append(ManifestDiff(k, None, act[k], "added"))
+    return diffs
+
+
+# ---------------------------------------------------------------------------
+# Junction classification + resolution (design CLONE / EC-8). Pure.
+# ---------------------------------------------------------------------------
+
+
+def classify_gamedata_entry(name: str, dev_sourced_mods: Sequence[str]) -> str:
+    """Classify a GameData entry into how CLONE handles it.
+
+    - ``junction-stock``: Squad / SquadExpansion stock asset payloads
+      (junctioned back to the dev install, negligible drift risk).
+    - ``copy-devsourced``: a non-stock mod folder the profile content-hashes and
+      COPIES (a dev-GameData change must not silently drift an instance).
+    - ``stack-install``: a stack component the script installs (kRPC,
+      TestingTools, MechJeb2, KRPC.MechJeb, Parsek) -- not from dev GameData.
+    - ``unknown``: anything else (logged, not silently copied).
+    """
+    if name in STOCK_JUNCTION_GAMEDATA:
+        return "junction-stock"
+    if name in dev_sourced_mods:
+        return "copy-devsourced"
+    # Normalize the stack-component GameData folder names.
+    lname = name.lower()
+    if lname in ("krpc", "krpc.mechjeb", "mechjeb2", "parsek", "testingtools"):
+        return "stack-install"
+    return "unknown"
+
+
+def verify_junctions(manifest: Dict, exists_fn: Callable[[str], bool]) -> List[str]:
+    """Return the list of junction LINK paths whose recorded TARGET no longer
+    resolves (EC-8). ``exists_fn(target_path) -> bool`` is injected so this is
+    pure over the filesystem. Empty list == all junctions resolve.
+    """
+    dangling: List[str] = []
+    targets = manifest.get("junctionTargets", {}) or {}
+    for link_path, target_path in targets.items():
+        if not exists_fn(target_path):
+            dangling.append(link_path)
+    return dangling
+
+
+# ---------------------------------------------------------------------------
+# UTF-16 signature grep (design DEPLOY / .claude/CLAUDE.md DLL-identity recipe).
+# ---------------------------------------------------------------------------
+
+
+def count_utf16(dll_bytes: bytes, signature: str) -> int:
+    """Count non-overlapping occurrences of ``signature`` encoded UTF-16-LE in
+    ``dll_bytes`` (the DLL-identity check; guards EC-9/EC-11)."""
+    if not signature:
+        return 0
+    needle = signature.encode("utf-16-le")
+    return dll_bytes.count(needle)
+
+
+def check_signatures(dll_bytes: bytes, expected: Dict[str, int]) -> Dict[str, Tuple[int, int, bool]]:
+    """For each ``signature -> expected_count``, return
+    ``signature -> (actual, expected, ok)``. A present signature counting 0 or an
+    absent one counting != expected fails."""
+    out: Dict[str, Tuple[int, int, bool]] = {}
+    for sig, exp in expected.items():
+        actual = count_utf16(dll_bytes, sig)
+        out[sig] = (actual, exp, actual == exp)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Disk budget + path length guards (design CLONE / EC-6 / EC-7). Pure.
+# ---------------------------------------------------------------------------
+
+
+def estimate_instance_bytes(
+    profile: Dict,
+    component_sizes: Dict[str, int],
+    base_copy_bytes: int = 0,
+) -> int:
+    """Estimate the COPIED (non-junctioned) byte footprint of one instance.
+
+    Junctioned stock trees (Squad / SquadExpansion / StreamingAssets) cost ~0.
+    The estimate sums a base copy surface plus every dev-sourced mod and stack
+    component whose size is known in ``component_sizes`` (bytes). Unknown
+    components contribute 0 (the orchestrator measures real sizes at run time;
+    this pure form is for the pre-CLONE budget check and its test).
+    """
+    total = int(base_copy_bytes)
+    for name in profile.get("devSourcedMods", []) or []:
+        total += int(component_sizes.get(name, 0))
+    for name in profile.get("stackComponents", []) or []:
+        total += int(component_sizes.get(name, 0))
+    return total
+
+
+def is_over_budget(estimate_bytes: int, free_bytes: int, safety_margin_bytes: int = 0) -> bool:
+    """True if ``estimate_bytes`` (+ margin) would not fit in ``free_bytes``
+    (EC-6: pre-check before CLONE/DOWNLOAD)."""
+    return (int(estimate_bytes) + int(safety_margin_bytes)) > int(free_bytes)
+
+
+EXTENDED_LENGTH_PREFIX = "\\\\?\\"
+
+
+def is_path_too_long(path: str, limit: int = 260) -> bool:
+    """True if ``path`` would exceed the Windows MAX_PATH limit (EC-7).
+
+    A path already carrying the extended-length ``\\\\?\\`` prefix is exempt
+    (that prefix opts out of MAX_PATH). Otherwise flags at >= limit.
+    """
+    if path.startswith(EXTENDED_LENGTH_PREFIX):
+        return False
+    return len(path) >= limit
+
+
+# ---------------------------------------------------------------------------
+# Lockfile acquire / reclaim (design EC-10). Pure over injected clock + pid +
+# liveness probe.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class LockDecision:
+    acquired: bool
+    reason: str  # "acquired-free" | "reclaimed-stale" | "refused-live"
+    holder_pid: Optional[int]
+
+
+def acquire_lock(
+    existing_lock: Optional[Dict],
+    pid: int,
+    now: float,
+    is_alive_fn: Callable[[int], bool],
+) -> LockDecision:
+    """Decide whether ``pid`` may acquire the instance lock.
+
+    ``existing_lock`` is None (no lock) or ``{"pid": int, "timestamp": float}``.
+    - No lock -> acquire (``acquired-free``).
+    - Lock held by this same pid -> acquire (re-entrant, ``acquired-free``).
+    - Lock held by a LIVE other pid -> refuse (``refused-live``, EC-10 second
+      concurrent run).
+    - Lock held by a DEAD pid -> reclaim (``reclaimed-stale``).
+    ``is_alive_fn(pid) -> bool`` and ``now`` are injected for purity.
+    """
+    if not existing_lock:
+        return LockDecision(True, "acquired-free", pid)
+    holder = existing_lock.get("pid")
+    if holder == pid:
+        return LockDecision(True, "acquired-free", pid)
+    if is_alive_fn(int(holder)):
+        return LockDecision(False, "refused-live", holder)
+    return LockDecision(True, "reclaimed-stale", holder)
+
+
+# ---------------------------------------------------------------------------
+# BUILD-TT source selection (design BUILD-TT / GT-2 / S-4). Pure.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class TestingToolsSourceSelection:
+    included: List[str]
+    dropped: List[str]
+    autoloader_excluded: bool
+    ok: bool
+    reason: str
+
+
+def select_testingtools_sources(available_files: Sequence[str]) -> TestingToolsSourceSelection:
+    """Select the TWO shim source files from the TestingTools source set.
+
+    Keeps OrbitTools.cs + TestingTools.cs; DROPS AutoLoadGame.cs and
+    AutoSwitchVessel.cs so the seam's LoadGame boot owns save selection without
+    a racing auto-loader (GT-2/GT-4). ``autoloader_excluded`` asserts
+    AutoLoadGame.cs is NOT in the included set (S-4 build-time guard). ``ok`` is
+    False if a required shim source is missing from ``available_files``.
+    """
+    avail = set(available_files)
+    included = [f for f in TESTINGTOOLS_SHIM_SOURCES if f in avail]
+    dropped = [f for f in TESTINGTOOLS_DROPPED_SOURCES if f in avail]
+    autoloader_excluded = "AutoLoadGame.cs" not in included
+    missing = [f for f in TESTINGTOOLS_SHIM_SOURCES if f not in avail]
+    if missing:
+        return TestingToolsSourceSelection(
+            included, dropped, autoloader_excluded, False,
+            "missing-shim-source:%s" % ",".join(missing),
+        )
+    if not autoloader_excluded:
+        return TestingToolsSourceSelection(
+            included, dropped, autoloader_excluded, False, "autoloader-not-excluded",
+        )
+    return TestingToolsSourceSelection(included, dropped, autoloader_excluded, True, "ok")
+
+
+# ---------------------------------------------------------------------------
+# OPEN-pin guard (design DOWNLOAD / EC-13). Pure.
+# ---------------------------------------------------------------------------
+
+OPEN_SENTINELS: Tuple[str, ...] = ("OPEN", "OPEN-fill-at-first-download")
+
+
+def is_open_pin(value: Optional[str]) -> bool:
+    """True if a pin field is an unresolved OPEN placeholder (EC-13: DOWNLOAD
+    must compute+print the hash then ABORT, never install unverified bytes)."""
+    if value is None:
+        return True
+    v = value.strip()
+    return v == "" or v in OPEN_SENTINELS or v.startswith("OPEN")
+
+
+# ---------------------------------------------------------------------------
+# Dry-run action plan model (design --dry-run). Pure builder so the plan is
+# testable and identical whether printed or (in a live run) executed.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class PlannedAction:
+    step: str
+    verb: str  # FETCH | BUILD | CLONE | JUNCTION | COPY | WRITE | DELETE | VERIFY
+    detail: str
+
+
+def build_action_plan(pins: Dict, profile: Dict) -> List[PlannedAction]:
+    """Build the ordered action plan for a profile without any I/O.
+
+    Mirrors the Behavior phases (PIN/FETCH/BUILD-TT/CLONE/SETTINGS/DEPLOY/
+    VERIFY/MANIFEST). Used by --dry-run to print exactly what a live run would
+    do, and by tests to assert plan coherence.
+    """
+    plan: List[PlannedAction] = []
+    krpc = pins.get("krpc", {})
+    mj = pins.get("mechjeb2", {})
+    kmj = pins.get("krpc_mechjeb", {})
+
+    plan.append(PlannedAction("PIN", "VERIFY",
+        "krpc %s -> %s (peel annotated tag ^{commit})" % (krpc.get("tag"), krpc.get("commit"))))
+    plan.append(PlannedAction("PIN", "VERIFY",
+        "krpc_mechjeb %s %s -> %s" % (kmj.get("fork"), kmj.get("tag"), kmj.get("commit"))))
+
+    plan.append(PlannedAction("FETCH", "FETCH",
+        "krpc release zip %s (sha256 %s)" % (krpc.get("releaseZipUrl"), krpc.get("releaseZipSha256"))))
+    plan.append(PlannedAction("FETCH", "FETCH",
+        "mechjeb2 build %s (%s, sha256 %s)" % (mj.get("buildNumber"), mj.get("downloadUrl"), mj.get("sha256"))))
+
+    sel = select_testingtools_sources(
+        list(TESTINGTOOLS_SHIM_SOURCES) + list(TESTINGTOOLS_DROPPED_SOURCES))
+    plan.append(PlannedAction("BUILD-TT", "BUILD",
+        "TestingTools.dll from %s (drop %s); assert AutoLoadGame absent"
+        % (",".join(sel.included), ",".join(sel.dropped))))
+
+    plan.append(PlannedAction("PAIR", "VERIFY",
+        "krpc_mechjeb fork=%s tag=%s paired with krpc %s"
+        % (kmj.get("fork"), kmj.get("tag"), kmj.get("pairedKrpcTag"))))
+
+    instance_dir = profile.get("instanceDir", "?")
+    plan.append(PlannedAction("CLONE", "CLONE",
+        "copy dev install -> %s (mutable surface)" % instance_dir))
+    for tree in STOCK_JUNCTION_TREES:
+        plan.append(PlannedAction("CLONE", "JUNCTION",
+            "%s/%s -> devInstall" % (instance_dir, tree)))
+    for name in STOCK_JUNCTION_GAMEDATA:
+        plan.append(PlannedAction("CLONE", "JUNCTION",
+            "%s/GameData/%s -> devInstall (stock payload)" % (instance_dir, name)))
+    for name in profile.get("devSourcedMods", []) or []:
+        plan.append(PlannedAction("CLONE", "COPY",
+            "%s/GameData/%s (dev-sourced, content-hashed)" % (instance_dir, name)))
+
+    deltas = profile.get("settings", {}) or {}
+    plan.append(PlannedAction("SETTINGS", "WRITE",
+        "settings.cfg with %d delta(s): %s" % (len(deltas), ", ".join(sorted(deltas)))))
+
+    plan.append(PlannedAction("DEPLOY", "COPY",
+        "Parsek.dll: source -> .stage (hash) -> %s/GameData/Parsek/Plugins (verify hash + UTF-16 grep)"
+        % instance_dir))
+
+    for name in profile.get("stackComponents", []) or []:
+        if name == "parsek":
+            continue
+        plan.append(PlannedAction("INSTALL", "COPY",
+            "%s/GameData/%s (stack component)" % (instance_dir, name)))
+
+    for cache in MM_CACHE_FILES:
+        plan.append(PlannedAction("MM-CACHE", "DELETE",
+            "%s/GameData/%s (regenerate on first boot)" % (instance_dir, cache)))
+
+    plan.append(PlannedAction("MANIFEST", "WRITE",
+        "%s/GameData/Parsek/provision-manifest.json (atomic tmp+rename)" % instance_dir))
+    plan.append(PlannedAction("VERIFY", "VERIFY",
+        "re-read instance; cross-check DLL hashes, UTF-16 grep, junctions, settingsFinalSha256, buildId64Sha256"))
+    return plan

--- a/harness/provision/provlib.py
+++ b/harness/provision/provlib.py
@@ -375,6 +375,63 @@ def is_path_too_long(path: str, limit: int = 260) -> bool:
 
 
 # ---------------------------------------------------------------------------
+# Dev-install aliasing guard (design EC-16). Pure string-path predicate over
+# already-absolute paths. Guards the destructive live primitives (settings
+# overwrite, DLL copy, MM-cache delete) from ever targeting the read-only dev
+# install or a path that overlaps it.
+# ---------------------------------------------------------------------------
+
+
+def _normcase_path(path: str) -> str:
+    """Case- and separator-normalize a path for boundary comparison.
+
+    Windows-targeted (KSP): fold case and unify separators to forward slashes,
+    strip a trailing slash. Pure string manipulation; no filesystem access.
+    """
+    return (path or "").replace("\\", "/").rstrip("/").lower()
+
+
+def is_path_within(child: str, parent: str) -> bool:
+    """True if ``child`` equals ``parent`` or is nested under it (path-boundary
+    aware: ``.../automation`` is NOT within ``.../auto``)."""
+    c = _normcase_path(child)
+    p = _normcase_path(parent)
+    if not p:
+        return False
+    return c == p or c.startswith(p + "/")
+
+
+@dataclass(frozen=True)
+class InstanceDirDecision:
+    ok: bool
+    reason: str  # "ok" | "equals-dev-install" | "nested-in-dev-install"
+                 # | "dev-install-nested-in-instance" | "not-under-automation"
+
+
+def check_instance_dir_alias(instance_dir: str, dev_install: str, instance_rel: str) -> InstanceDirDecision:
+    """Reject an instance dir that aliases or overlaps the dev install.
+
+    ``instance_dir`` / ``dev_install`` are absolute paths; ``instance_rel`` is
+    the profile's raw ``instanceDir`` value (which MUST live under
+    ``automation/`` so an instance can never be mistaken for the dev tree). The
+    live primitives overwrite settings.cfg, copy the DLL, and DELETE the MM
+    cache -- pointed at the dev install (or a parent/child of it) they would
+    corrupt the read-only clone source. Returns the first failing condition:
+    equal, instance nested in dev install, dev install nested in instance, or
+    the relative dir not under ``automation/``."""
+    if is_path_within(instance_dir, dev_install) and is_path_within(dev_install, instance_dir):
+        return InstanceDirDecision(False, "equals-dev-install")
+    if is_path_within(instance_dir, dev_install):
+        return InstanceDirDecision(False, "nested-in-dev-install")
+    if is_path_within(dev_install, instance_dir):
+        return InstanceDirDecision(False, "dev-install-nested-in-instance")
+    rel = (instance_rel or "").replace("\\", "/")
+    if not rel.startswith("automation/"):
+        return InstanceDirDecision(False, "not-under-automation")
+    return InstanceDirDecision(True, "ok")
+
+
+# ---------------------------------------------------------------------------
 # Lockfile acquire / reclaim (design EC-10). Pure over injected clock + pid +
 # liveness probe.
 # ---------------------------------------------------------------------------

--- a/harness/provision/provlib.py
+++ b/harness/provision/provlib.py
@@ -123,6 +123,64 @@ def resolve_pin(clone_ref_output: str, expected_commit: str) -> PinResolution:
 
 
 # ---------------------------------------------------------------------------
+# KRPC.MechJeb pairing (design PAIR / GT-6 / EC-14). Pure decision.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class PairDecision:
+    ok: bool
+    reason: str  # "match" | "mismatch" | "verify-required-nonv054"
+    requires_web_verify: bool
+
+
+def evaluate_krpc_mechjeb_pair(krpc_tag: str, fork: str, tag: str, paired_krpc_tag: str) -> PairDecision:
+    """Decide whether the pinned KRPC.MechJeb pairs with the pinned kRPC (GT-6).
+
+    Under the v0.5.4 kRPC pin the only CHANGELOG-proven pair is genhis v0.7.1
+    (``pairedKrpcTag == v0.5.4``); any deviation is EC-14 ``mismatch``. Under a
+    non-v0.5.4 kRPC pin the pairing cannot be verified locally: return
+    ``verify-required-nonv054`` with ``requires_web_verify=True`` so the caller
+    refuses to guess and prints the web-verification procedure (EC-14 deferred
+    branch)."""
+    if krpc_tag != "v0.5.4":
+        return PairDecision(False, "verify-required-nonv054", True)
+    ok = fork == "genhis" and tag == "v0.7.1" and paired_krpc_tag == "v0.5.4"
+    return PairDecision(ok, "match" if ok else "mismatch", False)
+
+
+# ---------------------------------------------------------------------------
+# Parsek.dll deploy-source selection (design DEPLOY). Pure.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class DeploySourceDecision:
+    source: str
+    reason: str  # "override" | "worktree-build" | "default"
+
+
+def select_parsek_dll_source(
+    override: Optional[str],
+    worktree_dll: str,
+    worktree_dll_exists: bool,
+    default_dll: str,
+) -> DeploySourceDecision:
+    """Pick the Parsek.dll source for DEPLOY.
+
+    An explicit ``--parsek-dll`` override always wins; otherwise the current
+    worktree's own ``bin/Debug`` build when it exists (so a build from this
+    worktree is preferred over a hardcoded sibling default); otherwise the
+    default path. ``worktree_dll_exists`` is injected so this stays pure over the
+    filesystem."""
+    if override:
+        return DeploySourceDecision(override, "override")
+    if worktree_dll_exists:
+        return DeploySourceDecision(worktree_dll, "worktree-build")
+    return DeploySourceDecision(default_dll, "default")
+
+
+# ---------------------------------------------------------------------------
 # Settings-delta application (design SETTINGS / EC-15). Pure, line-oriented.
 # ---------------------------------------------------------------------------
 
@@ -290,16 +348,25 @@ def classify_gamedata_entry(name: str, dev_sourced_mods: Sequence[str]) -> str:
     return "unknown"
 
 
-def verify_junctions(manifest: Dict, exists_fn: Callable[[str], bool]) -> List[str]:
-    """Return the list of junction LINK paths whose recorded TARGET no longer
-    resolves (EC-8). ``exists_fn(target_path) -> bool`` is injected so this is
-    pure over the filesystem. Empty list == all junctions resolve.
+def verify_junctions(manifest: Dict, resolve_fn: Callable[[str], Optional[str]]) -> List[str]:
+    """Return the junction LINK keys whose link no longer resolves to its
+    recorded TARGET (EC-8).
+
+    ``resolve_fn(link_key) -> realpath`` is injected (the orchestrator passes
+    ``os.path.realpath`` of the link path, or None/"" when the link is absent).
+    The check is on the LINK, not merely the target's existence: a directory
+    junction reports ``os.path.islink() == False``, so ``realpath`` of the link
+    is the correct probe. A link that is missing (dangling) OR repointed
+    (realpath != recorded target) fails; verifying only that the target exists
+    would pass a deleted or repointed junction. Empty list == all junctions
+    resolve to their recorded targets.
     """
     dangling: List[str] = []
     targets = manifest.get("junctionTargets", {}) or {}
-    for link_path, target_path in targets.items():
-        if not exists_fn(target_path):
-            dangling.append(link_path)
+    for link_key, target_path in targets.items():
+        actual = resolve_fn(link_key)
+        if not actual or _normcase_path(actual) != _normcase_path(target_path):
+            dangling.append(link_key)
     return dangling
 
 
@@ -465,9 +532,16 @@ def acquire_lock(
     holder = existing_lock.get("pid")
     if holder == pid:
         return LockDecision(True, "acquired-free", pid)
-    if is_alive_fn(int(holder)):
-        return LockDecision(False, "refused-live", holder)
-    return LockDecision(True, "reclaimed-stale", holder)
+    # A malformed holder pid (missing / None / non-integer -- a truncated or
+    # hand-corrupted lockfile) is treated as STALE and reclaimed, never a crash:
+    # a lockfile we cannot parse must not wedge every future run.
+    try:
+        holder_pid = int(holder)
+    except (TypeError, ValueError):
+        return LockDecision(True, "reclaimed-stale", None)
+    if is_alive_fn(holder_pid):
+        return LockDecision(False, "refused-live", holder_pid)
+    return LockDecision(True, "reclaimed-stale", holder_pid)
 
 
 # ---------------------------------------------------------------------------

--- a/harness/provision/test_provlib.py
+++ b/harness/provision/test_provlib.py
@@ -8,9 +8,72 @@ Each test names the regression it guards (design Test Plan). No pytest, no KSP,
 no network, no filesystem writes.
 """
 
+import os
+import tomllib
 import unittest
 
 import provlib
+
+
+PROFILES_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "profiles")
+
+
+class RealProfileFileTests(unittest.TestCase):
+    """Guards BLOCKER 1: a bare `stackComponents` key placed AFTER a
+    `[[optionalMods]]` array-of-tables header binds to that table entry (not the
+    top level), silently leaving the profile with NO stack components -- a live
+    run would then install nothing while still writing a manifest. Loads the two
+    REAL on-disk profile files (not inline dicts, which cannot catch a TOML
+    placement bug) and asserts the top-level stack list + a non-empty
+    devSourcedMods for both."""
+
+    EXPECTED_STACK = ["krpc", "testingtools", "mechjeb2", "krpc_mechjeb", "parsek"]
+
+    def _load(self, name):
+        with open(os.path.join(PROFILES_DIR, name), "rb") as fh:
+            return tomllib.load(fh)
+
+    def test_stock_minimal_stack_and_devmods(self):
+        p = self._load("stock-minimal.toml")
+        self.assertEqual(p.get("stackComponents"), self.EXPECTED_STACK)
+        self.assertTrue(p.get("devSourcedMods"), "stock-minimal devSourcedMods must be non-empty")
+
+    def test_modded_compat_stack_and_devmods(self):
+        p = self._load("modded-compat.toml")
+        self.assertEqual(p.get("stackComponents"), self.EXPECTED_STACK)
+        self.assertTrue(p.get("devSourcedMods"), "modded-compat devSourcedMods must be non-empty")
+
+    def test_modded_compat_stack_not_swallowed_by_optionalmods(self):
+        # The precise BLOCKER 1 regression: the stack list must be top-level, and
+        # the optionalMods entry must NOT carry a stackComponents key.
+        p = self._load("modded-compat.toml")
+        for entry in p.get("optionalMods", []):
+            self.assertNotIn("stackComponents", entry)
+
+
+class PhaseInstallEmptyStackTests(unittest.TestCase):
+    """Guards reviewer 14 (the mask that hid BLOCKER 1): phase_install must WARN
+    loudly when a profile has no stackComponents instead of silently doing
+    nothing."""
+
+    def test_empty_stack_warns(self):
+        import provision
+        ctx = provision.ProvisionContext(
+            profile_name="broken", pins={}, profile={"stackComponents": []},
+            umbrella_root=".", dry_run=True, repair=False, parsek_dll_override=None)
+        provision.phase_install(ctx)
+        self.assertTrue(any("NO stackComponents" in l for l in ctx.log_lines),
+                        "empty stackComponents must produce a WARN")
+        self.assertTrue(any(l.startswith("[Provision][Warn][Install]") for l in ctx.log_lines))
+
+    def test_nonempty_stack_no_warn(self):
+        import provision
+        ctx = provision.ProvisionContext(
+            profile_name="ok", pins={},
+            profile={"stackComponents": ["krpc", "parsek"]},
+            umbrella_root=".", dry_run=True, repair=False, parsek_dll_override=None)
+        provision.phase_install(ctx)
+        self.assertFalse(any("NO stackComponents" in l for l in ctx.log_lines))
 
 
 class ResolvePinTests(unittest.TestCase):

--- a/harness/provision/test_provlib.py
+++ b/harness/provision/test_provlib.py
@@ -79,34 +79,43 @@ class PhaseInstallEmptyStackTests(unittest.TestCase):
 class LiveUnimplementedTests(unittest.TestCase):
     """Guards BLOCKER 3: a live run must abort at the first unimplemented heavy
     phase (EC-LIVE) rather than half-provision; --dry-run is unaffected;
-    live --repair aborts up front."""
+    live --repair aborts up front.
 
-    def _ctx(self, dry_run, repair=False):
+    Live-mode ctxs use a throwaway umbrella tempdir: a non-dry-run abort() logs
+    through log(), which writes provision-log.txt under the instance dir, and
+    that must never land in the repo tree."""
+
+    def _ctx(self, umbrella, dry_run, repair=False):
         import provision
         return provision.ProvisionContext(
-            profile_name="x", pins={}, profile={}, umbrella_root=".",
+            profile_name="x", pins={}, profile={}, umbrella_root=umbrella,
             dry_run=dry_run, repair=repair, parsek_dll_override=None)
 
     def test_dry_run_phase_not_guarded(self):
         import provision
-        ctx = self._ctx(dry_run=True)
+        # dry-run log() writes nothing, so "." is safe here.
+        ctx = self._ctx(".", dry_run=True)
         self.assertFalse(provision._guard_live_unimplemented(ctx, "Build-TT"))
         self.assertFalse(ctx.aborted)
 
     def test_live_phase_aborts_ec_live(self):
+        import tempfile
         import provision
-        ctx = self._ctx(dry_run=False)
-        self.assertTrue(provision._guard_live_unimplemented(ctx, "Build-TT"))
-        self.assertTrue(ctx.aborted)
-        self.assertIn("EC-LIVE", ctx.abort_reason)
+        with tempfile.TemporaryDirectory() as umbrella:
+            ctx = self._ctx(umbrella, dry_run=False)
+            self.assertTrue(provision._guard_live_unimplemented(ctx, "Build-TT"))
+            self.assertTrue(ctx.aborted)
+            self.assertIn("EC-LIVE", ctx.abort_reason)
 
     def test_live_repair_aborts_in_run(self):
+        import tempfile
         import provision
-        ctx = self._ctx(dry_run=False, repair=True)
-        code = provision.run(ctx)
-        self.assertEqual(code, 2)
-        self.assertTrue(ctx.aborted)
-        self.assertIn("EC-LIVE", ctx.abort_reason)
+        with tempfile.TemporaryDirectory() as umbrella:
+            ctx = self._ctx(umbrella, dry_run=False, repair=True)
+            code = provision.run(ctx)
+            self.assertEqual(code, 2)
+            self.assertTrue(ctx.aborted)
+            self.assertIn("EC-LIVE", ctx.abort_reason)
 
 
 class ResolvePinTests(unittest.TestCase):
@@ -293,17 +302,25 @@ class JunctionTests(unittest.TestCase):
     not be reported OK. Plus junction-vs-copy classification (design CLONE)."""
 
     def test_dangling_junction_reported(self):
+        # The SquadExpansion LINK does not resolve (realpath returns None).
         manifest = {"junctionTargets": {
             "GameData/Squad": "/dev/Squad",
             "GameData/SquadExpansion": "/dev/SquadExpansion",
         }}
-        existing = {"/dev/Squad"}
-        dangling = provlib.verify_junctions(manifest, lambda p: p in existing)
+        resolved = {"GameData/Squad": "/dev/Squad"}
+        dangling = provlib.verify_junctions(manifest, lambda link: resolved.get(link))
         self.assertEqual(dangling, ["GameData/SquadExpansion"])
 
     def test_all_resolve_is_empty(self):
         manifest = {"junctionTargets": {"GameData/Squad": "/dev/Squad"}}
-        self.assertEqual(provlib.verify_junctions(manifest, lambda p: True), [])
+        self.assertEqual(provlib.verify_junctions(manifest, lambda link: "/dev/Squad"), [])
+
+    def test_repointed_junction_reported(self):
+        # The LINK exists but its realpath points somewhere other than the
+        # recorded target: must fail even though a target may still exist.
+        manifest = {"junctionTargets": {"GameData/Squad": "/dev/Squad"}}
+        dangling = provlib.verify_junctions(manifest, lambda link: "/other/Squad")
+        self.assertEqual(dangling, ["GameData/Squad"])
 
     def test_classify_stock_vs_devsourced_vs_stack(self):
         dev = ["000_Harmony", "CommunityTechTree"]
@@ -469,6 +486,96 @@ class LockTests(unittest.TestCase):
         lock = {"pid": 42, "timestamp": 1.0}
         d = provlib.acquire_lock(lock, pid=42, now=2.0, is_alive_fn=lambda p: True)
         self.assertTrue(d.acquired)
+
+    def test_malformed_holder_reclaimed_not_crash(self):
+        # A lockfile carrying an unparseable pid (None / non-integer) is stale,
+        # reclaimed, never a crash. (An entirely empty {} is a no-lock, handled
+        # by test_no_lock_acquires.)
+        for bad in ({"pid": "notapid"}, {"pid": None}):
+            d = provlib.acquire_lock(bad, pid=42, now=1.0, is_alive_fn=lambda p: True)
+            self.assertTrue(d.acquired, bad)
+            self.assertEqual(d.reason, "reclaimed-stale")
+
+
+class PairDecisionTests(unittest.TestCase):
+    """Reviewer 7: extracted PAIR assertion (GT-6 / EC-14)."""
+
+    def test_v054_genhis_071_matches(self):
+        d = provlib.evaluate_krpc_mechjeb_pair("v0.5.4", "genhis", "v0.7.1", "v0.5.4")
+        self.assertTrue(d.ok)
+        self.assertEqual(d.reason, "match")
+        self.assertFalse(d.requires_web_verify)
+
+    def test_v054_wrong_fork_mismatch(self):
+        d = provlib.evaluate_krpc_mechjeb_pair("v0.5.4", "darchambault", "v0.7.1", "v0.5.4")
+        self.assertFalse(d.ok)
+        self.assertEqual(d.reason, "mismatch")
+
+    def test_v054_wrong_paired_tag_mismatch(self):
+        d = provlib.evaluate_krpc_mechjeb_pair("v0.5.4", "genhis", "v0.7.1", "v0.5.3")
+        self.assertFalse(d.ok)
+        self.assertEqual(d.reason, "mismatch")
+
+    def test_nonv054_requires_web_verify(self):
+        d = provlib.evaluate_krpc_mechjeb_pair("master-abc123", "genhis", "v0.7.1", "v0.5.4")
+        self.assertFalse(d.ok)
+        self.assertTrue(d.requires_web_verify)
+        self.assertEqual(d.reason, "verify-required-nonv054")
+
+
+class DeploySourceTests(unittest.TestCase):
+    """Reviewer 7: extracted DEPLOY source selection."""
+
+    def test_override_always_wins(self):
+        d = provlib.select_parsek_dll_source("/x/over.dll", "/wt/Parsek.dll", True, "/def/Parsek.dll")
+        self.assertEqual(d.source, "/x/over.dll")
+        self.assertEqual(d.reason, "override")
+
+    def test_worktree_build_when_present(self):
+        d = provlib.select_parsek_dll_source(None, "/wt/Parsek.dll", True, "/def/Parsek.dll")
+        self.assertEqual(d.source, "/wt/Parsek.dll")
+        self.assertEqual(d.reason, "worktree-build")
+
+    def test_default_when_worktree_absent(self):
+        d = provlib.select_parsek_dll_source(None, "/wt/Parsek.dll", False, "/def/Parsek.dll")
+        self.assertEqual(d.source, "/def/Parsek.dll")
+        self.assertEqual(d.reason, "default")
+
+
+class LockfileReleaseTests(unittest.TestCase):
+    """Reviewer 10: a run removes ONLY a lockfile it created, on completion."""
+
+    def _ctx(self, umbrella):
+        import provision
+        return provision.ProvisionContext(
+            profile_name="x", pins={}, profile={}, umbrella_root=umbrella,
+            dry_run=False, repair=False, parsek_dll_override=None)
+
+    def test_owned_lock_removed_on_finish(self):
+        import json
+        import tempfile
+        import provision
+        with tempfile.TemporaryDirectory() as umbrella:
+            lock = os.path.join(umbrella, ".provision.lock")
+            with open(lock, "w") as fh:
+                json.dump({"pid": 1}, fh)
+            ctx = self._ctx(umbrella)
+            ctx.lock_path = lock
+            ctx.lock_acquired = True
+            provision._finish(ctx, 0)
+            self.assertFalse(os.path.exists(lock))
+
+    def test_unowned_lock_not_removed(self):
+        import json
+        import tempfile
+        import provision
+        with tempfile.TemporaryDirectory() as umbrella:
+            lock = os.path.join(umbrella, ".provision.lock")
+            with open(lock, "w") as fh:
+                json.dump({"pid": 999}, fh)
+            ctx = self._ctx(umbrella)  # lock_acquired never set: we do not own it
+            provision._finish(ctx, 0)
+            self.assertTrue(os.path.exists(lock))
 
 
 class OpenPinTests(unittest.TestCase):

--- a/harness/provision/test_provlib.py
+++ b/harness/provision/test_provlib.py
@@ -76,6 +76,39 @@ class PhaseInstallEmptyStackTests(unittest.TestCase):
         self.assertFalse(any("NO stackComponents" in l for l in ctx.log_lines))
 
 
+class LiveUnimplementedTests(unittest.TestCase):
+    """Guards BLOCKER 3: a live run must abort at the first unimplemented heavy
+    phase (EC-LIVE) rather than half-provision; --dry-run is unaffected;
+    live --repair aborts up front."""
+
+    def _ctx(self, dry_run, repair=False):
+        import provision
+        return provision.ProvisionContext(
+            profile_name="x", pins={}, profile={}, umbrella_root=".",
+            dry_run=dry_run, repair=repair, parsek_dll_override=None)
+
+    def test_dry_run_phase_not_guarded(self):
+        import provision
+        ctx = self._ctx(dry_run=True)
+        self.assertFalse(provision._guard_live_unimplemented(ctx, "Build-TT"))
+        self.assertFalse(ctx.aborted)
+
+    def test_live_phase_aborts_ec_live(self):
+        import provision
+        ctx = self._ctx(dry_run=False)
+        self.assertTrue(provision._guard_live_unimplemented(ctx, "Build-TT"))
+        self.assertTrue(ctx.aborted)
+        self.assertIn("EC-LIVE", ctx.abort_reason)
+
+    def test_live_repair_aborts_in_run(self):
+        import provision
+        ctx = self._ctx(dry_run=False, repair=True)
+        code = provision.run(ctx)
+        self.assertEqual(code, 2)
+        self.assertTrue(ctx.aborted)
+        self.assertIn("EC-LIVE", ctx.abort_reason)
+
+
 class ResolvePinTests(unittest.TestCase):
     """Design: resolve_pin -- guards GT-1 retag/move. A moved tag (tag resolves
     to a commit != recorded) must be rejected."""

--- a/harness/provision/test_provlib.py
+++ b/harness/provision/test_provlib.py
@@ -1,0 +1,358 @@
+"""Unit tests for provlib.py, the pure decision logic of the M-A6 provisioner.
+
+Runnable with the stdlib runner only::
+
+    python -m unittest discover -s harness/provision
+
+Each test names the regression it guards (design Test Plan). No pytest, no KSP,
+no network, no filesystem writes.
+"""
+
+import unittest
+
+import provlib
+
+
+class ResolvePinTests(unittest.TestCase):
+    """Design: resolve_pin -- guards GT-1 retag/move. A moved tag (tag resolves
+    to a commit != recorded) must be rejected."""
+
+    RECORDED = "11f1f1366fa4301049f6eac6640604127a9d763b"
+
+    def test_match(self):
+        r = provlib.resolve_pin(self.RECORDED + "\n", self.RECORDED)
+        self.assertTrue(r.ok)
+        self.assertEqual(r.reason, "match")
+
+    def test_match_case_insensitive_and_trimmed(self):
+        r = provlib.resolve_pin("  " + self.RECORDED.upper() + "  ", self.RECORDED)
+        self.assertTrue(r.ok)
+
+    def test_mismatch_moved_tag(self):
+        # The annotated-tag OBJECT sha (4e9dfbed) is NOT the commit; a caller
+        # that forgot to peel with ^{commit} must be reported as a mismatch,
+        # never silently accepted.
+        r = provlib.resolve_pin("4e9dfbedd21409fb75c19f55f839d68520e752c1", self.RECORDED)
+        self.assertFalse(r.ok)
+        self.assertEqual(r.reason, "mismatch")
+
+    def test_missing_tag(self):
+        r = provlib.resolve_pin("", self.RECORDED)
+        self.assertFalse(r.ok)
+        self.assertEqual(r.reason, "missing")
+
+
+class SettingsDeltaTests(unittest.TestCase):
+    """Design: apply_settings -- guards EC-15 and non-determinism. Existing keys
+    replaced, order/comments preserved, absent keys appended, unrelated keys
+    untouched."""
+
+    def test_replace_existing_preserves_order_and_unrelated(self):
+        base = [
+            "// header comment",
+            "FULLSCREEN = True",
+            "",
+            "FRAMERATE_LIMIT = 120",
+            "UI_SCALE = 1.2",
+        ]
+        out = provlib.apply_settings(base, {"FRAMERATE_LIMIT": "60", "FULLSCREEN": "False"})
+        self.assertEqual(out[0], "// header comment")
+        self.assertEqual(out[1], "FULLSCREEN = False")
+        self.assertEqual(out[2], "")
+        self.assertEqual(out[3], "FRAMERATE_LIMIT = 60")
+        self.assertEqual(out[4], "UI_SCALE = 1.2")  # unrelated key untouched
+
+    def test_append_missing_key(self):
+        base = ["FULLSCREEN = True"]
+        out = provlib.apply_settings(base, {"SCREEN_RESOLUTION_WIDTH": "1280"})
+        self.assertIn("SCREEN_RESOLUTION_WIDTH = 1280", out)
+        self.assertEqual(len(out), 2)
+
+    def test_noop_when_equal_value_still_rewrites_same_text(self):
+        base = ["QUALITY_PRESET = 0"]
+        out = provlib.apply_settings(base, {"QUALITY_PRESET": "0"})
+        self.assertEqual(out, ["QUALITY_PRESET = 0"])
+
+    def test_braces_and_comments_are_not_keys(self):
+        self.assertIsNone(provlib.settings_key_of("{"))
+        self.assertIsNone(provlib.settings_key_of("}"))
+        self.assertIsNone(provlib.settings_key_of("// FRAMERATE_LIMIT = 1"))
+        self.assertIsNone(provlib.settings_key_of(""))
+        self.assertEqual(provlib.settings_key_of("  FRAMERATE_LIMIT = 60"), "FRAMERATE_LIMIT")
+
+    def test_keys_present_classifies_replaced_vs_appended(self):
+        base = ["FULLSCREEN = True", "UI_SCALE = 1.2"]
+        present = provlib.keys_present(base, ["FULLSCREEN", "NEW_KEY"])
+        self.assertEqual(present, {"FULLSCREEN"})
+
+
+class ManifestDiffTests(unittest.TestCase):
+    """Design: compare_manifest -- guards EC-3/EC-5 silent admission of a
+    drifted instance. A changed hash, changed tag/commit, missing component, or
+    changed settings delta MUST be reported."""
+
+    def _manifest(self):
+        return {
+            "profile": "stock-minimal",
+            "kspVersion": "1.12.5",
+            "components": {
+                "krpc": {"tag": "v0.5.4", "commit": "11f1f13"},
+                "parsek": {"dllSha256": "aaaa", "signatureStrings": {"ParsekFlight": 3}},
+            },
+            "settingsDeltasApplied": {"FRAMERATE_LIMIT": "60"},
+            "devSourcedMods": {"000_Harmony": "treehash1"},
+            # non-admission fields must be ignored:
+            "generatedUtc": "2026-07-11T00:00:00Z",
+        }
+
+    def test_identical_is_empty(self):
+        m = self._manifest()
+        self.assertEqual(provlib.compare_manifest(m, dict(m)), [])
+
+    def test_ignores_nonadmission_fields(self):
+        a = self._manifest()
+        b = self._manifest()
+        b["generatedUtc"] = "different-timestamp"
+        self.assertEqual(provlib.compare_manifest(a, b), [])
+
+    def test_hash_drift_reported(self):
+        a = self._manifest()
+        b = self._manifest()
+        b["components"]["parsek"]["dllSha256"] = "bbbb"
+        diffs = provlib.compare_manifest(a, b)
+        self.assertTrue(any(d.field == "components.parsek.dllSha256" and d.kind == "changed" for d in diffs))
+
+    def test_pin_bump_reported(self):
+        a = self._manifest()
+        b = self._manifest()
+        b["components"]["krpc"]["tag"] = "v0.5.5"
+        diffs = provlib.compare_manifest(a, b)
+        self.assertTrue(any(d.field == "components.krpc.tag" and d.kind == "changed" for d in diffs))
+
+    def test_missing_component_reported(self):
+        a = self._manifest()
+        b = self._manifest()
+        del b["components"]["krpc"]
+        diffs = provlib.compare_manifest(a, b)
+        self.assertTrue(any(d.field.startswith("components.krpc") and d.kind == "missing" for d in diffs))
+
+    def test_added_component_reported(self):
+        a = self._manifest()
+        b = self._manifest()
+        b["components"]["extra"] = {"tag": "x"}
+        diffs = provlib.compare_manifest(a, b)
+        self.assertTrue(any(d.field.startswith("components.extra") and d.kind == "added" for d in diffs))
+
+    def test_settings_delta_change_reported(self):
+        a = self._manifest()
+        b = self._manifest()
+        b["settingsDeltasApplied"]["FRAMERATE_LIMIT"] = "120"
+        diffs = provlib.compare_manifest(a, b)
+        self.assertTrue(any(d.field == "settingsDeltasApplied.FRAMERATE_LIMIT" and d.kind == "changed" for d in diffs))
+
+    def test_signature_count_change_reported(self):
+        a = self._manifest()
+        b = self._manifest()
+        b["components"]["parsek"]["signatureStrings"]["ParsekFlight"] = 1
+        diffs = provlib.compare_manifest(a, b)
+        self.assertTrue(any("signatureStrings.ParsekFlight" in d.field for d in diffs))
+
+
+class TestingToolsSourceTests(unittest.TestCase):
+    """Design: BUILD-TT source set EXCLUDES AutoLoadGame (S-4). The 2-file shim
+    keeps only OrbitTools.cs + TestingTools.cs and asserts the auto-loader is
+    dropped so it cannot race the seam's LoadGame boot."""
+
+    ALL_FIVE = ["AutoLoadGame.cs", "AutoSwitchVessel.cs", "OrbitTools.cs",
+                "TestingTools.cs", "TestingTools.csproj"]
+
+    def test_selects_only_two_and_excludes_autoloader(self):
+        sel = provlib.select_testingtools_sources(self.ALL_FIVE)
+        self.assertTrue(sel.ok)
+        self.assertEqual(sorted(sel.included), ["OrbitTools.cs", "TestingTools.cs"])
+        self.assertNotIn("AutoLoadGame.cs", sel.included)
+        self.assertNotIn("AutoSwitchVessel.cs", sel.included)
+        self.assertTrue(sel.autoloader_excluded)
+
+    def test_drops_the_two_racing_sources(self):
+        sel = provlib.select_testingtools_sources(self.ALL_FIVE)
+        self.assertEqual(sorted(sel.dropped), ["AutoLoadGame.cs", "AutoSwitchVessel.cs"])
+
+    def test_missing_shim_source_fails(self):
+        sel = provlib.select_testingtools_sources(["OrbitTools.cs"])  # no TestingTools.cs
+        self.assertFalse(sel.ok)
+        self.assertIn("missing-shim-source", sel.reason)
+
+    def test_capability_table_matches_design(self):
+        self.assertEqual(
+            provlib.TESTINGTOOLS_CAPABILITIES,
+            ("LoadSave", "RemoveOtherVessels", "SetCircularOrbit", "SetOrbit",
+             "ClearRotation", "ApplyRotation"),
+        )
+        self.assertEqual(provlib.MISSING_VS_MASTER, ("autoLoadFlags", "Quit", "SetLanded"))
+
+
+class JunctionTests(unittest.TestCase):
+    """Design: verify_junctions -- guards EC-8. A dangling junction target must
+    not be reported OK. Plus junction-vs-copy classification (design CLONE)."""
+
+    def test_dangling_junction_reported(self):
+        manifest = {"junctionTargets": {
+            "GameData/Squad": "/dev/Squad",
+            "GameData/SquadExpansion": "/dev/SquadExpansion",
+        }}
+        existing = {"/dev/Squad"}
+        dangling = provlib.verify_junctions(manifest, lambda p: p in existing)
+        self.assertEqual(dangling, ["GameData/SquadExpansion"])
+
+    def test_all_resolve_is_empty(self):
+        manifest = {"junctionTargets": {"GameData/Squad": "/dev/Squad"}}
+        self.assertEqual(provlib.verify_junctions(manifest, lambda p: True), [])
+
+    def test_classify_stock_vs_devsourced_vs_stack(self):
+        dev = ["000_Harmony", "CommunityTechTree"]
+        self.assertEqual(provlib.classify_gamedata_entry("Squad", dev), "junction-stock")
+        self.assertEqual(provlib.classify_gamedata_entry("SquadExpansion", dev), "junction-stock")
+        self.assertEqual(provlib.classify_gamedata_entry("000_Harmony", dev), "copy-devsourced")
+        self.assertEqual(provlib.classify_gamedata_entry("kRPC", dev), "stack-install")
+        self.assertEqual(provlib.classify_gamedata_entry("Parsek", dev), "stack-install")
+        self.assertEqual(provlib.classify_gamedata_entry("MysteryMod", dev), "unknown")
+
+
+class Utf16Tests(unittest.TestCase):
+    """Design: count_utf16 -- guards the DLL-identity check and EC-9/EC-11. A
+    present signature must count > 0; an absent one must count 0."""
+
+    def test_present_signature_counts(self):
+        buf = "xx".encode("utf-16-le") + "ParsekFlight".encode("utf-16-le") \
+            + "yy".encode("utf-16-le") + "ParsekFlight".encode("utf-16-le")
+        self.assertEqual(provlib.count_utf16(buf, "ParsekFlight"), 2)
+
+    def test_absent_signature_zero(self):
+        buf = "nothing here".encode("utf-16-le")
+        self.assertEqual(provlib.count_utf16(buf, "MissingLabel"), 0)
+
+    def test_ascii_bytes_do_not_match_utf16(self):
+        # An ASCII-encoded copy must NOT satisfy the UTF-16-LE grep.
+        buf = "ParsekFlight".encode("ascii")
+        self.assertEqual(provlib.count_utf16(buf, "ParsekFlight"), 0)
+
+    def test_check_signatures_flags_wrong_count(self):
+        buf = "ParsekFlight".encode("utf-16-le")
+        res = provlib.check_signatures(buf, {"ParsekFlight": 1, "Absent": 0, "Wrong": 2})
+        self.assertTrue(res["ParsekFlight"][2])
+        self.assertTrue(res["Absent"][2])
+        self.assertFalse(res["Wrong"][2])
+
+
+class DiskAndPathGuardTests(unittest.TestCase):
+    """Design: estimate_instance_bytes / is_path_too_long -- guards EC-6/EC-7."""
+
+    def test_estimate_sums_copied_surface_only(self):
+        profile = {"devSourcedMods": ["A", "B"], "stackComponents": ["krpc", "parsek"]}
+        sizes = {"A": 100, "B": 200, "krpc": 50, "parsek": 10}
+        est = provlib.estimate_instance_bytes(profile, sizes, base_copy_bytes=1000)
+        self.assertEqual(est, 1000 + 100 + 200 + 50 + 10)
+
+    def test_over_budget_flagged(self):
+        self.assertTrue(provlib.is_over_budget(900, 1000, safety_margin_bytes=200))
+        self.assertFalse(provlib.is_over_budget(700, 1000, safety_margin_bytes=200))
+
+    def test_path_too_long_flagged(self):
+        self.assertTrue(provlib.is_path_too_long("C:/" + "a" * 300))
+        self.assertFalse(provlib.is_path_too_long("C:/short/path"))
+
+    def test_extended_length_prefix_exempt(self):
+        self.assertFalse(provlib.is_path_too_long("\\\\?\\C:/" + "a" * 300))
+
+
+class LockTests(unittest.TestCase):
+    """Design: acquire_lock -- guards EC-10. A live lock must not be stolen; a
+    stale (dead-pid) lock must be reclaimed."""
+
+    def test_no_lock_acquires(self):
+        d = provlib.acquire_lock(None, pid=42, now=1.0, is_alive_fn=lambda p: True)
+        self.assertTrue(d.acquired)
+        self.assertEqual(d.reason, "acquired-free")
+
+    def test_live_other_pid_refused(self):
+        lock = {"pid": 99, "timestamp": 1.0}
+        d = provlib.acquire_lock(lock, pid=42, now=2.0, is_alive_fn=lambda p: True)
+        self.assertFalse(d.acquired)
+        self.assertEqual(d.reason, "refused-live")
+        self.assertEqual(d.holder_pid, 99)
+
+    def test_dead_pid_reclaimed(self):
+        lock = {"pid": 99, "timestamp": 1.0}
+        d = provlib.acquire_lock(lock, pid=42, now=2.0, is_alive_fn=lambda p: False)
+        self.assertTrue(d.acquired)
+        self.assertEqual(d.reason, "reclaimed-stale")
+
+    def test_same_pid_reentrant(self):
+        lock = {"pid": 42, "timestamp": 1.0}
+        d = provlib.acquire_lock(lock, pid=42, now=2.0, is_alive_fn=lambda p: True)
+        self.assertTrue(d.acquired)
+
+
+class OpenPinTests(unittest.TestCase):
+    """Design: is_open_pin -- guards EC-13. An OPEN sha256 placeholder must be
+    detected so DOWNLOAD aborts instead of installing unverified bytes."""
+
+    def test_open_variants_detected(self):
+        for v in ["OPEN", "OPEN-fill-at-first-download", "OPEN-something", "", None, "  "]:
+            self.assertTrue(provlib.is_open_pin(v), v)
+
+    def test_real_hash_not_open(self):
+        self.assertFalse(provlib.is_open_pin("a" * 64))
+
+
+class LogFormatTests(unittest.TestCase):
+    """Design: Diagnostic Logging -- the provision-log line shape."""
+
+    def test_format(self):
+        line = provlib.format_log_line("Info", "PIN", "krpc match")
+        self.assertEqual(line, "[Provision][Info][PIN] krpc match")
+
+
+class ActionPlanTests(unittest.TestCase):
+    """Design: --dry-run action plan coherence."""
+
+    PINS = {
+        "krpc": {"tag": "v0.5.4", "commit": "11f1f13", "releaseZipUrl": "u", "releaseZipSha256": "OPEN"},
+        "mechjeb2": {"buildNumber": "2.15.x.x", "downloadUrl": "OPEN", "sha256": "OPEN"},
+        "krpc_mechjeb": {"fork": "genhis", "tag": "v0.7.1", "commit": "398bc33", "pairedKrpcTag": "v0.5.4"},
+    }
+    PROFILE = {
+        "instanceDir": "automation/stock-minimal",
+        "devSourcedMods": ["000_Harmony", "CommunityTechTree"],
+        "stackComponents": ["krpc", "testingtools", "mechjeb2", "krpc_mechjeb", "parsek"],
+        "settings": {"FRAMERATE_LIMIT": "60", "QUALITY_PRESET": "0"},
+    }
+
+    def test_plan_covers_all_phases(self):
+        plan = provlib.build_action_plan(self.PINS, self.PROFILE)
+        steps = {a.step for a in plan}
+        for expected in ("PIN", "FETCH", "BUILD-TT", "PAIR", "CLONE", "SETTINGS",
+                         "DEPLOY", "INSTALL", "MM-CACHE", "MANIFEST", "VERIFY"):
+            self.assertIn(expected, steps)
+
+    def test_plan_junctions_stock_and_copies_devsourced(self):
+        plan = provlib.build_action_plan(self.PINS, self.PROFILE)
+        junctions = [a.detail for a in plan if a.verb == "JUNCTION"]
+        self.assertTrue(any("Squad" in d for d in junctions))
+        copies = [a.detail for a in plan if a.verb == "COPY"]
+        self.assertTrue(any("000_Harmony" in d for d in copies))
+
+    def test_plan_deletes_mm_cache(self):
+        plan = provlib.build_action_plan(self.PINS, self.PROFILE)
+        deletes = [a.detail for a in plan if a.verb == "DELETE"]
+        self.assertTrue(any("ConfigCache" in d for d in deletes))
+
+    def test_parsek_not_double_installed(self):
+        plan = provlib.build_action_plan(self.PINS, self.PROFILE)
+        installs = [a.detail for a in plan if a.step == "INSTALL"]
+        self.assertFalse(any("GameData/parsek" in d for d in installs))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/harness/provision/test_provlib.py
+++ b/harness/provision/test_provlib.py
@@ -362,6 +362,87 @@ class DiskAndPathGuardTests(unittest.TestCase):
         self.assertFalse(provlib.is_path_too_long("\\\\?\\C:/" + "a" * 300))
 
 
+class InstanceDirAliasTests(unittest.TestCase):
+    """Design EC-16 / reviewer 4: an instance dir that equals, nests inside, or
+    contains the read-only dev install (or is not under automation/) must be
+    rejected before any destructive live primitive runs."""
+
+    DEV = "C:/Code/Parsek/Kerbal Space Program"
+    GOOD = "C:/Code/Parsek/automation/stock-minimal"
+
+    def test_good_instance_dir(self):
+        d = provlib.check_instance_dir_alias(self.GOOD, self.DEV, "automation/stock-minimal")
+        self.assertTrue(d.ok)
+        self.assertEqual(d.reason, "ok")
+
+    def test_equal_rejected(self):
+        d = provlib.check_instance_dir_alias(self.DEV, self.DEV, "automation/x")
+        self.assertFalse(d.ok)
+        self.assertEqual(d.reason, "equals-dev-install")
+
+    def test_equal_rejected_case_and_sep_insensitive(self):
+        d = provlib.check_instance_dir_alias(
+            "c:\\code\\parsek\\kerbal space program", self.DEV, "automation/x")
+        self.assertFalse(d.ok)
+        self.assertEqual(d.reason, "equals-dev-install")
+
+    def test_nested_in_dev_install_rejected(self):
+        d = provlib.check_instance_dir_alias(
+            self.DEV + "/GameData/instance", self.DEV, "automation/x")
+        self.assertFalse(d.ok)
+        self.assertEqual(d.reason, "nested-in-dev-install")
+
+    def test_dev_install_nested_in_instance_rejected(self):
+        parent = "C:/Code/Parsek"
+        d = provlib.check_instance_dir_alias(parent, self.DEV, "automation/x")
+        self.assertFalse(d.ok)
+        self.assertEqual(d.reason, "dev-install-nested-in-instance")
+
+    def test_not_under_automation_rejected(self):
+        d = provlib.check_instance_dir_alias(
+            "C:/Code/Parsek/instances/x", self.DEV, "instances/x")
+        self.assertFalse(d.ok)
+        self.assertEqual(d.reason, "not-under-automation")
+
+    def test_prefix_sibling_is_not_nested(self):
+        # "automation" must not be treated as nested under "auto".
+        self.assertFalse(provlib.is_path_within("C:/x/automation", "C:/x/auto"))
+        self.assertTrue(provlib.is_path_within("C:/x/auto/child", "C:/x/auto"))
+
+
+class SettingsHashRoundTripTests(unittest.TestCase):
+    """Guards BLOCKER 2: settingsFinalSha256 must equal the hash of the bytes
+    actually written. Writing with newline='\\n' and recording the re-read hash
+    means a live VERIFY re-hash can never spuriously exit 3 DRIFT (the old code
+    hashed '\\n' text but wrote CRLF on Windows)."""
+
+    def test_written_settings_hash_matches_recorded_and_uses_lf(self):
+        import hashlib
+        import tempfile
+        import provision
+        with tempfile.TemporaryDirectory() as umbrella:
+            dev = os.path.join(umbrella, "Kerbal Space Program")
+            os.makedirs(dev)
+            # Dev file deliberately CRLF: proves the platform-translation trap.
+            with open(os.path.join(dev, "settings.cfg"), "wb") as fh:
+                fh.write(b"FRAMERATE_LIMIT = 120\r\nUI_SCALE = 1.2\r\n")
+            profile = {"baseInstall": "Kerbal Space Program",
+                       "instanceDir": "automation/x",
+                       "settings": {"FRAMERATE_LIMIT": "60", "NEW_KEY": "1"}}
+            ctx = provision.ProvisionContext(
+                profile_name="x", pins={}, profile=profile,
+                umbrella_root=umbrella, dry_run=False, repair=False,
+                parsek_dll_override=None)
+            provision.phase_settings(ctx)
+            written = os.path.join(ctx.instance_dir, "settings.cfg")
+            with open(written, "rb") as fh:
+                raw = fh.read()
+            self.assertNotIn(b"\r\n", raw, "instance settings.cfg must be LF-only")
+            on_disk = hashlib.sha256(raw).hexdigest()
+            self.assertEqual(on_disk, ctx.settings_final_sha,
+                             "recorded settingsFinalSha256 must equal the on-disk byte hash")
+
+
 class LockTests(unittest.TestCase):
     """Design: acquire_lock -- guards EC-10. A live lock must not be stolen; a
     stale (dead-pid) lock must be reclaimed."""


### PR DESCRIPTION
## Summary

Third implementation module of the automated-testing initiative (design doc: docs/dev/design-autotest-stack-setup.md, amended in this PR with the v1 status note and deferred items).

harness/provision/: the automation-KSP-instance provisioning tool.

- **v1 scope (honest)**: a dry-run action planner + a fully-tested pure decision library (provlib). Live execution of the heavy phases (CLONE/BUILD-TT/INSTALL) aborts loudly as not-yet-implemented rather than half-provisioning; it lands with the coordinated live smoke-run task once the OPEN pins (release sha256s, MechJeb build number) are filled via the documented verification commands.
- **Ground truth encoded**: kRPC v0.5.4 pin with annotated-tag peeling (rev-parse the tag object is a MISMATCH; only ^{commit} counts), the 2-file TestingTools shim with AutoLoadGame excluded and a build-output absence assert planned, genhis KRPC.MechJeb 0.7.1 pairing gate (EC-14), Squad/SquadExpansion junction strategy with link-probing verification, manifest with settingsFinalSha256 (byte-accurate: written newline=LF, hash re-read from disk) + buildId64Sha256.
- **Safety**: dev-install aliasing guard (EC-16) - the instance dir may never equal, contain, or be contained by the dev KSP install and must live under automation/; the destructive primitives (settings write, DLL deploy, MM-cache delete) are unreachable otherwise. Review traced every live write path: the dev install and mod clones are read-only sources throughout.

## Review

Passed a clean-context adversarial review; all 3 blockers fixed (modded-compat TOML structure bug that emptied stackComponents, CRLF hash mismatch that would have made every live VERIFY drift, live-stub honesty) plus the safety guard and five cheap inclusions; six items tracked as deferred-to-live-execution in the design doc.

## Test plan

70 unittest cases (real-profile-file loading regression, pin/peel matrix, manifest drift, settings CRLF round-trip, aliasing guard, junction link probing, lock edge cases); both profiles dry-run to exit 0. No Parsek C# code touched; no CI impact.